### PR TITLE
[#151] Renamed numWorkerThreads to numberOfWorkerThreads

### DIFF
--- a/config/coordinator.yaml
+++ b/config/coordinator.yaml
@@ -37,7 +37,7 @@
 #bufferSizeInBytes: 4096
 
 # Number of threads available for the worker node. Defines how many queries can run in parallel.
-#numWorkerThreads: 1
+#numberOfWorkerThreads: 1
 
 # The number of queries to be processed together
 #queryBatchSize: 1

--- a/config/worker.yaml
+++ b/config/worker.yaml
@@ -21,7 +21,7 @@
 #numberOfSlots: 65535
 
 # Set the number of worker threads
-#numWorkerThreads: 1
+#numberOfWorkerThreads: 1
 
 # Number buffers in global buffer pool
 #numberOfBuffersInGlobalBufferManager: 1024

--- a/nes-configurations/include/Configurations/ConfigurationsNames.hpp
+++ b/nes-configurations/include/Configurations/ConfigurationsNames.hpp
@@ -66,7 +66,7 @@ const std::string ENABLE_SOURCE_SHARING_CONFIG = "enableSourceSharing";
 const std::string ENABLE_USE_COMPILATION_CACHE_CONFIG = "useCompilationCache";
 
 const std::string ENABLE_STATISTIC_OUTPUT_CONFIG = "enableStatisticOutput";
-const std::string NUM_WORKER_THREADS_CONFIG = "numWorkerThreads";
+const std::string NUMBER_OF_WORKER_THREADS_CONFIG = "numberOfWorkerThreads";
 const std::string OPTIMIZER_CONFIG = "optimizer";
 const std::string WORKER_CONFIG = "worker";
 const std::string WORKER_CONFIG_PATH = "workerConfigPath";

--- a/nes-configurations/include/Configurations/Worker/WorkerConfiguration.hpp
+++ b/nes-configurations/include/Configurations/Worker/WorkerConfiguration.hpp
@@ -122,11 +122,9 @@ public:
      */
     UIntOption latency = {LATENCY_IN_MS, "0", "The link latency in milliseconds.", {std::make_shared<NumberValidation>()}};
 
-    /**
-     * @brief Configures the number of worker threads.
-     */
-    UIntOption numWorkerThreads
-        = {"numWorkerThreads",
+    /// Configures the number of worker threads with a default value of 1.
+    UIntOption numberOfWorkerThreads
+        = {"numberOfWorkerThreads",
            "1",
            "Number of worker threads.",
            {std::make_shared<NonZeroValidation>(), std::make_shared<NumberValidation>()}};
@@ -298,7 +296,7 @@ private:
             &numberOfSlots,
             &bandwidth,
             &latency,
-            &numWorkerThreads,
+            &numberOfWorkerThreads,
             &numberOfBuffersInGlobalBufferManager,
             &numberOfBuffersPerWorker,
             &numberOfBuffersInSourceLocalBufferPool,

--- a/nes-configurations/tests/TestData/emptyWorker.yaml
+++ b/nes-configurations/tests/TestData/emptyWorker.yaml
@@ -9,7 +9,7 @@ localWorkerHost: localhost
 coordinatorPort: 5000
 
 # Set the number of worker threads
-numWorkerThreads: 5
+numberOfWorkerThreads: 5
 
 # Number buffers in global buffer pool
 numberOfBuffersInGlobalBufferManager: 2048

--- a/nes-configurations/tests/TestData/workerWithAdaptiveCSVSource.yaml
+++ b/nes-configurations/tests/TestData/workerWithAdaptiveCSVSource.yaml
@@ -9,7 +9,7 @@ localWorkerHost: localhost
 coordinatorPort: 5000
 
 # Set the number of worker threads
-numWorkerThreads: 5
+numberOfWorkerThreads: 5
 
 # Number buffers in global buffer pool
 numberOfBuffersInGlobalBufferManager: 2048

--- a/nes-configurations/tests/TestData/workerWithPhysicalSources.yaml
+++ b/nes-configurations/tests/TestData/workerWithPhysicalSources.yaml
@@ -9,7 +9,7 @@ localWorkerHost: localhost
 coordinatorPort: 5000
 
 # Set the number of worker threads
-numWorkerThreads: 5
+numberOfWorkerThreads: 5
 
 # Number buffers in global buffer pool
 numberOfBuffersInGlobalBufferManager: 2048

--- a/nes-configurations/tests/UnitTests/Configurations/ConfigurationTests.cpp
+++ b/nes-configurations/tests/UnitTests/Configurations/ConfigurationTests.cpp
@@ -84,7 +84,9 @@ TEST_F(ConfigTest, testEmptyParamsAndMissingParamsCoordinatorYAMLFile)
         coordinatorConfigPtr->worker.numberOfBuffersInSourceLocalBufferPool.getValue(),
         coordinatorConfigPtr->worker.numberOfBuffersInSourceLocalBufferPool.getDefaultValue());
     EXPECT_NE(coordinatorConfigPtr->worker.bufferSizeInBytes.getValue(), coordinatorConfigPtr->worker.bufferSizeInBytes.getDefaultValue());
-    EXPECT_EQ(coordinatorConfigPtr->worker.numWorkerThreads.getValue(), coordinatorConfigPtr->worker.numWorkerThreads.getDefaultValue());
+    EXPECT_EQ(
+        coordinatorConfigPtr->worker.numberOfWorkerThreads.getValue(),
+        coordinatorConfigPtr->worker.numberOfWorkerThreads.getDefaultValue());
     EXPECT_EQ(
         coordinatorConfigPtr->optimizer.queryMergerRule.getValue(), coordinatorConfigPtr->optimizer.queryMergerRule.getDefaultValue());
     EXPECT_EQ(
@@ -142,10 +144,14 @@ TEST_F(ConfigTest, testCoordinatorEPERATPRmptyParamsConsoleInput)
         coordinatorConfigPtr->worker.numberOfBuffersInSourceLocalBufferPool.getValue(),
         coordinatorConfigPtr->worker.numberOfBuffersInSourceLocalBufferPool.getDefaultValue());
     EXPECT_NE(coordinatorConfigPtr->worker.bufferSizeInBytes.getValue(), coordinatorConfigPtr->worker.bufferSizeInBytes.getDefaultValue());
-    EXPECT_EQ(coordinatorConfigPtr->worker.numWorkerThreads.getValue(), coordinatorConfigPtr->worker.numWorkerThreads.getDefaultValue());
+    EXPECT_EQ(
+        coordinatorConfigPtr->worker.numberOfWorkerThreads.getValue(),
+        coordinatorConfigPtr->worker.numberOfWorkerThreads.getDefaultValue());
     EXPECT_EQ(
         coordinatorConfigPtr->optimizer.queryMergerRule.getValue(), coordinatorConfigPtr->optimizer.queryMergerRule.getDefaultValue());
-    EXPECT_EQ(coordinatorConfigPtr->worker.numWorkerThreads.getValue(), coordinatorConfigPtr->worker.numWorkerThreads.getDefaultValue());
+    EXPECT_EQ(
+        coordinatorConfigPtr->worker.numberOfWorkerThreads.getValue(),
+        coordinatorConfigPtr->worker.numberOfWorkerThreads.getDefaultValue());
 }
 
 TEST_F(ConfigTest, testEmptyParamsAndMissingParamsWorkerYAMLFile)
@@ -169,7 +175,7 @@ TEST_F(ConfigTest, testEmptyParamsAndMissingParamsWorkerYAMLFile)
         workerConfigPtr->numberOfBuffersInSourceLocalBufferPool.getDefaultValue());
     EXPECT_EQ(workerConfigPtr->bufferSizeInBytes.getValue(), workerConfigPtr->bufferSizeInBytes.getDefaultValue());
     EXPECT_EQ(workerConfigPtr->numberOfBuffersPerEpoch.getValue(), workerConfigPtr->numberOfBuffersPerEpoch.getDefaultValue());
-    EXPECT_NE(workerConfigPtr->numWorkerThreads.getValue(), workerConfigPtr->numWorkerThreads.getDefaultValue());
+    EXPECT_NE(workerConfigPtr->numberOfWorkerThreads.getValue(), workerConfigPtr->numberOfWorkerThreads.getDefaultValue());
     EXPECT_TRUE(workerConfigPtr->physicalSourceTypes.empty());
 }
 
@@ -193,7 +199,7 @@ TEST_F(ConfigTest, testWorkerYAMLFileWithMultiplePhysicalSource)
         workerConfigPtr->numberOfBuffersInSourceLocalBufferPool.getValue(),
         workerConfigPtr->numberOfBuffersInSourceLocalBufferPool.getDefaultValue());
     EXPECT_EQ(workerConfigPtr->bufferSizeInBytes.getValue(), workerConfigPtr->bufferSizeInBytes.getDefaultValue());
-    EXPECT_NE(workerConfigPtr->numWorkerThreads.getValue(), workerConfigPtr->numWorkerThreads.getDefaultValue());
+    EXPECT_NE(workerConfigPtr->numberOfWorkerThreads.getValue(), workerConfigPtr->numberOfWorkerThreads.getDefaultValue());
     EXPECT_TRUE(!workerConfigPtr->physicalSourceTypes.empty());
     EXPECT_TRUE(workerConfigPtr->physicalSourceTypes.size() == 2);
 }
@@ -205,7 +211,7 @@ TEST_F(ConfigTest, testWorkerEmptyParamsConsoleInput)
     auto commandLineParams = makeCommandLineArgs(
         {"--localWorkerHost=localhost",
          "--coordinatorPort=5000",
-         "--numWorkerThreads=5",
+         "--numberOfWorkerThreads=5",
          "--numberOfBuffersInGlobalBufferManager=2048",
          "--numberOfBuffersInSourceLocalBufferPool=128",
          "--queryCompiler.compilationStrategy=FAST",
@@ -235,7 +241,7 @@ TEST_F(ConfigTest, testWorkerEmptyParamsConsoleInput)
         workerConfigPtr->numberOfBuffersInSourceLocalBufferPool.getValue(),
         workerConfigPtr->numberOfBuffersInSourceLocalBufferPool.getDefaultValue());
     EXPECT_EQ(workerConfigPtr->bufferSizeInBytes.getValue(), workerConfigPtr->bufferSizeInBytes.getDefaultValue());
-    EXPECT_NE(workerConfigPtr->numWorkerThreads.getValue(), workerConfigPtr->numWorkerThreads.getDefaultValue());
+    EXPECT_NE(workerConfigPtr->numberOfWorkerThreads.getValue(), workerConfigPtr->numberOfWorkerThreads.getDefaultValue());
     EXPECT_NE(
         workerConfigPtr->queryCompiler.compilationStrategy.getValue(),
         workerConfigPtr->queryCompiler.compilationStrategy.getDefaultValue());
@@ -253,7 +259,7 @@ TEST_F(ConfigTest, testWorkerCSCVSourceConsoleInput)
     auto commandLineParams = makeCommandLineArgs(
         {"--localWorkerHost=localhost",
          "--coordinatorPort=5000",
-         "--numWorkerThreads=5",
+         "--numberOfWorkerThreads=5",
          "--numberOfBuffersInGlobalBufferManager=2048",
          "--numberOfBuffersInSourceLocalBufferPool=128",
          "--queryCompiler.compilationStrategy=FAST",
@@ -282,7 +288,7 @@ TEST_F(ConfigTest, testWorkerCSCVSourceConsoleInput)
         workerConfigPtr->numberOfBuffersInSourceLocalBufferPool.getValue(),
         workerConfigPtr->numberOfBuffersInSourceLocalBufferPool.getDefaultValue());
     EXPECT_EQ(workerConfigPtr->bufferSizeInBytes.getValue(), workerConfigPtr->bufferSizeInBytes.getDefaultValue());
-    EXPECT_NE(workerConfigPtr->numWorkerThreads.getValue(), workerConfigPtr->numWorkerThreads.getDefaultValue());
+    EXPECT_NE(workerConfigPtr->numberOfWorkerThreads.getValue(), workerConfigPtr->numberOfWorkerThreads.getDefaultValue());
     EXPECT_NE(
         workerConfigPtr->queryCompiler.compilationStrategy.getValue(),
         workerConfigPtr->queryCompiler.compilationStrategy.getDefaultValue());
@@ -373,8 +379,8 @@ TEST_F(ConfigTest, invalidCommandLineInputForIntOptions)
            {"--rpcPort", {"not_an_int", "1.5", "-1"}},
            {"--dataPort", {"not_an_int", "1.5", "-1"}},
            {"--coordinatorPort", {"not_an_int", "1.5", "-1"}},
-           {"--numWorkerThreads", {"not_an_int", "1.5", "-1"}},
-           {"--numWorkerThreads", {"non_zero", "0", "0.0"}},
+           {"--numberOfWorkerThreads", {"not_an_int", "1.5", "-1"}},
+           {"--numberOfWorkerThreads", {"non_zero", "0", "0.0"}},
            {"--numberOfBuffersInGlobalBufferManager", {"not_an_int", "1.5", "-1"}},
            {"--numberOfBuffersPerWorker", {"not_an_int", "1.5", "-1"}},
            {"--numberOfBuffersInSourceLocalBufferPool", {"not_an_int", "1.5", "-1"}},
@@ -468,8 +474,8 @@ TEST_F(ConfigTest, invalidIntYamlInputs)
            {"--rpcPort", {"not_an_int", "1.5", "-1"}},
            {"--dataPort", {"not_an_int", "1.5", "-1"}},
            {"--coordinatorPort", {"not_an_int", "1.5", "-1"}},
-           {"--numWorkerThreads", {"not_an_int", "1.5", "-1"}},
-           {"--numWorkerThreads", {"non_zero", "0", "0.0"}},
+           {"--numberOfWorkerThreads", {"not_an_int", "1.5", "-1"}},
+           {"--numberOfWorkerThreads", {"non_zero", "0", "0.0"}},
            {"--numberOfBuffersInGlobalBufferManager", {"not_an_int", "1.5", "-1"}},
            {"--numberOfBuffersPerWorker", {"not_an_int", "1.5", "-1"}},
            {"--numberOfBuffersInSourceLocalBufferPool", {"not_an_int", "1.5", "-1"}},

--- a/nes-execution/src/Runtime/NodeEngineBuilder.cpp
+++ b/nes-execution/src/Runtime/NodeEngineBuilder.cpp
@@ -102,7 +102,7 @@ std::unique_ptr<NodeEngine> NodeEngineBuilder::build()
         QueryManagerPtr queryManager{this->queryManager};
         if (!this->queryManager)
         {
-            auto numOfThreads = static_cast<uint16_t>(workerConfiguration.numWorkerThreads.getValue());
+            auto numOfThreads = static_cast<uint16_t>(workerConfiguration.numberOfWorkerThreads.getValue());
             auto numberOfBuffersPerEpoch = static_cast<uint16_t>(workerConfiguration.numberOfBuffersPerEpoch.getValue());
             std::vector<uint64_t> workerToCoreMappingVec
                 = NES::Util::splitWithStringDelimiter<uint64_t>(workerConfiguration.workerPinList.getValue(), ",");


### PR DESCRIPTION
## What is the purpose of the change
This pull request renames numWorkerThreads to numberOfWorkerThreads in config (yaml files) and tests.

## Brief change log
- Renamed numWorkerThreads

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- The compiler: (don't know)
- The threading model: (don't know)
- The Runtime per-record code paths (performance sensitive): - (don't know)
- The network stack: (no)
- Anything that affects deployment or recovery: Coordinator (and its components), NodeEngine (and its components): (don't know)

## Documentation
- Does this pull request introduce a new feature? (no)

## Issue Closed by this pull request:

This PR closes #151  
