### PR TITLE
#211 : Renamed CI-relevant occurrences of 'master' to 'main'.

### DIFF
--- a/.github/ISSUE_TEMPLATE/nebulastream_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/nebulastream_bug_report.yml
@@ -90,7 +90,7 @@ body:
       options:
         - label: >
             I agree to follow this project's
-            [Code of Conduct](https://github.com/nebulastream/nebulastream/blob/master/CODE_OF_CONDUCT.md)
+            [Code of Conduct](https://github.com/nebulastream/nebulastream/blob/main/CODE_OF_CONDUCT.md)
           required: true
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/nebulastream_docs.yml
+++ b/.github/ISSUE_TEMPLATE/nebulastream_docs.yml
@@ -48,7 +48,7 @@ body:
       options:
         - label: >
             I agree to follow this project's
-            [Code of Conduct](https://github.com/nebulastream/nebulastream/blob/master/CODE_OF_CONDUCT.md)
+            [Code of Conduct](https://github.com/nebulastream/nebulastream/blob/main/CODE_OF_CONDUCT.md)
           required: true
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/nebulastream_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/nebulastream_feature_request.yml
@@ -49,7 +49,7 @@ body:
       options:
         - label: >
             I agree to follow this project's
-            [Code of Conduct](https://github.com/nebulastream/nebulastream/blob/master/CODE_OF_CONDUCT.md)
+            [Code of Conduct](https://github.com/nebulastream/nebulastream/blob/main/CODE_OF_CONDUCT.md)
           required: true
   - type: markdown
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ This pull request adds support for variable sized data to the nested loop join. 
 This change is tested by
 *(for example:)*
 - *Added integration tests for end-to-end deployment with large payloads (100MB)*
-- *Extended integration test for recovery after master failure*
+- *Extended integration test for recovery after main failure*
 - *Added test that validates that TaskInfo is transferred only once across recoveries*
 
 ## What components does this pull request potentially affect?

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,7 +34,7 @@ jobs:
           exclude_assets: '*.py,*.so'
           keep_files: true
           external_repository: nebulastream/benchmark-data
-          publish_branch: master
+          publish_branch: main
       - name: docker cleanup
         if: ${{ always() }}
         run: |

--- a/.github/workflows/docker_image_on_demand.yml
+++ b/.github/workflows/docker_image_on_demand.yml
@@ -11,7 +11,7 @@ on:
       branch:
         description: 'Branch to build docker executable images for'
         required: true
-        default: 'master'
+        default: 'main'
 
 jobs:
     build-docker:
@@ -44,7 +44,7 @@ jobs:
             ref: ${{ github.event.inputs.branch }}
         - name: Build Executable Docker Image
           working-directory: ${{ github.workspace }}/docker
-          # Will create a docker image with the name dod-<branchname>-<arch>, e.g., dod-master-X64
+          # Will create a docker image with the name dod-<branchname>-<arch>, e.g., dod-main-X64
           run: bash scripts/build_docker_image_executable_image.sh dod-${{ github.event.inputs.branch }}-${{ matrix.arch }} ${{ matrix.arch }} ${{ matrix.package_name }} ${{ matrix.platform }} nes-public-executable-image
         - name: "Release and Push NES Executable Image"
           run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,7 +1,7 @@
 name: NES Nightly
 
 # This workflow is triggered every night at 2:30 AM UTC.
-# This is a good way to ensure that the master branch is always in a good state.
+# This is a good way to ensure that the main branch is always in a good state.
 # For now, this workflow file runs the same tests as `pr.yml` and then creates a docker image nes-executable-image:nightly, if the test pass.
 # For pushing an image to the docker hub, we build debian packages (nes-amd64.deb and nes-arm64.deb) and then use them to build the docker image.
 # We will add long-running test for stability and performance checks in the future.
@@ -27,7 +27,7 @@ jobs:
   create-nightly-image:
     runs-on: [ self-hosted, linux, '${{ matrix.arch }}', Build ]
     needs: [ long-running-tests ]
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     env:
       DOCKER_USER_NAME: ${{ secrets.DOCKER_USER_NAME}}
       DOCKER_SECRET: ${{ secrets.DOCKER_SECRET}}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ on:
       - opened
       - reopened
     branches:
-      - master
+      - main
       - 'feature/**'
     paths-ignore:
       - nes-common/include/Version/version.hpp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: NES Release
 
 # The following pipeline, is executed whenever we create a new version tag at the main repository.
 # The pipeline first creates a new tag at nebulastream/nebulastream-dev-builds and nebulastream/nebulastream-demo, which
-# have the same tag_name as the $GITHUB_REF_NAME. Thus, if the master version tag is v10 also the tag_name is v10.
+# have the same tag_name as the $GITHUB_REF_NAME. Thus, if the main version tag is v10 also the tag_name is v10.
 # In the final step, the pipeline builds the individual debian packages and adds them to a release under the new tag.
 # This pipeline is not triggered automatically and must be triggered manually whenever a new version is ready to be released.
 
@@ -20,7 +20,7 @@ on:
 jobs:
   release:
     runs-on: [ self-hosted, linux, X64, Build ]
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     env:
       DOCKER_USER_NAME: ${{ secrets.DOCKER_USER_NAME}}
       DOCKER_SECRET: ${{ secrets.DOCKER_SECRET}}

--- a/CHECKLIST.yml
+++ b/CHECKLIST.yml
@@ -9,4 +9,4 @@ paths:
   "docker/**":
     - You are doing changes to docker configurations. Did you update all images? Did you assign member of build management team to your PR for change review?
   "./**/*":
-    - I went over the checklist in [PR CheckList](https://github.com/nebulastream/nebulastream-public/blob/master/docs/git/checklist_pr.md)?
+    - I went over the checklist in [PR CheckList](https://github.com/nebulastream/nebulastream-public/blob/main/docs/git/checklist_pr.md)?

--- a/scripts/build/run_clang_tidy_extra.py
+++ b/scripts/build/run_clang_tidy_extra.py
@@ -40,7 +40,7 @@ class CheckConfig(object):
             We also tell git to only diff new or modified files (filter=AM)
         """
         with os.popen('(git ls-files --full-name :/;'
-                      ' git diff origin/master... --name-only --diff-filter=AM)'
+                      ' git diff origin/main... --name-only --diff-filter=AM)'
                       '| sort | uniq -u') as diff:
             for line in diff:
                 self.ignore_pats.append("/%s" % line.strip())


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
We changed the name of our master branch to main and had to update several of our repository files related to CI worflows, renaming master to main.

## Verifying this change
- CI passes

## What components does this pull request potentially affect?
- CI

## Documentation
- updated existing documentation

## Issue Closed by this pull request:

This PR closes #211
