### PR TITLE
fix(deps): allow user-supplied VCPKG_ROOT

### DIFF
--- a/docker/dependency/Dependency.dockerfile
+++ b/docker/dependency/Dependency.dockerfile
@@ -16,4 +16,4 @@ RUN cd /vcpkg_input \
     && cp vcpkg_repository/scripts/vcpkgTools.xml /vcpkg/scripts/ \
     && rm -rf /vcpkg_input \
     && chmod -R g=u,o=u /vcpkg
-ENV VCPKG_ROOT=/vcpkg
+ENV NES_PREBUILT_VCPKG_ROOT=/vcpkg

--- a/docs/dependency.md
+++ b/docs/dependency.md
@@ -50,7 +50,7 @@ initially resolved via vcpkg-managed dependencies. Running the initial CMake con
 options for how NebulaStream detects the dependencies.
 The developer passes a vcpkg toolchain file directly via
 `-DCMAKE_TOOLCHAIN_FILE=/path/to/vcpkg/scripts/buildsystems/vcpkg.cmake`
-The developer configures the CMake build in the developer container with the VCPKG_ROOT environment variable prepared.
+The developer configures the CMake build in the developer container with the NES_PREBUILT_VCPKG_ROOT environment variable prepared.
 If the developer does not specify a toolchain file and no environment is set, the build system will clone a new
 vcpkg-repository into the current working directory and set the toolchain file automatically.
 

--- a/docs/design/20240710_dependency-management.md
+++ b/docs/design/20240710_dependency-management.md
@@ -164,7 +164,7 @@ Lastly, a docker image at `luukas/nebula stream:alpine` contains a set of prebui
 
 > docker pull docker pull luukas/nebulastream:alpine
 
-A new docker-based toolchain needs to be created in CLion. A CMake build inside the docker container will pick up the destination of the pre-installed VCPKG-registry based on the `VCPKG_ROOT` environment variable, so no further CMake configuration parameters are required.
+A new docker-based toolchain needs to be created in CLion. A CMake build inside the docker container will pick up the destination of the pre-installed VCPKG-registry based on the `NES_PREBUILT_VCPKG_ROOT` environment variable, so no further CMake configuration parameters are required.
 
 
 # Open Questions

--- a/docs/development.md
+++ b/docs/development.md
@@ -68,7 +68,7 @@ docker run
 
 ### Dependencies via VCPKG
 
-The development container has an environment variable `VCPKG_ROOT`, which, once detected by the CMake build system, will
+The development container has an environment variable `NES_PREBUILT_VCPKG_ROOT`, which, once detected by the CMake build system, will
 configure the correct toolchain to use.
 
 Since the development environment only provides a pre-built set of dependencies, changing the dependencies in the


### PR DESCRIPTION
introduces `NES_PREBUILT_VCPKG_ROOT` env var to signal that pre-built dependencies exist.

previously, `VCPKG_ROOT` was used for this, which prevents user-managed, out-of-tree vcpkg install (which is e.g. nice when using git worktrees).

Now `VCPKG_ROOT` works as expected.