### PR TITLE
Small ci improvements

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -186,11 +186,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Configure CMake
         run: cmake -B build
-      - name: check-preamble
+      - name: Check preamble
         run: cmake --build build --target check-preamble
-      - name: check-format
+      - name: Check format
         run: cmake --build build --target check-format
-      - name: check-comment-format
+      - name: Check comment format
         run: cmake --build build --target check-comment-format
 
   build-linux:


### PR DESCRIPTION
- Some small stuff
- junit report as artifact
- remove names of simple CI steps: [f277e13](https://github.com/nebulastream/nebulastream-public/pull/231/commits/f277e1371135a6c05e22731f0429d344e9846c84)

Removing the names clutters the rendered display a bit, but I think it increases readability of the workflow yaml.
I'll happily remove the commit if you don't like the tradeoff :)

---

(before:)

![image](https://github.com/user-attachments/assets/a2b25b90-34d9-4365-a399-8273c2c22cad)

(after:)

![image](https://github.com/user-attachments/assets/34e4445b-8bc8-4b5a-a22d-8216aa494f7a)



