### PR TITLE
Provide script to Run Github Actions Locally #107

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,8 +20,8 @@ on:
 
 jobs:
   validateTrigger:
-    # This ensures we won't run the CI if it is in draft mode.
-    if: ${{ !github.event.pull_request.draft }}
+    # This ensures we won't run the CI if it is in draft mode, or we called it via act.
+    if: ${{ !github.event.pull_request.draft && !env.ACT }}
     runs-on: [ self-hosted, linux, Build ]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What is the purpose of the change

This pull request enables users to run the GitHub CLI locally using the following command:

`gh act pull_request -P self-hosted=catthehacker/ubuntu:runner-latest --container-options "--group-add $(stat -c %g /var/run/docker.sock)" --matrix osversion:ubuntu-22_04 --matrix arch:X64 --matrix runner_group:default`



## Brief change log

The job `ValidateTrigger` has been skipped.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The compiler: no
  - The threading model: no
  - The Runtime per-record code paths (performance sensitive): no
  - The network stack: no
  - Anything that affects deployment or recovery: Coordinator (and its components), NodeEngine (and its components): no

## Documentation

  - Does this pull request introduce a new feature? no

## Issue Closed by this pull request:

This PR closes #107 
