### PR TITLE
Temporary adds a 100ms sleep before stopping the CSV Query

### DIFF
--- a/nes-single-node-worker/tests/Integration/SingleNodeIntegrationTestsCSV.cpp
+++ b/nes-single-node-worker/tests/Integration/SingleNodeIntegrationTestsCSV.cpp
@@ -92,6 +92,9 @@ TEST_P(SingleNodeIntegrationTest, TestQueryRegistration)
 
     auto queryId = IntegrationTestUtil::registerQueryPlan(queryPlan, uut);
     IntegrationTestUtil::startQuery(queryId, uut);
+    ///TODO(#246) Use Query Status to determine of the query has stopped
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    IntegrationTestUtil::stopQuery(queryId, HardStop, uut);
     IntegrationTestUtil::unregisterQuery(queryId, uut);
 
     auto bufferManager = std::make_shared<NES::Runtime::BufferManager>();


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

This PR adds a temporary fix to the flaky csv integration test until we can use the QueryStatus to properly determine if a query has stopped.

## Verifying this change

The CI passes

## What components does this pull request potentially affect?

None

## Documentation

Yes, it adds a TODO linking to #246

