### PR TITLE
run CI tests for draft PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -90,7 +90,7 @@ jobs:
     # The Dependency Image contains a pre-built sdk based on the vcpkg manifest
     # The Development Image contains the dependencies and additional tooling like clang-format.
     name: "Build Development Images"
-    needs: [ validateTrigger, detect-dependency-changes ]
+    needs: [ detect-dependency-changes ]
     if: needs.detect-dependency-changes.outputs.change == 'true'
     runs-on: [ self-hosted, linux, Build, "${{ matrix.platform }}" ]
     strategy:


### PR DESCRIPTION
also runs CI (except for the QA checklist) for draft PRs.

[Previously](https://github.com/nebulastream/nebulastream-public/actions/runs/10515262831), build/test and checks were (unintendedly?) run, but no new container were built, leading to failure if the dependencies changed.

closes #252 