### PR TITLE
feat(Build) Reduces the MLIR dependencies in nautilus

### DIFF
--- a/nes-nautilus/CMakeLists.txt
+++ b/nes-nautilus/CMakeLists.txt
@@ -50,21 +50,15 @@ if (NES_ENABLE_EXPERIMENTAL_EXECUTION_MLIR)
                 $<BUILD_INTERFACE:${MLIR_INCLUDE_DIRS}>
                 $<INSTALL_INTERFACE:include/nebulastream/>)
         add_compile_definitions(MLIR_COMPILER)
-        get_property(mlir_libs GLOBAL PROPERTY MLIR_ALL_LIBS)
-        get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
-        get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
-        message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
-        message(DEBUG "mlir_libs: ${mlir_libs}")
-        message(DEBUG "dialect_libs: ${dialect_libs}")
-        message(DEBUG "conversion_libs: ${MLIR_INCLUDE_DIRS}")
-        target_link_libraries(nes-nautilus PRIVATE ${mlir_libs} ${dialect_libs}
-                ${conversion_libs}
-                MLIRReconcileUnrealizedCasts
-                MLIRMemRefToLLVM
-                MLIRExecutionEngine)
+        target_link_libraries(nes-nautilus PRIVATE
+                MLIRExecutionEngine
+                MLIRFuncAllExtensions
 
-        # Include necessary mlir library in the deb package and install it in the lib folder
-        install(IMPORTED_RUNTIME_ARTIFACTS mlir_float16_utils mlir_runner_utils mlir_c_runner_utils mlir_async_runtime DESTINATION lib)
+                # Dialects
+                MLIRSCFDialect
+                MLIRFuncToLLVM
+                MLIRSCFToControlFlow
+        )
 
     else ()
         message(FATAL_ERROR "Cannot find mlir")


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This removes unnecessary mir dependencies for Nautilus. It also removes all shared mlir libraries previously included, which also needed to be installed.

## Verifying this change
Build + Tests work. No Dynamic Library Loader error occurs when installing Nautilus via cpack. 

## What components does this pull request potentially affect?
- QueryCompiler


## Documentation
N/A

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
