### PR TITLE
feat(Nebuli) Use the default compiler instead of a specific clang version

### DIFF
--- a/nes-nebuli/src/Compiler/Util/ExecutablePath.cpp
+++ b/nes-nebuli/src/Compiler/Util/ExecutablePath.cpp
@@ -23,7 +23,7 @@ namespace NES::Compiler::ExecutablePath
 std::string UNIX_INSTALL_BIN_DIR = "/usr/local/bin";
 std::string DEFAULT_PUBLIC_INCLUDE_DIR_UNIX_INSTALL = "/usr/local/include/nebulastream";
 std::string DEFAULT_LIB_UNIX_INSTALL = "/usr/local/lib";
-std::string DEFAULT_CLANG_PATH_UNIX_INSTALL = "/usr/local/bin/nes-clang";
+std::string DEFAULT_CLANG_PATH_UNIX_INSTALL = "/usr/bin/c++";
 
 bool isInBuildDir()
 {


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Previously the `CPPCompiler` was using a nes specific clang compiler.
However since we are only using the compiler for the query parsing we
can use any compiler. This PR changes the default path to just use
the default compiler located at /usr/bin/c++.

## Verifying this change
Subsequent PRs will introduce a docker image which uses the default
compiler.

## What components does this pull request potentially affect?
Nebuli

## Documentation
No

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
