### PR TITLE
feat(Nebuli) Adds dockerimage for packaging nebuli

### DIFF
--- a/docker/nebuli/Nebuli.dockerfile
+++ b/docker/nebuli/Nebuli.dockerfile
@@ -1,0 +1,16 @@
+ARG TAG=latest
+FROM nebulastream/nes-development:${TAG} AS build
+
+USER root
+ADD . /home/ubuntu/src
+RUN cd /home/ubuntu/src \
+    && cmake -B build -S . -DCPACK_COMPONENTS_ALL="nebuli" -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    && cmake --build build --target nebuli -j \
+    && cd build \
+    && cpack \
+    && mv *.deb /nebuli.deb
+
+FROM nebulastream/nes-development-base:${TAG} AS app
+COPY --from=build /nebuli.deb /nebuli.deb
+RUN apt install /nebuli.deb -y
+ENTRYPOINT ["nebuli"]

--- a/docker/nebuli/Nebuli.dockerfile.dockerignore
+++ b/docker/nebuli/Nebuli.dockerfile.dockerignore
@@ -1,0 +1,9 @@
+build/
+cmake-build*/
+docker/
+docs/
+config/
+.github/
+scripts/
+vcpkg/
+test/


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR introduces a docker image for Nebuli.
Nebuli is build using cpack because it requires headers to 
be placed at a location where the compiler can pick them up for 
our query parsing.

## Verifying this change
Build and Run using the following docker commands
```
docker build -f docker/nebuli/Nebuli.dockerfile -t nebuli
cat query.yaml | docker run -i nebuli dump
```

## What components does this pull request potentially affect?
None

## Documentation
Not Yet

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
