### PR TITLE
feat(Worker) Adds dockerimage for packaging single-node-worker

### DIFF
--- a/docker/single-node-worker/SingleNodeWorker.dockerfile
+++ b/docker/single-node-worker/SingleNodeWorker.dockerfile
@@ -1,0 +1,26 @@
+ARG TAG=latest
+ARG BUILD_TYPE=RelWithDebInfo
+FROM nebulastream/nes-development:${TAG} AS build
+
+USER root
+ADD . /home/ubuntu/src
+RUN cd /home/ubuntu/src \
+    && cmake -B build -S . -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+    && cmake --build build --target single-node -j \
+    && mkdir /tmp/lib /tmp/bin \
+    && find build -name '*.so' -exec mv -t /tmp/lib {} + \
+    && find build -name 'single-node' -exec mv -t /tmp/bin {} +
+
+
+FROM ubuntu:24.04 AS app
+ENV LLVM_VERSION=18
+RUN apt update -y && apt install curl gpg -y
+RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/keyrings/llvm-snapshot.gpg \
+    && chmod a+r /etc/apt/keyrings/llvm-snapshot.gpg \
+    && echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/"$(. /etc/os-release && echo "$VERSION_CODENAME")"/ llvm-toolchain-"$(. /etc/os-release && echo "$VERSION_CODENAME")"-${LLVM_VERSION} main" > /etc/apt/sources.list.d/llvm-snapshot.list \
+    && echo "deb-src [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/"$(. /etc/os-release && echo "$VERSION_CODENAME")"/ llvm-toolchain-"$(. /etc/os-release && echo "$VERSION_CODENAME")"-${LLVM_VERSION} main" >> /etc/apt/sources.list.d/llvm-snapshot.list \
+    && apt update -y && apt install libc++1-${LLVM_VERSION} libc++abi1-${LLVM_VERSION} -y
+
+COPY --from=build /tmp/lib /usr/lib
+COPY --from=build /tmp/bin /usr/bin
+ENTRYPOINT ["single-node"]

--- a/docker/single-node-worker/SingleNodeWorker.dockerfile.dockerignore
+++ b/docker/single-node-worker/SingleNodeWorker.dockerfile.dockerignore
@@ -1,0 +1,9 @@
+build/
+cmake-build*/
+docker/
+docs/
+config/
+.github/
+scripts/
+vcpkg/
+test/


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Creates docker images for the SingleNodeWorker.

The docker build will build the single-node-worker and manually copy
the binary + all shared libraries into a docker image.
The resulting docker image does not contain any development dependencies.

## Verifying this change
Build and run the docker image using the following commands
```
docker build -f docker/single-node-worker/SingleNodeWorker.dockerfiler . -t worker
docker run worker
```

## What components does this pull request potentially affect?
None

## Documentation
Not Yet

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
