### PR TITLE
Hotfix(CI): rm `paths-ignored` from `pr.yml`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,11 +16,6 @@ on:
     branches:
       - "main"
       - "feature/**"
-    paths-ignore:
-      - README.md
-      - CODE_OF_CONDUCT.md
-      - CHANGELOG.md
-      - 'docs/**'
     # The ready_for_review event is used when a draft pr is changed into a non-draft version. If we did
     # not use the ready_for_review the ci would not be triggered and appear to have passed.
     types: [ ready_for_review, synchronize, opened, reopened ]


### PR DESCRIPTION
We remove `paths-ignored` from `pr.yml`. This lead to the situation that PRs got stuck as not run checks block the merge.