### PR TITLE
#307 : Added workflow and script for Zulip pr reminder

### DIFF
--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -1,0 +1,35 @@
+name: PR Review Reminder
+
+# This workflow is triggered from Monday to Friday at 9:00 AM, 12:45 PM and 4:00 PM CEST.
+# It creates a message consisting of every missing review of every open pull request on this repository.
+# The message is sent into a topic of the NebulaStream Zulip organization.
+
+on: 
+    schedule:
+        - cron: '0 7 * * 1-5'
+        - cron: '45 10 * * 1-5'
+        - cron: '0 14 * * 1-5'
+
+jobs:
+    remind-to-review:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v2
+
+            - name: Use reminder action
+              uses: LeoRaasch/my-github-actions/zulip-pr-reminder@v1
+              with:
+                git-token: ${{ secrets.GITHUB_TOKEN }}
+                mapping: |
+                  {
+                    "adrianmichalke": "@**Adrian Michalke**",
+                    "alepping": "@**Aljoscha Lepping**",
+                    "ls-1801": "@**ls-1801**",
+                    "keyseven123": "@**Nils**",
+                    "zeuchste": "@**Steffen Zeuch**"
+                  }
+                bot-api-key: ${{ secrets.PRBOT_API_KEY }}
+                bot-email: "pr-reminder-bot@nebulastream.zulipchat.com"
+                organization-url: "https://nebulastream.zulipchat.com"


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This pull request adds a workflow that sends a message containing every open pull request aswell as missing reviews from assigned reviewers into a Zulip channel via a bot. This happens from Monday to Friday at 9:00 AM, 12:45 PM and 4:00 PM CEST.
- Added pr-review-reminder.yml workflow, which utilizes the [zulip/github-actions-zulip/send-message@v1](https://github.com/zulip/github-actions-zulip/blob/main/send-message) and my [zulip-pr-reminder](https://github.com/LeoRaasch/my-github-actions/tree/main/zulip-pr-reminder) action to send a pr reminder via a bot to Zulip.

## What components does this pull request potentially affect?
- Executed workflows
## Issue Closed by this pull request:

This PR closes #307 
