### PR TITLE
Fixes issue when using nebuli from the development directory

### DIFF
--- a/nes-nebuli/CMakeLists.txt
+++ b/nes-nebuli/CMakeLists.txt
@@ -53,6 +53,11 @@ target_include_directories(nebuli
 # Collect all headers required for our "query-parsing" and store them in a file_set
 macro(add_nebuli_header TARGET PATH)
     file(GLOB_RECURSE HEADER ${CMAKE_CURRENT_SOURCE_DIR}/../${TARGET}/include/${PATH}/*.hpp)
+    foreach (ABSOLUTE_PATH_TO_HEADER IN LISTS HEADER)
+        file(RELATIVE_PATH RELATIVE_PATH_TO_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/../${TARGET}/include/" "${ABSOLUTE_PATH_TO_HEADER}")
+        configure_file(${ABSOLUTE_PATH_TO_HEADER} "${CMAKE_BINARY_DIR}/include/nebulastream/${RELATIVE_PATH_TO_HEADER}" COPYONLY)
+    endforeach ()
+
     if (NOT HEADER)
         file(GLOB_RECURSE HEADER ${CMAKE_CURRENT_SOURCE_DIR}/../${TARGET}/include/${PATH})
     endif ()


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This fixes a regression of `Nebuli` which in its current state
could not be used without installing it. We now once again
copy all relevant header files into the build directory so
the "query parser" can find them if used in a development
environment.

## Verifying this change
- Headers are properly copied into the build directory under /include/nebulastream.
- Run nebuli from clion directly without installing.


## What components does this pull request potentially affect?
- Nebuli

## Documentation
n/a

