### PR TITLE
docs(Development) Force rootless on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,7 @@ Afterward, there exist multiple new targets:
 - `check-format-clang` runs clang-format and checks if the code is formatted correctly but does not fix it
 - `tidy`  runs clang-tidy 
 - `check-license-and-pragma-once` runs a script that checks that all of our header files start with our license preamble followed by `#pragma once` 
+
+
+# Development
+Follow the [development guide](docs/development.md) to learn how to setup up the development environment.

--- a/docs/development.md
+++ b/docs/development.md
@@ -55,7 +55,7 @@ To run all tests you have to run ctest inside the docker container. The '-j' fla
 refer to the [ctest guide](https://cmake.org/cmake/help/latest/manual/ctest.1.html) for further instruction.
 
 ```shell
-docker run 
+docker run \
     --workdir $(pwd) \
     -v $(pwd):$(pwd) \
      nebulastream/nes-development:local \

--- a/scripts/install-local-docker-environment.sh
+++ b/scripts/install-local-docker-environment.sh
@@ -36,6 +36,12 @@ done
 cd "$(git rev-parse --show-toplevel)"
 HASH=$(docker/dependency/hash_dependencies.sh)
 
+# Docker on macOS appears to always enable the mapping from the container root user to the hosts current 
+# user
+if [[ $OSTYPE == 'darwin'* ]]; then
+  FORCE_ROOTLESS=1
+fi
+
 # If Docker is running in rootless mode, the root user inside the container
 # maps to the user running the rootless Docker daemon (likely the current user).
 # Therefore, we can safely use the root user within the container.


### PR DESCRIPTION

This PR changes the local development image installation script to always use the rootless mode on macOS, which seems to be the most common method of using docker on macos.

