### PR TITLE
338 task adding missing argument in pr reminder workflow

### DIFF
--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -21,6 +21,7 @@ jobs:
             - name: Use reminder action
               uses: LeoRaasch/my-github-actions/zulip-pr-reminder@v1
               with:
+                git-name: 'nebulastream/nebulastream-public'
                 git-token: ${{ secrets.GITHUB_TOKEN }}
                 mapping: |
                   {


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This pull request adds a missing input to the pr-review-reminder workflow that came up when fixing an issue with the corresponding action in the action's repository.
- Added the git-name input to the zulip-pr-reminder call

## What components does this pull request potentially affect?
- Workflows

## Issue Closed by this pull request:

This PR closes #338 
