### PR TITLE
Fixed bug: two parameterized tests with the same queryName.

### DIFF
--- a/nes-single-node-worker/tests/Util/include/IntegrationTestUtil.hpp
+++ b/nes-single-node-worker/tests/Util/include/IntegrationTestUtil.hpp
@@ -73,6 +73,7 @@ void replaceFileSinkPath(SerializableDecomposedQueryPlan& decomposedQueryPlan, c
 /// @brief Iterates over a decomposed query plan and replaces all sockets with the a free port generated for the mocked tcp server.
 void replacePortInTcpSources(
     SerializableDecomposedQueryPlan& decomposedQueryPlan, const uint16_t mockTcpServerPort, const int sourceNumber);
-}
 
+std::string getUniqueTestIdentifier();
+}
 }

--- a/nes-single-node-worker/tests/Util/src/IntegrationTestUtil.cpp
+++ b/nes-single-node-worker/tests/Util/src/IntegrationTestUtil.cpp
@@ -288,4 +288,16 @@ void replacePortInTcpSources(SerializableDecomposedQueryPlan& decomposedQueryPla
         }
     }
 }
+
+std::string getUniqueTestIdentifier()
+{
+    const auto timestamp
+        = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+    const testing::TestInfo* const test_info = testing::UnitTest::GetInstance()->current_test_info();
+
+    auto uniqueTestIdentifier
+        = std::format("{}_{}_{}", std::string(test_info->test_suite_name()), std::string(test_info->name()), timestamp);
+    std::ranges::replace(uniqueTestIdentifier, '/', '_');
+    return uniqueTestIdentifier;
+}
 }


### PR DESCRIPTION
Fixes a bug where two concurrently running tests would interfere, writing to the same query result file.