### PR TITLE
fix(Build/SLT) Used macro enable_test_if_needed for SLT

### DIFF
--- a/tests/utils/SQLLogicTest.cpp
+++ b/tests/utils/SQLLogicTest.cpp
@@ -64,7 +64,7 @@ public:
         std::cout << "Find the log at: file://" << logPath.string() << std::endl;
         std::cout << "Find the test file at: file://" SYSTEM_TEST_FILE_PATH << std::endl;
 
-        IntegrationTestUtil::removeFile(CMAKE_BINARY_DIR "/test/result/" + systemTestName + std::to_string(testId) + ".csv");
+        IntegrationTestUtil::removeFile(CMAKE_BINARY_DIR "/tests/result/" + systemTestName + std::to_string(testId) + ".csv");
 
         SerializableDecomposedQueryPlan queryPlan;
         std::ifstream file(cachedQueryPlanFile);


### PR DESCRIPTION
Renamed one leftover occurrence from `test` ---> `tests`.