### PR TITLE
ExecutionContext Refactor

### DIFF
--- a/nes-execution/include/Execution/Operators/Operator.hpp
+++ b/nes-execution/include/Execution/Operators/Operator.hpp
@@ -19,7 +19,7 @@
 
 namespace NES::Runtime::Execution
 {
-class ExecutionContext;
+struct ExecutionContext;
 class RecordBuffer;
 }
 namespace NES::Runtime::Execution::Operators

--- a/nes-execution/include/Execution/Operators/Watermark/TimeFunction.hpp
+++ b/nes-execution/include/Execution/Operators/Watermark/TimeFunction.hpp
@@ -25,7 +25,7 @@ class Record;
 namespace NES::Runtime::Execution
 {
 class RecordBuffer;
-class ExecutionContext;
+struct ExecutionContext;
 
 }
 

--- a/nes-execution/src/Execution/Operators/Emit.cpp
+++ b/nes-execution/src/Execution/Operators/Emit.cpp
@@ -76,12 +76,12 @@ void Emit::emitRecordBuffer(
     ExecutionContext& ctx, RecordBuffer& recordBuffer, const nautilus::val<uint64_t>& numRecords, const nautilus::val<bool>& lastChunk)
 {
     recordBuffer.setNumRecords(numRecords);
-    recordBuffer.setWatermarkTs(ctx.getWatermarkTs());
-    recordBuffer.setOriginId(ctx.getOriginId());
-    recordBuffer.setSequenceNr(ctx.getSequenceNumber());
-    recordBuffer.setChunkNr(ctx.getNextChunkNr());
+    recordBuffer.setWatermarkTs(ctx.watermarkTs);
+    recordBuffer.setOriginId(ctx.originId);
+    recordBuffer.setSequenceNr(ctx.sequenceNumber);
+    recordBuffer.setChunkNr(ctx.getNextChunkNumber());
     recordBuffer.setLastChunk(lastChunk);
-    recordBuffer.setCreationTs(ctx.getCurrentTs());
+    recordBuffer.setCreationTs(ctx.currentTs);
     ctx.emitBuffer(recordBuffer);
 
     if (lastChunk == true)

--- a/nes-execution/src/Execution/Operators/ExecutionContext.cpp
+++ b/nes-execution/src/Execution/Operators/ExecutionContext.cpp
@@ -29,7 +29,7 @@ ExecutionContext::ExecutionContext(
     const nautilus::val<WorkerContext*>& workerContext, const nautilus::val<PipelineExecutionContext*>& pipelineContext)
     : workerContext(workerContext)
     , pipelineContext(pipelineContext)
-    , origin(0_u64)
+    , originId(0_u64)
     , watermarkTs(0_u64)
     , currentTs(0_u64)
     , sequenceNumber(0_u64)
@@ -124,75 +124,6 @@ nautilus::val<OperatorHandler*> ExecutionContext::getGlobalOperatorHandler(uint6
     return nautilus::invoke(getGlobalOperatorHandlerProxy, pipelineContext, handlerIndexValue);
 }
 
-const nautilus::val<WorkerContext*>& ExecutionContext::getWorkerContext() const
-{
-    return workerContext;
-}
-const nautilus::val<PipelineExecutionContext*>& ExecutionContext::getPipelineContext() const
-{
-    return pipelineContext;
-}
-
-const nautilus::val<uint64_t>& ExecutionContext::getWatermarkTs() const
-{
-    return watermarkTs;
-}
-
-void ExecutionContext::setWatermarkTs(const nautilus::val<uint64_t>& watermarkTs)
-{
-    this->watermarkTs = watermarkTs;
-}
-
-const nautilus::val<uint64_t>& ExecutionContext::getSequenceNumber() const
-{
-    return sequenceNumber;
-}
-
-void ExecutionContext::setSequenceNumber(const nautilus::val<uint64_t>& sequenceNumber)
-{
-    this->sequenceNumber = sequenceNumber;
-}
-
-const nautilus::val<uint64_t>& ExecutionContext::getOriginId() const
-{
-    return origin;
-}
-
-void ExecutionContext::setOriginId(const nautilus::val<uint64_t>& origin)
-{
-    this->origin = origin;
-}
-
-const nautilus::val<uint64_t>& ExecutionContext::getCurrentTs() const
-{
-    return currentTs;
-}
-
-void ExecutionContext::setCurrentTs(const nautilus::val<uint64_t>& currentTs)
-{
-    this->currentTs = currentTs;
-}
-
-const nautilus::val<uint64_t>& ExecutionContext::getChunkNumber() const
-{
-    return chunkNumber;
-}
-
-void ExecutionContext::setChunkNumber(const nautilus::val<uint64_t>& chunkNumber)
-{
-    this->chunkNumber = chunkNumber;
-}
-
-const nautilus::val<bool>& ExecutionContext::getLastChunk() const
-{
-    return lastChunk;
-}
-
-void ExecutionContext::setLastChunk(const nautilus::val<bool>& lastChunk)
-{
-    this->lastChunk = lastChunk;
-}
-
 uint64_t getNextChunkNumberProxy(PipelineExecutionContext* pipelineCtx, uint64_t originId, uint64_t sequenceNumber)
 {
     NES_ASSERT2_FMT(pipelineCtx != nullptr, "operator handler should not be null");
@@ -215,22 +146,17 @@ void removeSequenceStateProxy(PipelineExecutionContext* pipelineCtx, uint64_t or
 nautilus::val<bool> ExecutionContext::isLastChunk() const
 {
     return nautilus::invoke(
-        isLastChunkProxy,
-        this->getPipelineContext(),
-        this->getOriginId(),
-        this->getSequenceNumber(),
-        this->getChunkNumber(),
-        this->getLastChunk());
+        isLastChunkProxy, this->pipelineContext, this->originId, this->sequenceNumber, this->chunkNumber, this->lastChunk);
 }
 
-nautilus::val<uint64_t> ExecutionContext::getNextChunkNr() const
+nautilus::val<uint64_t> ExecutionContext::getNextChunkNumber() const
 {
-    return nautilus::invoke(getNextChunkNumberProxy, this->getPipelineContext(), this->getOriginId(), this->getSequenceNumber());
+    return nautilus::invoke(getNextChunkNumberProxy, this->pipelineContext, this->originId, this->sequenceNumber);
 }
 
 void ExecutionContext::removeSequenceState() const
 {
-    nautilus::invoke(removeSequenceStateProxy, this->getPipelineContext(), this->getOriginId(), this->getSequenceNumber());
+    nautilus::invoke(removeSequenceStateProxy, this->pipelineContext, this->originId, this->sequenceNumber);
 }
 
 }

--- a/nes-execution/src/Execution/Operators/Scan.cpp
+++ b/nes-execution/src/Execution/Operators/Scan.cpp
@@ -20,7 +20,6 @@
 #include <Execution/RecordBuffer.hpp>
 #include <Nautilus/Interface/Record.hpp>
 #include <Nautilus/Util.hpp>
-#include <Util/Logger/Logger.hpp>
 #include <Util/StdInt.hpp>
 
 namespace NES::Runtime::Execution::Operators
@@ -32,23 +31,23 @@ Scan::Scan(
 {
 }
 
-void Scan::open(ExecutionContext& ctx, RecordBuffer& recordBuffer) const
+void Scan::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
 {
     /// initialize global state variables to keep track of the watermark ts and the origin id
-    ctx.setWatermarkTs(recordBuffer.getWatermarkTs());
-    ctx.setOriginId(recordBuffer.getOriginId());
-    ctx.setCurrentTs(recordBuffer.getCreatingTs());
-    ctx.setSequenceNumber(recordBuffer.getSequenceNr());
-    ctx.setChunkNumber(recordBuffer.getChunkNr());
-    ctx.setLastChunk(recordBuffer.isLastChunk());
+    executionCtx.watermarkTs = recordBuffer.getWatermarkTs();
+    executionCtx.originId = recordBuffer.getOriginId();
+    executionCtx.currentTs = recordBuffer.getCreatingTs();
+    executionCtx.sequenceNumber = recordBuffer.getSequenceNr();
+    executionCtx.chunkNumber = recordBuffer.getChunkNr();
+    executionCtx.lastChunk = recordBuffer.isLastChunk();
     /// call open on all child operators
-    child->open(ctx, recordBuffer);
+    child->open(executionCtx, recordBuffer);
     /// iterate over records in buffer
     auto numberOfRecords = recordBuffer.getNumRecords();
     for (nautilus::val<uint64_t> i = 0_u64; i < numberOfRecords; i = i + 1_u64)
     {
         auto record = memoryProvider->readRecord(projections, recordBuffer, i);
-        child->execute(ctx, record);
+        child->execute(executionCtx, record);
     }
 }
 

--- a/nes-execution/src/Execution/Operators/Watermark/EventTimeWatermarkAssignment.cpp
+++ b/nes-execution/src/Execution/Operators/Watermark/EventTimeWatermarkAssignment.cpp
@@ -58,7 +58,7 @@ void EventTimeWatermarkAssignment::close(ExecutionContext& executionCtx, RecordB
         NES::Util::instanceOf<const WatermarkState>(*executionCtx.getLocalState(this)),
         "Expects the local state to be of type WatermarkState");
     const auto state = static_cast<WatermarkState*>(executionCtx.getLocalState(this));
-    executionCtx.setWatermarkTs(state->currentWatermark);
+    executionCtx.watermarkTs = state->currentWatermark;
     Operator::close(executionCtx, recordBuffer);
 }
 

--- a/nes-execution/src/Execution/Operators/Watermark/IngestionTimeWatermarkAssignment.cpp
+++ b/nes-execution/src/Execution/Operators/Watermark/IngestionTimeWatermarkAssignment.cpp
@@ -31,10 +31,10 @@ void IngestionTimeWatermarkAssignment::open(ExecutionContext& executionCtx, Reco
     timeFunction->open(executionCtx, recordBuffer);
     auto emptyRecord = Record();
     const auto tsField = timeFunction->getTs(executionCtx, emptyRecord);
-    const auto currentWatermark = executionCtx.getWatermarkTs();
+    const auto currentWatermark = executionCtx.watermarkTs;
     if (tsField > currentWatermark)
     {
-        executionCtx.setWatermarkTs(tsField);
+        executionCtx.watermarkTs = tsField;
     }
 }
 

--- a/nes-execution/src/Execution/Operators/Watermark/TimeFunction.cpp
+++ b/nes-execution/src/Execution/Operators/Watermark/TimeFunction.cpp
@@ -38,18 +38,18 @@ nautilus::val<WatermarkTs> EventTimeFunction::getTs(Execution::ExecutionContext&
     const auto ts = this->timestampFunction->execute(record).cast<nautilus::val<uint64_t>>();
     const auto timeMultiplier = nautilus::val<uint64_t>(unit.getMillisecondsConversionMultiplier());
     const auto tsInMs = ts * timeMultiplier;
-    ctx.setCurrentTs(tsInMs);
+    ctx.currentTs = tsInMs;
     return tsInMs;
 }
 
 void IngestionTimeFunction::open(Execution::ExecutionContext& ctx, Execution::RecordBuffer& buffer)
 {
-    ctx.setCurrentTs(buffer.getCreatingTs());
+    ctx.currentTs = buffer.getCreatingTs();
 }
 
 nautilus::val<uint64_t> IngestionTimeFunction::getTs(Execution::ExecutionContext& ctx, Nautilus::Record&)
 {
-    return ctx.getCurrentTs();
+    return ctx.currentTs;
 }
 
 }


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR refactors the execution context to make it a struct and therefore all members public.

## Verifying this change
This change is tested by running the CI tests.

## Issue Closed by this pull request:

This PR closes #350 .

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"102-integrate-nautilus-dependency","parentHead":"8c5f593cef1700f5a98983fe6b3aa7b8d4763f4a","parentPull":337,"trunk":"main"}
```
-->
