### PR TITLE
Rename text to variable sized data

### DIFF
--- a/grpc/SerializableDataType.proto
+++ b/grpc/SerializableDataType.proto
@@ -28,7 +28,7 @@ message SerializableDataType{
     CHAR = 3;
     ARRAY = 4;
     BOOLEAN = 5;
-    TEXT = 6;
+    VARIABLE_SIZED_DATA = 6;
   }
 
   /**

--- a/nes-data-types/include/Common/DataTypes/DataTypeFactory.hpp
+++ b/nes-data-types/include/Common/DataTypes/DataTypeFactory.hpp
@@ -22,8 +22,8 @@ namespace NES
 class DataType;
 using DataTypePtr = std::shared_ptr<DataType>;
 
-class TextType;
-using TextTypePtr = std::shared_ptr<TextType>;
+class VariableSizedDataType;
+using VariableSizedDataTypePtr = std::shared_ptr<VariableSizedDataType>;
 
 class ValueType;
 using ValueTypePtr = std::shared_ptr<ValueType>;
@@ -141,10 +141,10 @@ public:
     static DataTypePtr createUInt64();
 
     /**
-    * @brief Creates a new text data type.
+    * @brief Creates a new VariableSizedDataType data type.
     * @return DataTypePtr
     */
-    static DataTypePtr createText();
+    static DataTypePtr createVariableSizedData();
 
     /**
     * @brief Creates a new Char data type.

--- a/nes-data-types/include/Common/DataTypes/VariableSizedDataType.hpp
+++ b/nes-data-types/include/Common/DataTypes/VariableSizedDataType.hpp
@@ -11,7 +11,6 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-
 #pragma once
 
 #include <Common/DataTypes/DataType.hpp>
@@ -19,15 +18,12 @@
 namespace NES
 {
 
-/**
- * @brief The Text type represents a variable-sized text field.
- */
-class TextType : public DataType
+class VariableSizedDataType : public DataType
 {
 public:
-    inline TextType() noexcept { }
+    inline VariableSizedDataType() noexcept { }
 
-    ~TextType() override = default;
+    ~VariableSizedDataType() override = default;
 
     bool equals(DataTypePtr otherDataType) override;
 

--- a/nes-data-types/include/Common/PhysicalTypes/DefaultPhysicalTypeFactory.hpp
+++ b/nes-data-types/include/Common/PhysicalTypes/DefaultPhysicalTypeFactory.hpp
@@ -28,8 +28,8 @@ using FloatPtr = std::shared_ptr<Float>;
 class Char;
 using CharPtr = std::shared_ptr<Char>;
 
-class TextType;
-using TextPtr = std::shared_ptr<TextType>;
+class VariableSizedDataType;
+using VariableSizedDataTypePtr = std::shared_ptr<VariableSizedDataType>;
 
 /**
  * @brief This is a default physical type factory, which maps nes types to common x86 types.

--- a/nes-data-types/include/Common/PhysicalTypes/PhysicalType.hpp
+++ b/nes-data-types/include/Common/PhysicalTypes/PhysicalType.hpp
@@ -49,7 +49,7 @@ public:
 
     [[nodiscard]] virtual bool isBasicType() const noexcept { return false; }
 
-    [[nodiscard]] virtual bool isTextType() const noexcept { return false; }
+    [[nodiscard]] virtual bool isVariableSizedDataType() const noexcept { return false; }
 
     bool operator==(const PhysicalType& rhs) const { return type->equals(rhs.type); }
 

--- a/nes-data-types/include/Common/PhysicalTypes/PhysicalTypeUtil.hpp
+++ b/nes-data-types/include/Common/PhysicalTypes/PhysicalTypeUtil.hpp
@@ -28,12 +28,8 @@ namespace NES::PhysicalTypes
  */
 bool isChar(PhysicalTypePtr physicalType);
 
-/**
- * @brief Function to check if the physical type is text
- * @param physicalType
- * @return true if the physical type is text
- */
-bool isText(PhysicalTypePtr physicalType);
+
+bool isVariableSizedData(PhysicalTypePtr physicalType);
 
 /**
  * @brief Function to check if the physical type is a bool
@@ -122,7 +118,7 @@ bool isDouble(PhysicalTypePtr physicalType);
 template <class Type>
 bool isSamePhysicalType(PhysicalTypePtr physicalType)
 {
-    if (isText(physicalType) && std::is_same_v<std::remove_cvref_t<Type>, std::uint32_t>)
+    if (isVariableSizedData(physicalType) && std::is_same_v<std::remove_cvref_t<Type>, std::uint32_t>)
     {
         return true;
     }

--- a/nes-data-types/include/Common/PhysicalTypes/VariableSizedDataPhysicalType.hpp
+++ b/nes-data-types/include/Common/PhysicalTypes/VariableSizedDataPhysicalType.hpp
@@ -21,18 +21,18 @@ namespace NES
 {
 
 /**
- * @brief The text physical type, which represent TextType and FixedChar types in NES.
+ * @brief The VariableSizedDataType physical type, which represent VariableSizedDataType and FixedChar types in NES.
  */
-class TextPhysicalType final : public PhysicalType
+class VariableSizedDataPhysicalType final : public PhysicalType
 {
 public:
-    inline TextPhysicalType(DataTypePtr type) noexcept : PhysicalType(std::move(type)) { }
+    inline VariableSizedDataPhysicalType(DataTypePtr type) noexcept : PhysicalType(std::move(type)) { }
 
-    ~TextPhysicalType() override = default;
+    ~VariableSizedDataPhysicalType() override = default;
 
-    static inline PhysicalTypePtr create(const DataTypePtr& type) noexcept { return std::make_shared<TextPhysicalType>(type); }
+    static inline PhysicalTypePtr create(const DataTypePtr& type) noexcept { return std::make_shared<VariableSizedDataPhysicalType>(type); }
 
-    [[nodiscard]] bool isTextType() const noexcept override { return true; }
+    [[nodiscard]] bool isVariableSizedDataType() const noexcept override { return true; }
 
     [[nodiscard]] uint64_t size() const override;
 
@@ -41,6 +41,10 @@ public:
     std::string convertRawToStringWithoutFill(void const* rawData) const noexcept override;
 
     [[nodiscard]] std::string toString() const noexcept override;
+
+private:
+    static constexpr size_t sizeVal = sizeof(uint32_t);
 };
+
 
 }

--- a/nes-data-types/include/Serialization/DataTypeSerializationUtil.hpp
+++ b/nes-data-types/include/Serialization/DataTypeSerializationUtil.hpp
@@ -19,7 +19,7 @@
 namespace NES
 {
 
-class TextType;
+class VariableSizedDataType;
 
 class DataType;
 using DataTypePtr = std::shared_ptr<DataType>;

--- a/nes-data-types/src/Common/DataTypes/CMakeLists.txt
+++ b/nes-data-types/src/Common/DataTypes/CMakeLists.txt
@@ -18,5 +18,5 @@ add_source_files(nes-data-types
         Integer.cpp
         Float.cpp
         DataTypeFactory.cpp
-        TextType.cpp
+        VariableSizedDataType.cpp
         )

--- a/nes-data-types/src/Common/DataTypes/DataTypeFactory.cpp
+++ b/nes-data-types/src/Common/DataTypes/DataTypeFactory.cpp
@@ -25,8 +25,8 @@
 #include <Common/DataTypes/DataTypeFactory.hpp>
 #include <Common/DataTypes/Float.hpp>
 #include <Common/DataTypes/Integer.hpp>
-#include <Common/DataTypes/TextType.hpp>
 #include <Common/DataTypes/Undefined.hpp>
+#include <Common/DataTypes/VariableSizedDataType.hpp>
 #include <Common/ValueTypes/BasicValue.hpp>
 
 namespace NES
@@ -115,9 +115,9 @@ DataTypePtr DataTypeFactory::createUInt32()
     return createInteger(32, 0, UINT32_MAX);
 };
 
-DataTypePtr DataTypeFactory::createText()
+DataTypePtr DataTypeFactory::createVariableSizedData()
 {
-    return std::make_shared<TextType>();
+    return std::make_shared<VariableSizedDataType>();
 }
 
 DataTypePtr DataTypeFactory::createChar()

--- a/nes-data-types/src/Common/DataTypes/VariableSizedDataType.cpp
+++ b/nes-data-types/src/Common/DataTypes/VariableSizedDataType.cpp
@@ -14,25 +14,25 @@
 
 #include <Util/Common.hpp>
 #include <Common/DataTypes/DataTypeFactory.hpp>
-#include <Common/DataTypes/TextType.hpp>
+#include <Common/DataTypes/VariableSizedDataType.hpp>
 
 namespace NES
 {
 
-bool TextType::equals(DataTypePtr otherDataType)
+bool VariableSizedDataType::equals(DataTypePtr otherDataType)
 {
-    return NES::Util::instanceOf<TextType>(otherDataType);
+    return NES::Util::instanceOf<VariableSizedDataType>(otherDataType);
 }
 
-/// A text type cannot be joined with another type.
-DataTypePtr TextType::join(DataTypePtr)
+/// A VariableSizedData type cannot be joined with another type.
+DataTypePtr VariableSizedDataType::join(DataTypePtr)
 {
     return DataTypeFactory::createUndefined();
 }
 
-std::string TextType::toString()
+std::string VariableSizedDataType::toString()
 {
-    return "Text";
+    return "VariableSizedData";
 }
 
 }

--- a/nes-data-types/src/Common/PhysicalTypes/CMakeLists.txt
+++ b/nes-data-types/src/Common/PhysicalTypes/CMakeLists.txt
@@ -14,5 +14,5 @@ add_source_files(nes-data-types
         BasicPhysicalType.cpp
         DefaultPhysicalTypeFactory.cpp
         PhysicalTypeUtil.cpp
-        TextPhysicalType.cpp
+        VariableSizedDataPhysicalType.cpp
 )

--- a/nes-data-types/src/Common/PhysicalTypes/DefaultPhysicalTypeFactory.cpp
+++ b/nes-data-types/src/Common/PhysicalTypes/DefaultPhysicalTypeFactory.cpp
@@ -20,10 +20,10 @@
 #include <Common/DataTypes/DataTypeFactory.hpp>
 #include <Common/DataTypes/Float.hpp>
 #include <Common/DataTypes/Integer.hpp>
-#include <Common/DataTypes/TextType.hpp>
+#include <Common/DataTypes/VariableSizedDataType.hpp>
 #include <Common/PhysicalTypes/BasicPhysicalType.hpp>
 #include <Common/PhysicalTypes/DefaultPhysicalTypeFactory.hpp>
-#include <Common/PhysicalTypes/TextPhysicalType.hpp>
+#include <Common/PhysicalTypes/VariableSizedDataPhysicalType.hpp>
 namespace NES
 {
 
@@ -47,9 +47,9 @@ PhysicalTypePtr DefaultPhysicalTypeFactory::getPhysicalType(DataTypePtr dataType
     {
         return BasicPhysicalType::create(DataType::as<Char>(dataType), BasicPhysicalType::NativeType::CHAR);
     }
-    else if (NES::Util::instanceOf<TextType>(dataType))
+    else if (NES::Util::instanceOf<VariableSizedDataType>(dataType))
     {
-        return TextPhysicalType::create(DataType::as<TextType>(dataType));
+        return VariableSizedDataPhysicalType::create(DataType::as<VariableSizedDataType>(dataType));
     }
     else
     {

--- a/nes-data-types/src/Common/PhysicalTypes/PhysicalTypeUtil.cpp
+++ b/nes-data-types/src/Common/PhysicalTypes/PhysicalTypeUtil.cpp
@@ -78,9 +78,9 @@ bool isDouble(PhysicalTypePtr physicalType)
         && std::dynamic_pointer_cast<BasicPhysicalType>(physicalType)->nativeType == BasicPhysicalType::NativeType::DOUBLE;
 }
 
-bool isText(PhysicalTypePtr physicalType)
+bool isVariableSizedData(PhysicalTypePtr physicalType)
 {
-    return physicalType->isTextType();
+    return physicalType->isVariableSizedDataType();
 }
 
 }

--- a/nes-data-types/src/Common/PhysicalTypes/VariableSizedDataPhysicalType.cpp
+++ b/nes-data-types/src/Common/PhysicalTypes/VariableSizedDataPhysicalType.cpp
@@ -14,24 +14,24 @@
 
 #include <Util/Logger/Logger.hpp>
 #include <fmt/core.h>
-#include <Common/PhysicalTypes/TextPhysicalType.hpp>
+#include <Common/PhysicalTypes/VariableSizedDataPhysicalType.hpp>
 
 namespace NES
 {
 
-uint64_t TextPhysicalType::size() const
+uint64_t VariableSizedDataPhysicalType::size() const
 {
-    /// returning the size of the index to the child buffer that contains the text data
-    return sizeof(uint32_t);
+    /// returning the size of the index to the child buffer that contains the VariableSizedData data
+    return sizeVal;
 }
 
-std::string TextPhysicalType::convertRawToString(void const* data) const noexcept
+std::string VariableSizedDataPhysicalType::convertRawToString(void const* data) const noexcept
 {
-    /// We always read the exact number of bytes contained by the Text.
+    /// We always read the exact number of bytes contained by the VariableSizedDataType.
     return convertRawToStringWithoutFill(data);
 }
 
-std::string TextPhysicalType::convertRawToStringWithoutFill(void const* data) const noexcept
+std::string VariableSizedDataPhysicalType::convertRawToStringWithoutFill(void const* data) const noexcept
 {
     if (!data)
     {
@@ -39,22 +39,22 @@ std::string TextPhysicalType::convertRawToStringWithoutFill(void const* data) co
         return "";
     }
 
-    /// Read the length of the Text from the first StringLengthType bytes from the buffer and adjust the data pointer.
+    /// Read the length of the VariableSizedDataType from the first StringLengthType bytes from the buffer and adjust the data pointer.
     using StringLengthType = uint32_t;
     StringLengthType textLength = *static_cast<uint32_t const*>(data);
     const auto* textPointer = static_cast<char const*>(data);
     textPointer += sizeof(StringLengthType);
     if (!textPointer)
     {
-        NES_ERROR("Pointer to text is invalid.");
+        NES_ERROR("Pointer to VariableSizedData is invalid.");
         return "";
     }
     return std::string(textPointer, textLength);
 }
 
-std::string TextPhysicalType::toString() const noexcept
+std::string VariableSizedDataPhysicalType::toString() const noexcept
 {
-    return "TEXT";
+    return "VariableSizedData " + std::to_string(sizeVal);
 }
 
 }

--- a/nes-data-types/src/Serialization/DataTypeSerializationUtil.cpp
+++ b/nes-data-types/src/Serialization/DataTypeSerializationUtil.cpp
@@ -23,8 +23,8 @@
 #include <Common/DataTypes/DataTypeFactory.hpp>
 #include <Common/DataTypes/Float.hpp>
 #include <Common/DataTypes/Integer.hpp>
-#include <Common/DataTypes/TextType.hpp>
 #include <Common/DataTypes/Undefined.hpp>
+#include <Common/DataTypes/VariableSizedDataType.hpp>
 #include <Common/ValueTypes/BasicValue.hpp>
 namespace NES
 {
@@ -63,9 +63,9 @@ SerializableDataType* DataTypeSerializationUtil::serializeDataType(const DataTyp
     {
         serializedDataType->set_type(SerializableDataType_Type_CHAR);
     }
-    else if (NES::Util::instanceOf<TextType>(dataType))
+    else if (NES::Util::instanceOf<VariableSizedDataType>(dataType))
     {
-        serializedDataType->set_type(SerializableDataType_Type_TEXT);
+        serializedDataType->set_type(SerializableDataType_Type_VARIABLE_SIZED_DATA);
     }
     else
     {
@@ -124,10 +124,9 @@ DataTypePtr DataTypeSerializationUtil::deserializeDataType(const SerializableDat
     {
         return DataTypeFactory::createChar();
     }
-    else if (serializedDataType.type() == SerializableDataType_Type_TEXT)
+    else if (serializedDataType.type() == SerializableDataType_Type_VARIABLE_SIZED_DATA)
     {
-        return std::make_shared<TextType>();
-        ;
+        return DataTypeFactory::createVariableSizedData();
     }
     NES_THROW_RUNTIME_ERROR("DataTypeSerializationUtil: data type which is to be serialized not registered. "
                             "Deserialization is not possible");

--- a/nes-execution/src/Execution/MemoryProvider/TupleBufferMemoryProvider.cpp
+++ b/nes-execution/src/Execution/MemoryProvider/TupleBufferMemoryProvider.cpp
@@ -44,7 +44,7 @@ Nautilus::VarVal TupleBufferMemoryProvider::loadValue(
     {
         return Nautilus::VarVal::readVarValFromMemory(fieldReference, type);
     }
-    else if (type->isTextType())
+    else if (type->isVariableSizedDataType())
     {
         const auto childIndex = Nautilus::Util::readValueFromMemRef<uint32_t>(fieldReference);
         const auto textPtr = nautilus::invoke(loadAssociatedTextValue, recordBuffer.getReference(), childIndex);
@@ -70,7 +70,7 @@ Nautilus::VarVal TupleBufferMemoryProvider::storeValue(
         value.writeToMemory(fieldReference);
         return value;
     }
-    else if (type->isTextType())
+    else if (type->isVariableSizedDataType())
     {
         const auto textValue = value.cast<Nautilus::VariableSizedData>();
         const auto childIndex = nautilus::invoke(storeAssociatedTextValueProxy, recordBuffer.getReference(), textValue.getReference());

--- a/nes-functions/src/Functions/LogicalFunctions/NodeFunctionEquals.cpp
+++ b/nes-functions/src/Functions/LogicalFunctions/NodeFunctionEquals.cpp
@@ -18,7 +18,7 @@
 #include <Util/Logger/Logger.hpp>
 #include <ErrorHandling.hpp>
 #include <Common/DataTypes/DataType.hpp>
-#include <Common/DataTypes/TextType.hpp>
+#include <Common/DataTypes/VariableSizedDataType.hpp>
 
 namespace NES
 {
@@ -73,7 +73,8 @@ bool NodeFunctionEquals::validateBeforeLowering() const
     const auto childRight = Util::as<NodeFunction>(children[1]);
 
     /// If one of the children has a stamp of type text, the other child must also have a stamp of type text
-    if (NES::Util::instanceOf<TextType>(childLeft->getStamp()) != NES::Util::instanceOf<TextType>(childRight->getStamp()))
+    if (NES::Util::instanceOf<VariableSizedDataType>(childLeft->getStamp())
+        != NES::Util::instanceOf<VariableSizedDataType>(childRight->getStamp()))
     {
         return false;
     }

--- a/nes-functions/src/Functions/LogicalFunctions/NodeFunctionLogicalBinary.cpp
+++ b/nes-functions/src/Functions/LogicalFunctions/NodeFunctionLogicalBinary.cpp
@@ -18,7 +18,7 @@
 #include <Common/DataTypes/Char.hpp>
 #include <Common/DataTypes/DataType.hpp>
 #include <Common/DataTypes/DataTypeFactory.hpp>
-#include <Common/DataTypes/TextType.hpp>
+#include <Common/DataTypes/VariableSizedDataType.hpp>
 
 
 namespace NES
@@ -53,7 +53,8 @@ bool NodeFunctionLogicalBinary::validateBeforeLowering() const
     const auto childRight = Util::as<NodeFunction>(children[1]);
 
     /// If one of the children has a stamp of type text, we do not support comparison for text or arrays at the moment
-    if (NES::Util::instanceOf<TextType>(childLeft->getStamp()) || NES::Util::instanceOf<TextType>(childRight->getStamp()))
+    if (NES::Util::instanceOf<VariableSizedDataType>(childLeft->getStamp())
+        || NES::Util::instanceOf<VariableSizedDataType>(childRight->getStamp()))
     {
         return false;
     }

--- a/nes-memory/TestTupleBuffer.cpp
+++ b/nes-memory/TestTupleBuffer.cpp
@@ -24,7 +24,7 @@
 #include <include/Util/TestTupleBuffer.hpp>
 #include <ErrorHandling.hpp>
 #include <Common/DataTypes/DataType.hpp>
-#include <Common/DataTypes/TextType.hpp>
+#include <Common/DataTypes/VariableSizedDataType.hpp>
 #include <Common/PhysicalTypes/DefaultPhysicalTypeFactory.hpp>
 
 namespace NES::Memory::MemoryLayouts
@@ -118,7 +118,7 @@ std::string DynamicTuple::toString(const SchemaPtr& schema)
     {
         const auto dataType = schema->get(i)->getDataType();
         DynamicField currentField = this->operator[](i);
-        if (NES::Util::instanceOf<TextType>(dataType))
+        if (NES::Util::instanceOf<VariableSizedDataType>(dataType))
         {
             const auto index = currentField.read<Memory::TupleBuffer::NestedTupleBufferKey>();
             const auto string = readVarSizedData(buffer, index);
@@ -155,7 +155,7 @@ bool DynamicTuple::operator==(const DynamicTuple& other) const
         auto thisDynamicField = (*this)[field->getName()];
         auto otherDynamicField = other[field->getName()];
 
-        if (NES::Util::instanceOf<TextType>(field->getDataType()))
+        if (NES::Util::instanceOf<VariableSizedDataType>(field->getDataType()))
         {
             const auto thisString = readVarSizedData(buffer, thisDynamicField.read<Memory::TupleBuffer::NestedTupleBufferKey>());
             const auto otherString = readVarSizedData(other.buffer, otherDynamicField.read<Memory::TupleBuffer::NestedTupleBufferKey>());

--- a/nes-nebuli/src/QueryValidation/SemanticQueryValidation.cpp
+++ b/nes-nebuli/src/QueryValidation/SemanticQueryValidation.cpp
@@ -28,8 +28,8 @@
 #include <Common/DataTypes/Boolean.hpp>
 #include <Common/DataTypes/DataTypeFactory.hpp>
 #include <Common/DataTypes/Numeric.hpp>
-#include <Common/DataTypes/TextType.hpp>
 #include <Common/DataTypes/Undefined.hpp>
+#include <Common/DataTypes/VariableSizedDataType.hpp>
 
 using namespace std::string_literals;
 
@@ -182,7 +182,7 @@ void SemanticQueryValidation::inferModelValidityCheck(const QueryPlanPtr& queryP
             {
                 auto field = NES::Util::as<NodeFunctionFieldAccess>(inputField);
                 if (!NES::Util::instanceOf<Numeric>(field->getStamp()) && !NES::Util::instanceOf<Boolean>(field->getStamp())
-                    && !NES::Util::instanceOf<TextType>(field->getStamp()))
+                    && !NES::Util::instanceOf<VariableSizedDataType>(field->getStamp()))
                 {
                     throw QueryInvalid(
                         "SemanticQueryValidation::advanceSemanticQueryValidation: Inputted data type for infer model not supported: "

--- a/nes-runtime/src/Util/Core.cpp
+++ b/nes-runtime/src/Util/Core.cpp
@@ -29,7 +29,7 @@
 #include <Util/Common.hpp>
 #include <Util/Core.hpp>
 #include <Util/Logger/Logger.hpp>
-#include <Common/DataTypes/TextType.hpp>
+#include <Common/DataTypes/VariableSizedDataType.hpp>
 #include <Common/PhysicalTypes/DefaultPhysicalTypeFactory.hpp>
 
 
@@ -65,9 +65,9 @@ std::string Util::printTupleBufferAsCSV(Memory::TupleBuffer tbuffer, const Schem
             auto indexInBuffer = buffer + offset + i * schema->getSchemaSizeInBytes();
 
             /// handle variable-length field
-            if (NES::Util::instanceOf<TextType>(dataType))
+            if (NES::Util::instanceOf<VariableSizedDataType>(dataType))
             {
-                NES_DEBUG("Util::printTupleBufferAsCSV(): trying to read the variable length TEXT field: "
+                NES_DEBUG("Util::printTupleBufferAsCSV(): trying to read the variable length VARIABLE_SIZED_DATA field: "
                           "from the tuple buffer");
 
                 /// read the child buffer index from the tuple buffer

--- a/nes-runtime/tests/UnitTests/Util/TestTupleBufferTest.cpp
+++ b/nes-runtime/tests/UnitTests/Util/TestTupleBufferTest.cpp
@@ -53,9 +53,9 @@ public:
 
         varSizedDataSchema = Schema::create(memoryLayout)
                                  ->addField("test$t1", BasicType::UINT16)
-                                 ->addField("test$t2", DataTypeFactory::createText())
+                                 ->addField("test$t2", DataTypeFactory::createVariableSizedData())
                                  ->addField("test$t3", BasicType::FLOAT64)
-                                 ->addField("test$t4", DataTypeFactory::createText());
+                                 ->addField("test$t4", DataTypeFactory::createVariableSizedData());
 
         auto tupleBuffer = bufferManager->getBufferBlocking();
         auto tupleBufferVarSizedData = bufferManager->getBufferBlocking();

--- a/nes-single-node-worker/tests/Util/src/IntegrationTestUtil.cpp
+++ b/nes-single-node-worker/tests/Util/src/IntegrationTestUtil.cpp
@@ -231,7 +231,7 @@ void writeFieldValueToTupleBuffer(
                     NES_FATAL_ERROR("Parser::writeFieldValueToTupleBuffer: Field Type UNDEFINED");
             }
         }
-        else if (physicalType->isTextType())
+        else if (physicalType->isVariableSizedDataType())
         {
             NES_TRACE(
                 "Parser::writeFieldValueToTupleBuffer(): trying to write the variable length input string: {}"

--- a/nes-sinks/src/SinksParsing/CSVFormat.cpp
+++ b/nes-sinks/src/SinksParsing/CSVFormat.cpp
@@ -23,7 +23,7 @@
 #include <SinksParsing/CSVFormat.hpp>
 #include <Util/Common.hpp>
 #include <Util/Logger/Logger.hpp>
-#include <Common/DataTypes/TextType.hpp>
+#include <Common/DataTypes/VariableSizedDataType.hpp>
 #include <Common/PhysicalTypes/DefaultPhysicalTypeFactory.hpp>
 #include <Common/PhysicalTypes/PhysicalType.hpp>
 
@@ -109,7 +109,7 @@ std::string CSVFormat::tupleBufferToFormattedCSVString(Memory::TupleBuffer tbuff
             auto indexInBuffer = buffer + offset + i * schema->getSchemaSizeInBytes();
 
             /// handle variable-length field
-            if (NES::Util::instanceOf<TextType>(dataType))
+            if (NES::Util::instanceOf<VariableSizedDataType>(dataType))
             {
                 NES_DEBUG("trying to read the variable length TEXT field: {} from the tuple buffer", field->toString());
 

--- a/nes-sources/src/Source.cpp
+++ b/nes-sources/src/Source.cpp
@@ -16,7 +16,6 @@
 
 namespace NES::Sources
 {
-
 std::ostream& operator<<(std::ostream& out, const Source& source)
 {
     return source.toString(out);


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
rename all instances of text to variable sized Data.

## Verifying this change
This change is tested by

## What components does this pull request potentially affect?
- TextType (VariableSizedDataType)
- PhysicalTextType (PhysicalVariableSizedDataType

## Documentation
- The change is reflected in the necessary documentation, e.g., design document, in-code documentation.
- All necessary methods (no getter, setter, or constructor) have a documentation.

## Issue Closed by this pull request:

This PR closes #352


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"102-integrate-nautilus-dependency","parentHead":"8c5f593cef1700f5a98983fe6b3aa7b8d4763f4a","parentPull":337,"trunk":"main"}
```
-->
