### PR TITLE
Hotfix nightly workflow file incorrect

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,10 +12,14 @@ on:
     - cron: '30 2 * * *' # gets executed every night at 4:30 AM CEST
 
 jobs:
-  # We call the pr.yml workflow to run the same tests as for a PR.
+  # We call the pr.yml workflow to run the same tests as for a PR. As soon as we have long-running/regression tests,
+  # we will get rid of this step and call long-running/regression tests directly.
   pr-tests:
     uses: ./.github/workflows/pr.yml
     secrets: inherit
+    with:
+        branch: "main"
+
 
   # This is a placeholder for adding long-running tests in the future. Currently, it simply prints a message.
   long-running-tests:
@@ -26,6 +30,7 @@ jobs:
         run: echo "Long running tests will be added in the future."
 
   create-nightly-image:
+    needs: [ pr-tests, long-running-tests ]
     if: ${{ !github.event.act }}
     uses: ./.github/workflows/create_release_image.yml
     secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,11 @@ name: NES PR CI
 # Otherwise, we are not running the job, as mentioned: https://github.com/nektos/act/issues/720
 
 on:
+  workflow_call:
+    inputs:
+      branch:
+        required: true
+        type: string
   pull_request:
     # The ready_for_review event is used when a draft pr is changed into a non-draft version. If we did
     # not use the ready_for_review the ci would not be triggered and appear to have passed.


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
- Adds a manual workflow trigger to the `nightly` job
- Fixes the `nightly` job by setting the branch for the `pr` job and made the `pr` job callable via another workflow.

## Verifying this change
This change is tested by running the CI and the corresponding tests.
Additionally, we triggered the `nightly` job once manually and it passed: https://github.com/nebulastream/nebulastream-public/actions/runs/11291686156