### PR TITLE
Build nautilus with local mlir

### DIFF
--- a/docker/dependency/Dependency.dockerfile
+++ b/docker/dependency/Dependency.dockerfile
@@ -14,6 +14,8 @@ ADD https://github.com/nebulastream/clang-binaries/releases/download/vllvm-18-li
 RUN 7z x nes-clang && rm nes-clang
 
 FROM nebulastream/nes-development-base:${TAG}
+COPY --from=llvm-download /clang /clang
+ENV CMAKE_PREFIX_PATH="/clang/:${CMAKE_PREFIX_PATH}"
 ADD vcpkg /vcpkg_input
 # Which vcpkg variant, e.g. with enabled sanitizers or the default `nes` variant.
 ARG VARIANT=nes
@@ -29,8 +31,6 @@ RUN cd /vcpkg_input \
     && rm -rf /vcpkg_input \
     && chmod -R g=u,o=u /vcpkg
 
-COPY --from=llvm-download /clang /clang
-ENV CMAKE_PREFIX_PATH="/clang/:${CMAKE_PREFIX_PATH}"
 
 # This hash is used to determine if a development/dependency image is compatible with the current checked out branch
 ARG VCPKG_DEPENDENCY_HASH

--- a/vcpkg/vcpkg-registry/ports/nautilus/portfile.cmake
+++ b/vcpkg/vcpkg-registry/ports/nautilus/portfile.cmake
@@ -6,6 +6,13 @@ vcpkg_from_github(
 		PATCHES
 )
 
+set(ADDITIONAL_CMAKE_OPTIONS "")
+if (NOT "mlir" IN_LIST FEATURES)
+    if($ENV{MLIR_DIR})
+	    set(ADDITIONAL_CMAKE_OPTIONS "${ADDITIONAL_CMAKE_OPTIONS}-DMLIR_DIR=$ENV{MLIR_DIR} ")
+    endif ()
+endif ()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
 		OPTIONS
@@ -17,6 +24,7 @@ vcpkg_cmake_configure(
 		-DUSE_EXTERNAL_MLIR=ON
 		-DUSE_EXTERNAL_SPDLOG=ON
 		-DUSE_EXTERNAL_FMT=ON
+		${ADDITIONAL_CMAKE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/vcpkg/vcpkg-registry/ports/nautilus/vcpkg.json
+++ b/vcpkg/vcpkg-registry/ports/nautilus/vcpkg.json
@@ -4,6 +4,22 @@
   "description": "nautilus",
   "homepage": "https://github.com/nebulastream/nautilus",
   "supports": "x64 | (arm64 & !windows)",
+  "features": {
+    "mlir": {
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "mlir",
+            "target-x86",
+            "target-aarch64"
+          ]
+        }
+      ],
+      "description": "Build with mlir support"
+    }
+  },
   "dependencies": [
     {
       "name": "vcpkg-cmake",
@@ -13,15 +29,6 @@
       "name": "vcpkg-cmake-config",
       "host": true
     },
-    "spdlog",
-    {
-      "name": "llvm",
-      "default-features": false,
-      "features": [
-        "mlir",
-        "target-x86",
-        "target-aarch64"
-      ]
-    }
+    "spdlog"
   ]
 }

--- a/vcpkg/vcpkg.json
+++ b/vcpkg/vcpkg.json
@@ -9,12 +9,9 @@
       "description": "nautilus mlir backend",
       "dependencies": [
         {
-          "name": "llvm",
-          "default-features": false,
+          "name": "nautilus",
           "features": [
-            "mlir",
-            "target-x86",
-            "target-aarch64"
+            "mlir"
           ]
         }
       ]


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR enables nautilus used via vcpkg to be built with a local version of mlir
instead of building mlir via vcpkg.
The option `-DUSE_LOCAL_MLIR=ON` is exactly the same as it was earlier.

## Verifying this change
Following instructions in the development guide, works as expected using the new nautilus version.

## What components does this pull request potentially affect?
- Dependencies

## Documentation
Feature was already documented.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"102-integrate-nautilus-dependency","parentHead":"8c5f593cef1700f5a98983fe6b3aa7b8d4763f4a","parentPull":337,"trunk":"main"}
```
-->
