### PR TITLE
feat(CodeCoverage) Set the correct base ref for building code coverage

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -58,9 +58,7 @@ jobs:
         if: ${{ steps.ref-cov-cache.outputs.cache-hit != 'true' }}
         uses: actions/checkout@v4
         with:
-          # As on the current main, we have not added the test coverage targets yet, therefore, we need to check out a specific commit for now.
-          # This will be removed with PR #393
-          ref: code-coverage-the-third-base-branch
+          ref: ${{ github.base_ref }}
       - name: Build base coverage if not in cache
         if: ${{ steps.ref-cov-cache.outputs.cache-hit != 'true' }}
         run: |


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
As we do not have the code coverage specific changes in the main, we had to hardcode the branch to base the code coverage delta on in the PR #392 . This PR changes this to be the base_ref of the PR.