### PR TITLE
feat(Build) Adds building a local docker image with libstdc++

### DIFF
--- a/docker/dependency/Development.dockerfile
+++ b/docker/dependency/Development.dockerfile
@@ -24,6 +24,3 @@ RUN git clone https://github.com/aras-p/ClangBuildAnalyzer.git \
     && cmake --install ClangBuildAnalyzer/build \
     && rm -rf ClangBuildAnalyzer \
     && ClangBuildAnalyzer --version
-
-USER ubuntu
-WORKDIR /home/ubuntu

--- a/docker/dependency/DevelopmentLocal.dockerfile
+++ b/docker/dependency/DevelopmentLocal.dockerfile
@@ -8,7 +8,9 @@ ARG UID=1000
 ARG GID=1000
 ARG USERNAME=ubuntu
 ARG ROOTLESS=false
-RUN (${ROOTLESS} || (echo "uid: ${UID} gid ${GID} username ${USERNAME}" && groupdel ubuntu && deluser --remove-home ubuntu && \
+RUN (${ROOTLESS} || (echo "uid: ${UID} gid ${GID} username ${USERNAME}" && \
+    (delgroup ubuntu || true) && \
+    (deluser ubuntu || true) && \
     addgroup --gid ${GID} ${USERNAME} && \
     adduser --uid ${UID} --gid ${GID} ${USERNAME})) && \
     chown -R ${UID}:${GID} ${NES_PREBUILT_VCPKG_ROOT}

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,6 +19,9 @@ docker container, which prevents permission issues. Building a local image will 
 image which matches the current set of dependencies (based on a hash). If you are using docker in rootless mode the
 user inside the container will be root.
 
+If no development image matches the current dependency hash, you can build the development environment locally (using the
+`-l` flag). If you want to use `libstdc++` instead of the default libc++, you can use the `--libstdcxx` flag.
+
 ```shell
 ./scripts/install-local-docker-environment.sh
 ```


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Adds `--libstdcxx` flag to the `install-local-docker-environment.sh` script which will
build a local development image using libstdc++ instead of libc++

## Verifying this change
run:
```bash
./scripts/install-local-docker-environment.sh -l --libstdcxx
```

## Documentation
Added development documentation.
