### PR TITLE
feat(Development) Adds devcontainer

### DIFF
--- a/devcontainer.json
+++ b/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "image": "nebulastream/nes-development:local",
+  "customizations": {
+    "jetbrains": {
+      "settings": {
+        "com.intellij:app:BuiltInServerOptions.builtInServerPort": 64492,
+        "Docker:app:DockerSettings.dockerComposePath": "/usr/bin/docker",
+        "Docker:app:DockerSettings.dockerPath": "/usr/bin/docker"
+      }
+    }
+  },
+  "mounts": ["source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"],
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/ls-1801/av/av:latest": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  }
+}


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Adds a .devcontainer file. The devcontainer can be used by CLion to launch a container on
a remote node.

## Verifying this change
This change is still experimental, however we need a .devcontainer file on the main branch
to start.

You can try to use the .devcontainer by launching CLion or Gateway and select the Docker Dev Containers
option. Choose a docker daemon (which could be remote). Choose the nebulastream repository which should
automatically pick the devcontainer json.


## What components does this pull request potentially affect?
- n/a

## Documentation
Documentation will be added once the devcontainer is fully supported.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
