### PR TITLE
GRPC Status Codes

### DIFF
--- a/nes-common/include/ErrorHandling.hpp
+++ b/nes-common/include/ErrorHandling.hpp
@@ -102,6 +102,9 @@ private:
  */
 void tryLogCurrentException();
 
+/// The wrapped exception gets the error code 9999.
+Exception wrapExternalException();
+
 /**
  * @brief This function is used to get the current exception code.
  * @warning This function should be used only in a catch block.

--- a/nes-common/src/ErrorHandling.cpp
+++ b/nes-common/src/ErrorHandling.cpp
@@ -125,6 +125,25 @@ void tryLogCurrentException()
         NES_ERROR("failed to process with unknown error\n")
     }
 }
+Exception wrapExternalException()
+{
+    try
+    {
+        throw;
+    }
+    catch (const Exception& e)
+    {
+        return e;
+    }
+    catch (const std::exception& e)
+    {
+        return UnknownException(e.what());
+    }
+    catch (...)
+    {
+        return UnknownException();
+    }
+}
 
 
 uint64_t getCurrentExceptionCode()

--- a/nes-single-node-worker/src/GrpcService.cpp
+++ b/nes-single-node-worker/src/GrpcService.cpp
@@ -12,10 +12,31 @@
     limitations under the License.
 */
 
+#include <string>
+#include <Identifiers/Identifiers.hpp>
 #include <Operators/Serialization/DecomposedQueryPlanSerializationUtil.hpp>
+#include <Runtime/QueryTerminationType.hpp>
+#include <google/protobuf/empty.pb.h>
+#include <grpcpp/server_context.h>
+#include <grpcpp/support/status.h>
+#include <ErrorHandling.hpp>
 #include <GrpcService.hpp>
+#include <SingleNodeWorkerRPCService.pb.h>
 
-grpc::Status NES::GRPCServer::RegisterQuery(grpc::ServerContext*, const RegisterQueryRequest* request, RegisterQueryReply* response)
+namespace NES
+{
+grpc::Status handleError(const Exception& exception, grpc::ServerContext* context)
+{
+    context->AddTrailingMetadata("code", std::to_string(exception.code()));
+    context->AddTrailingMetadata("what", exception.what());
+    if (auto where = exception.where())
+    {
+        context->AddTrailingMetadata("where", where->to_string());
+    }
+    return grpc::Status(grpc::INTERNAL, exception.what());
+}
+
+grpc::Status GRPCServer::RegisterQuery(grpc::ServerContext* context, const RegisterQueryRequest* request, RegisterQueryReply* response)
 {
     auto fullySpecifiedQueryPlan = DecomposedQueryPlanSerializationUtil::deserializeDecomposedQueryPlan(&request->decomposedqueryplan());
     try
@@ -26,10 +47,10 @@ grpc::Status NES::GRPCServer::RegisterQuery(grpc::ServerContext*, const Register
     }
     catch (...)
     {
-        return {grpc::StatusCode::UNKNOWN, "This could have been a nice error message, sorry"};
+        return handleError(wrapExternalException(), context);
     }
 }
-grpc::Status NES::GRPCServer::UnregisterQuery(grpc::ServerContext*, const UnregisterQueryRequest* request, google::protobuf::Empty*)
+grpc::Status GRPCServer::UnregisterQuery(grpc::ServerContext* context, const UnregisterQueryRequest* request, google::protobuf::Empty*)
 {
     auto queryId = QueryId(request->queryid());
     try
@@ -39,10 +60,10 @@ grpc::Status NES::GRPCServer::UnregisterQuery(grpc::ServerContext*, const Unregi
     }
     catch (...)
     {
-        return {grpc::StatusCode::UNKNOWN, "This could have been a nice error message, sorry"};
+        return handleError(wrapExternalException(), context);
     }
 }
-grpc::Status NES::GRPCServer::StartQuery(grpc::ServerContext*, const StartQueryRequest* request, google::protobuf::Empty*)
+grpc::Status GRPCServer::StartQuery(grpc::ServerContext* context, const StartQueryRequest* request, google::protobuf::Empty*)
 {
     auto queryId = QueryId(request->queryid());
     try
@@ -52,10 +73,10 @@ grpc::Status NES::GRPCServer::StartQuery(grpc::ServerContext*, const StartQueryR
     }
     catch (...)
     {
-        return {grpc::StatusCode::UNKNOWN, "This could have been a nice error message, sorry"};
+        return handleError(wrapExternalException(), context);
     }
 }
-grpc::Status NES::GRPCServer::StopQuery(grpc::ServerContext*, const StopQueryRequest* request, google::protobuf::Empty*)
+grpc::Status GRPCServer::StopQuery(grpc::ServerContext* context, const StopQueryRequest* request, google::protobuf::Empty*)
 {
     auto queryId = QueryId(request->queryid());
     auto terminationType = static_cast<Runtime::QueryTerminationType>(request->terminationtype());
@@ -66,11 +87,11 @@ grpc::Status NES::GRPCServer::StopQuery(grpc::ServerContext*, const StopQueryReq
     }
     catch (...)
     {
-        return {grpc::StatusCode::UNKNOWN, "This could have been a nice error message, sorry"};
+        return handleError(wrapExternalException(), context);
     }
 }
 
-grpc::Status NES::GRPCServer::RequestQuerySummary(grpc::ServerContext*, const QuerySummaryRequest* request, QuerySummaryReply* reply)
+grpc::Status GRPCServer::RequestQuerySummary(grpc::ServerContext* context, const QuerySummaryRequest* request, QuerySummaryReply* reply)
 {
     try
     {
@@ -89,22 +110,17 @@ grpc::Status NES::GRPCServer::RequestQuerySummary(grpc::ServerContext*, const Qu
                 error.set_location(std::string(exception.where()->filename) + ":" + std::to_string(exception.where()->line.value_or(0)));
                 reply->add_error()->CopyFrom(error);
             }
+            return grpc::Status::OK;
         }
-        else
-        {
-            reply->set_status(QueryStatus::Invalid);
-            reply->set_numberofrestarts(0);
-            reply->clear_error();
-        }
-        return grpc::Status::OK;
+        return grpc::Status(grpc::NOT_FOUND, "Query does not exist");
     }
     catch (...)
     {
-        return {grpc::StatusCode::UNKNOWN, "This could have been a nice error message, sorry"};
+        return handleError(wrapExternalException(), context);
     }
 }
 
-grpc::Status NES::GRPCServer::RequestQueryLog(grpc::ServerContext*, const QueryLogRequest* request, QueryLogReply* reply)
+grpc::Status GRPCServer::RequestQueryLog(grpc::ServerContext* context, const QueryLogRequest* request, QueryLogReply* reply)
 {
     try
     {
@@ -131,15 +147,14 @@ grpc::Status NES::GRPCServer::RequestQueryLog(grpc::ServerContext*, const QueryL
                 }
                 reply->add_entries()->CopyFrom(logEntry);
             }
+            return grpc::Status::OK;
         }
-        else
-        {
-            reply->clear_entries();
-        }
-        return grpc::Status::OK;
+        return grpc::Status(grpc::NOT_FOUND, "Query does not exist");
     }
     catch (...)
     {
-        return {grpc::StatusCode::UNKNOWN, "This could have been a nice error message, sorry"};
+        return handleError(wrapExternalException(), context);
     }
+}
+
 }

--- a/nes-single-node-worker/tests/Integration/SingleNodeIntegrationTestsQueryStatus.cpp
+++ b/nes-single-node-worker/tests/Integration/SingleNodeIntegrationTestsQueryStatus.cpp
@@ -12,9 +12,8 @@
     limitations under the License.
 */
 
-#include <filesystem>
-#include <fstream>
 #include <fmt/core.h>
+#include <grpcpp/support/status.h>
 #include <BaseIntegrationTest.hpp>
 #include <GrpcService.hpp>
 #include <IntegrationTestUtil.hpp>
@@ -118,10 +117,7 @@ TEST_F(SingleNodeIntegrationTest, TestQueryStatusSimple)
 
     /// Test for invalid queryId
     auto invalidQueryId = QueryId{42};
-    summary = IntegrationTestUtil::querySummary(invalidQueryId, uut);
-    EXPECT_EQ(summary.status(), Invalid);
-    EXPECT_EQ(summary.numberofrestarts(), 0);
-    EXPECT_EQ(summary.error_size(), 0);
+    IntegrationTestUtil::querySummaryFailure(invalidQueryId, uut, grpc::NOT_FOUND);
 
     IntegrationTestUtil::removeFile(queryResultFile);
     IntegrationTestUtil::removeFile(querySpecificDataFileName);

--- a/nes-single-node-worker/tests/Util/include/IntegrationTestUtil.hpp
+++ b/nes-single-node-worker/tests/Util/include/IntegrationTestUtil.hpp
@@ -14,15 +14,16 @@
 
 #pragma once
 
-#include <memory>
+#include <string>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
 #include <Util/TestTupleBuffer.hpp>
+#include <grpcpp/support/status.h>
+#include <gtest/gtest-assertion-result.h>
 #include <GrpcService.hpp>
 
-namespace NES
-{
-namespace IntegrationTestUtil
+
+namespace NES::IntegrationTestUtil
 {
 static inline const std::string SERRIALIZED_QUERIES_DIRECTORY = "queriesSerialized";
 static inline const std::string INPUT_CSV_FILES = "inputCSVFiles";
@@ -71,6 +72,9 @@ void unregisterQuery(QueryId queryId, GRPCServer& uut);
 /// Summary structure of the query containing current status, number of retries and the exceptions.
 QuerySummaryReply querySummary(QueryId queryId, GRPCServer& uut);
 
+/// Expect query summary to fail for queryId with the following sc.
+void querySummaryFailure(QueryId queryId, GRPCServer& uut, grpc::StatusCode statusCode);
+
 /// Current status of the query.
 QueryStatus queryStatus(QueryId queryId, GRPCServer& uut);
 
@@ -107,5 +111,4 @@ void replacePortInSourceTCPs(
 std::string getUniqueTestIdentifier();
 
 
-}
 }

--- a/nes-single-node-worker/tests/Util/src/IntegrationTestUtil.cpp
+++ b/nes-single-node-worker/tests/Util/src/IntegrationTestUtil.cpp
@@ -29,6 +29,7 @@
 #include <Sources/SourceTCP.hpp>
 #include <Util/Common.hpp>
 #include <fmt/core.h>
+#include <grpcpp/support/status.h>
 #include <gtest/gtest.h>
 #include <GrpcService.hpp>
 #include <IntegrationTestUtil.hpp>
@@ -321,6 +322,17 @@ QuerySummaryReply querySummary(QueryId queryId, GRPCServer& uut)
     request.set_queryid(queryId.getRawValue());
     EXPECT_TRUE(uut.RequestQuerySummary(&context, &request, &reply).ok());
     return reply;
+}
+
+void querySummaryFailure(QueryId queryId, GRPCServer& uut, grpc::StatusCode statusCode)
+{
+    grpc::ServerContext context;
+    QuerySummaryRequest request;
+    QuerySummaryReply reply;
+    request.set_queryid(queryId.getRawValue());
+    auto response = uut.RequestQuerySummary(&context, &request, &reply);
+    EXPECT_FALSE(response.ok()) << "Expected QuerySummary request to fail";
+    EXPECT_EQ(response.error_code(), statusCode);
 }
 
 QueryStatus queryStatus(QueryId queryId, GRPCServer& uut)

--- a/nes-systests/systest/include/SystestState.hpp
+++ b/nes-systests/systest/include/SystestState.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
-#include <algorithm>
+#include <cstdint>
 #include <filesystem>
-#include <regex>
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <Identifiers/Identifiers.hpp>
 #include <Operators/Serialization/DecomposedQueryPlanSerializationUtil.hpp>
 #include <fmt/base.h>
 #include <fmt/format.h>
@@ -47,11 +47,11 @@ struct Query
         : name(std::move(name))
         , queryDefinition(std::move(queryDefinition))
         , sqlLogicTestFile(std::move(sqlLogicTestFile))
-        , queryPlan(queryPlan)
+        , queryPlan(std::move(queryPlan))
         , queryIdInFile(queryIdInFile)
         , resultFileBaseDir(std::move(resultFileBaseDir)) {};
 
-    [[nodiscard]] inline std::filesystem::path resultFile() const
+    [[nodiscard]] std::filesystem::path resultFile() const
     {
         return resultFileBaseDir / std::filesystem::path(fmt::format("{}_{}.csv", name, queryIdInFile));
     }
@@ -67,7 +67,7 @@ struct Query
 struct RunningQuery
 {
     Query query;
-    QueryId queryId;
+    QueryId queryId = INVALID_QUERY_ID;
 };
 
 struct TestFile
@@ -79,9 +79,9 @@ struct TestFile
 
     [[nodiscard]] TestName name() const { return file.stem().string(); }
 
-    const std::filesystem::path file;
-    const std::vector<uint64_t> onlyEnableQueriesWithTestQueryNumber{};
-    const std::vector<TestGroup> groups;
+    std::filesystem::path file;
+    std::vector<uint64_t> onlyEnableQueriesWithTestQueryNumber;
+    std::vector<TestGroup> groups;
 
     std::vector<Query> queries;
 };

--- a/nes-systests/systest/src/SystestStarter.cpp
+++ b/nes-systests/systest/src/SystestStarter.cpp
@@ -16,12 +16,8 @@
 #include <cctype>
 #include <chrono>
 #include <filesystem>
-#include <fstream>
-#include <future>
 #include <iostream>
-#include <regex>
 #include <vector>
-#include <unistd.h>
 #include <Configurations/Util.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <argparse/argparse.hpp>

--- a/nes-systests/systest/src/SystestState.cpp
+++ b/nes-systests/systest/src/SystestState.cpp
@@ -12,9 +12,11 @@
     limitations under the License.
 */
 
+#include <fstream>
 #include <iostream>
 #include <ostream>
 #include <ranges>
+#include <vector>
 #include <SystestState.hpp>
 
 namespace NES::Systest


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR introduces proper error handling to our GRPC Interface. Exceptions are reported
via GRPC errors. By default the GRPC Error Code will be `INTERNAL`, which should indicate
that we are not using the GRPC specific error codes. The actual error code and error message
is appended as a metadata and can be inspected by the caller.

Certain GRPC Endpoints may still use GRPC Error Codes, e.g. to report if something is `NOT_FOUND`.
The QuerySummary API will report an `NOT_FOUND` status if no query summary exists for a certain 
queryId.

## Verifying this change
QueryStatus Integration Test covers the scenario of a not existing QuerySummary.

## What components does this pull request potentially affect?
- GRPC API

## Documentation
No functionality has changed, except that internal status codes and error messages are reported

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
