### PR TITLE
chore(Legacy) Removes old FaultTolerance code

### DIFF
--- a/nes-execution/src/Runtime/NodeEngineBuilder.cpp
+++ b/nes-execution/src/Runtime/NodeEngineBuilder.cpp
@@ -48,8 +48,8 @@ std::unique_ptr<NodeEngine> NodeEngineBuilder::build()
         auto numThreads = static_cast<uint16_t>(workerConfiguration.numberOfWorkerThreads.getValue());
         std::vector<uint64_t> workerToCoreMapping;
         std::vector<Memory::BufferManagerPtr> bufferManagers = {bufferManager};
-        /// TODO #34: For now, the worker id is always 0 and the numberOfBuffersPerEpoch always 100. We need to change this during the refactoring.
-        queryManager = std::make_shared<QueryManager>(queryLog, bufferManagers, WorkerId(0), numThreads, 100, workerToCoreMapping);
+        /// TODO #34: For now, the worker id is always 0. We need to change this during the refactoring.
+        queryManager = std::make_shared<QueryManager>(queryLog, bufferManagers, WorkerId(0), numThreads, workerToCoreMapping);
         if (!queryManager)
         {
             throw CannotStartQueryManager("during creation of NodeEngine");

--- a/nes-runtime/include/Runtime/QueryManager.hpp
+++ b/nes-runtime/include/Runtime/QueryManager.hpp
@@ -80,7 +80,6 @@ public:
         std::vector<Memory::BufferManagerPtr> bufferManagers,
         WorkerId nodeEngineId,
         uint16_t numThreads,
-        uint64_t numberOfBuffersPerEpoch,
         std::vector<uint64_t> workerToCoreMapping = {});
 
     ~QueryManager() NES_NOEXCEPT(false) override;
@@ -259,8 +258,6 @@ protected:
 
     /// Todo #241: In #241, we introduce a way to uniquely identify sources globally, which we should use here to map from identifiers to sources
     std::unordered_map<OriginId, std::vector<Execution::ExecutableQueryPlanPtr>> sourceToQEPMapping;
-
-    uint64_t numberOfBuffersPerEpoch;
 
 #ifdef ENABLE_PAPI_PROFILER
     std::vector<Profiler::PapiCpuProfilerPtr> cpuProfilers;

--- a/nes-runtime/src/Runtime/QueryManager.cpp
+++ b/nes-runtime/src/Runtime/QueryManager.cpp
@@ -39,7 +39,6 @@ QueryManager::QueryManager(
     std::vector<Memory::BufferManagerPtr> bufferManagers,
     WorkerId nodeEngineId,
     uint16_t numThreads,
-    uint64_t numberOfBuffersPerEpoch,
     std::vector<uint64_t> workerToCoreMapping)
     : taskQueue(folly::MPMCQueue<Task>(DEFAULT_QUEUE_INITIAL_CAPACITY))
     , nodeEngineId(nodeEngineId)
@@ -47,7 +46,6 @@ QueryManager::QueryManager(
     , numThreads(numThreads)
     , workerToCoreMapping(std::move(workerToCoreMapping))
     , queryStatusListener(std::move(queryStatusListener))
-    , numberOfBuffersPerEpoch(numberOfBuffersPerEpoch)
 {
     tempCounterTasksCompleted.resize(numThreads);
 


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Removes legacy fault tolerance code.

## Verifying this change

The code was not used.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
