### PR TITLE
chore(CI) Updates clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -301,5 +301,6 @@ CheckOptions:
   readability-identifier-naming.TypeTemplateParameterIgnoredRegexp: expr-type
   cppcoreguidelines-avoid-do-while.IgnoreMacros: 'true'
   readability-function-cognitive-complexity.IgnoreMacros: 'true'
+  # All allowed abbreviations are covered in the `frequently_used_abbreviations.md` document
   readability-identifier-length.IgnoredParameterNames: "bm|tb|id|os|lhs|rhs"
   readability-identifier-length.IgnoredVariableNames: 'bm|tb|id|os|lhs|rhs'

--- a/docs/frequently_used_abbreviations.md
+++ b/docs/frequently_used_abbreviations.md
@@ -1,0 +1,12 @@
+# Frequently used abbreviations
+
+This documents covers abbreviations and terms which are frequently used throughout the code base.
+
+| Abbreviation | Long          | Description                                                  |
+|--------------|---------------|--------------------------------------------------------------|
+| TB           | TupleBuffer   | TupleBuffers are the unit of data used within the system.    |
+| BM           | BufferManager | The BufferManager provides access to new TupleBuffers        |
+| LHS          | LeftHandSide  | Usually refers to the left parameter of a binary expression  |
+| RHS          | RightHandSide | Usually refers to the right parameter of a binary expression |
+| ID           | Identifier    | Some value used to identify objects e.g., `QueryId`          |
+| OS           | Output Stream | Commonly used when implementing the ostream operator         |


### PR DESCRIPTION
Removes llvm-header-guard and disables identifier length checks for parameters

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
