### PR TITLE
feat(Clang-Tidy): Added a pre clang-tidy check

### DIFF
--- a/.clang-tidy-pre-check
+++ b/.clang-tidy-pre-check
@@ -1,0 +1,9 @@
+Checks: [
+  -clang-diagnostic-*
+]
+
+WarningsAsErrors: '
+  -*,
+'
+
+HeaderFilterRegex: '.*\/nes-.*' # Only check files in nes- directories

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -122,12 +122,7 @@ jobs:
           cmake -DCODE_COVERAGE:BOOL=ON -B build
           cmake --build build -j -- -k 0
           cmake --build build --target ccov-all
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v44
       - name: Copy code coverage of changed files
-        env:
-          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           mkdir -p /tmp/cache/code-coverage-${{ matrix.platform }}
           rm -rf /tmp/cache/code-coverage-${{ matrix.platform }}/*
@@ -138,7 +133,7 @@ jobs:
           
           # We only want to copy the html files of the changed files to the cache
           # Otherwise, we would copy all html files, which would be a lot of data and we run into the data limit of github.
-          for file in ${ALL_CHANGED_FILES}; do
+          for file in $(git diff --name-status ${{ inputs.head_sha }} ${{ inputs.base_sha }}); do
             base_name=$(basename ${file})
             filepath=$(find build -name "${base_name}.html" -print)
             echo "Outside of the loop: <${filepath}<"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -76,6 +76,9 @@ jobs:
       # We need to build the project, as some headers are only created during the build.
       - name: Build NebulaStream
         run: cmake --build build -j -- -k 0
+      # We run clang-tidy-diff with only one single rule, as we want to check if there are any compiler errors
+      - name: Clang-Tidy Precheck
+        run: git diff -U0 "$(git merge-base HEAD "origin/${{ github.event.pull_request.base.ref }}")" -- ':!*.inc' | python3 /clang-tidy-diff.py -clang-tidy-binary clang-tidy-18 -p1 -path build -config-file .clang-tidy-pre-check -j $(nproc)
       - name: Create results directory
         run: mkdir clang-tidy-result
       - name: Analyze by running Clang-Tidy


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
We added a pre clang-tidy check that runs clang-tidy with a single rule. This way, we can make sure that we find compiler errors faster.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
