### PR TITLE
Fixes incorrect libstdc++ tag when using local docker image

### DIFF
--- a/scripts/install-local-docker-environment.sh
+++ b/scripts/install-local-docker-environment.sh
@@ -43,7 +43,7 @@ cd "$(git rev-parse --show-toplevel)"
 HASH=$(docker/dependency/hash_dependencies.sh)
 TAG=${HASH}
 if [[ $STDLIB != 'libcxx' ]]; then
-    TAG=${TAG}-stdlibcxx
+    TAG=${TAG}-libstdcxx
 fi
 
 # Docker on macOS appears to always enable the mapping from the container root user to the hosts current 


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

When using the local-docker-environment setup script with libstdc++ the
script picked the wrong tag. (stdlibcxx instead of libstdcxx)

## Verifying this change
Fetching the latest version of the libstdc++ docker image should work with
```bash
scripts/install-local-docker-environment.sh --libstdcxx
```

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
