### PR TITLE
fix(Systest) Fixed systest not using provided command line worker config

### DIFF
--- a/nes-systests/systest/src/SystestStarter.cpp
+++ b/nes-systests/systest/src/SystestStarter.cpp
@@ -308,6 +308,10 @@ int main(int argc, const char** argv)
             {
                 singleNodeWorkerConfiguration.workerConfiguration.overwriteConfigWithYAMLFileInput(config.workerConfig);
             }
+            else if (config.singleNodeWorkerConfig.has_value())
+            {
+                singleNodeWorkerConfiguration = config.singleNodeWorkerConfig.value();
+            }
 
             failedQueries = runQueriesAtLocalWorker(queries, numberConcurrentQueries, singleNodeWorkerConfiguration);
         }


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Fixes a bug that would disregard all provided command line arguments for the systest target. This means that on our CI the systest are currently being run twice with compilation.

## Verifying this change
This change is tested by running the CI.