### PR TITLE
chore(CI/CodeCoverage):  Fixed no sticky notes created for CI run job url

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -170,6 +170,7 @@ jobs:
   # For now, we build the code coverage for x64 only
   build-code-coverage:
     needs: [ build-code-coverage-ref, build-code-coverage-pr-branch ]
+    if: ${{ github.event_name == 'pull_request' }}
     container:
       image: nebulastream/nes-development:${{ inputs.dev_image_tag }}
       # TODO #401 Investigate rootless docker containers
@@ -203,7 +204,7 @@ jobs:
 
   create_sticky_note:
     needs: [ build-code-coverage-ref, build-code-coverage-pr-branch ]
-    if: ${{ github.event_type == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' }}
     container:
       image: nebulastream/nes-development:${{ inputs.dev_image_tag }}
       # TODO #401 Investigate rootless docker containers


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR is a hotfix, as currently the CI job  is always skipped. 
![image](https://github.com/user-attachments/assets/2ce3cabe-8da8-4c12-8892-01752638e34d)


