### PR TITLE
NebulaStream CI Image

### DIFF
--- a/.github/workflows/clang_tidy_diff.yml
+++ b/.github/workflows/clang_tidy_diff.yml
@@ -26,7 +26,7 @@ jobs:
   check-clang-tidy:
     runs-on: [ self-hosted, linux, Build ]
     container:
-      image: nebulastream/nes-development:${{ inputs.dev_image_tag }}
+      image: nebulastream/nes-ci:${{ inputs.dev_image_tag }}
       options: --user root
       volumes:
         - ccache:/ccache
@@ -50,9 +50,9 @@ jobs:
       - name: Create results directory
         run: mkdir clang-tidy-result
       - name: Clang-Tidy Precheck
-        run: git diff -U0 ${{ inputs.base_sha }} -- ':!*.inc' | python3 /clang-tidy-diff.py -clang-tidy-binary clang-tidy-18 -p1 -path build -config-file .clang-tidy-pre-check -j $(nproc)
+        run: git diff -U0 ${{ inputs.base_sha }} -- ':!*.inc' | clang-tidy-diff.py -clang-tidy-binary clang-tidy-18 -p1 -path build -config-file .clang-tidy-pre-check -j $(nproc)
       - name: Analyze by running Clang-Tidy
-        run: git diff -U0 ${{ inputs.base_sha }} -- ':!*.inc' | python3 /clang-tidy-diff.py -clang-tidy-binary clang-tidy-18 -p1 -path build -export-fixes clang-tidy-result/fixes.yml -config-file .clang-tidy -j $(nproc)
+        run: git diff -U0 ${{ inputs.base_sha }} -- ':!*.inc' | clang-tidy-diff.py -clang-tidy-binary clang-tidy-18 -p1 -path build -export-fixes clang-tidy-result/fixes.yml -j $(nproc)
       - name: Upload Clang-Tidy Results
         if: ${{ !cancelled() && !github.event.act }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/clang_tidy_full.yml
+++ b/.github/workflows/clang_tidy_full.yml
@@ -19,9 +19,9 @@ jobs:
   clang-tidy-full:
     runs-on: [ self-hosted, linux, Build ]
     container:
-      image: nebulastream/nes-development:${{ inputs.dev_image_tag }}
       # TODO #401 Investigate rootless docker containers
       options: --user root
+      image: nebulastream/nes-ci:${{ inputs.dev_image_tag }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -34,7 +34,7 @@ jobs:
 
   build-code-coverage-ref:
     container:
-      image: nebulastream/nes-development:${{ inputs.base_dev_image_tag }}
+      image: nebulastream/nes-ci:${{ inputs.dev_image_tag }}
       volumes:
         - ccache:/ccache
       env:
@@ -81,7 +81,7 @@ jobs:
 
   build-code-coverage-pr-branch:
     container:
-      image: nebulastream/nes-development:${{ inputs.dev_image_tag }}
+      image: nebulastream/nes-ci:${{ inputs.dev_image_tag }}
       volumes:
         - ccache:/ccache
       env:
@@ -172,7 +172,7 @@ jobs:
     needs: [ build-code-coverage-ref, build-code-coverage-pr-branch ]
     if: ${{ github.event_name == 'pull_request' }}
     container:
-      image: nebulastream/nes-development:${{ inputs.dev_image_tag }}
+      image: nebulastream/nes-ci:${{ inputs.dev_image_tag }}
       # TODO #401 Investigate rootless docker containers
       options: --user root
     timeout-minutes: 40
@@ -206,7 +206,7 @@ jobs:
     needs: [ build-code-coverage-ref, build-code-coverage-pr-branch ]
     if: ${{ github.event_name == 'pull_request' }}
     container:
-      image: nebulastream/nes-development:${{ inputs.dev_image_tag }}
+      image: nebulastream/nes-ci:${{ inputs.dev_image_tag }}
       # TODO #401 Investigate rootless docker containers
       options: --user root
     timeout-minutes: 40

--- a/.github/workflows/compile_time_regression.yml
+++ b/.github/workflows/compile_time_regression.yml
@@ -19,15 +19,7 @@ jobs:
   compile-time-regression:
     runs-on: [ self-hosted, linux, Build, "${{ matrix.arch }}" ]
     container:
-      image: nebulastream/nes-development:${{ inputs.dev_image_tag }}
-      # TODO #401 Investigate rootless docker containers
-      options: --user root
-    env:
-      MOLD_JOBS: 1
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [ x64, arm64 ]
+      image: nebulastream/nes-ci:${{ inputs.dev_image_tag }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -23,8 +23,7 @@ jobs:
   check-format:
     runs-on: [ self-hosted, linux, Build ]
     container:
-      image: nebulastream/nes-development:${{ inputs.dev_image_tag }}
-      # TODO #401 Investigate rootless docker containers
+      image: nebulastream/nes-ci:${{ inputs.dev_image_tag }}
       options: --user root
       env:
         GH_TOKEN: ${{ github.token }}
@@ -39,5 +38,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: ${{ steps.increment.outputs.result }}
+          ref: ${{ inputs.head_sha }}
       - name: Check Format
         run: ./scripts/format.sh

--- a/.github/workflows/get_dev_images.yml
+++ b/.github/workflows/get_dev_images.yml
@@ -5,6 +5,11 @@ name: Dependency Image
 on:
   workflow_call:
     inputs:
+      branch-name:
+        required: false
+        type: string
+        default: ''
+        description: "Branch name to tag the docker image with"
       ref:
         required: true
         type: string
@@ -35,6 +40,15 @@ jobs:
           HASH=$(docker/dependency/hash_dependencies.sh)
           echo "Using Hash: $HASH"
           
+          # Output the tag (hash) to GitHub Actions
+          echo "tag=$HASH" >> "$GITHUB_OUTPUT"
+          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
+          
+          if docker manifest inspect nebulastream/nes-ci:$HASH; then
+            echo "build-dependency=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          
           # Check if jq is installed
           if ! command -v jq &> /dev/null; then
             echo "jq is not installed."
@@ -42,7 +56,7 @@ jobs:
           fi
           
           # fetch all available tags for the nes-development image
-          DOCKERHUB_RESPONSE=$(curl -s "https://hub.docker.com/v2/namespaces/nebulastream/repositories/nes-development/tags?page_size=1000")
+          DOCKERHUB_RESPONSE=$(curl -s "https://hub.docker.com/v2/namespaces/nebulastream/repositories/nes-ci/tags?page_size=1000")
           if [ $? -ne 0 ]; then
             echo "could not fetch tags from the docker repository"
             exit 1
@@ -53,16 +67,11 @@ jobs:
           # Check if the Docker manifest exists for the computed hash
           if [[ "$TAG_FOUND" == "$HASH" ]]; then
             echo "build-dependency=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Development image with $HASH does not exist in the docker registry"
-            echo "build-dependency=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
-          # Output the tag (hash) to GitHub Actions
-          echo "tag=$HASH" >> "$GITHUB_OUTPUT"
-          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
-
-
+          echo "Development image with $HASH does not exist in the docker registry"
+          echo "build-dependency=true" >> "$GITHUB_OUTPUT"
   build-dev-images:
     # We run the docker image build on separate machines and combine them into a single
     # multi-arch docker image in the docker-development-images job.
@@ -133,7 +142,14 @@ jobs:
           build-args: TAG=${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}-${{matrix.stdlib}}
           context: .
           file: docker/dependency/Development.dockerfile
-
+      - name: Build CI Image
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: nebulastream/nes-ci:${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}-${{matrix.stdlib}}
+          build-args: TAG=${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}-${{matrix.stdlib}}
+          context: .
+          file: docker/dependency/DevelopmentCI.dockerfile
   merge-dev-images:
     # This Job merges platform specific images into a single multi-platform image
     name: "Merge Dev Images"
@@ -159,37 +175,32 @@ jobs:
           docker buildx imagetools create -t nebulastream/nes-development-base:${{ needs.detect-dependency-changes.outputs.tag }} \
             nebulastream/nes-development-base:${{ needs.detect-dependency-changes.outputs.tag }}-x64 \
             nebulastream/nes-development-base:${{ needs.detect-dependency-changes.outputs.tag }}-arm64
-
-          docker buildx imagetools create -t nebulastream/nes-development-dependency:${{ needs.detect-dependency-changes.outputs.tag }}-libstdcxx \
-            nebulastream/nes-development-dependency:${{ needs.detect-dependency-changes.outputs.tag }}-x64-libstdcxx \
-            nebulastream/nes-development-dependency:${{ needs.detect-dependency-changes.outputs.tag }}-arm64-libstdcxx
-
-          docker buildx imagetools create -t nebulastream/nes-development:${{ needs.detect-dependency-changes.outputs.tag }}-libstdcxx \
-            nebulastream/nes-development:${{ needs.detect-dependency-changes.outputs.tag }}-x64-libstdcxx \
-            nebulastream/nes-development:${{ needs.detect-dependency-changes.outputs.tag }}-arm64-libstdcxx
-
-          docker buildx imagetools create -t nebulastream/nes-development-dependency:${{ needs.detect-dependency-changes.outputs.tag }} \
-            nebulastream/nes-development-dependency:${{ needs.detect-dependency-changes.outputs.tag }}-x64-libcxx \
-            nebulastream/nes-development-dependency:${{ needs.detect-dependency-changes.outputs.tag }}-arm64-libcxx
           
-          docker buildx imagetools create -t nebulastream/nes-development:${{ needs.detect-dependency-changes.outputs.tag }} \
-            nebulastream/nes-development:${{ needs.detect-dependency-changes.outputs.tag }}-x64-libcxx \
-            nebulastream/nes-development:${{ needs.detect-dependency-changes.outputs.tag }}-arm64-libcxx
+          for image_tag in development-dependency development ci; do
+            docker buildx imagetools create -t nebulastream/nes-$image_tag:${{ needs.detect-dependency-changes.outputs.tag }} \
+              nebulastream/nes-$image_tag:${{ needs.detect-dependency-changes.outputs.tag }}-x64-libcxx \
+              nebulastream/nes-$image_tag:${{ needs.detect-dependency-changes.outputs.tag }}-arm64-libcxx
           
-          docker buildx imagetools create -t nebulastream/nes-development:${{ needs.detect-dependency-changes.outputs.tag }}-libcxx \
-            nebulastream/nes-development:${{ needs.detect-dependency-changes.outputs.tag }}
+            docker buildx imagetools create -t nebulastream/nes-$image_tag:${{ needs.detect-dependency-changes.outputs.tag }}-libcxx \
+              nebulastream/nes-$image_tag:${{ needs.detect-dependency-changes.outputs.tag }}-x64-libcxx \
+              nebulastream/nes-$image_tag:${{ needs.detect-dependency-changes.outputs.tag }}-arm64-libcxx
           
-          docker buildx imagetools create -t nebulastream/nes-development-base:${{ inputs.ref }} \
-            nebulastream/nes-development-base:${{ needs.detect-dependency-changes.outputs.tag }}
-
-          docker buildx imagetools create -t nebulastream/nes-development-dependency:${{ inputs.ref }} \
-            nebulastream/nes-development-dependency:${{ needs.detect-dependency-changes.outputs.tag }}
-
-          docker buildx imagetools create -t nebulastream/nes-development-dependency:${{ inputs.ref }}-libstdcxx \
-            nebulastream/nes-development-dependency:${{ needs.detect-dependency-changes.outputs.tag }}-libstdcxx
+            docker buildx imagetools create -t nebulastream/nes-$image_tag:${{ needs.detect-dependency-changes.outputs.tag }}-libstdcxx \
+              nebulastream/nes-$image_tag:${{ needs.detect-dependency-changes.outputs.tag }}-x64-libstdcxx \
+              nebulastream/nes-$image_tag:${{ needs.detect-dependency-changes.outputs.tag }}-arm64-libstdcxx 
+          done
+      - name: Combine Manifests for branch specific docker image
+        if: ${{ inputs.branch-name != '' }}
+        run: |
+          for image_tag in development-dependency development ci; do
+            docker buildx imagetools create -t nebulastream/nes-$image_tag:${{ inputs.branch-name }} \
+              nebulastream/nes-$image_tag:${{ needs.detect-dependency-changes.outputs.tag }}-x64-libcxx \
+              nebulastream/nes-$image_tag:${{ needs.detect-dependency-changes.outputs.tag }}-arm64-libcxx
           
-          docker buildx imagetools create -t nebulastream/nes-development:${{ inputs.ref }} \
-            nebulastream/nes-development:${{ needs.detect-dependency-changes.outputs.tag }}
+            docker buildx imagetools create -t nebulastream/nes-$image_tag:${{ inputs.branch-name }}-libcxx \
+              nebulastream/nes-$image_tag:${{ needs.detect-dependency-changes.outputs.tag }}-x64-libcxx \
+              nebulastream/nes-$image_tag:${{ needs.detect-dependency-changes.outputs.tag }}-arm64-libcxx
           
-          docker buildx imagetools create -t nebulastream/nes-development:${{ inputs.ref }}-libstdcxx \
-            nebulastream/nes-development:${{ needs.detect-dependency-changes.outputs.tag }}-libstdcxx
+            docker buildx imagetools create -t nebulastream/nes-$image_tag:${{ inputs.branch-name }}-libstdcxx \
+              nebulastream/nes-$image_tag:${{ needs.detect-dependency-changes.outputs.tag }}-x64-libstdcxx 
+          done

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,6 +24,7 @@ jobs:
     uses: ./.github/workflows/get_dev_images.yml
     secrets: inherit
     with:
+      branch-name: ${{ github.head_ref }}
       ref: ${{ github.event.pull_request.head.sha }}
 
   check-format:

--- a/docker/dependency/Development.dockerfile
+++ b/docker/dependency/Development.dockerfile
@@ -8,8 +8,8 @@ RUN apt update -y \
     && apt install clang-format-${LLVM_VERSION} clang-tidy-${LLVM_VERSION} lldb-${LLVM_VERSION} gdb jq -y
 
 # As clang-tidy-diff is not available in the apt repository, we need download it from the github repo and install it
-ADD --checksum=sha256:ec28c743ce3354df22b52db59feeac2d98556b8fc81cb7c1a877f3a862ae5726\
- https://raw.githubusercontent.com/duckdb/duckdb/52b43b166091c82b3f04bf8af15f0ace18207a64/scripts/clang-tidy-diff.py /clang-tidy-diff.py
+ADD --checksum=sha256:ec28c743ce3354df22b52db59feeac2d98556b8fc81cb7c1a877f3a862ae5726 --chmod=755 \
+ https://raw.githubusercontent.com/duckdb/duckdb/52b43b166091c82b3f04bf8af15f0ace18207a64/scripts/clang-tidy-diff.py /usr/bin/
 
 RUN apt-get update && \
         apt-get install -y software-properties-common && \
@@ -20,9 +20,6 @@ RUN apt-get update && \
 # The vcpkg port of antlr requires the jar to be available somewhere
 ADD --checksum=sha256:bc13a9c57a8dd7d5196888211e5ede657cb64a3ce968608697e4f668251a8487 \
   https://www.antlr.org/download/antlr-${ANTLR4_VERSION}-complete.jar /opt/antlr-${ANTLR4_VERSION}-complete.jar
-
-
-RUN export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
 RUN git clone https://github.com/aras-p/ClangBuildAnalyzer.git \
     && cmake -B ClangBuildAnalyzer/build -S ClangBuildAnalyzer -DCMAKE_INSTALL_PREFIX=/usr \

--- a/docker/dependency/DevelopmentCI.dockerfile
+++ b/docker/dependency/DevelopmentCI.dockerfile
@@ -1,0 +1,17 @@
+# The Development CI image installs a github runner specific user
+ARG TAG=latest
+FROM nebulastream/nes-development:${TAG}
+
+# The UID env var should be used in child Containerfile.
+ENV UID=1001
+ENV GID=1001
+ENV USERNAME="runner"
+USER root
+RUN groupadd --gid ${GID} runner && useradd $USERNAME --gid ${GID} --uid ${UID}
+RUN mkdir -p /home/${USERNAME} \
+    && chown -R $USERNAME:$GID /home/runner
+
+WORKDIR /home/runner
+ENV HOME=/home/${USERNAME}
+ENV MOLD_JOBS=1
+USER 1001:1001

--- a/docker/dependency/DevelopmentCI.dockerfile.dockerignore
+++ b/docker/dependency/DevelopmentCI.dockerfile.dockerignore
@@ -1,0 +1,2 @@
+# Ignore everything
+*


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Adds nebulastream CI Images that do not require root. This is required as a base branch
for the kubernetes CI PR.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
