### PR TITLE
#545 : Use correct CSV test query name in nes-single-node-worker integration tests

### DIFF
--- a/nes-single-node-worker/tests/Integration/SingleNodeIntegrationTestsCSV.cpp
+++ b/nes-single-node-worker/tests/Integration/SingleNodeIntegrationTestsCSV.cpp
@@ -122,5 +122,5 @@ INSTANTIATE_TEST_CASE_P(
     SingleNodeIntegrationTest,
     testing::Values(
         /// Todo 396: as soon as system level tests support multiple sources, we can get rid of the CSV integration tests
-        QueryTestParam{"qTwoSourcesCSVWithFilter", 62, 960 /*  2 * (SUM(0, 1, ..., 32) - 16) */}));
+        QueryTestParam{"qTwoCSVSourcesWithFilter", 62, 960 /*  2 * (SUM(0, 1, ..., 32) - 16) */}));
 }

--- a/nes-single-node-worker/tests/Integration/SingleNodeIntegrationTestsQueryStatus.cpp
+++ b/nes-single-node-worker/tests/Integration/SingleNodeIntegrationTestsQueryStatus.cpp
@@ -86,7 +86,7 @@ TEST_F(SingleNodeIntegrationTest, TestQueryStatusSimple)
 {
     const auto* const resultFileName = "TestQueryStatusSimple";
     /// Todo 396: as soon as system level tests support multiple sources, we get rid of the CSV integration tests and cannot depend on this .bin anymore.
-    const std::string queryInputFile = fmt::format("{}.bin", "qTwoSourcesCSVWithFilter");
+    const std::string queryInputFile = fmt::format("{}.bin", "qTwoCSVSourcesWithFilter");
     const std::string queryResultFile = fmt::format("{}.csv", resultFileName);
     IntegrationTestUtil::removeFile(queryResultFile); /// remove outputFile if exists
 


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This pull request makes `nes-single-node-worker/tests/Integration/SingleNodeIntegrationTestsCSV.cpp` and `nes-single-node-worker/tests/Integration/SingleNodeIntegrationTestsQueryStatus.cpp` refer to our current CSV test query name "qTwoCSVSourcesWithFilter" instead of the old name "qTwoSourcesCSVWithFilter".

Now, the tests "TestQueryStatusSimple" and "single-node-integration-tests-csv", which were previously skipped due to the usage of the old name, run again. 

## Issue Closed by this pull request:

This PR closes #545 