### PR TITLE
343 prevent non-printable characters from breaking todo check

### DIFF
--- a/scripts/check_todos.py
+++ b/scripts/check_todos.py
@@ -13,8 +13,8 @@ import urllib.request
 
 def run_cmd(cmd: list) -> str:
     try:
-        #ignoring errors to pass format check. Proper fix in: Todo #343
-        p = subprocess.run(cmd, capture_output=True, check=True, text=True, errors='ignore')
+        # Handle decode errors by replacing illegal chars with � (see #343)
+        p = subprocess.run(cmd, capture_output=True, check=True, text=True, errors='replace')
     except subprocess.CalledProcessError as e:
         print(e)
         print("\nstderr output:")


### PR DESCRIPTION
The `check_todos.py` script was [breaking when encountering non-printable characters in the git diff](https://github.com/nebulastream/nebulastream-public/issues/343#issuecomment-2437867527).

@alepping hot-fixed this in d16be1b9c8779b6b5462475bd0b93f7aefbe1904  and created #343 for further investigation.

This PR improves and documents the fix, and thus closes #343

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
