### PR TITLE
Search for antlr4 during cmake configure

### DIFF
--- a/nes-sql-parser/CMakeLists.txt
+++ b/nes-sql-parser/CMakeLists.txt
@@ -13,6 +13,7 @@
 add_subdirectory(src)
 get_source(nes-sql-parser SQL_PARSER_SOURCE_FILES)
 
+find_program(ANTLR_EXECUTABLE antlr4 REQUIRED)
 add_custom_command(
         OUTPUT
         ${CMAKE_CURRENT_BINARY_DIR}/AntlrSQLBaseListener.cpp
@@ -20,7 +21,7 @@ add_custom_command(
         ${CMAKE_CURRENT_BINARY_DIR}/AntlrSQLListener.cpp
         ${CMAKE_CURRENT_BINARY_DIR}/AntlrSQLParser.cpp
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/AntlrSQL.g4
-        COMMAND antlr4 -Dlanguage=Cpp ${CMAKE_CURRENT_SOURCE_DIR}/AntlrSQL.g4 -o ${CMAKE_CURRENT_BINARY_DIR}
+        COMMAND ${ANTLR_EXECUTABLE} -Dlanguage=Cpp ${CMAKE_CURRENT_SOURCE_DIR}/AntlrSQL.g4 -o ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 # The VCPKG port is called 'antlr4', finding the package requires to look for 'antlr4-runtime' and


### PR DESCRIPTION
When ANTLR is not installed, this is only discovered during build.

With this change, ANTLR is searched for during the cmake configure/generate phase.
This way, the error pops up earlier and the error msg is improved.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
