### PR TITLE
502 bug mixing in place and file source semantics causes systest to stall indefinitely

### DIFF
--- a/nes-systests/bug/MixingInPlaceSourceAndFileSourceSemantics.test.disabled
+++ b/nes-systests/bug/MixingInPlaceSourceAndFileSourceSemantics.test.disabled
@@ -2,7 +2,7 @@
 # description: Simple source/buffer tests
 # groups: [Tuples]
 
-# Todo 502
+# Todo 484 Validate that exception is thrown
 # The 'TESTDATA/200x8-rows-fields.csv' is wrong. However, our test parser does not catch this.
 # Instead the systest-utils runs indefinitely.
 Source fiveTuples UINT64 field_1 TESTDATA/200x8-rows-fields.csv
@@ -17,8 +17,4 @@ SINK fiveTuplesSink UINT64 fiveTuples$field_1
 # Description: simply reads in five tuples with a single value and produces the same tuples
 SELECT field_1 FROM fiveTuples INTO fiveTuplesSink
 ----
-1
-2
-3
-4
-5
+ErrorCode 1003 # or fitting Code

--- a/nes-systests/systest/src/SystestParser.cpp
+++ b/nes-systests/systest/src/SystestParser.cpp
@@ -60,11 +60,12 @@ SystestParser::Schema parseSchemaFields(const std::vector<std::string>& argument
     SystestParser::Schema schema;
     if (arguments.size() % 2 != 0)
     {
-        if(const auto& lastArg = arguments.back(); lastArg.ends_with(".csv"))
+        if (const auto& lastArg = arguments.back(); lastArg.ends_with(".csv"))
         {
             throw SLTUnexpectedToken(
                 "Incomplete fieldtype/fieldname pair for arguments {}; {} potentially is a CSV file? Are you mixing semantics",
-                fmt::join(arguments, ","), lastArg);
+                fmt::join(arguments, ","),
+                lastArg);
         }
         throw SLTUnexpectedToken("Incomplete fieldtype/fieldname pair for arguments {}", fmt::join(arguments, ", "));
     }


### PR DESCRIPTION
This pull request adds a more clear error message for logging if in place and file semantics are mixed. The MixingInPlace test can reused for #484 

## Issue Closed by this pull request:

This PR closes #502, the stalling seems to have already been fixed.
