### PR TITLE
503 bug systest crashes if it contains multiple sources

### DIFF
--- a/nes-systests/bug/TwoSources.test
+++ b/nes-systests/bug/TwoSources.test
@@ -1,8 +1,7 @@
 # name: sources/TESTDATACanNotAppearInTestName.test
-# description: Simple source/buffer tests
+# description: #503
 # groups: [Tuples]
 
-# Todo #503
 # Both queries below should pass, but the first fails.
 Source fiveTuples UINT64 field_1
 1
@@ -19,8 +18,11 @@ Source sixTuples UINT64 field_1
 5
 6
 
+SINK fiveTuplesSink UINT64 fiveTuples$field_1
+SINK sixTuplesSink UINT64 sixTuples$field_1
+
 # Description: simply reads in five tuples with a single value and produces the same tuples
-SELECT field_1 FROM fiveTuples INTO SINK
+SELECT field_1 FROM fiveTuples INTO fiveTuplesSink
 ----
 1
 2
@@ -29,7 +31,7 @@ SELECT field_1 FROM fiveTuples INTO SINK
 5
 
 # Description: simply reads in six tuples with a single value and produces the same tuples
-SELECT field_1 FROM sixTuples INTO SINK
+SELECT field_1 FROM sixTuples INTO sixTuplesSink
 ----
 1
 2

--- a/nes-systests/bug/TwoSourcesOneEmtpy.test
+++ b/nes-systests/bug/TwoSourcesOneEmtpy.test
@@ -1,18 +1,20 @@
 # name: buffersize/TwoSourcesOneEmtpy.test
-# description: Simple source/buffer tests
+# description: #503: Two sources do not work. Is this a special case that is different from 'TwoSources.test'?
 # groups: [Sources]
 
-# Todo #503: Two sources do not work. Is this a special case that is different from 'TwoSources.test'?
 Source noTuple UINT64 field_1
 
 Source oneTuple UINT64 field_1 # Probably triggers a parser bug (parser still looks for tuples)
 1
 
+SINK noTupleSink UINT64_t noTuple$field_1
+SINK oneTupleSink UINT64_t oneTuple$field_1
+
 # Description: check if we run into an error if we process a single tuple.
-SELECT field_1 FROM noTuple INTO SINK
+SELECT field_1 FROM noTuple INTO noTupleSink
 ----
 
 # Description: check if we run into an error if we process a single tuple.
-SELECT field_1 FROM oneTuple INTO SINK
+SELECT field_1 FROM oneTuple INTO oneTupleSink
 ----
 1


### PR DESCRIPTION
Input from multiple sources now works. The tests can be reused to ensure this functionality works. Closes #503 