### PR TITLE
Improve antlr setup

### DIFF
--- a/docker/dependency/Development.dockerfile
+++ b/docker/dependency/Development.dockerfile
@@ -2,6 +2,8 @@
 ARG TAG=latest
 FROM nebulastream/nes-development-dependency:${TAG}
 
+ARG ANTLR4_VERSION=4.13.1
+
 RUN apt update -y \
     && apt install clang-format-${LLVM_VERSION} clang-tidy-${LLVM_VERSION} lldb-${LLVM_VERSION} gdb jq -y
 
@@ -13,14 +15,11 @@ RUN apt-get update && \
         apt-get install -y software-properties-common && \
         add-apt-repository ppa:deadsnakes/ppa && \
         apt-get update && \
-        apt-get install -y default-jre-headless python3.11 python3.11-dev python3.11-distutils pipx -y
+        apt-get install -y default-jre-headless python3.11 python3.11-dev python3.11-distutils -y
 
-# Had to install antlr4-tools via pipx as the antlr4-tools package is not available in the apt repository
-# Additionally, we had to change the homedir in the antlr4_tool_runner.py file to /opt as the Path.home() function
-# Otherwise, we would need to downoad the antlr4.jar during the building of the project
-RUN PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin PIPX_MAN_DIR=/usr/local/share/man pipx install antlr4-tools  && \
-    sed -i "s|homedir = Path.home()|homedir = '/opt'|" /opt/pipx/venvs/antlr4-tools/lib/python3.12/site-packages/antlr4_tool_runner.py && \
-    antlr4
+# The vcpkg port of antlr requires the jar to be available somewhere
+ADD --checksum=sha256:bc13a9c57a8dd7d5196888211e5ede657cb64a3ce968608697e4f668251a8487 \
+  https://www.antlr.org/download/antlr-${ANTLR4_VERSION}-complete.jar /opt/antlr-${ANTLR4_VERSION}-complete.jar
 
 
 RUN export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib

--- a/nes-sql-parser/CMakeLists.txt
+++ b/nes-sql-parser/CMakeLists.txt
@@ -13,31 +13,41 @@
 add_subdirectory(src)
 get_source(nes-sql-parser SQL_PARSER_SOURCE_FILES)
 
-add_custom_command(
-        OUTPUT
-        ${CMAKE_CURRENT_BINARY_DIR}/AntlrSQLBaseListener.cpp
-        ${CMAKE_CURRENT_BINARY_DIR}/AntlrSQLLexer.cpp
-        ${CMAKE_CURRENT_BINARY_DIR}/AntlrSQLListener.cpp
-        ${CMAKE_CURRENT_BINARY_DIR}/AntlrSQLParser.cpp
-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/AntlrSQL.g4
-        COMMAND antlr4 -Dlanguage=Cpp ${CMAKE_CURRENT_SOURCE_DIR}/AntlrSQL.g4 -o ${CMAKE_CURRENT_BINARY_DIR}
-)
+find_package(antlr4-generator CONFIG REQUIRED)
+
+set(ANTLR_JAR_FILE "antlr-${ANTLR_VERSION}-complete.jar")
+
+if (DEFINED ENV{NES_PREBUILT_VCPKG_ROOT})
+  # if in prebuilt docker, expect jar _with correct version_ in /opt
+  if (NOT EXISTS "/opt/${ANTLR_JAR_FILE}")
+    message(FATAL_ERROR "could not find expected ANTLR jar file /opt/${ANTLR_JAR_FILE}. "
+                        "Maybe there is a version mismatch?")
+  endif ()
+  set(ANTLR4_JAR_LOCATION "/opt/${ANTLR_JAR_FILE}")
+else ()
+  include(FetchContent)
+  FetchContent_Declare(
+    antlr4_jar
+    URL      https://www.antlr.org/download/${ANTLR_JAR_FILE}
+    URL_HASH SHA256=bc13a9c57a8dd7d5196888211e5ede657cb64a3ce968608697e4f668251a8487
+    DOWNLOAD_NO_EXTRACT TRUE
+  )
+  FetchContent_MakeAvailable(antlr4_jar)
+  set(ANTLR4_JAR_LOCATION "${antlr4_jar_SOURCE_DIR}/${ANTLR_JAR_FILE}")
+endif ()
+
+# generate BOTH parser and lexer, and additionaly listener
+antlr4_generate(NES_SQL_PARSER ${CMAKE_CURRENT_SOURCE_DIR}/AntlrSQL.g4 BOTH -listener)
 
 # The VCPKG port is called 'antlr4', finding the package requires to look for 'antlr4-runtime' and
 # adding antlr library as a dependency to another library, requires to link against 'antlr-static'.
 find_package(antlr4-runtime CONFIG REQUIRED)
-add_library(nes-sql-parser
-        ${SQL_PARSER_SOURCE_FILES}
-        ${CMAKE_CURRENT_BINARY_DIR}/AntlrSQLBaseListener.cpp
-        ${CMAKE_CURRENT_BINARY_DIR}/AntlrSQLLexer.cpp
-        ${CMAKE_CURRENT_BINARY_DIR}/AntlrSQLListener.cpp
-        ${CMAKE_CURRENT_BINARY_DIR}/AntlrSQLParser.cpp
-)
+add_library(nes-sql-parser ${SQL_PARSER_SOURCE_FILES} ${ANTLR4_SRC_FILES_NES_SQL_PARSER})
 
 target_include_directories(nes-sql-parser PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include/nebulastream/>
-        ${CMAKE_CURRENT_BINARY_DIR} ${ANTLR4_INCLUDE_DIR}
+        ${ANTLR4_INCLUDE_DIR_NES_SQL_PARSER} ${ANTLR4_INCLUDE_DIR}
         PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/private>)
 target_link_libraries(nes-sql-parser PUBLIC antlr4_static nes-common nes-functions nes-sinks nes-sources nes-client nes-operators PRIVATE nes-client)
 


### PR DESCRIPTION
Currently, the user/developer has to install the correct antlr version for local builds
and using docker there is a risk of version mismatch between pipx and vcpkg
antlr versions.

With this PR, the version mismatch is prevented and antlr is fetched when
building locally.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"vcpkg-set-llvm-version","parentHead":"07d9c3a264e909a2f6a7ff674801989ea5e3ae0c","parentPull":562,"trunk":"main"}
```
-->
