### PR TITLE
hotfix(CI) Wrong cache image tag and missing branch specific base image

### DIFF
--- a/.github/workflows/get_dev_images.yml
+++ b/.github/workflows/get_dev_images.yml
@@ -108,9 +108,9 @@ jobs:
         with:
           push: true
           tags: nebulastream/nes-development-base:${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}
-          cache-to: type=registry,ref=nebulastream/nes-development-base-cache:${{ inputs.ref }}-${{matrix.arch}},mode=max
+          cache-to: type=registry,ref=nebulastream/nes-development-base-cache:${{inputs.branch-name}}-${{matrix.arch}},mode=max
           cache-from: |
-            type=registry,ref=nebulastream/nes-development-base-cache:${{ inputs.ref }}-${{matrix.arch}}
+            type=registry,ref=nebulastream/nes-development-base-cache:${{inputs.branch-name}}-${{matrix.arch}}
             type=registry,ref=nebulastream/nes-development-base-cache:latest-${{matrix.arch}}
           context: .
           file: docker/dependency/Base.dockerfile
@@ -119,9 +119,9 @@ jobs:
         with:
           push: true
           tags: nebulastream/nes-development-dependency:${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}-${{matrix.stdlib}}
-          cache-to: type=registry,ref=nebulastream/nes-development-dependency-cache:${{ inputs.ref }}-${{matrix.arch}}-${{matrix.stdlib}},mode=max
+          cache-to: type=registry,ref=nebulastream/nes-development-dependency-cache:${{inputs.branch-name}}-${{matrix.arch}}-${{matrix.stdlib}},mode=max
           cache-from: |
-            type=registry,ref=nebulastream/nes-development-dependency-cache:${{ inputs.ref }}-${{matrix.arch}}-${{matrix.stdlib}}
+            type=registry,ref=nebulastream/nes-development-dependency-cache:${{inputs.branch-name}}-${{matrix.arch}}-${{matrix.stdlib}}
             type=registry,ref=nebulastream/nes-development-dependency-cache:latest-${{matrix.arch}}-${{matrix.stdlib}}
           build-args: |
             TAG=${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}
@@ -135,9 +135,9 @@ jobs:
         with:
           push: true
           tags: nebulastream/nes-development:${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}-${{matrix.stdlib}}
-          cache-to: type=registry,ref=nebulastream/nes-development-cache:${{ inputs.ref }}-${{matrix.arch}}-${{matrix.stdlib}},mode=max
+          cache-to: type=registry,ref=nebulastream/nes-development-cache:${{inputs.branch-name}}-${{matrix.arch}}-${{matrix.stdlib}},mode=max
           cache-from: |
-            type=registry,ref=nebulastream/nes-development-cache:${{ inputs.ref }}-${{matrix.arch}}-${{matrix.stdlib}}
+            type=registry,ref=nebulastream/nes-development-cache:${{inputs.branch-name}}-${{matrix.arch}}-${{matrix.stdlib}}
             type=registry,ref=nebulastream/nes-development-dependency-cache:latest-${{matrix.arch}}-${{matrix.stdlib}}
           build-args: TAG=${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}-${{matrix.stdlib}}
           context: .
@@ -192,6 +192,10 @@ jobs:
       - name: Combine Manifests for branch specific docker image
         if: ${{ inputs.branch-name != '' }}
         run: |
+          docker buildx imagetools create -t nebulastream/nes-development-base:${{ inputs.branch-name }} \
+            nebulastream/nes-development-base:${{ needs.detect-dependency-changes.outputs.tag }}-x64 \
+            nebulastream/nes-development-base:${{ needs.detect-dependency-changes.outputs.tag }}-arm64
+          
           for image_tag in development-dependency development ci; do
             docker buildx imagetools create -t nebulastream/nes-$image_tag:${{ inputs.branch-name }} \
               nebulastream/nes-$image_tag:${{ needs.detect-dependency-changes.outputs.tag }}-x64-libcxx \

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -34,22 +34,22 @@ jobs:
         id: image-tag
         if: ${{ steps.changed-files.outputs.any_modified == 'true' }}
         run: |
-          docker buildx imagetools create -t nebulastream/nes-development-base:latest nebulastream/nes-development-base:${{ github.event.pull_request.head.ref }}          
-          docker buildx imagetools create -t nebulastream/nes-development-dependency:latest nebulastream/nes-development-dependency:${{ github.event.pull_request.head.ref }}          
-          docker buildx imagetools create -t nebulastream/nes-development-dependency:latest-libstdcxx nebulastream/nes-development-dependency:${{ github.event.pull_request.head.ref }}-libstdcxx 
-          docker buildx imagetools create -t nebulastream/nes-development:latest nebulastream/nes-development:${{ github.event.pull_request.head.ref }}          
-          docker buildx imagetools create -t nebulastream/nes-development:latest-libstdcxx nebulastream/nes-development:${{ github.event.pull_request.head.ref }}-libstdcxx         
+          docker buildx imagetools create -t nebulastream/nes-development-base:latest nebulastream/nes-development-base:nebulastream-ci-images          
+          docker buildx imagetools create -t nebulastream/nes-development-dependency:latest nebulastream/nes-development-dependency:nebulastream-ci-images          
+          docker buildx imagetools create -t nebulastream/nes-development-dependency:latest-libstdcxx nebulastream/nes-development-dependency:nebulastream-ci-images-libstdcxx 
+          docker buildx imagetools create -t nebulastream/nes-development:latest nebulastream/nes-development:nebulastream-ci-images          
+          docker buildx imagetools create -t nebulastream/nes-development:latest-libstdcxx nebulastream/nes-development:nebulastream-ci-images-libstdcxx         
           
           # Arm64 Cache Images
-          docker buildx imagetools create -t nebulastream/nes-development-base-cache:latest-arm64 nebulastream/nes-development-base-cache:${{ github.event.pull_request.head.ref }}-arm64          
-          docker buildx imagetools create -t nebulastream/nes-development-dependency-cache:latest-arm64 nebulastream/nes-development-dependency-cache:${{ github.event.pull_request.head.ref }}-arm64         
-          docker buildx imagetools create -t nebulastream/nes-development-dependency-cache:latest-arm64-libstdcxx nebulastream/nes-development-dependency-cache:${{ github.event.pull_request.head.ref }}-arm64-libstdcxx         
-          docker buildx imagetools create -t nebulastream/nes-development-cache:latest-arm64 nebulastream/nes-development-cache:${{ github.event.pull_request.head.ref }}-arm64           
-          docker buildx imagetools create -t nebulastream/nes-development-cache:latest-arm64-libstdcxx nebulastream/nes-development-cache:${{ github.event.pull_request.head.ref }}-arm64-libstdcxx           
+          docker buildx imagetools create -t nebulastream/nes-development-base-cache:latest-arm64 nebulastream/nes-development-base-cache:nebulastream-ci-images-arm64          
+          docker buildx imagetools create -t nebulastream/nes-development-dependency-cache:latest-arm64 nebulastream/nes-development-dependency-cache:nebulastream-ci-images-arm64         
+          docker buildx imagetools create -t nebulastream/nes-development-dependency-cache:latest-arm64-libstdcxx nebulastream/nes-development-dependency-cache:nebulastream-ci-images-arm64-libstdcxx         
+          docker buildx imagetools create -t nebulastream/nes-development-cache:latest-arm64 nebulastream/nes-development-cache:nebulastream-ci-images-arm64           
+          docker buildx imagetools create -t nebulastream/nes-development-cache:latest-arm64-libstdcxx nebulastream/nes-development-cache:nebulastream-ci-images-arm64-libstdcxx           
           
           # x64 Cache Images
-          docker buildx imagetools create -t nebulastream/nes-development-base-cache:latest-x64 nebulastream/nes-development-base-cache:${{ github.event.pull_request.head.ref }}-x64          
-          docker buildx imagetools create -t nebulastream/nes-development-dependency-cache:latest-x64 nebulastream/nes-development-dependency-cache:${{ github.event.pull_request.head.ref }}-x64          
-          docker buildx imagetools create -t nebulastream/nes-development-dependency-cache:latest-x64-libstdcxx nebulastream/nes-development-dependency-cache:${{ github.event.pull_request.head.ref }}-x64-libstdcxx          
-          docker buildx imagetools create -t nebulastream/nes-development-cache:latest-x64 nebulastream/nes-development-cache:${{ github.event.pull_request.head.ref }}-x64          
-          docker buildx imagetools create -t nebulastream/nes-development-cache:latest-x64-libstdcxx nebulastream/nes-development-cache:${{ github.event.pull_request.head.ref }}-x64-libstdcxx          
+          docker buildx imagetools create -t nebulastream/nes-development-base-cache:latest-x64 nebulastream/nes-development-base-cache:nebulastream-ci-images-x64          
+          docker buildx imagetools create -t nebulastream/nes-development-dependency-cache:latest-x64 nebulastream/nes-development-dependency-cache:nebulastream-ci-images-x64          
+          docker buildx imagetools create -t nebulastream/nes-development-dependency-cache:latest-x64-libstdcxx nebulastream/nes-development-dependency-cache:nebulastream-ci-images-x64-libstdcxx          
+          docker buildx imagetools create -t nebulastream/nes-development-cache:latest-x64 nebulastream/nes-development-cache:nebulastream-ci-images-x64          
+          docker buildx imagetools create -t nebulastream/nes-development-cache:latest-x64-libstdcxx nebulastream/nes-development-cache:nebulastream-ci-images-x64-libstdcxx          


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Fixes problem with docker build caches. The cache name was based on the commit sha not on the
branch name. Merging Images into the latest image expected the branch name.

The cache will now use the branch name.

## Verifying this change
CI passes. Merging causes the latest images to be updated.

## What components does this pull request potentially affect?
CI

## Documentation
Intended behaivor is documentend


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
