### PR TITLE
582 task add test for memory layout

### DIFF
--- a/nes-memory/MemoryLayout/ColumnLayout.cpp
+++ b/nes-memory/MemoryLayout/ColumnLayout.cpp
@@ -30,7 +30,8 @@ ColumnLayout::ColumnLayout(SchemaPtr schema, uint64_t bufferSize) : MemoryLayout
     }
 }
 
-ColumnLayout::ColumnLayout(const ColumnLayout& other) : ColumnLayout(other.schema, other.bufferSize)
+ColumnLayout::ColumnLayout(const ColumnLayout& other) /// NOLINT(*-copy-constructor-init)
+    : MemoryLayout(other), columnOffsets(other.columnOffsets)
 {
 }
 

--- a/nes-memory/MemoryLayout/MemoryLayout.cpp
+++ b/nes-memory/MemoryLayout/MemoryLayout.cpp
@@ -140,7 +140,8 @@ void MemoryLayout::setKeyFieldNames(const std::vector<std::string>& keyFields)
 bool MemoryLayout::operator==(const MemoryLayout& rhs) const
 {
     return bufferSize == rhs.bufferSize && (*schema == *rhs.schema) && recordSize == rhs.recordSize && capacity == rhs.capacity
-        && physicalFieldSizes == rhs.physicalFieldSizes && physicalTypes == rhs.physicalTypes && nameFieldIndexMap == rhs.nameFieldIndexMap;
+        && physicalFieldSizes == rhs.physicalFieldSizes && physicalTypes == rhs.physicalTypes && nameFieldIndexMap == rhs.nameFieldIndexMap
+        && keyFieldNames == rhs.keyFieldNames;
 }
 
 bool MemoryLayout::operator!=(const MemoryLayout& rhs) const

--- a/nes-memory/MemoryLayout/RowLayout.cpp
+++ b/nes-memory/MemoryLayout/RowLayout.cpp
@@ -30,7 +30,7 @@ RowLayout::RowLayout(SchemaPtr schema, uint64_t bufferSize) : MemoryLayout(buffe
     }
 }
 
-RowLayout::RowLayout(const RowLayout& other) : RowLayout(other.schema, other.bufferSize)
+RowLayout::RowLayout(const RowLayout& other) : MemoryLayout(other), fieldOffSets(other.fieldOffSets) /// NOLINT(*-copy-constructor-init)
 {
 }
 

--- a/nes-runtime/tests/UnitTests/Runtime/MemoryLayouts/ColumnarMemoryLayoutTest.cpp
+++ b/nes-runtime/tests/UnitTests/Runtime/MemoryLayouts/ColumnarMemoryLayoutTest.cpp
@@ -328,4 +328,32 @@ TEST_F(ColumnarMemoryLayoutTest, pushRecordTooManyRecordsColumnLayout)
     ASSERT_EQ(testBuffer->getNumberOfTuples(), NUM_TUPLES);
 }
 
+TEST_F(ColumnarMemoryLayoutTest, getFieldOffset)
+{
+    const auto schema
+        = Schema::create()->addField("t1", BasicType::UINT8)->addField("t2", BasicType::UINT8)->addField("t3", BasicType::UINT8);
+    const auto columnLayout = ColumnLayout::create(schema, bufferManager->getBufferSize());
+
+    ASSERT_EXCEPTION_ERRORCODE(auto result = columnLayout->getFieldOffset(2, 4), ErrorCode::CannotAccessBuffer);
+    ASSERT_EXCEPTION_ERRORCODE(auto result = columnLayout->getFieldOffset(1000000000, 2), ErrorCode::CannotAccessBuffer);
+}
+
+TEST_F(ColumnarMemoryLayoutTest, deepCopy)
+{
+    const auto schema
+        = Schema::create()->addField("t1", BasicType::UINT8)->addField("t2", BasicType::UINT8)->addField("t3", BasicType::UINT8);
+    auto columnLayout = ColumnLayout::create(schema, bufferManager->getBufferSize());
+
+    const auto deepCopy = columnLayout->deepCopy();
+
+    ASSERT_NE(deepCopy, columnLayout);
+    ASSERT_EQ(*deepCopy, *columnLayout);
+
+    /// checking if changing the schema does not affect the deep copy
+    const auto schema2 = Schema::create()->addField("r1", BasicType::UINT8);
+    columnLayout = ColumnLayout::create(schema2, bufferManager->getBufferSize());
+
+    ASSERT_TRUE(deepCopy->getSchema() != columnLayout->getSchema());
+}
+
 }


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR adds test coverage for getFieldOffset() Exceptions for ColumnarMemoryLayout and RowMemoryLayout

## Verifying this change
This change is tested by

## What components does this pull request potentially affect?
ColumnarMemoryLayout
RowMemoryLayout 

## Issue Closed by this pull request:

This PR closes #582 
