### PR TITLE
fix hash_dependencies.sh on macos

### DIFF
--- a/docker/dependency/hash_dependencies.sh
+++ b/docker/dependency/hash_dependencies.sh
@@ -10,9 +10,11 @@ set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
 # paths of dirs or files that affect the dependency images
+#
+# Do not use trailing slashes on dirs since this leads to diverging hashes on macos.
 HASH_PATHS=(
-  vcpkg/
-  docker/dependency/
+  vcpkg
+  docker/dependency
 )
 
 # we set LC_ALL to override the system-specific locale, to have consistent sort order


### PR DESCRIPTION
The trailing slashes of the dirs in HASH_PATHS caused diverging hashes on macos since the result of 'find -exec sha256sum' contained duplicate slashes, i.e.

    0ed237... docker/dependency//Base.dockerfile
    ...
    9d6b13... vcpkg//custom-triplets/arm64...
    ...

Removing the trailing slash fixes this.

