### PR TITLE
fix(Configurations) Fixed reading configs from file

### DIFF
--- a/nes-configurations/include/Configurations/Util.hpp
+++ b/nes-configurations/include/Configurations/Util.hpp
@@ -54,9 +54,11 @@ std::optional<T> loadConfiguration(const int argc, const char** argv)
     T config;
 
     /// Read options from the YAML file.
-    if (const auto configPath = commandLineParams.find("--" + CONFIG_PATH); configPath != commandLineParams.end())
+    const auto configPathCLIParam = "--" + CONFIG_PATH;
+    if (const auto configPath = commandLineParams.find(configPathCLIParam); configPath != commandLineParams.end())
     {
         config.overwriteConfigWithYAMLFileInput(configPath->second);
+        commandLineParams.erase(configPathCLIParam);
     }
 
     /// Options specified on the command line have the highest precedence.


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR fixes a crash that would occur if one would read configs from a file.
For example, `--configPath=worker/yaml` would throw an exception as the `loadConfiguration` function would try to parse the `configPath` as a configuration of the worker.
