### PR TITLE
document that antlr version depends on vcpkg baseline

### DIFF
--- a/vcpkg/vcpkg.json
+++ b/vcpkg/vcpkg.json
@@ -3,7 +3,16 @@
   "version-string": "latest",
   "homepage": "https://nebula.stream",
   "description": "Data Management for the Internet of Things.",
+
   "builtin-baseline": "f04dfe440cf94fed029a729b5c9fc65575408001",
+  "$comment": [
+    "BEWARE: changing the baseline might change the expected ANTLR_VERSION",
+    "        supplied to cmake by the antlr4 dependency." ,
+    "        This in turn requires changing the version of the antlr jar that",
+    "        is fetched by cmake or baked into the dev docker image.",
+    "        (c.f. nes-sql-parser/CMakeLists.txt)"
+  ],
+
   "features": {
     "mlir": {
       "description": "nautilus mlir backend",


### PR DESCRIPTION
@Artraxon stumbled upon ANTLR version problems ([corresponding zulip topic](https://nebulastream.zulipchat.com/#narrow/channel/452216-general/topic/ANTLR.20jar.20not.20found)). This PR aims to improve the documentation to improve this by documenting the implications of changing the vcpkg baseline for the ANTLR_VERSION.

Afaics, there is sadly no better way of adding comments inside the vcpkg.json. The [docs](https://learn.microsoft.com/en-us/vcpkg/reference/vcpkg-json) suggest this approach but forbid its usage in certain fields like `features` (But vcpkg doesn't complain about such "illegal" comments).