### PR TITLE
systest: fail when given unknown group

### DIFF
--- a/nes-systests/systest/src/SystestStarter.cpp
+++ b/nes-systests/systest/src/SystestStarter.cpp
@@ -154,6 +154,11 @@ Configuration::SystestConfiguration readConfiguration(int argc, const char** arg
                 const auto& groups = testfile.groups;
                 return std::any_of(groups.begin(), groups.end(), [&expectedGroup](const auto& group) { return group == expectedGroup; });
             });
+        if (!found)
+        {
+            std::cerr << "Unknown group '" << expectedGroup << "'!" << std::endl;
+            std::exit(1);
+        }
         config.testGroup = expectedGroup;
     }
 


### PR DESCRIPTION
Previously, systest simply ran no tests when given an unknown group with `-g`.

This PR prints an error and exits with status code `1`.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"fix-nightly","parentHead":"e34e376d553347088c7e6a3f22b1f19f03df5af9","parentPull":659,"trunk":"main"}
```
-->
