### PR TITLE
Fix get-dev-images with empty branch-name input

### DIFF
--- a/.github/workflows/get_dev_images.yml
+++ b/.github/workflows/get_dev_images.yml
@@ -8,7 +8,7 @@ on:
       branch-name:
         required: false
         type: string
-        default: ''
+        default: ${{ inputs.ref }}
         description: "Branch name to tag the docker image with"
       ref:
         required: true


### PR DESCRIPTION
Since inputs.branch-name is not required for calling the workflow, it might be empty, which in turn causes the build steps to fail with:

    buildx failed with: ERROR: failed to solve: failed to configure registry cache exporter: invalid reference format

See e.g. [this run](https://github.com/nebulastream/nebulastream-public/actions/runs/13282631707) for such a failure.