### PR TITLE
Hotfix(Test) Changes default working-dir

### DIFF
--- a/nes-systests/systest/include/SystestConfiguration.hpp
+++ b/nes-systests/systest/include/SystestConfiguration.hpp
@@ -38,7 +38,8 @@ public:
         = {"testQueryNumbers", "Directly specified test files. If directly specified no lookup at the test discovery dir will happen."};
     Configurations::StringOption testFileExtension
         = {"testFileExtension", ".test", "File extension to find test files for. Default: .test"};
-    Configurations::StringOption workingDir = {"workingDir", PATH_TO_BINARY_DIR "/nes-systests", "Directory with source and result files"};
+    Configurations::StringOption workingDir
+        = {"workingDir", PATH_TO_BINARY_DIR "/nes-systests/working-dir", "Directory with source and result files"};
     Configurations::BoolOption randomQueryOrder = {"randomQueryOrder", "false", "run queries in random order"};
     Configurations::UIntOption numberConcurrentQueries = {"numberConcurrentQueries", "6", "number of maximal concurrently running queries"};
     Configurations::StringOption testGroup = {"testGroup", "", "test group to run"};


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Previous change sets the default working directory to be the cmake build directory of the systest tool.
Systest starts by cleaning up the working directory and deleting everything within.
This change sets the default working directory to point somewhere else a new folder working-dir is created 
in the cmake build directory which should not contain any files.

## Verifying this change
Use the systest tool locally

## What components does this pull request potentially affect?
Systest

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
