### PR TITLE
fix(CI): fix check_todos.py "no merge base found"

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,10 +12,6 @@ on:
         type: string
         required: true
         description: "commit sha of head"
-      base_sha:
-        type: string
-        required: true
-        description: "commit sha of base"
       number_of_commits:
         type: number
         required: false
@@ -29,7 +25,7 @@ jobs:
       options: --user root
       env:
         GH_TOKEN: ${{ github.token }}
-        BASE_REF: ${{ inputs.base_sha }}
+        NUM_COMMITS: ${{ inputs.number_of_commits }}
     permissions:
       issues: read
       contents: read

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,7 +34,6 @@ jobs:
     with:
       head_sha: ${{ github.event.pull_request.head.sha }}
       dev_image_tag: ${{ needs.get-dev-images.outputs.image-tag }}
-      base_sha: ${{ github.event.pull_request.base.sha }}
       number_of_commits: ${{ github.event.pull_request.commits }}
 
   build-and-test:

--- a/scripts/check_todos.py
+++ b/scripts/check_todos.py
@@ -84,25 +84,23 @@ def main():
     OWNER = "nebulastream"
     REPO = "nebulastream-public"
 
-    if "CI" in os.environ and "BASE_REF" not in os.environ:
-        print("Error: running in CI, but BASE_REF not set")
+    if "CI" in os.environ and "NUM_COMMITS" not in os.environ:
+        print("Error: running in CI, but NUM_COMMITS not set")
         sys.exit(1)
     if "CI" in os.environ and "GH_TOKEN" not in os.environ:
         print("Error: running in CI, but GH_TOKEN not set")
         sys.exit(1)
 
-    if "BASE_REF" in os.environ:
-        base = os.environ["BASE_REF"]
+    if "NUM_COMMITS" in os.environ:
+        distance_main = os.environ["NUM_COMMITS"]
     else:
-        base = "main"
-
         merge_base = run_cmd(["git", "merge-base", "HEAD", "main"]).strip()
         distance_main = int(run_cmd(["git", "rev-list", "--count", f"{merge_base}..HEAD"]).strip())
         print(f"checking added TODOs for last {distance_main} commits (i.e. since forking off 'main')")
-        print("Set env var BASE_REF to override base, e.g. call:")
-        print(f"\n  BASE_REF=origin/main python3 {sys.argv[0]}")
+        print("Set env var NUM_COMMITS to override the number of commits to be checked, e.g. call:")
+        print(f"\n  NUM_COMMITS=42 python3 {sys.argv[0]}\n\n")
 
-    diff = run_cmd(["git", "diff", "--merge-base", base, "--",
+    diff = run_cmd(["git", "diff", f"HEAD~{distance_main}", "--",
                     # Ignore patch files in our vcpkg ports
                     ":!vcpkg/vcpkg-registry/**/*.patch"
                     ])


### PR DESCRIPTION
Previously, the script would sometimes break with

    fatal: no merge base found

as in e.g. [this run](https://github.com/nebulastream/nebulastream-public/actions/runs/13314984928/job/37186783236) (maybe when not based directly on main?)

It could be that since `BASE_REF` would point to main but the checkout action would only fetch commits from HEAD to the merge base, thus the sha of main would be unknown, causing a failure.

Anyhow, this should prevent the failure.