### PR TITLE
hotfix(CI) Fixes image merge workflow

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -34,22 +34,22 @@ jobs:
         id: image-tag
         if: ${{ steps.changed-files.outputs.any_modified == 'true' }}
         run: |
-          docker buildx imagetools create -t nebulastream/nes-development-base:latest nebulastream/nes-development-base:${{ github.head_ref }}          
-          docker buildx imagetools create -t nebulastream/nes-development-dependency:latest nebulastream/nes-development-dependency:${{ github.head_ref }}          
-          docker buildx imagetools create -t nebulastream/nes-development-dependency:latest-libstdcxx nebulastream/nes-development-dependency:${{ github.head_ref }}-libstdcxx 
-          docker buildx imagetools create -t nebulastream/nes-development:latest nebulastream/nes-development:${{ github.head_ref }}          
-          docker buildx imagetools create -t nebulastream/nes-development:latest-libstdcxx nebulastream/nes-development:${{ github.head_ref }}-libstdcxx         
-          
+          docker buildx imagetools create -t nebulastream/nes-development-base:latest nebulastream/nes-development-base:${{ github.head_ref }}
+          docker buildx imagetools create -t nebulastream/nes-development-dependency:latest nebulastream/nes-development-dependency:${{ github.head_ref }}
+          docker buildx imagetools create -t nebulastream/nes-development-dependency:latest-libstdcxx nebulastream/nes-development-dependency:${{ github.head_ref }}-libstdcxx
+          docker buildx imagetools create -t nebulastream/nes-development:latest nebulastream/nes-development:${{ github.head_ref }}
+          docker buildx imagetools create -t nebulastream/nes-development:latest-libstdcxx nebulastream/nes-development:${{ github.head_ref }}-libstdcxx
+
           # Arm64 Cache Images
-          docker buildx imagetools create -t nebulastream/nes-development-base-cache:latest-arm64 nebulastream/nes-development-base-cache:${{ github.head_ref }}-arm64          
-          docker buildx imagetools create -t nebulastream/nes-development-dependency-cache:latest-arm64 nebulastream/nes-development-dependency-cache:${{ github.head_ref }}-arm64         
-          docker buildx imagetools create -t nebulastream/nes-development-dependency-cache:latest-arm64-libstdcxx nebulastream/nes-development-dependency-cache:${{ github.head_ref }}-arm64-libstdcxx         
-          docker buildx imagetools create -t nebulastream/nes-development-cache:latest-arm64 nebulastream/nes-development-cache:${{ github.head_ref }}-arm64           
-          docker buildx imagetools create -t nebulastream/nes-development-cache:latest-arm64-libstdcxx nebulastream/nes-development-cache:${{ github.head_ref }}-arm64-libstdcxx           
-          
+          docker buildx imagetools create -t nebulastream/nes-development-base-cache:latest-arm64 nebulastream/nes-development-base-cache:${{ github.head_ref }}-arm64
+          docker buildx imagetools create -t nebulastream/nes-development-dependency-cache:latest-arm64 nebulastream/nes-development-dependency-cache:${{ github.head_ref }}-arm64-libcxx
+          docker buildx imagetools create -t nebulastream/nes-development-dependency-cache:latest-arm64-libstdcxx nebulastream/nes-development-dependency-cache:${{ github.head_ref }}-arm64-libstdcxx
+          docker buildx imagetools create -t nebulastream/nes-development-cache:latest-arm64 nebulastream/nes-development-cache:${{ github.head_ref }}-arm64-libcxx
+          docker buildx imagetools create -t nebulastream/nes-development-cache:latest-arm64-libstdcxx nebulastream/nes-development-cache:${{ github.head_ref }}-arm64-libstdcxx
+
           # x64 Cache Images
-          docker buildx imagetools create -t nebulastream/nes-development-base-cache:latest-x64 nebulastream/nes-development-base-cache:${{ github.head_ref }}-x64          
-          docker buildx imagetools create -t nebulastream/nes-development-dependency-cache:latest-x64 nebulastream/nes-development-dependency-cache:${{ github.head_ref }}-x64          
-          docker buildx imagetools create -t nebulastream/nes-development-dependency-cache:latest-x64-libstdcxx nebulastream/nes-development-dependency-cache:${{ github.head_ref }}-x64-libstdcxx          
-          docker buildx imagetools create -t nebulastream/nes-development-cache:latest-x64 nebulastream/nes-development-cache:${{ github.head_ref }}-x64          
-          docker buildx imagetools create -t nebulastream/nes-development-cache:latest-x64-libstdcxx nebulastream/nes-development-cache:${{ github.head_ref }}-x64-libstdcxx          
+          docker buildx imagetools create -t nebulastream/nes-development-base-cache:latest-x64 nebulastream/nes-development-base-cache:${{ github.head_ref }}-x64
+          docker buildx imagetools create -t nebulastream/nes-development-dependency-cache:latest-x64 nebulastream/nes-development-dependency-cache:${{ github.head_ref }}-x64-libcxx
+          docker buildx imagetools create -t nebulastream/nes-development-dependency-cache:latest-x64-libstdcxx nebulastream/nes-development-dependency-cache:${{ github.head_ref }}-x64-libstdcxx
+          docker buildx imagetools create -t nebulastream/nes-development-cache:latest-x64 nebulastream/nes-development-cache:${{ github.head_ref }}-x64-libcxx
+          docker buildx imagetools create -t nebulastream/nes-development-cache:latest-x64-libstdcxx nebulastream/nes-development-cache:${{ github.head_ref }}-x64-libstdcxx


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Image merge CI Job failed because it was using the wrong cache image names.

## Verifying this change

You could run the following script by replacing ${{ github.head_ref }} with the latest branch, e.g. `535-code-coverage-html-script`

```bash
          docker buildx imagetools create -t nebulastream/nes-development-base:latest nebulastream/nes-development-base:${{ github.head_ref }}
          docker buildx imagetools create -t nebulastream/nes-development-dependency:latest nebulastream/nes-development-dependency:${{ github.head_ref }}
          docker buildx imagetools create -t nebulastream/nes-development-dependency:latest-libstdcxx nebulastream/nes-development-dependency:${{ github.head_ref }}-libstdcxx
          docker buildx imagetools create -t nebulastream/nes-development:latest nebulastream/nes-development:${{ github.head_ref }}
          docker buildx imagetools create -t nebulastream/nes-development:latest-libstdcxx nebulastream/nes-development:${{ github.head_ref }}-libstdcxx

          # Arm64 Cache Images
          docker buildx imagetools create -t nebulastream/nes-development-base-cache:latest-arm64 nebulastream/nes-development-base-cache:${{ github.head_ref }}-arm64
          docker buildx imagetools create -t nebulastream/nes-development-dependency-cache:latest-arm64 nebulastream/nes-development-dependency-cache:${{ github.head_ref }}-arm64-libcxx
          docker buildx imagetools create -t nebulastream/nes-development-dependency-cache:latest-arm64-libstdcxx nebulastream/nes-development-dependency-cache:${{ github.head_ref }}-arm64-libstdcxx
          docker buildx imagetools create -t nebulastream/nes-development-cache:latest-arm64 nebulastream/nes-development-cache:${{ github.head_ref }}-arm64-libcxx
          docker buildx imagetools create -t nebulastream/nes-development-cache:latest-arm64-libstdcxx nebulastream/nes-development-cache:${{ github.head_ref }}-arm64-libstdcxx

          # x64 Cache Images
          docker buildx imagetools create -t nebulastream/nes-development-base-cache:latest-x64 nebulastream/nes-development-base-cache:${{ github.head_ref }}-x64
          docker buildx imagetools create -t nebulastream/nes-development-dependency-cache:latest-x64 nebulastream/nes-development-dependency-cache:${{ github.head_ref }}-x64-libcxx
          docker buildx imagetools create -t nebulastream/nes-development-dependency-cache:latest-x64-libstdcxx nebulastream/nes-development-dependency-cache:${{ github.head_ref }}-x64-libstdcxx
          docker buildx imagetools create -t nebulastream/nes-development-cache:latest-x64 nebulastream/nes-development-cache:${{ github.head_ref }}-x64-libcxx
          docker buildx imagetools create -t nebulastream/nes-development-cache:latest-x64-libstdcxx nebulastream/nes-development-cache:${{ github.head_ref }}-x64-libstdcxx
```

## What components does this pull request potentially affect?
CI

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
