### PR TITLE
Introduces new Interface for InputFormatters.

### DIFF
--- a/nes-common/include/ExceptionDefinitions.inc
+++ b/nes-common/include/ExceptionDefinitions.inc
@@ -99,7 +99,7 @@ EXCEPTION(MalformatedTuple, 4001, "malformed tuple")
 EXCEPTION(RunningRoutineFailure, 4002, "error in running routine of SourceThread") ///Todo #237: Improve error handling in sources
 EXCEPTION(StopBeforeStartFailure, 4003, "source was stopped before it was started") ///Todo #237: Improve error handling in sources
 EXCEPTION(CannotOpenSource, 4004, "failed to open a source")
-EXCEPTION(CSVParsingError, 4005, "error during csv parsing")
+EXCEPTION(FormattingError, 4005, "error during formatting")
 EXCEPTION(CannotOpenSink, 4006, "failed to open a sink")
 
 /// 5XXX Network errors

--- a/nes-common/src/Util/Strings.cpp
+++ b/nes-common/src/Util/Strings.cpp
@@ -66,7 +66,7 @@ std::optional<char> from_chars<char>(const std::string_view input)
 }
 
 template <>
-bool from_chars_with_exception(std::string_view input)
+bool from_chars_with_exception<bool>(std::string_view input)
 {
     if (const auto boolValue = from_chars<bool>(input); boolValue.has_value())
     {

--- a/nes-common/src/Util/Strings.cpp
+++ b/nes-common/src/Util/Strings.cpp
@@ -29,6 +29,7 @@
 
 namespace NES::Util
 {
+
 template <>
 std::optional<float> from_chars<float>(const std::string_view input)
 {
@@ -58,6 +59,52 @@ std::optional<bool> from_chars<bool>(const std::string_view input)
     return {};
 }
 
+template <>
+std::optional<char> from_chars<char>(const std::string_view input)
+{
+    return (input.size() == 1) ? std::optional(input.front()) : std::nullopt;
+}
+
+template <>
+bool from_chars_with_exception(std::string_view input)
+{
+    if (const auto boolValue = from_chars<bool>(input); boolValue.has_value())
+    {
+        return boolValue.value();
+    }
+    throw CannotFormatMalformedStringValue("'{}' is not a supported boolean value.", input);
+}
+
+template <>
+float from_chars_with_exception<float>(std::string_view input)
+{
+    if (const auto floatValue = from_chars<float>(input); floatValue.has_value())
+    {
+        return floatValue.value();
+    }
+    throw CannotFormatMalformedStringValue("'{}' is not a supported float value.", input);
+}
+
+template <>
+double from_chars_with_exception<double>(std::string_view input)
+{
+    if (const auto doubleValue = from_chars<double>(input); doubleValue.has_value())
+    {
+        return doubleValue.value();
+    }
+    throw CannotFormatMalformedStringValue("'{}' is not a supported double value.", input);
+}
+
+template <>
+char from_chars_with_exception<char>(std::string_view input)
+{
+    if (const auto charValue = from_chars<char>(input); charValue.has_value())
+    {
+        return charValue.value();
+    }
+    throw CannotFormatMalformedStringValue("'{}' is not a supported char value.", input);
+}
+
 std::string formatFloat(std::floating_point auto value)
 {
     std::string formatted = fmt::format("{:.6f}", value);
@@ -75,9 +122,6 @@ std::string formatFloat(std::floating_point auto value)
 
     return formatted.substr(0, lastNonZero + 1);
 }
-/// explicit instantiations
-template std::string formatFloat(float);
-template std::string formatFloat(double);
 
 template <>
 std::optional<double> from_chars<double>(const std::string_view input)
@@ -92,6 +136,10 @@ std::optional<double> from_chars<double>(const std::string_view input)
         return {};
     }
 }
+
+/// explicit instantiations
+template std::string formatFloat(float);
+template std::string formatFloat(double);
 
 template <>
 std::optional<std::string> from_chars<std::string>(const std::string_view input)

--- a/nes-executable/tests/TestUtils/TestTaskQueue.hpp
+++ b/nes-executable/tests/TestUtils/TestTaskQueue.hpp
@@ -118,12 +118,12 @@ private:
 
 /// Represents a single ExecutablePipelineStage with multiple functions ('taskSteps').
 /// Executes all 'taskSteps' in its 'execute' function.
-class TestablePipelineStage : public ExecutablePipelineStage
+class TestPipelineStage : public ExecutablePipelineStage
 {
 public:
     using ExecuteFunction = std::function<void(const Memory::TupleBuffer&, PipelineExecutionContext&)>;
-    TestablePipelineStage() = default;
-    TestablePipelineStage(const std::string& stepName, ExecuteFunction testTask) { addStep(stepName, std::move(testTask)); }
+    TestPipelineStage() = default;
+    TestPipelineStage(const std::string& stepName, ExecuteFunction testTask) { addStep(stepName, std::move(testTask)); }
 
     void addStep(const std::string& stepName, ExecuteFunction testTask) { taskSteps.emplace_back(stepName, std::move(testTask)); }
 
@@ -139,14 +139,14 @@ private:
 };
 
 /// Maps a pipeline task to a specific worker thread and therefore allows a test task queue to execute a specific task on a specific worker.
-struct TestablePipelineTask
+struct TestPipelineTask
 {
-    TestablePipelineTask() : workerThreadId(WorkerThreadId(WorkerThreadId::INVALID)) { };
-    TestablePipelineTask(const WorkerThreadId workerThreadId, Memory::TupleBuffer tupleBuffer, std::shared_ptr<ExecutablePipelineStage> eps)
+    TestPipelineTask() : workerThreadId(WorkerThreadId(WorkerThreadId::INVALID)) { };
+    TestPipelineTask(const WorkerThreadId workerThreadId, Memory::TupleBuffer tupleBuffer, std::shared_ptr<ExecutablePipelineStage> eps)
         : workerThreadId(workerThreadId), tupleBuffer(std::move(tupleBuffer)), eps(std::move(eps))
     {
     }
-    TestablePipelineTask(const WorkerThreadId workerThreadId, std::shared_ptr<ExecutablePipelineStage> eps)
+    TestPipelineTask(const WorkerThreadId workerThreadId, std::shared_ptr<ExecutablePipelineStage> eps)
         : workerThreadId(workerThreadId), eps(std::move(eps))
     {
     }
@@ -161,7 +161,7 @@ struct TestablePipelineTask
 
 struct WorkTask
 {
-    TestablePipelineTask task;
+    TestPipelineTask task;
     std::shared_ptr<TestPipelineExecutionContext> pipelineExecutionContext;
 };
 
@@ -178,7 +178,7 @@ public:
     ~SingleThreadedTestTaskQueue() = default;
 
     /// Sequentially processes pipeline tasks on respective threads. Stops all threads.
-    void processTasks(std::vector<TestablePipelineTask> pipelineTasks);
+    void processTasks(std::vector<TestPipelineTask> pipelineTasks);
 
 private:
     std::queue<WorkTask> tasks;
@@ -188,7 +188,7 @@ private:
     std::shared_ptr<ExecutablePipelineStage> eps;
 
     /// Sets up all tasks for the threads.
-    void enqueueTasks(std::vector<TestablePipelineTask> pipelineTasks);
+    void enqueueTasks(std::vector<TestPipelineTask> pipelineTasks);
     /// Executes tasks on respective threads.
     void runTasks();
 };
@@ -200,7 +200,7 @@ class MultiThreadedTestTaskQueue
 public:
     MultiThreadedTestTaskQueue(
         size_t numberOfThreads,
-        const std::vector<TestablePipelineTask>& testTasks,
+        const std::vector<TestPipelineTask>& testTasks,
         std::shared_ptr<Memory::AbstractBufferProvider> bufferProvider,
         std::shared_ptr<std::vector<std::vector<Memory::TupleBuffer>>> resultBuffers);
 

--- a/nes-input-formatters/CMakeLists.txt
+++ b/nes-input-formatters/CMakeLists.txt
@@ -21,7 +21,7 @@ get_source(nes-input-formatters NES_SOURCE_PARSERS_SOURCE_FILES)
 add_library(nes-input-formatters ${NES_SOURCE_PARSERS_SOURCE_FILES})
 
 # Exposing TupleBuffer (nes-memory) and PipelineExecutionContext (nes-executable) from public APIs
-target_link_libraries(nes-input-formatters PUBLIC nes-memory nes-executable PRIVATE nes-common nes-configurations nes-runtime)
+target_link_libraries(nes-input-formatters PUBLIC nes-memory nes-executable PRIVATE nes-common nes-configurations nes-runtime nes-executable)
 
 target_include_directories(nes-input-formatters PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/nes-input-formatters/include/InputFormatters/InputFormatter.hpp
+++ b/nes-input-formatters/include/InputFormatters/InputFormatter.hpp
@@ -14,21 +14,27 @@
 
 #pragma once
 
-#include <cstddef>
-#include <memory>
 #include <ostream>
-#include <Identifiers/Identifiers.hpp>
-#include <Runtime/TupleBuffer.hpp>
-#include <PipelineExecutionContext.hpp>
+#include <string_view>
+
+#include <InputFormatters/InputFormatterTask.hpp>
 
 namespace NES::InputFormatters
 {
-/// Forward referencing SequenceShredder to keep it as a private implementation detail of nes-input-formatters
-class SequenceShredder;
-
+/// Implements format-specific (CSV, JSON, Protobuf, etc.) indexing of raw buffers.
+/// The InputFormatterTask uses the InputFormatter to determine byte offsets of all fields of a given tuple and all tuples of a given buffer.
+/// The offsets allow the InputFormatterTask to parse only the fields that it needs to for the particular query.
+/// @Note All InputFormatter implementations must be thread-safe. NebulaStream's query engine concurrently executes InputFormatterTasks.
+///       Thus, the InputFormatterTask calls the interface functions of the InputFormatter concurrently.
 class InputFormatter
 {
 public:
+    struct FirstAndLastTupleDelimiterOffsets
+    {
+        /// If the offsetOfFirstTupleDelimiter is >= size of the raw buffer, the InputFormatterTask assumes there is no tuple delimiter in the buffer
+        FieldOffsetsType offsetOfFirstTupleDelimiter;
+        FieldOffsetsType offsetOfLastTupleDelimiter;
+    };
     InputFormatter() = default;
     virtual ~InputFormatter() = default;
 
@@ -37,22 +43,16 @@ public:
     InputFormatter(InputFormatter&&) = delete;
     InputFormatter& operator=(InputFormatter&&) = delete;
 
-    /// Must only manipulate the sequenceShredder and otherwise be free of side-effects
-    virtual void parseTupleBufferRaw(
-        const NES::Memory::TupleBuffer& rawTB,
-        NES::PipelineExecutionContext& pipelineExecutionContext,
-        size_t numBytesInRawTB,
-        SequenceShredder& sequenceShredder)
-        = 0;
+    /// Determines the byte-offsets to all fields in one tuple, including the offset to the first byte that is not part of the tuple.
+    /// Must write all offsets to the correct position to the fieldOffsets pointer.
+    /// @Note Must be thread-safe (see description of class)
+    virtual void indexTuple(std::string_view tuple, FieldOffsetsType* fieldOffsets, FieldOffsetsType startIdxOfTuple) const = 0;
 
-    /// Since there is no symbol that represents EoF/EoS, the final buffer does not end in a tuple delimiter. We need to 'manually' flush
-    /// the final tuple, between the last tuple delimiter of the final buffer and (including) the last byte of the final buffer.
-    virtual void
-    flushFinalTuple(OriginId originId, NES::PipelineExecutionContext& pipelineExecutionContext, SequenceShredder& sequenceShredder)
-        = 0;
-
-    virtual size_t getSizeOfTupleDelimiter() = 0;
-    virtual size_t getSizeOfFieldDelimiter() = 0;
+    /// Determines the byte-offsets to all fields in one buffer.
+    /// Must write all offsets to the correct position to the fieldOffsets pointer.
+    /// @return the bytes-offset to the first and last tuple delimiter (we use these offsets to construct tuples that span buffers (see SequenceShredder))
+    /// @Note Must be thread-safe (see description of class)
+    virtual FirstAndLastTupleDelimiterOffsets indexBuffer(std::string_view bufferView, FieldOffsets& fieldOffsets) const = 0;
 
     friend std::ostream& operator<<(std::ostream& os, const InputFormatter& inputFormatter) { return inputFormatter.toString(os); }
 

--- a/nes-input-formatters/include/InputFormatters/InputFormatterProvider.hpp
+++ b/nes-input-formatters/include/InputFormatters/InputFormatterProvider.hpp
@@ -15,14 +15,15 @@
 #pragma once
 
 #include <memory>
-#include <string>
+
 #include <DataTypes/Schema.hpp>
-#include <InputFormatters/InputFormatter.hpp>
+#include <Identifiers/Identifiers.hpp>
+#include <InputFormatters/InputFormatterTask.hpp>
+#include <Sources/SourceDescriptor.hpp>
 
 namespace NES::InputFormatters::InputFormatterProvider
 {
-std::unique_ptr<InputFormatter>
-provideInputFormatter(const std::string& parserType, const Schema& schema, std::string tupleDelimiter, std::string fieldDelimiter);
+std::unique_ptr<InputFormatterTask> provideInputFormatterTask(OriginId originId, const Schema& schema, const ParserConfig& config);
 
 bool contains(const std::string& parserType);
 }

--- a/nes-input-formatters/include/InputFormatters/InputFormatterTask.hpp
+++ b/nes-input-formatters/include/InputFormatters/InputFormatterTask.hpp
@@ -75,7 +75,7 @@ public:
 
     void start(PipelineExecutionContext&) override { /* noop */ }
 
-    /// Attempts to flush out a final (spanning) tuple that ends in the last byte of the last seen raw buffer.
+    /// Logs the final state of the SequenceShredder.
     void stop(PipelineExecutionContext&) override;
 
     /// (concurrently) executes an InputFormatterTask.
@@ -126,7 +126,6 @@ private:
     /// Second, appends all bytes of all raw buffers that are not the last buffer to the spanning tuple.
     /// Third, determines the end of the spanning tuple in the last buffer to format. Appends the required bytes to the spanning tuple.
     /// Lastly, formats the full spanning tuple.
-    template <bool IsFlush = false>
     void processSpanningTuple(
         const SpanningTuple& spanningTuple,
         const std::vector<StagedBuffer>& buffersToFormat,

--- a/nes-input-formatters/include/InputFormatters/InputFormatterTask.hpp
+++ b/nes-input-formatters/include/InputFormatters/InputFormatterTask.hpp
@@ -13,26 +13,59 @@
 */
 #pragma once
 
+#include <cstdint>
+#include <memory>
 #include <ostream>
+#include <string>
+#include <string_view>
+#include <vector>
+#include <DataTypes/Schema.hpp>
 #include <Identifiers/Identifiers.hpp>
-#include <InputFormatters/InputFormatter.hpp>
+#include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Util/Logger/Formatter.hpp>
+#include <Sources/SourceDescriptor.hpp>
 #include <ExecutablePipelineStage.hpp>
 #include <PipelineExecutionContext.hpp>
 
 namespace NES::InputFormatters
 {
+/// The type that all formatters use to represent indexes to fields.
+using FieldOffsetsType = uint32_t;
 
-/// Forward referencing SequenceShredder to keep it as a private implementation detail of nes-input-formatters
+/// Forward referencing SequenceShredder/InputFormatter/FieldOffsets to keep it as a private implementation detail of nes-input-formatters
 class SequenceShredder;
+class InputFormatter;
+class FieldOffsets;
+/// Data structures of private classes (or containing types of private classes)
+struct RawBufferData;
+struct SpanningTuple;
+struct StagedBuffer;
 
+namespace RawInputDataParser
+{
+struct FieldConfig;
+}
 
-/// Takes tuple buffers with raw bytes (TBRaw/TBR), parses the TBRs and writes the formatted data to formatted tuple buffers (TBFormatted/TBF)
-class InputFormatterTask : public NES::ExecutablePipelineStage
+/// TODO #496: Implement InputFormatterTask a Nautilus Operator (CompiledExecutablePipelineStage/Special Scan)
+/// -> figure out how to best call SequenceShredder and handle return values of SequenceShredder
+/// -> figure out how to best process spanning tuples (currently we use a string to allocate memory)
+/// -> convert FieldOffsetIterator to Nautilus data structure
+/// -> implement CSVInputFormatter as Nautilus operator/function
+/// (potentially make heavy use of proxy functions first)
+
+/// InputFormatterTasks concurrently take (potentially) raw input buffers and format all full tuples in these raw input buffers that the
+/// individual InputFormatterTasks see during execution.
+/// The only point of synchronization is a call to the SequenceShredder data structure, which determines which buffers the InputFormatterTask
+/// needs to process (resolving tuples that span multiple raw buffers).
+/// An InputFormatterTask belongs to exactly one source. The source reads raw data into buffers, constructs a Task from the
+/// raw buffer and its successor (the InputFormatterTask) and writes it to the task queue of the QueryEngine.
+/// The QueryEngine concurrently executes InputFormatterTasks. Thus, even if the source writes the InputFormatterTasks to the task queue sequentially,
+/// the QueryEngine may still execute them in any order.
+class InputFormatterTask final : public ExecutablePipelineStage
 {
 public:
-    explicit InputFormatterTask(OriginId originId, std::unique_ptr<InputFormatter> inputFormatter);
+    explicit InputFormatterTask(
+        OriginId originId, std::unique_ptr<InputFormatter> inputFormatter, const Schema& schema, const ParserConfig& parserConfig);
     ~InputFormatterTask() override;
 
     InputFormatterTask(const InputFormatterTask&) = delete;
@@ -41,18 +74,70 @@ public:
     InputFormatterTask& operator=(InputFormatterTask&&) = delete;
 
     void start(PipelineExecutionContext&) override { /* noop */ }
+
+    /// Attempts to flush out a final (spanning) tuple that ends in the last byte of the last seen raw buffer.
     void stop(PipelineExecutionContext&) override;
-    void execute(const Memory::TupleBuffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext) override;
+
+    /// (concurrently) executes an InputFormatterTask.
+    /// First, uses the concrete input formatter implementation to determine the indexes of all fields of all full tuples.
+    /// Second, uses the SequenceShredder to find spanning tuples.
+    /// Third, processes (leading) spanning tuple and if it contains at least two tuple delimiters and therefore one complete tuple,
+    /// process all complete tuples and trailing spanning tuple.
+    void execute(const Memory::TupleBuffer& rawBuffer, PipelineExecutionContext& pec) override;
 
     std::ostream& toString(std::ostream& os) const override;
 
 private:
     OriginId originId;
-    /// Synchronizes between different InputFormatterTasks (see documentation of class for details)
-    std::unique_ptr<SequenceShredder> sequenceShredder;
-    /// TODO #679: realize below comment
-    /// Implements the format-specific functions to determine the offsets of fields, as well as format-specific parsing functions of fields
     std::unique_ptr<InputFormatter> inputFormatter;
+    std::unique_ptr<SequenceShredder> sequenceShredder;
+    std::vector<RawInputDataParser::FieldConfig> fieldConfigs;
+    std::string tupleDelimiter;
+    std::string fieldDelimiter;
+    const uint32_t numberOfFieldsInSchema;
+    uint32_t sizeOfTupleInBytes;
+
+    /// Called by processRawBufferWithTupleDelimiter if the raw buffer contains at least one full tuple.
+    /// Iterates over all full tuples, using the indexes in FieldOffsets and parses the tuples into formatted data.
+    void processRawBuffer(
+        const RawBufferData& bufferData,
+        NES::ChunkNumber::Underlying& runningChunkNumber,
+        FieldOffsets& fieldOffsets,
+        NES::Memory::TupleBuffer& formattedBuffer,
+        PipelineExecutionContext& pec) const;
+
+    /// Called by execute if the buffer delimits at least two tuples.
+    /// First, processes the leading spanning tuple, if the raw buffer completed it.
+    /// Second, processes the raw buffer, if it contains at least one full tuple.
+    /// Third, processes the trailing spanning tuple, if the raw buffer completed it.
+    void processRawBufferWithTupleDelimiter(
+        const RawBufferData& bufferData,
+        ChunkNumber::Underlying& runningChunkNumber,
+        FieldOffsets& fieldOffsets,
+        PipelineExecutionContext& pec) const;
+
+    /// Called by execute, if the buffer does not delimit any tuples.
+    /// Processes a spanning tuple, if the raw buffer connects two raw buffers that delimit tuples.
+    void processRawBufferWithoutTupleDelimiter(
+        const RawBufferData& bufferData, ChunkNumber::Underlying& runningChunkNumber, PipelineExecutionContext& pec) const;
+
+    /// Constructs a spanning tuple (string) that spans over at least two buffers (buffersToFormat).
+    /// First, determines the start of the spanning tuple in the first buffer to format. Constructs a spanning tuple from the required bytes.
+    /// Second, appends all bytes of all raw buffers that are not the last buffer to the spanning tuple.
+    /// Third, determines the end of the spanning tuple in the last buffer to format. Appends the required bytes to the spanning tuple.
+    /// Lastly, formats the full spanning tuple.
+    template <bool IsFlush = false>
+    void processSpanningTuple(
+        const SpanningTuple& spanningTuple,
+        const std::vector<StagedBuffer>& buffersToFormat,
+        Memory::AbstractBufferProvider& bufferProvider,
+        Memory::TupleBuffer& formattedBuffer) const;
+
+    void processTuple(
+        std::string_view tuple,
+        const FieldOffsetsType* fieldIndexes,
+        Memory::AbstractBufferProvider& bufferProvider,
+        Memory::TupleBuffer& formattedBuffer) const;
 };
 
 

--- a/nes-input-formatters/private/CSVInputFormatter.hpp
+++ b/nes-input-formatters/private/CSVInputFormatter.hpp
@@ -15,81 +15,37 @@
 #pragma once
 
 #include <cstddef>
-#include <cstdint>
-#include <functional>
-#include <memory>
 #include <ostream>
-#include <string>
 #include <string_view>
-#include <vector>
-#include <DataTypes/Schema.hpp>
-#include <Identifiers/Identifiers.hpp>
+
 #include <InputFormatters/InputFormatter.hpp>
-#include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
-#include <PipelineExecutionContext.hpp>
-#include <SequenceShredder.hpp>
+#include <InputFormatters/InputFormatterTask.hpp>
+#include <Sources/SourceDescriptor.hpp>
+#include <InputFormatterRegistry.hpp>
 
 namespace NES::InputFormatters
 {
 
-/// Implementation detail of CSVInputFormatter
-class ProgressTracker;
-
-/// TODO #679: Major refactoring of CSVInputFormatter (see issue description for details)
 class CSVInputFormatter final : public InputFormatter
 {
-private:
-    enum class FormattedTupleIs : uint8_t
-    {
-        EMTPY = 0,
-        NOT_EMPTY = 1,
-    };
-
 public:
-    using CastFunctionSignature = std::function<void(
-        std::string inputString,
-        int8_t* fieldPointer,
-        Memory::AbstractBufferProvider& bufferProvider,
-        Memory::TupleBuffer& tupleBufferFormatted)>;
-
-    CSVInputFormatter(const Schema& schema, std::string tupleDelimiter, std::string fieldDelimiter);
-    ~CSVInputFormatter() override; /// needs implementation in source file to allow for forward declaring 'InputFormatter'
+    explicit CSVInputFormatter(InputFormatterRegistryArguments args);
+    ~CSVInputFormatter() override = default;
 
     CSVInputFormatter(const CSVInputFormatter&) = delete;
     CSVInputFormatter& operator=(const CSVInputFormatter&) = delete;
     CSVInputFormatter(CSVInputFormatter&&) = delete;
     CSVInputFormatter& operator=(CSVInputFormatter&&) = delete;
 
-    void parseTupleBufferRaw(
-        const Memory::TupleBuffer& rawTB,
-        PipelineExecutionContext& pipelineExecutionContext,
-        size_t numBytesInRawTB,
-        SequenceShredder& sequenceShredder) override;
+    void indexTuple(std::string_view tuple, FieldOffsetsType* fieldOffsets, FieldOffsetsType startIdxOfTuple) const override;
 
-    /// Currently allocates new buffer if there is a trailing tuple. Would require keeping state between potentially different threads otherwise,
-    /// since the stop call of the InputFormatterTask (pipeline) triggers the flush call.
-    void
-    flushFinalTuple(OriginId originId, PipelineExecutionContext& pipelineExecutionContext, SequenceShredder& sequenceShredder) override;
-
-    size_t getSizeOfTupleDelimiter() override;
-    size_t getSizeOfFieldDelimiter() override;
+    FirstAndLastTupleDelimiterOffsets indexBuffer(std::string_view bufferView, FieldOffsets& fieldOffsets) const override;
 
     [[nodiscard]] std::ostream& toString(std::ostream& str) const override;
 
 private:
-    const Schema schema;
-    const std::string fieldDelimiter;
-    const std::string tupleDelimiter;
-    std::vector<size_t> fieldSizes;
-    std::vector<CastFunctionSignature> fieldParseFunctions;
-
-    FormattedTupleIs processPartialTuple(
-        const size_t partialTupleStartIdx,
-        const size_t partialTupleEndIdx,
-        const std::vector<SequenceShredder::StagedBuffer>& buffersToFormat,
-        ProgressTracker& progressTracker,
-        PipelineExecutionContext& pipelineExecutionContext);
+    ParserConfig config;
+    size_t numberOfFieldsInSchema;
 };
 
 }

--- a/nes-input-formatters/private/FieldOffsets.hpp
+++ b/nes-input-formatters/private/FieldOffsets.hpp
@@ -1,0 +1,88 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+
+#include <InputFormatters/InputFormatterTask.hpp>
+#include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/TupleBuffer.hpp>
+
+namespace NES::InputFormatters
+{
+
+/// TODO #496: Implement as Nautilus data structure
+/// The FieldOffsets data structure allows input formatters to write field offsets into a tuple buffer.
+/// After the input formatter finishes calculating offsets to fields, the InputFormatterTask finalizes the offset calculation,
+/// resets the FieldOffsets, and parses each required field.
+class FieldOffsets
+{
+    static constexpr size_t NUMBER_OF_RESERVED_FIELDS = 2; /// layout: [numberOfTuples | indexToChildBuffer | filedOffsets ...]
+    static constexpr size_t NUMBER_OF_RESERVED_BYTES = NUMBER_OF_RESERVED_FIELDS * sizeof(FieldOffsetsType);
+    static constexpr size_t OFFSET_OF_TOTAL_NUMBER_OF_TUPLES = 0;
+    static constexpr size_t OFFSET_OF_INDEX_TO_CHILD_BUFFER = 1;
+
+public:
+    /// Gets AbstractBufferProvider* from InputFormatterTask, which constructs the
+    /// FieldOffsets object and is guaranteed to outlive it.
+    FieldOffsets(
+        size_t numberOfFieldsInSchema, size_t sizeOfFormattedBufferInBytes, std::shared_ptr<Memory::AbstractBufferProvider> bufferProvider);
+
+    ~FieldOffsets() = default;
+
+    FieldOffsets(const FieldOffsets&) = default;
+    FieldOffsets& operator=(const FieldOffsets&) = delete;
+    FieldOffsets(FieldOffsets&&) = delete;
+    FieldOffsets& operator=(FieldOffsets&&) = delete;
+
+    /// Assures that there is space to write one more tuple and returns a pointer to write the field offsets (of one tuple) to.
+    /// @Note expects that users of function write 'number of fields in schema + 1' offsets to pointer, manually incrementing the pointer by one for each offset.
+    [[nodiscard]] FieldOffsetsType* writeOffsetsOfNextTuple();
+
+    /// Returns a pointer to field offsets for one tuple that are consecutive in memory.
+    /// @Note expects that users of function read 'number of fields in schema + 1' offsets from pointer, manually incrementing the pointer by one fo reach offset.
+    [[nodiscard]] FieldOffsetsType* readOffsetsOfNextTuple();
+
+    /// Resets the indexes and pointers, calculates and sets the number of tuples in the current buffer, returns the total number of tuples.
+    [[nodiscard]] size_t finishWrite();
+
+
+private:
+    size_t currentIndex;
+    size_t numberOfFieldsInSchema;
+    size_t maxNumberOfTuplesInFormattedBuffer;
+    size_t maxIndex;
+    size_t totalNumberOfTuples;
+    Memory::TupleBuffer rootFieldOffsetBuffer;
+    std::shared_ptr<Memory::AbstractBufferProvider> bufferProvider;
+    Memory::TupleBuffer currentFieldOffsetBuffer;
+
+    /// Sets the metadata for the current buffer, uses the buffer provider to get a new buffer.
+    void allocateNewChildBuffer();
+
+    /// Called by 'writeNextTuple'/'readNextTuple'
+    /// (write) allocates a new buffer, if the current buffer does not have space for one more tuple
+    /// (read) moves pointer to next buffer, if the current buffer does not hold another tuple
+    FieldOffsetsType* processTuple(const std::function<void()>& handleOutOfSpaceFn);
+
+    /// We always add 1 to the number of tuples, because we represent an overfull buffer as the max number of tuples + 1.
+    /// When iterating over the index buffers, we always deduct 1 from the number of tuples, yielding the correct number of tuples in both cases
+    /// (overfull, not overfull)
+    inline void setNumberOfRawTuples(FieldOffsetsType numberOfTuples);
+};
+
+}

--- a/nes-input-formatters/private/RawInputDataParser.hpp
+++ b/nes-input-formatters/private/RawInputDataParser.hpp
@@ -56,5 +56,5 @@ auto parseFieldString()
 ParseFunctionSignature getBasicStringParseFunction();
 
 /// Takes a vector containing parse function for fields. Adds a parse function that parses a basic NebulaStream type to the vector.
-ParseFunctionSignature getBasicTypeParseFunction(const DataType::Type physicalType);
+ParseFunctionSignature getBasicTypeParseFunction(DataType::Type physicalType);
 }

--- a/nes-input-formatters/private/RawInputDataParser.hpp
+++ b/nes-input-formatters/private/RawInputDataParser.hpp
@@ -1,0 +1,60 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string_view>
+
+#include <DataTypes/DataType.hpp>
+#include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/TupleBuffer.hpp>
+#include <Util/Strings.hpp>
+
+namespace NES::InputFormatters::RawInputDataParser
+{
+
+using ParseFunctionSignature = std::function<void(
+    std::string_view inputString,
+    int8_t* fieldPointer,
+    Memory::AbstractBufferProvider& bufferProvider,
+    Memory::TupleBuffer& tupleBufferFormatted)>;
+
+struct FieldConfig
+{
+    size_t fieldSize;
+    ParseFunctionSignature parseFunction;
+};
+
+/// Takes a target integer type and an integer value represented as a string. Attempts to parse the string to a C++ integer of the target type.
+/// @Note throws CannotFormatMalformedStringValue if the parsing fails.
+/// @Note given a string like '0751' and an integer value, from_chars creates an integer '751' from it. Also, '0.751' becomes '0'.
+template <typename T>
+auto parseFieldString()
+{
+    return [](const std::string_view fieldValueString, int8_t* fieldPointer, Memory::AbstractBufferProvider&, Memory::TupleBuffer&)
+    {
+        auto* value = reinterpret_cast<T*>(fieldPointer); ///NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+        *value = Util::from_chars_with_exception<T>(fieldValueString);
+    };
+}
+
+/// Takes a vector containing parse function for fields. Adds a parse function that parses strings to the vector.
+ParseFunctionSignature getBasicStringParseFunction();
+
+/// Takes a vector containing parse function for fields. Adds a parse function that parses a basic NebulaStream type to the vector.
+ParseFunctionSignature getBasicTypeParseFunction(const DataType::Type physicalType);
+}

--- a/nes-input-formatters/registry/include/InputFormatterRegistry.hpp
+++ b/nes-input-formatters/registry/include/InputFormatterRegistry.hpp
@@ -14,10 +14,12 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <string>
-#include <DataTypes/Schema.hpp>
+
 #include <InputFormatters/InputFormatter.hpp>
+#include <Sources/SourceDescriptor.hpp>
 #include <Util/Registry.hpp>
 
 namespace NES::InputFormatters
@@ -27,9 +29,8 @@ using InputFormatterRegistryReturnType = std::unique_ptr<InputFormatter>;
 /// A InputFormatter requires a schema, a tuple separator and a field delimiter.
 struct InputFormatterRegistryArguments
 {
-    Schema schema;
-    std::string tupleDelimiter;
-    std::string fieldDelimiter;
+    ParserConfig inputFormatterConfig;
+    size_t numberOfFieldsInSchema;
 };
 
 class InputFormatterRegistry

--- a/nes-input-formatters/src/CMakeLists.txt
+++ b/nes-input-formatters/src/CMakeLists.txt
@@ -15,6 +15,8 @@ add_source_files(nes-input-formatters
         CSVInputFormatter.cpp
         InputFormatterProvider.cpp
         SequenceShredder.cpp
+        RawInputDataParser.cpp
+        FieldOffsets.cpp
 )
 
 # Register plugins

--- a/nes-input-formatters/src/CSVInputFormatter.cpp
+++ b/nes-input-formatters/src/CSVInputFormatter.cpp
@@ -14,649 +14,105 @@
 
 #include <CSVInputFormatter.hpp>
 
-#include <charconv>
+#include <CSVInputFormatter.hpp>
 #include <cstddef>
 #include <cstdint>
-#include <cstring>
-#include <functional>
-#include <iostream>
 #include <limits>
 #include <memory>
 #include <ostream>
-#include <ranges>
 #include <string>
 #include <string_view>
-#include <system_error>
 #include <utility>
-#include <vector>
-#include <strings.h>
-#include <DataTypes/DataType.hpp>
-#include <DataTypes/Schema.hpp>
-#include <Identifiers/Identifiers.hpp>
+
 #include <InputFormatters/InputFormatter.hpp>
 #include <InputFormatters/InputFormatterTask.hpp>
-#include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Sources/SourceDescriptor.hpp>
 #include <Util/Logger/Logger.hpp>
-#include <boost/token_functions.hpp>
-#include <boost/tokenizer.hpp>
 #include <fmt/format.h>
 #include <magic_enum/magic_enum.hpp>
 #include <ErrorHandling.hpp>
+#include <FieldOffsets.hpp>
 #include <InputFormatterRegistry.hpp>
-#include <PipelineExecutionContext.hpp>
-#include <SequenceShredder.hpp>
 
 namespace NES::InputFormatters
 {
 
-struct PartialTuple
+CSVInputFormatter::CSVInputFormatter(InputFormatterRegistryArguments args)
+    : config(std::move(args.inputFormatterConfig)), numberOfFieldsInSchema(args.numberOfFieldsInSchema)
 {
-    uint64_t offsetInBuffer;
-    Memory::TupleBuffer rawTB;
-
-    [[nodiscard]] std::string_view getStringView() const
-    {
-        return {rawTB.getBuffer<const char>() + offsetInBuffer, rawTB.getBufferSize() - offsetInBuffer};
-    }
-};
-
-class ProgressTracker
-{
-public:
-    ProgressTracker(
-        SequenceNumber sequenceNumber,
-        const OriginId originId,
-        std::string tupleDelimiter,
-        const size_t tupleSizeInBytes,
-        const size_t numberOfSchemaFields)
-        : sequenceNumber(sequenceNumber)
-        , chunkNumber(ChunkNumber(1))
-        , originId(originId)
-        , tupleDelimiter(std::move(tupleDelimiter))
-        , tupleSizeInBytes(tupleSizeInBytes)
-        , numSchemaFields(numberOfSchemaFields) { };
-
-    ~ProgressTracker() = default;
-
-    void resetForNewRawTB(
-        const size_t sizeOfNewTupleBufferRawInBytes, const char* newTupleBufferRaw, const size_t startOffset, const size_t endOffset)
-    {
-        this->numTotalBytesInrawTB = sizeOfNewTupleBufferRawInBytes;
-        this->currentTupleStartrawTB = startOffset;
-        this->endOfTuplesInRawTB = (endOffset == 0) ? sizeOfNewTupleBufferRawInBytes : endOffset + tupleSizeInBytes;
-        this->tupleBufferRawSV = std::string_view(newTupleBufferRaw, numTotalBytesInrawTB);
-        this->currentTupleEndrawTB = findIndexOfNextTuple();
-    }
-
-    void resetForNewRawTB(
-        const size_t sizeOfNewTupleBufferRawInBytes,
-        const char* newTupleBufferRaw,
-        const size_t startOffset,
-        const size_t endOffset,
-        const size_t currentFieldOffsetTBFormatted)
-    {
-        this->numTotalBytesInrawTB = sizeOfNewTupleBufferRawInBytes;
-        this->currentTupleStartrawTB = startOffset;
-        this->endOfTuplesInRawTB = (endOffset == 0) ? sizeOfNewTupleBufferRawInBytes : endOffset + tupleSizeInBytes;
-        this->currentFieldOffsetTBFormatted = currentFieldOffsetTBFormatted;
-        this->tupleBufferRawSV = std::string_view(newTupleBufferRaw, numTotalBytesInrawTB);
-        this->currentTupleEndrawTB = findIndexOfNextTuple();
-        this->numTuplesInTBFormatted = 0;
-    }
-
-    int8_t* getCurrentFieldPointer() { return (this->tupleBufferFormatted.getBuffer() + currentFieldOffsetTBFormatted); }
-
-    [[nodiscard]] size_t getOffsetOfFirstTupleDelimiter() const { return currentTupleEndrawTB; }
-    [[nodiscard]] size_t getOffsetOfLastTupleDelimiter() const
-    {
-        return tupleBufferRawSV.rfind(tupleDelimiter, tupleBufferRawSV.size() - 1);
-    }
-
-
-    void processCurrentTuple(
-        std::string_view currentTuple,
-        const std::string& fieldDelimiter,
-        const std::vector<CSVInputFormatter::CastFunctionSignature>& fieldParseFunctions,
-        const std::vector<size_t>& fieldSizes,
-        Memory::AbstractBufferProvider& bufferProvider)
-    {
-        const boost::char_separator sep{fieldDelimiter.c_str()};
-        const boost::tokenizer tupleTokenizer{currentTuple.begin(), currentTuple.end(), sep};
-        /// Iterate over all fields, parse the string values and write the formatted data into the TBF.
-        for (auto [token, parseFunction, fieldSize] : std::views::zip(tupleTokenizer, fieldParseFunctions, fieldSizes))
-        {
-            const auto fieldPointer = this->tupleBufferFormatted.getBuffer() + currentFieldOffsetTBFormatted;
-            parseFunction(token, fieldPointer, bufferProvider, getTupleBufferFormatted());
-            currentFieldOffsetTBFormatted += fieldSize;
-        }
-    }
-
-    void checkAndHandleFullBuffer(PipelineExecutionContext& pipelineExecutionContext)
-    {
-        const auto availableBytes = tupleBufferFormatted.getBufferSize() - currentFieldOffsetTBFormatted;
-        if (const auto isFull = availableBytes < tupleSizeInBytes)
-        {
-            /// Emit TBF and get new TBF
-            setNumberOfTuplesInTBFormatted();
-            NES_TRACE("emitting TupleBuffer with {} tuples.", numTuplesInTBFormatted);
-
-            /// As we are not done with the current sequence number, we need to emit the TBF with the lastChunk flag set to false.
-            auto tbf = getTupleBufferFormatted();
-            tbf.setLastChunk(false);
-            pipelineExecutionContext.emitBuffer(tbf, NES::PipelineExecutionContext::ContinuationPolicy::POSSIBLE);
-
-
-            /// We need to increment the chunk number as we are not done with the current sequence number.
-            chunkNumber = ChunkNumber(chunkNumber.getRawValue() + 1);
-            setNewTupleBufferFormatted(pipelineExecutionContext.allocateTupleBuffer());
-            currentFieldOffsetTBFormatted = 0;
-            numTuplesInTBFormatted = 0;
-        }
-    }
-
-    void processCurrentBuffer(
-        PipelineExecutionContext& pipelineExecutionContext,
-        const std::string& fieldDelimiter,
-        const std::vector<CSVInputFormatter::CastFunctionSignature>& fieldParseFunctions,
-        const std::vector<size_t>& fieldSizes)
-    {
-        auto& bufferProvider = *pipelineExecutionContext.getBufferManager();
-
-        while (hasOneMoreTupleInRawTB())
-        {
-            /// If we parsed a (prior) partial tuple before, the TBF may not fit another tuple. We emit the single (prior) partial tuple.
-            /// Otherwise, the TBF is empty. Since we assume that a tuple is never bigger than a TBF, we can fit at least one more tuple.
-            checkAndHandleFullBuffer(pipelineExecutionContext);
-
-            /// Get next tuple
-            const auto currentTuple = getNextTuple();
-            /// Parse fields of tuple
-            processCurrentTuple(currentTuple, fieldDelimiter, fieldParseFunctions, fieldSizes, bufferProvider);
-
-            /// Progress one tuple
-            progressOneTuple();
-        }
-    }
-    [[nodiscard]] bool hasOneMoreTupleInRawTB() const { return currentTupleEndrawTB != std::numeric_limits<uint64_t>::max(); }
-
-    [[nodiscard]] size_t sizeOfCurrentTuple() const { return this->currentTupleEndrawTB - this->currentTupleStartrawTB; }
-
-    void progressOneTuple()
-    {
-        ++numTuplesInTBFormatted;
-        currentTupleStartrawTB = currentTupleEndrawTB + 1;
-        currentTupleEndrawTB = findIndexOfNextTuple();
-    }
-
-    [[nodiscard]] std::string_view getInitialPartialTuple(const size_t sizeOfPartialTuple) const
-    {
-        return this->tupleBufferRawSV.substr(0, sizeOfPartialTuple);
-    }
-
-    [[nodiscard]] std::string_view getNextTuple() const
-    {
-        return this->tupleBufferRawSV.substr(currentTupleStartrawTB, sizeOfCurrentTuple());
-    }
-
-    void setNewTupleBufferFormatted(NES::Memory::TupleBuffer&& tupleBufferFormatted)
-    {
-        tupleBufferFormatted.setSequenceNumber(sequenceNumber);
-        tupleBufferFormatted.setChunkNumber(chunkNumber);
-        tupleBufferFormatted.setOriginId(originId);
-        this->tupleBufferFormatted = std::move(tupleBufferFormatted);
-    }
-
-    std::string handlePriorPartialTuple()
-    {
-        std::string partialTuple;
-        if (not(this->partialTuple.empty()))
-        {
-            partialTuple.resize(this->partialTuple.size() + currentTupleEndrawTB);
-            partialTuple = std::string(this->partialTuple) + std::string(tupleBufferRawSV.substr(0, currentTupleEndrawTB));
-        }
-        return partialTuple;
-    }
-
-    std::string_view getEndingPartialTuple() const { return tupleBufferRawSV.substr(currentTupleStartrawTB, numTotalBytesInrawTB); }
-
-    friend std::ostream& operator<<(std::ostream& out, const ProgressTracker& progressTracker)
-    {
-        return out << fmt::format(
-                   "tupleDelimiter: {}, size of tuples in bytes: {}, number of fields in schema: {}, rawTB(total number of bytes: {}, "
-                   "start of "
-                   "current tuple: {}, end of current tuple: {}), tbFormatted(number of tuples: {}, current field offset: {})",
-                   (progressTracker.tupleDelimiter == "\n") ? "\\n" : progressTracker.tupleDelimiter,
-                   progressTracker.tupleSizeInBytes,
-                   progressTracker.numSchemaFields,
-                   progressTracker.numTotalBytesInrawTB,
-                   progressTracker.currentTupleStartrawTB,
-                   progressTracker.currentTupleEndrawTB,
-                   progressTracker.numTuplesInTBFormatted,
-                   progressTracker.currentFieldOffsetTBFormatted);
-    }
-
-    /// Getter & Setter
-    [[nodiscard]] uint64_t getNumSchemaFields() const { return this->numSchemaFields; }
-    NES::Memory::TupleBuffer& getTupleBufferFormatted() { return this->tupleBufferFormatted; }
-    void setCurrentTupleStartrawTB(const size_t newCurrentTupleStartrawTB) { this->currentTupleStartrawTB = newCurrentTupleStartrawTB; }
-    void setNumberOfTuplesInTBFormatted() { this->tupleBufferFormatted.setNumberOfTuples(numTuplesInTBFormatted); }
-    uint64_t getNumTuplesInTBFormatted() { return numTuplesInTBFormatted; }
-    const std::string& getTupleDelimiter() { return this->tupleDelimiter; }
-
-    size_t currentTupleStartrawTB{0};
-    size_t endOfTuplesInRawTB{0};
-    size_t currentTupleEndrawTB{0};
-    uint64_t numTotalBytesInrawTB{0};
-    size_t numTuplesInTBFormatted{0};
-    size_t currentFieldOffsetTBFormatted{0};
-
-private:
-    SequenceNumber sequenceNumber;
-    ChunkNumber chunkNumber;
-    OriginId originId;
-    std::string tupleDelimiter;
-    size_t tupleSizeInBytes{0};
-    uint64_t numSchemaFields{0};
-    std::string_view tupleBufferRawSV;
-    std::string_view partialTuple;
-    NES::Memory::TupleBuffer tupleBufferFormatted;
-
-    size_t findIndexOfNextTuple() const { return tupleBufferRawSV.find(tupleDelimiter, currentTupleStartrawTB); }
-};
-
-template <typename T>
-auto parseIntegerString()
-{
-    return [](const std::string& fieldValueString, int8_t* fieldPointer, NES::Memory::AbstractBufferProvider&, Memory::TupleBuffer&)
-    {
-        const auto sizeOfString = fieldValueString.size();
-        T* value = reinterpret_cast<T*>(fieldPointer);
-        auto [_, ec] = std::from_chars(fieldValueString.data(), fieldValueString.data() + sizeOfString, *value);
-        if (ec == std::errc())
-        {
-            return;
-        }
-        if (ec == std::errc::invalid_argument)
-        {
-            throw CannotFormatMalformedStringValue(
-                "Integer value '{}', is not a valid integer of type: {}.", fieldValueString, typeid(T).name());
-        }
-        if (ec == std::errc::result_out_of_range)
-        {
-            throw CannotFormatMalformedStringValue("Integer value '{}', is too large for type: {}.", fieldValueString, typeid(T).name());
-        }
-    };
 }
 
-void addBasicTypeParseFunction(
-    const DataType::Type physicalType, std::vector<CSVInputFormatter::CastFunctionSignature>& fieldParseFunctions)
+void CSVInputFormatter::indexTuple(
+    const std::string_view tuple, FieldOffsetsType* fieldOffsets, const FieldOffsetsType startIdxOfTuple) const
 {
-    switch (physicalType)
+    PRECONDITION(fieldOffsets != nullptr, "FieldOffsets cannot be null.");
+
+    /// The start of the tuple is the offset of the first field of the tuple
+    *fieldOffsets = startIdxOfTuple;
+    size_t fieldIdx = 1;
+    /// Find field delimiters, until reaching the end of the tuple
+    /// The position of the field delimiter (+ size of field delimiter) is the beginning of the next field
+    for (size_t nextFieldOffset = tuple.find(this->config.fieldDelimiter, 0); nextFieldOffset != std::string_view::npos;
+         nextFieldOffset = tuple.find(this->config.fieldDelimiter, nextFieldOffset))
     {
-        case NES::DataType::Type::INT8: {
-            fieldParseFunctions.emplace_back(parseIntegerString<int8_t>());
-            break;
-        }
-        case NES::DataType::Type::INT16: {
-            fieldParseFunctions.emplace_back(parseIntegerString<int16_t>());
-            break;
-        }
-        case NES::DataType::Type::INT32: {
-            fieldParseFunctions.emplace_back(parseIntegerString<int32_t>());
-            break;
-        }
-        case NES::DataType::Type::INT64: {
-            fieldParseFunctions.emplace_back(parseIntegerString<int64_t>());
-            break;
-        }
-        case NES::DataType::Type::UINT8: {
-            fieldParseFunctions.emplace_back(parseIntegerString<uint8_t>());
-            break;
-        }
-        case NES::DataType::Type::UINT16: {
-            fieldParseFunctions.emplace_back(parseIntegerString<uint16_t>());
-            break;
-        }
-        case NES::DataType::Type::UINT32: {
-            fieldParseFunctions.emplace_back(parseIntegerString<uint32_t>());
-            break;
-        }
-        case NES::DataType::Type::UINT64: {
-            fieldParseFunctions.emplace_back(parseIntegerString<uint64_t>());
-            break;
-        }
-        case NES::DataType::Type::FLOAT32: {
-            const auto validateAndParseFloat
-                = [](const std::string& fieldValueString, int8_t* fieldPointer, NES::Memory::AbstractBufferProvider&, Memory::TupleBuffer&)
-            {
-                if (fieldValueString.find(',') != std::string_view::npos)
-                {
-                    throw CannotFormatMalformedStringValue(
-                        "Floats must use '.' as the decimal point. Parsed: {}, which uses ',' instead.", fieldValueString);
-                }
-                *reinterpret_cast<float*>(fieldPointer) = std::stof(fieldValueString);
-            };
-            fieldParseFunctions.emplace_back(std::move(validateAndParseFloat));
-            break;
-        }
-        case NES::DataType::Type::FLOAT64: {
-            const auto validateAndParseDouble
-                = [](const std::string& fieldValueString, int8_t* fieldPointer, NES::Memory::AbstractBufferProvider&, Memory::TupleBuffer&)
-            {
-                if (fieldValueString.find(',') != std::string_view::npos)
-                {
-                    throw CannotFormatMalformedStringValue(
-                        "Doubles must use '.' as the decimal point. Parsed: {}, which uses ',' instead.", fieldValueString);
-                }
-                *reinterpret_cast<double*>(fieldPointer) = std::stod(fieldValueString);
-            };
-            fieldParseFunctions.emplace_back(std::move(validateAndParseDouble));
-            break;
-        }
-        case NES::DataType::Type::CHAR: {
-            ///verify that only a single char was transmitted
-            fieldParseFunctions.emplace_back(
-                [](const std::string& inputString, int8_t* fieldPointer, Memory::AbstractBufferProvider&, Memory::TupleBuffer&)
-                {
-                    PRECONDITION(inputString.size() == 1, "A char must not have a size bigger than 1.");
-                    const auto value = inputString.front();
-                    *fieldPointer = value;
-                    return sizeof(char);
-                });
-            break;
-        }
-        case NES::DataType::Type::BOOLEAN: {
-            ///verify that a valid bool was transmitted (valid{true,false,0,1})
-            fieldParseFunctions.emplace_back(
-                [](const std::string& inputString, int8_t* fieldPointer, Memory::AbstractBufferProvider&, Memory::TupleBuffer&)
-                {
-                    const bool value = (strcasecmp(inputString.c_str(), "true") == 0) || (strcasecmp(inputString.c_str(), "1") == 0);
-                    if (!value)
-                    {
-                        if ((static_cast<int>(strcasecmp(inputString.c_str(), "false") != 0) != 0)
-                            && (strcasecmp(inputString.c_str(), "0") != 0))
-                        {
-                            throw CannotFormatMalformedStringValue("Value: {} is not a boolean", inputString);
-                        }
-                    }
-                    *fieldPointer = static_cast<int8_t>(value);
-                    return sizeof(bool);
-                });
-            break;
-        }
-        case NES::DataType::Type::UNDEFINED: {
-            throw UnknownDataType("Parser::writeFieldValueToTupleBuffer: Field Type UNDEFINED");
-        }
-        default:
-            throw UnknownDataType("Unknown physical type: {}", magic_enum::enum_name(physicalType));
+        nextFieldOffset += this->config.fieldDelimiter.size();
+        *(fieldOffsets + fieldIdx) = startIdxOfTuple + nextFieldOffset; ///NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        ++fieldIdx;
+    }
+    if (fieldIdx != numberOfFieldsInSchema)
+    {
+        throw CannotFormatSourceData(
+            "Number of parsed fields does not match number of fields in schema (parsed {} vs {} schema", fieldIdx, numberOfFieldsInSchema);
     }
 }
 
-CSVInputFormatter::CSVInputFormatter(const Schema& schema, std::string tupleDelimiter, std::string fieldDelimiter)
-    : schema(schema), fieldDelimiter(std::move(fieldDelimiter)), tupleDelimiter(std::move(tupleDelimiter))
+InputFormatter::FirstAndLastTupleDelimiterOffsets
+CSVInputFormatter::indexBuffer(std::string_view bufferView, FieldOffsets& fieldOffsets) const
 {
-    this->fieldSizes.reserve(schema.getNumberOfFields());
-    this->fieldParseFunctions.reserve(schema.getNumberOfFields());
-    std::vector<DataType> physicalTypes;
-    physicalTypes.reserve(schema.getNumberOfFields());
-    for (const auto& field : schema.getFields())
+    const auto sizeOfTupleDelimiter = this->config.tupleDelimiter.size();
+    const auto offsetOfFirstTupleDelimiter = static_cast<FieldOffsetsType>(bufferView.find(this->config.tupleDelimiter));
+
+    /// If the buffer does not contain a delimiter, set the 'offsetOfFirstTupleDelimiter' to a value larger than the buffer size to tell
+    /// the InputFormatterTask that there was no tuple delimiter in the buffer and return
+    if (offsetOfFirstTupleDelimiter == static_cast<FieldOffsetsType>(std::string::npos))
     {
-        physicalTypes.emplace_back(field.dataType);
+        return {
+            .offsetOfFirstTupleDelimiter = std::numeric_limits<FieldOffsetsType>::max(),
+            .offsetOfLastTupleDelimiter = std::numeric_limits<FieldOffsetsType>::max()};
     }
 
-    /// Since we know the schema, we can create a vector that contains a function that converts the string representation of a field value
-    /// to our internal representation in the correct order. During parsing, we iterate over the fields in each tuple, and, using the current
-    /// field number, load the correct function for parsing from the vector.
-    for (const auto& physicalType : physicalTypes)
+    /// If the buffer contains at least one delimiter, check if it contains more and index all tuples between the tuple delimiters
+    size_t startIdxOfCurrentTuple = offsetOfFirstTupleDelimiter + sizeOfTupleDelimiter;
+    size_t endIdxOfCurrentTuple = bufferView.find(this->config.tupleDelimiter, startIdxOfCurrentTuple);
+    while (endIdxOfCurrentTuple != std::string::npos)
     {
-        /// Store the size of the field in bytes (for offset calculations).
-        this->fieldSizes.emplace_back(physicalType.getSizeInBytes());
-        /// Store the parsing function in a vector.
-        if (physicalType.type != DataType::Type::VARSIZED)
-        {
-            addBasicTypeParseFunction(physicalType.type, this->fieldParseFunctions);
-        }
-        else
-        {
-            this->fieldParseFunctions.emplace_back(
-                [](const std::string& inputString,
-                   int8_t* fieldPointer,
-                   Memory::AbstractBufferProvider& bufferProvider,
-                   const NES::Memory::TupleBuffer& tupleBufferFormatted)
-                {
-                    NES_TRACE(
-                        "Parser::writeFieldValueToTupleBuffer(): trying to write the variable length input string: {}"
-                        "to tuple buffer",
-                        inputString);
-                    const auto valueLength = inputString.length();
-                    auto childBuffer = bufferProvider.getUnpooledBuffer(valueLength + sizeof(uint32_t));
-                    INVARIANT(childBuffer.has_value(), "Could not store string, because we cannot allocate a child buffer.");
+        INVARIANT(startIdxOfCurrentTuple <= endIdxOfCurrentTuple, "The start index of a tuple cannot be larger than the end index.");
+        auto* tupleOffsetPtr = fieldOffsets.writeOffsetsOfNextTuple();
+        const auto sizeOfCurrentTuple = endIdxOfCurrentTuple - startIdxOfCurrentTuple;
+        /// WE ALWAYS skip the first partial tuple and start with the first full tuple delimiter, thus, we can ALWAYS add the size of the tuple delimiter
+        const auto currentTuple = std::string_view(bufferView.begin() + startIdxOfCurrentTuple, sizeOfCurrentTuple);
 
-                    auto& childBufferVal = childBuffer.value();
-                    *childBufferVal.getBuffer<uint32_t>() = valueLength;
-                    std::memcpy(childBufferVal.getBuffer<char>() + sizeof(uint32_t), inputString.data(), valueLength);
-                    const auto index = tupleBufferFormatted.storeChildBuffer(childBufferVal);
-                    auto* childBufferIndexPointer = reinterpret_cast<uint32_t*>(fieldPointer);
-                    *childBufferIndexPointer = index;
-                });
-        }
+        indexTuple(currentTuple, tupleOffsetPtr, startIdxOfCurrentTuple);
+        /// The last delimiter is the size of the tuple itself, which allows the next phase to determine the last field without any extra calculations
+        *(tupleOffsetPtr + numberOfFieldsInSchema) = endIdxOfCurrentTuple; ///NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+
+        startIdxOfCurrentTuple = endIdxOfCurrentTuple + sizeOfTupleDelimiter;
+        endIdxOfCurrentTuple = bufferView.find(this->config.tupleDelimiter, startIdxOfCurrentTuple);
     }
-}
-
-CSVInputFormatter::~CSVInputFormatter() = default;
-
-void CSVInputFormatter::parseTupleBufferRaw(
-    const NES::Memory::TupleBuffer& rawTB,
-    PipelineExecutionContext& pipelineExecutionContext,
-    const size_t numBytesInRawTB,
-    SequenceShredder& sequenceShredder)
-{
-    PRECONDITION(rawTB.getBufferSize() != 0, "A raw tuple buffer must not be of empty.");
-
-    const auto isInRange = sequenceShredder.isInRange(rawTB.getSequenceNumber().getRawValue());
-    if (not(isInRange))
-    {
-        pipelineExecutionContext.emitBuffer(rawTB, NES::PipelineExecutionContext::ContinuationPolicy::REPEAT);
-        return;
-    }
-
-    /// Creating a ProgressTracker on each call makes the CSVInputFormatter stateless
-    auto progressTracker = ProgressTracker(
-        rawTB.getSequenceNumber(), rawTB.getOriginId(), tupleDelimiter, schema.getSizeOfSchemaInBytes(), schema.getNumberOfFields());
-    /// Reset all values that are tied to a specific rawTB.
-    /// Also resets numTuplesInTBFormatted, because we always start with a new TBF when parsing a new TBR.
-    progressTracker.resetForNewRawTB(numBytesInRawTB, rawTB.getBuffer<const char>(), 0, 0, 0);
-    const auto sequenceNumberOfBuffer = rawTB.getSequenceNumber().getRawValue();
-    constexpr auto maxSequenceNumber = std::numeric_limits<uint64_t>::max();
-    const auto hasTupleDelimiter = progressTracker.getOffsetOfFirstTupleDelimiter() != maxSequenceNumber;
-    const uint32_t offsetOfFirstTupleDelimiter = (hasTupleDelimiter) ? progressTracker.getOffsetOfFirstTupleDelimiter() : 0;
-    const uint32_t offsetOfLastTupleDelimiter = (hasTupleDelimiter) ? progressTracker.getOffsetOfLastTupleDelimiter() : numBytesInRawTB;
-
-    if (hasTupleDelimiter)
-    {
-        const auto [indexOfBuffer, buffersToFormat] = sequenceShredder.processSequenceNumber<true>(
-            SequenceShredder::StagedBuffer{
-                .buffer = rawTB,
-                .sizeOfBufferInBytes = numBytesInRawTB,
-                .offsetOfFirstTupleDelimiter = offsetOfFirstTupleDelimiter,
-                .offsetOfLastTupleDelimiter = offsetOfLastTupleDelimiter},
-            sequenceNumberOfBuffer);
-        /// Skip, if there is only a single buffer, with a single tuple delimiter, since there are no possible tuples to parse
-        if (buffersToFormat.size() == 1
-            and (buffersToFormat[0].offsetOfFirstTupleDelimiter == buffersToFormat[0].offsetOfLastTupleDelimiter))
-        {
-            return;
-        }
-        /// 0. Allocate formatted buffer to write formatted tuples into.
-        progressTracker.setNewTupleBufferFormatted(pipelineExecutionContext.allocateTupleBuffer());
-
-        INVARIANT(indexOfBuffer < buffersToFormat.size(), "Index of buffer must be smaller than the size of the buffers.");
-
-        /// 1. Process leading partial tuple if exists
-        const auto hasLeadingPartialTuple = (indexOfBuffer != 0);
-        if (hasLeadingPartialTuple)
-        {
-            processPartialTuple(0, indexOfBuffer, buffersToFormat, progressTracker, pipelineExecutionContext);
-        }
-        progressTracker.getTupleBufferFormatted().setNumberOfTuples(progressTracker.getNumTuplesInTBFormatted());
-
-        /// 2. Process buffer itself
-        const auto& bufferOfSequenceNumber = buffersToFormat.at(indexOfBuffer);
-        progressTracker.resetForNewRawTB(
-            bufferOfSequenceNumber.sizeOfBufferInBytes,
-            bufferOfSequenceNumber.buffer.getBuffer<const char>(),
-            bufferOfSequenceNumber.offsetOfFirstTupleDelimiter + tupleDelimiter.size(),
-            bufferOfSequenceNumber.offsetOfLastTupleDelimiter);
-        progressTracker.processCurrentBuffer(pipelineExecutionContext, fieldDelimiter, fieldParseFunctions, fieldSizes);
-
-        /// 3. Process trailing  partial tuple if exists
-        const auto hasTrailingPartialTuple = indexOfBuffer < buffersToFormat.size() - 1;
-        if (hasTrailingPartialTuple)
-        {
-            /// We first need to check if the tuple can fit into the current formatted buffer
-            progressTracker.checkAndHandleFullBuffer(pipelineExecutionContext);
-            processPartialTuple(indexOfBuffer, buffersToFormat.size() - 1, buffersToFormat, progressTracker, pipelineExecutionContext);
-        }
-        auto finalFormattedBuffer = progressTracker.getTupleBufferFormatted();
-        finalFormattedBuffer.setNumberOfTuples(progressTracker.getNumTuplesInTBFormatted());
-        finalFormattedBuffer.setLastChunk(true);
-
-        pipelineExecutionContext.emitBuffer(finalFormattedBuffer, NES::PipelineExecutionContext::ContinuationPolicy::POSSIBLE);
-    }
-    else
-    {
-        const auto [_, buffersToFormat] = sequenceShredder.processSequenceNumber<false>(
-            SequenceShredder::StagedBuffer{
-                .buffer = rawTB,
-                .sizeOfBufferInBytes = numBytesInRawTB,
-                .offsetOfFirstTupleDelimiter = offsetOfFirstTupleDelimiter,
-                .offsetOfLastTupleDelimiter = offsetOfLastTupleDelimiter},
-            sequenceNumberOfBuffer);
-        /// A buffer without a tuple delimiter can only find a spanning tuple, if it can reach a buffer with a spanning tuple to the left and right
-        /// [buffer with tuple delimiter (TD)][buffer without TD][buffer with TD] <-- minimal spanning tuple for a buffer without TD
-        if (buffersToFormat.size() < 3)
-        {
-            return;
-        }
-
-        /// Allocate formatted buffer to write formatted tuples into and process partial tuple.
-        progressTracker.setNewTupleBufferFormatted(pipelineExecutionContext.allocateTupleBuffer());
-        processPartialTuple(0, buffersToFormat.size() - 1, buffersToFormat, progressTracker, pipelineExecutionContext);
-        auto finalFormattedBuffer = progressTracker.getTupleBufferFormatted();
-        finalFormattedBuffer.setNumberOfTuples(finalFormattedBuffer.getNumberOfTuples() + 1);
-        finalFormattedBuffer.setLastChunk(true);
-        pipelineExecutionContext.emitBuffer(finalFormattedBuffer, NES::PipelineExecutionContext::ContinuationPolicy::POSSIBLE);
-    }
-}
-
-CSVInputFormatter::FormattedTupleIs CSVInputFormatter::processPartialTuple(
-    const size_t partialTupleStartIdx,
-    const size_t partialTupleEndIdx,
-    const std::vector<SequenceShredder::StagedBuffer>& buffersToFormat,
-    ProgressTracker& progressTracker,
-    PipelineExecutionContext& pipelineExecutionContext)
-{
-    PRECONDITION(partialTupleStartIdx < partialTupleEndIdx, "Partial tuple start index must be smaller than the end index.");
-    PRECONDITION(partialTupleEndIdx <= buffersToFormat.size(), "Partial tuple end index must be smaller than the size of the buffers.");
-
-    /// If the buffers are not empty, there are at least three buffers
-    /// 1. Process the first buffer
-    const auto& firstBuffer = buffersToFormat[partialTupleStartIdx];
-    const auto sizeOfLeadingPartialTuple
-        = firstBuffer.sizeOfBufferInBytes - (firstBuffer.offsetOfLastTupleDelimiter + tupleDelimiter.size());
-    INVARIANT(
-        sizeOfLeadingPartialTuple <= firstBuffer.buffer.getBufferSize(),
-        "Partial tuple is larger {} than buffer size {}",
-        sizeOfLeadingPartialTuple,
-        firstBuffer.buffer.getBufferSize());
-
-    const std::string_view firstBytesOfPartialTuple = firstBuffer.buffer.getBuffer()
-        ? std::string_view(
-              firstBuffer.buffer.getBuffer<const char>() + (firstBuffer.offsetOfLastTupleDelimiter + 1), sizeOfLeadingPartialTuple)
-        : std::string_view();
-
-    std::string partialTuple(firstBytesOfPartialTuple);
-    /// 2. Process all buffers in-between the first and the last
-    for (size_t bufferIndex = partialTupleStartIdx + 1; bufferIndex < partialTupleEndIdx; ++bufferIndex)
-    {
-        const auto& currentBuffer = buffersToFormat[bufferIndex];
-        const std::string_view intermediatePartialTuple
-            = std::string_view(currentBuffer.buffer.getBuffer<const char>(), currentBuffer.sizeOfBufferInBytes);
-        partialTuple.append(intermediatePartialTuple);
-    }
-
-    /// 3. Process the last buffer
-    const auto& lastBuffer = buffersToFormat[partialTupleEndIdx];
-    const std::string_view lastPartialTuple
-        = std::string_view(lastBuffer.buffer.getBuffer<const char>(), lastBuffer.offsetOfFirstTupleDelimiter);
-    partialTuple.append(lastPartialTuple);
-    const auto stateOfPartialTuple = static_cast<FormattedTupleIs>(not(partialTuple.empty()));
-    progressTracker.processCurrentTuple(
-        std::move(partialTuple), fieldDelimiter, fieldParseFunctions, fieldSizes, *pipelineExecutionContext.getBufferManager());
-    progressTracker.progressOneTuple();
-    return stateOfPartialTuple;
-}
-
-void CSVInputFormatter::flushFinalTuple(
-    OriginId originId, NES::PipelineExecutionContext& pipelineExecutionContext, SequenceShredder& sequenceShredder)
-{
-    const auto [resultBuffers, sequenceNumberToUseForFlushedTuple] = sequenceShredder.flushFinalPartialTuple();
-    const auto flushedBuffers = std::move(resultBuffers.stagedBuffers);
-    /// The sequence shredder insert a dummy buffer with a delimiter in its flush call.
-    /// If it returns a single buffer, it is that dummy buffer and we can return.
-    if (flushedBuffers.size() == 1)
-    {
-        return;
-    }
-    /// Get the final buffer (size - 1 is dummy buffer that just contains tuple delimiter)
-    auto progressTracker = ProgressTracker(
-        SequenceNumber(sequenceNumberToUseForFlushedTuple),
-        originId,
-        tupleDelimiter,
-        schema.getSizeOfSchemaInBytes(),
-        schema.getNumberOfFields());
-    /// Allocate formatted buffer to write formatted tuples into.
-    progressTracker.setNewTupleBufferFormatted(pipelineExecutionContext.allocateTupleBuffer());
-    const auto formattedTupleIs
-        = processPartialTuple(0, flushedBuffers.size() - 1, flushedBuffers, progressTracker, pipelineExecutionContext);
-    /// Emit formatted buffer with single flushed tuple
-    if (formattedTupleIs == FormattedTupleIs::NOT_EMPTY)
-    {
-        auto finalFormattedBuffer = progressTracker.getTupleBufferFormatted();
-        finalFormattedBuffer.setNumberOfTuples(finalFormattedBuffer.getNumberOfTuples() + 1);
-        finalFormattedBuffer.setLastChunk(true);
-        pipelineExecutionContext.emitBuffer(finalFormattedBuffer, NES::PipelineExecutionContext::ContinuationPolicy::POSSIBLE);
-    }
-}
-size_t CSVInputFormatter::getSizeOfTupleDelimiter()
-{
-    return this->tupleDelimiter.size();
-}
-size_t CSVInputFormatter::getSizeOfFieldDelimiter()
-{
-    return this->fieldDelimiter.size();
+    const auto offsetOfLastTupleDelimiter = static_cast<FieldOffsetsType>(startIdxOfCurrentTuple - sizeOfTupleDelimiter);
+    return {.offsetOfFirstTupleDelimiter = offsetOfFirstTupleDelimiter, .offsetOfLastTupleDelimiter = offsetOfLastTupleDelimiter};
 }
 
 std::ostream& CSVInputFormatter::toString(std::ostream& os) const
 {
-    os << "CSVInputFormatter: {\n";
-    os << "  tuple delimiter: " << ((this->tupleDelimiter == "\n") ? "\\n" : this->tupleDelimiter) << ", \n";
-    os << "  field delimiter: " << this->fieldDelimiter << ", \n";
-    os << "  number of fields: " << this->fieldSizes.size() << ", \n";
-    os << "  schema: " << schema;
-    os << "\n}\n";
-
-    return os;
+    return os << fmt::format(
+               "CSVInputFormatter(tupleDelimiter: {}, fieldDelimiter: {})", this->config.tupleDelimiter, this->config.fieldDelimiter);
 }
 
-InputFormatterRegistryReturnType
-InputFormatterGeneratedRegistrar::RegisterCSVInputFormatter(InputFormatterRegistryArguments inputFormatterRegistryArguments)
+InputFormatterRegistryReturnType InputFormatterGeneratedRegistrar::RegisterCSVInputFormatter(
+    InputFormatterRegistryArguments arguments) ///NOLINT(performance-unnecessary-value-param)
 {
-    return std::make_unique<CSVInputFormatter>(
-        inputFormatterRegistryArguments.schema,
-        inputFormatterRegistryArguments.tupleDelimiter,
-        inputFormatterRegistryArguments.fieldDelimiter);
+    return std::make_unique<CSVInputFormatter>(arguments);
 }
 
 }

--- a/nes-input-formatters/src/FieldOffsets.cpp
+++ b/nes-input-formatters/src/FieldOffsets.cpp
@@ -1,0 +1,135 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <FieldOffsets.hpp>
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <utility>
+#include <InputFormatters/InputFormatterTask.hpp>
+#include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/TupleBuffer.hpp>
+#include <ErrorHandling.hpp>
+
+namespace NES::InputFormatters
+{
+
+FieldOffsets::FieldOffsets(
+    const size_t numberOfFieldsInSchema,
+    const size_t sizeOfFormattedBufferInBytes,
+    std::shared_ptr<Memory::AbstractBufferProvider> bufferProvider)
+    : currentIndex(NUMBER_OF_RESERVED_FIELDS)
+    , numberOfFieldsInSchema(numberOfFieldsInSchema)
+    , maxNumberOfTuplesInFormattedBuffer(
+          (sizeOfFormattedBufferInBytes - NUMBER_OF_RESERVED_BYTES) / ((numberOfFieldsInSchema + 1) * sizeof(FieldOffsetsType)))
+    , maxIndex(NUMBER_OF_RESERVED_FIELDS + ((numberOfFieldsInSchema + 1) * maxNumberOfTuplesInFormattedBuffer))
+    , totalNumberOfTuples(0)
+    , rootFieldOffsetBuffer(bufferProvider->getBufferBlocking())
+    , bufferProvider(std::move(bufferProvider))
+    , currentFieldOffsetBuffer(this->rootFieldOffsetBuffer)
+{
+}
+
+
+FieldOffsetsType* FieldOffsets::writeOffsetsOfNextTuple()
+{
+    const auto getNextWriteBuffer = [this]() -> void { allocateNewChildBuffer(); };
+    return processTuple(getNextWriteBuffer);
+}
+
+FieldOffsetsType* FieldOffsets::readOffsetsOfNextTuple()
+{
+    const auto getNextReadBuffer = [this]() -> void
+    {
+        INVARIANT(
+            this->currentFieldOffsetBuffer.getNumberOfChildrenBuffer() > 0,
+            "Cannot get next fields if current buffer does not have child buffer.");
+        const auto childBufferIndex = this->currentFieldOffsetBuffer.getBuffer< ///NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            FieldOffsetsType>()[OFFSET_OF_INDEX_TO_CHILD_BUFFER];
+        this->currentFieldOffsetBuffer = currentFieldOffsetBuffer.loadChildBuffer(childBufferIndex);
+        --this->currentFieldOffsetBuffer
+              .getBuffer<FieldOffsetsType>()[OFFSET_OF_TOTAL_NUMBER_OF_TUPLES]; ///NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    };
+    return processTuple(getNextReadBuffer);
+}
+
+FieldOffsetsType* FieldOffsets::processTuple(const std::function<void()>& handleOutOfSpaceFn)
+{
+    if (currentIndex + (numberOfFieldsInSchema + 1) > maxIndex)
+    {
+        handleOutOfSpaceFn();
+        currentIndex = NUMBER_OF_RESERVED_FIELDS;
+    }
+    const auto currentFieldIndex = currentIndex;
+    currentIndex += numberOfFieldsInSchema + 1;
+    return currentFieldOffsetBuffer.getBuffer<FieldOffsetsType>()
+        + currentFieldIndex; ///NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+}
+
+void FieldOffsets::allocateNewChildBuffer()
+{
+    auto newBuffer = bufferProvider->getBufferBlocking();
+    const auto indexOfNewBuffer = currentFieldOffsetBuffer.storeChildBuffer(newBuffer);
+    /// The number of tuples communicate whether the buffer has a child buffer or not. Thus, the index to the child buffer is optional.
+    /// We could write it to the last bytes of the buffer, if necessary, but that creates room for error when writing actual offsets.
+    /// Overall a few bytes 'lost' is a good trait for better clarity/safety.
+    /// (it also does not seem like we can simply assume that the first index is '0' and so on, so we need to store it somewhere)
+    INVARIANT(
+        (currentIndex - NUMBER_OF_RESERVED_FIELDS) % (numberOfFieldsInSchema + 1) == 0,
+        "Number of indexes {} must be a multiple of number of fields in tuple {}",
+        currentIndex - NUMBER_OF_RESERVED_FIELDS,
+        (numberOfFieldsInSchema + 1));
+
+    setNumberOfRawTuples(maxNumberOfTuplesInFormattedBuffer);
+    totalNumberOfTuples += maxNumberOfTuplesInFormattedBuffer;
+    this->currentFieldOffsetBuffer
+        .getBuffer<FieldOffsetsType>()[OFFSET_OF_INDEX_TO_CHILD_BUFFER] ///NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        = indexOfNewBuffer; ///NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    this->currentFieldOffsetBuffer = currentFieldOffsetBuffer.loadChildBuffer(indexOfNewBuffer);
+    this->currentIndex = NUMBER_OF_RESERVED_FIELDS;
+}
+
+size_t FieldOffsets::finishWrite()
+{
+    /// Make sure that the number of read fields matches the expected value.
+    if ((currentIndex - NUMBER_OF_RESERVED_FIELDS) % (numberOfFieldsInSchema + 1) != 0)
+    {
+        throw CSVParsingError(
+            "Number of indexes {} must be a multiple of number of fields in tuple {}",
+            currentIndex - NUMBER_OF_RESERVED_FIELDS,
+            (numberOfFieldsInSchema + 1));
+    }
+
+    /// First, set the number of tuples for the current field offsets buffer
+    const auto numberOfTuplesRepresentedInCurrentBuffer = (currentIndex - NUMBER_OF_RESERVED_FIELDS) / (numberOfFieldsInSchema + 1);
+    totalNumberOfTuples += numberOfTuplesRepresentedInCurrentBuffer;
+    setNumberOfRawTuples(numberOfTuplesRepresentedInCurrentBuffer);
+
+    this->currentIndex = NUMBER_OF_RESERVED_FIELDS;
+    /// Set the first buffer as the current buffer. Adjusts the number of tuples of the first buffer. Determines if there is a child buffer.
+    this->currentFieldOffsetBuffer = rootFieldOffsetBuffer;
+    --this->currentFieldOffsetBuffer
+          .getBuffer<FieldOffsetsType>()[OFFSET_OF_TOTAL_NUMBER_OF_TUPLES]; ///NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    return totalNumberOfTuples;
+}
+
+void FieldOffsets::setNumberOfRawTuples(const FieldOffsetsType numberOfTuples)
+{
+    this->currentFieldOffsetBuffer
+        .getBuffer<FieldOffsetsType>()[OFFSET_OF_TOTAL_NUMBER_OF_TUPLES] ///NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        = numberOfTuples + 1;
+}
+
+};

--- a/nes-input-formatters/src/FieldOffsets.cpp
+++ b/nes-input-formatters/src/FieldOffsets.cpp
@@ -42,7 +42,6 @@ FieldOffsets::FieldOffsets(
 {
 }
 
-
 FieldOffsetsType* FieldOffsets::writeOffsetsOfNextTuple()
 {
     const auto getNextWriteBuffer = [this]() -> void { allocateNewChildBuffer(); };
@@ -54,7 +53,7 @@ FieldOffsetsType* FieldOffsets::readOffsetsOfNextTuple()
     const auto getNextReadBuffer = [this]() -> void
     {
         INVARIANT(
-            this->currentFieldOffsetBuffer.getNumberOfChildrenBuffer() > 0,
+            this->currentFieldOffsetBuffer.getNumberOfChildBuffers() > 0,
             "Cannot get next fields if current buffer does not have child buffer.");
         const auto childBufferIndex = this->currentFieldOffsetBuffer.getBuffer< ///NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             FieldOffsetsType>()[OFFSET_OF_INDEX_TO_CHILD_BUFFER];
@@ -82,10 +81,6 @@ void FieldOffsets::allocateNewChildBuffer()
 {
     auto newBuffer = bufferProvider->getBufferBlocking();
     const auto indexOfNewBuffer = currentFieldOffsetBuffer.storeChildBuffer(newBuffer);
-    /// The number of tuples communicate whether the buffer has a child buffer or not. Thus, the index to the child buffer is optional.
-    /// We could write it to the last bytes of the buffer, if necessary, but that creates room for error when writing actual offsets.
-    /// Overall a few bytes 'lost' is a good trait for better clarity/safety.
-    /// (it also does not seem like we can simply assume that the first index is '0' and so on, so we need to store it somewhere)
     INVARIANT(
         (currentIndex - NUMBER_OF_RESERVED_FIELDS) % (numberOfFieldsInSchema + 1) == 0,
         "Number of indexes {} must be a multiple of number of fields in tuple {}",

--- a/nes-input-formatters/src/FieldOffsets.cpp
+++ b/nes-input-formatters/src/FieldOffsets.cpp
@@ -101,7 +101,7 @@ size_t FieldOffsets::finishWrite()
     /// Make sure that the number of read fields matches the expected value.
     if ((currentIndex - NUMBER_OF_RESERVED_FIELDS) % (numberOfFieldsInSchema + 1) != 0)
     {
-        throw CSVParsingError(
+        throw FormattingError(
             "Number of indexes {} must be a multiple of number of fields in tuple {}",
             currentIndex - NUMBER_OF_RESERVED_FIELDS,
             (numberOfFieldsInSchema + 1));

--- a/nes-input-formatters/src/InputFormatterProvider.cpp
+++ b/nes-input-formatters/src/InputFormatterProvider.cpp
@@ -15,10 +15,10 @@
 #include <InputFormatters/InputFormatterProvider.hpp>
 
 #include <memory>
-#include <string>
 #include <utility>
 
 #include <DataTypes/Schema.hpp>
+#include <Identifiers/Identifiers.hpp>
 #include <InputFormatters/InputFormatter.hpp>
 #include <ErrorHandling.hpp>
 #include <InputFormatterRegistry.hpp>
@@ -26,16 +26,14 @@
 namespace NES::InputFormatters::InputFormatterProvider
 {
 
-std::unique_ptr<InputFormatter>
-provideInputFormatter(const std::string& parserType, const Schema& schema, std::string tupleDelimiter, std::string fieldDelimiter)
+std::unique_ptr<InputFormatterTask> provideInputFormatterTask(const OriginId originId, const Schema& schema, const ParserConfig& config)
 {
-    auto inputFormatterArguments
-        = NES::InputFormatters::InputFormatterRegistryArguments(schema, std::move(tupleDelimiter), std::move(fieldDelimiter));
-    if (auto inputFormatter = InputFormatterRegistry::instance().create(parserType, inputFormatterArguments))
+    if (auto inputFormatter
+        = InputFormatterRegistry::instance().create(config.parserType, InputFormatterRegistryArguments{config, schema.getNumberOfFields()}))
     {
-        return std::move(inputFormatter.value());
+        return std::make_unique<InputFormatterTask>(originId, std::move(inputFormatter.value()), schema, config);
     }
-    throw UnknownParserType("unknown type of parser: {}", parserType);
+    throw UnknownParserType("unknown type of parser: {}", config.parserType);
 }
 bool contains(const std::string& parserType)
 {

--- a/nes-input-formatters/src/InputFormatterProvider.cpp
+++ b/nes-input-formatters/src/InputFormatterProvider.cpp
@@ -29,7 +29,7 @@ namespace NES::InputFormatters::InputFormatterProvider
 std::unique_ptr<InputFormatterTask> provideInputFormatterTask(const OriginId originId, const Schema& schema, const ParserConfig& config)
 {
     if (auto inputFormatter
-        = InputFormatterRegistry::instance().create(config.parserType, InputFormatterRegistryArguments{config, schema.getNumberOfFields()}))
+        = InputFormatterRegistry::instance().create(config.parserType, InputFormatterRegistryArguments{.inputFormatterConfig=config, .numberOfFieldsInSchema=schema.getNumberOfFields()}))
     {
         return std::make_unique<InputFormatterTask>(originId, std::move(inputFormatter.value()), schema, config);
     }

--- a/nes-input-formatters/src/InputFormatterTask.cpp
+++ b/nes-input-formatters/src/InputFormatterTask.cpp
@@ -150,10 +150,10 @@ void InputFormatterTask::processRawBufferWithTupleDelimiter(
     const auto bufferProvider = pec.getBufferManager();
     const auto [indexOfSequenceNumberInStagedBuffers, stagedBuffers] = sequenceShredder->processSequenceNumber<true>(
         StagedBuffer{
-            rawBufferData.buffer,
-            rawBufferData.buffer.getNumberOfTuples(),
-            rawBufferData.offsetOfFirstTupleDelimiter,
-            rawBufferData.offsetOfLastTupleDelimiter},
+            .buffer=rawBufferData.buffer,
+            .sizeOfBufferInBytes=rawBufferData.buffer.getNumberOfTuples(),
+            .offsetOfFirstTupleDelimiter=rawBufferData.offsetOfFirstTupleDelimiter,
+            .offsetOfLastTupleDelimiter=rawBufferData.offsetOfLastTupleDelimiter},
         rawBufferData.buffer.getSequenceNumber().getRawValue());
 
     /// 1. process leading spanning tuple if required
@@ -205,10 +205,10 @@ void InputFormatterTask::processRawBufferWithoutTupleDelimiter(
     const auto bufferProvider = pec.getBufferManager();
     const auto [indexOfSequenceNumberInStagedBuffers, stagedBuffers] = sequenceShredder->processSequenceNumber<false>(
         StagedBuffer{
-            rawBufferData.buffer,
-            rawBufferData.buffer.getNumberOfTuples(),
-            rawBufferData.offsetOfFirstTupleDelimiter,
-            rawBufferData.offsetOfLastTupleDelimiter},
+            .buffer=rawBufferData.buffer,
+            .sizeOfBufferInBytes=rawBufferData.buffer.getNumberOfTuples(),
+            .offsetOfFirstTupleDelimiter=rawBufferData.offsetOfFirstTupleDelimiter,
+            .offsetOfLastTupleDelimiter=rawBufferData.offsetOfLastTupleDelimiter},
         rawBufferData.buffer.getSequenceNumber().getRawValue());
     if (stagedBuffers.size() < 3)
     {

--- a/nes-input-formatters/src/InputFormatterTask.cpp
+++ b/nes-input-formatters/src/InputFormatterTask.cpp
@@ -12,36 +12,391 @@
     limitations under the License.
 */
 
+#include <InputFormatters/InputFormatterTask.hpp>
+
+#include <algorithm>
+#include <cstddef>
 #include <memory>
 #include <ostream>
+#include <string>
+#include <string_view>
 #include <utility>
+#include <vector>
+
+#include <DataTypes/Schema.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <InputFormatters/InputFormatter.hpp>
-#include <InputFormatters/InputFormatterTask.hpp>
+#include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
+#include <Sources/SourceDescriptor.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <ErrorHandling.hpp>
+#include <FieldOffsets.hpp>
 #include <PipelineExecutionContext.hpp>
+#include <RawInputDataParser.hpp>
 #include <SequenceShredder.hpp>
+
+namespace
+{
+size_t estimateNumberOfRequiredBuffers(
+    const size_t totalNumberOfTuplesInRawBuffer, const size_t numberOfTuplesInFirstFormattedBuffer, const size_t numberOfTuplesPerBuffer)
+{
+    const auto capacityOfFirstBuffer
+        = std::min(numberOfTuplesPerBuffer - numberOfTuplesInFirstFormattedBuffer, totalNumberOfTuplesInRawBuffer);
+    const auto numberOfTuplesThatDoNotFitIntoFirstFormattedBuffer = totalNumberOfTuplesInRawBuffer - capacityOfFirstBuffer;
+    /// We need at least one (first) formatted buffer. We need additional buffers if we have leftover raw tuples.
+    /// Overflow-safe calculation of ceil taken from (https://stackoverflow.com/questions/2745074/fast-ceiling-of-an-integer-division-in-c-c)
+    /// 1 + ceil(numberOfTuplesThatDoNotFitIntoFirstFormattedBuffer / numberOfTuplesPerBuffer)
+    const auto numberOfBuffersToFill = 1
+        + ((numberOfTuplesThatDoNotFitIntoFirstFormattedBuffer % numberOfTuplesPerBuffer != 0U)
+               ? (numberOfTuplesThatDoNotFitIntoFirstFormattedBuffer / numberOfTuplesPerBuffer) + 1
+               : numberOfTuplesThatDoNotFitIntoFirstFormattedBuffer / numberOfTuplesPerBuffer);
+    return numberOfBuffersToFill;
+}
+
+}
 
 namespace NES::InputFormatters
 {
 
-InputFormatterTask::InputFormatterTask(const OriginId originId, std::unique_ptr<InputFormatter> inputFormatter)
+
+struct RawBufferData
+{
+    Memory::TupleBuffer buffer;
+    FieldOffsetsType offsetOfFirstTupleDelimiter = 0;
+    FieldOffsetsType offsetOfLastTupleDelimiter = 0;
+    size_t numberOfTuplesInBuffer = 0;
+};
+
+InputFormatterTask::InputFormatterTask(
+    const OriginId originId, std::unique_ptr<InputFormatter> inputFormatter, const Schema& schema, const ParserConfig& parserConfig)
     : originId(originId)
-    , sequenceShredder(std::make_unique<SequenceShredder>(inputFormatter->getSizeOfTupleDelimiter()))
     , inputFormatter(std::move(inputFormatter))
+    , sequenceShredder(std::make_unique<SequenceShredder>(parserConfig.tupleDelimiter.size()))
+    , tupleDelimiter(parserConfig.tupleDelimiter)
+    , fieldDelimiter(parserConfig.fieldDelimiter)
+    , numberOfFieldsInSchema(schema.getNumberOfFields())
+    , sizeOfTupleInBytes(schema.getSizeOfSchemaInBytes())
 {
-}
-InputFormatterTask::~InputFormatterTask() = default;
-void InputFormatterTask::stop(PipelineExecutionContext& pipelineExecutionContext)
-{
-    inputFormatter->flushFinalTuple(originId, pipelineExecutionContext, *sequenceShredder);
+    this->fieldConfigs.reserve(numberOfFieldsInSchema);
+
+    /// Since we know the schema, we can create a vector that contains a function that converts the string representation of a field value
+    /// to our internal representation in the correct order. During parsing, we iterate over the fields in each tuple, and, using the current
+    /// field number, load the correct function for parsing from the vector.
+    for (const Schema::Field& field : schema)
+    {
+        /// Store the size of the field in bytes (for offset calculations).
+        /// Store the parsing function in a vector.
+        fieldConfigs.emplace_back(field.dataType.getSizeInBytes(), RawInputDataParser::getBasicTypeParseFunction(field.dataType.type));
+    }
 }
 
-void InputFormatterTask::execute(const Memory::TupleBuffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext)
+InputFormatterTask::~InputFormatterTask() = default;
+
+void InputFormatterTask::execute(const Memory::TupleBuffer& rawBuffer, PipelineExecutionContext& pec)
 {
-    inputFormatter->parseTupleBufferRaw(
-        inputTupleBuffer, pipelineExecutionContext, inputTupleBuffer.getNumberOfTuples(), *sequenceShredder);
+    if (rawBuffer.getBufferSize() == 0)
+    {
+        NES_WARNING("Received empty buffer in InputFormatterTask.");
+        return;
+    }
+    /// Check if the current sequence number is in the range of the ring buffer of the sequence shredder.
+    /// If not (should very rarely be the case), we put the task back.
+    /// After enough out-of-range requests, the SequenceShredder increases the size of its ring buffer.
+    if (not sequenceShredder->isInRange(rawBuffer.getSequenceNumber().getRawValue()))
+    {
+        pec.emitBuffer(rawBuffer, PipelineExecutionContext::ContinuationPolicy::REPEAT);
+        return;
+    }
+
+    auto rawBufferData = RawBufferData{};
+    rawBufferData.buffer = rawBuffer;
+    ChunkNumber::Underlying runningChunkNumber = ChunkNumber::INITIAL;
+
+    /// Construct new FieldOffsets object
+    auto fieldOffsets = FieldOffsets(numberOfFieldsInSchema, pec.getBufferManager()->getBufferSize(), pec.getBufferManager());
+
+    /// Get indexes field delimiters in the raw buffer using the InputFormatter implementation
+    const auto bufferView = std::string_view(rawBufferData.buffer.getBuffer<char>(), rawBufferData.buffer.getNumberOfTuples());
+    const auto [offsetOfFirstTupleDelimiter, offsetOfLastTupleDelimiter] = inputFormatter->indexBuffer(bufferView, fieldOffsets);
+    rawBufferData.offsetOfFirstTupleDelimiter = offsetOfFirstTupleDelimiter;
+    rawBufferData.offsetOfLastTupleDelimiter = offsetOfLastTupleDelimiter;
+
+    /// Finalize the state of the field offsets and get the final number of tuples.
+    /// Determine whether raw input buffer delimits at least two tuples.
+    rawBufferData.numberOfTuplesInBuffer = fieldOffsets.finishWrite();
+
+    /// If the offset of the _first_ tuple delimiter is not within the rawBuffer, the InputFormatter did not find any tuple delimiter
+    if (/* hasTupleDelimiter */ rawBufferData.offsetOfFirstTupleDelimiter < rawBuffer.getBufferSize())
+    {
+        /// If the buffer delimits at least two tuples, it may produce two (leading/trailing) spanning tuples and may contain full tuples
+        /// in its raw input buffer.
+        processRawBufferWithTupleDelimiter(rawBufferData, runningChunkNumber, fieldOffsets, pec);
+    }
+    else
+    {
+        /// If the buffer does not delimit a single tuple, it may still connect two buffers that delimit tuples and therefore comple a
+        /// spanning tuple.
+        processRawBufferWithoutTupleDelimiter(rawBufferData, runningChunkNumber, pec);
+    }
 }
+
+void InputFormatterTask::processRawBufferWithTupleDelimiter(
+    const RawBufferData& rawBufferData,
+    ChunkNumber::Underlying& runningChunkNumber,
+    FieldOffsets& fieldOffsets,
+    PipelineExecutionContext& pec) const
+{
+    const auto bufferProvider = pec.getBufferManager();
+    const auto [indexOfSequenceNumberInStagedBuffers, stagedBuffers] = sequenceShredder->processSequenceNumber<true>(
+        StagedBuffer{
+            rawBufferData.buffer,
+            rawBufferData.buffer.getNumberOfTuples(),
+            rawBufferData.offsetOfFirstTupleDelimiter,
+            rawBufferData.offsetOfLastTupleDelimiter},
+        rawBufferData.buffer.getSequenceNumber().getRawValue());
+
+    /// 1. process leading spanning tuple if required
+    auto formattedBuffer = bufferProvider->getBufferBlocking();
+    if (/* hasLeadingSpanningTuple */ indexOfSequenceNumberInStagedBuffers != 0)
+    {
+        processSpanningTuple(
+            {.spanStart = 0, .spanEnd = indexOfSequenceNumberInStagedBuffers}, stagedBuffers, *bufferProvider, formattedBuffer);
+    }
+
+    /// 2. process tuples in buffer
+    if (rawBufferData.numberOfTuplesInBuffer > 0)
+    {
+        processRawBuffer(rawBufferData, runningChunkNumber, fieldOffsets, formattedBuffer, pec);
+    }
+
+    /// 3. process trailing spanning tuple if required
+    if (/* hasTrailingSpanningTuple */ indexOfSequenceNumberInStagedBuffers < (stagedBuffers.size() - 1))
+    {
+        const auto numBytesInFormattedBuffer = formattedBuffer.getNumberOfTuples() * sizeOfTupleInBytes;
+        if (formattedBuffer.getBufferSize() - numBytesInFormattedBuffer < sizeOfTupleInBytes)
+        {
+            formattedBuffer.setSequenceNumber(rawBufferData.buffer.getSequenceNumber());
+            formattedBuffer.setChunkNumber(NES::ChunkNumber(runningChunkNumber++));
+            formattedBuffer.setOriginId(rawBufferData.buffer.getOriginId());
+            pec.emitBuffer(formattedBuffer, NES::PipelineExecutionContext::ContinuationPolicy::POSSIBLE);
+            formattedBuffer = bufferProvider->getBufferBlocking();
+        }
+
+        processSpanningTuple(
+            {.spanStart = indexOfSequenceNumberInStagedBuffers, .spanEnd = stagedBuffers.size() - 1},
+            stagedBuffers,
+            *bufferProvider,
+            formattedBuffer);
+    }
+    /// If a raw buffer contains exactly one delimiter, but does not complete a spanning tuple, the formatted buffer does not contain a tuple
+    if (formattedBuffer.getNumberOfTuples() != 0)
+    {
+        formattedBuffer.setSequenceNumber(rawBufferData.buffer.getSequenceNumber());
+        formattedBuffer.setChunkNumber(NES::ChunkNumber(runningChunkNumber++));
+        formattedBuffer.setOriginId(rawBufferData.buffer.getOriginId());
+        pec.emitBuffer(formattedBuffer, NES::PipelineExecutionContext::ContinuationPolicy::POSSIBLE);
+    }
+}
+
+void InputFormatterTask::processRawBufferWithoutTupleDelimiter(
+    const RawBufferData& rawBufferData, ChunkNumber::Underlying& runningChunkNumber, PipelineExecutionContext& pec) const
+{
+    const auto bufferProvider = pec.getBufferManager();
+    const auto [indexOfSequenceNumberInStagedBuffers, stagedBuffers] = sequenceShredder->processSequenceNumber<false>(
+        StagedBuffer{
+            rawBufferData.buffer,
+            rawBufferData.buffer.getNumberOfTuples(),
+            rawBufferData.offsetOfFirstTupleDelimiter,
+            rawBufferData.offsetOfLastTupleDelimiter},
+        rawBufferData.buffer.getSequenceNumber().getRawValue());
+    if (stagedBuffers.size() < 3)
+    {
+        return;
+    }
+    /// If there is a spanning tuple, get a new buffer for formatted data and process the spanning tuples
+    auto formattedBuffer = bufferProvider->getBufferBlocking();
+    processSpanningTuple({.spanStart = 0, .spanEnd = stagedBuffers.size() - 1}, stagedBuffers, *bufferProvider, formattedBuffer);
+
+    formattedBuffer.setSequenceNumber(rawBufferData.buffer.getSequenceNumber());
+    formattedBuffer.setChunkNumber(NES::ChunkNumber(runningChunkNumber++));
+    formattedBuffer.setOriginId(rawBufferData.buffer.getOriginId());
+    pec.emitBuffer(formattedBuffer, NES::PipelineExecutionContext::ContinuationPolicy::POSSIBLE);
+}
+
+void InputFormatterTask::processTuple(
+    const std::string_view tuple,
+    const FieldOffsetsType* fieldIndexes,
+    Memory::AbstractBufferProvider& bufferProvider,
+    Memory::TupleBuffer& formattedBuffer) const
+{
+    size_t fieldOffsetInRawData = 0;
+    size_t fieldOffsetInFormattedData = 0;
+
+    /// There is one more field offset than there are fields, to enclose all fields, which allows to exactly calculate the size of all fields
+    /// including the first and the last field of the tuple
+    for (size_t fieldIndex = 0; fieldIndex < numberOfFieldsInSchema; ++fieldIndex)
+    {
+        FieldOffsetsType sizeOfCurrentRawField
+            = fieldIndexes[fieldIndex + 1] - fieldIndexes[fieldIndex]; ///NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        auto* const currentFormattedFieldsPtr = formattedBuffer.getBuffer()
+            + fieldOffsetInFormattedData ///NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            + (formattedBuffer.getNumberOfTuples() * sizeOfTupleInBytes); ///NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+
+        /// Deduct the size of the field delimiter for all fields except for the last field (which is already adjusted)
+        const auto isLastField = fieldIndex == numberOfFieldsInSchema - 1;
+        sizeOfCurrentRawField = (isLastField) ? sizeOfCurrentRawField : sizeOfCurrentRawField - fieldDelimiter.size();
+
+        const auto sizeOfCurrentFormattedField = fieldConfigs[fieldIndex].fieldSize;
+
+        const auto currentFieldSV = tuple.substr(fieldOffsetInRawData, sizeOfCurrentRawField);
+        fieldConfigs[fieldIndex].parseFunction(currentFieldSV, currentFormattedFieldsPtr, bufferProvider, formattedBuffer);
+
+        fieldOffsetInRawData += sizeOfCurrentRawField + fieldDelimiter.size();
+        fieldOffsetInFormattedData += sizeOfCurrentFormattedField;
+    }
+}
+
+template <bool IsFlush>
+void InputFormatterTask::processSpanningTuple(
+    const SpanningTuple& spanningTuple,
+    const std::vector<StagedBuffer>& buffersToFormat,
+    Memory::AbstractBufferProvider& bufferProvider,
+    Memory::TupleBuffer& formattedBuffer) const
+{
+    std::string spanningTupleString;
+    /// 1. Process the first buffer
+    const auto& firstBuffer = buffersToFormat[spanningTuple.spanStart];
+    const auto offsetOfFirstByteInFirstBuffer = firstBuffer.offsetOfLastTupleDelimiter + tupleDelimiter.size();
+    PRECONDITION(
+        firstBuffer.sizeOfBufferInBytes >= (offsetOfFirstByteInFirstBuffer),
+        "Cannot create a spanning tuple from from an offset ({}) that is larger or equal to the size of the buffer ({}).",
+        firstBuffer.sizeOfBufferInBytes,
+        offsetOfFirstByteInFirstBuffer);
+    PRECONDITION(buffersToFormat.size() > 1, "Need at least two buffers to create a spanning tuple.");
+    PRECONDITION( ///NOLINT(readability-simplify-boolean-expr)
+        IsFlush or buffersToFormat.at(1).buffer.getSequenceNumber().getRawValue() == NES::SequenceNumber::INITIAL
+            or firstBuffer.buffer.getBuffer() != nullptr,
+        "Non-flush and non-initial buffer cannot have 'null' data.");
+    const auto sizeOfLeadingSpanningTuple = firstBuffer.sizeOfBufferInBytes - (offsetOfFirstByteInFirstBuffer);
+    const std::string_view firstSpanningTuple = std::string_view(
+        firstBuffer.buffer.getBuffer<const char>() ///NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            + offsetOfFirstByteInFirstBuffer, ///NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        sizeOfLeadingSpanningTuple);
+    spanningTupleString.append(firstSpanningTuple);
+    /// 2. Process all buffers in-between the first and the last
+    for (size_t bufferIndex = spanningTuple.spanStart + 1; bufferIndex < spanningTuple.spanEnd; ++bufferIndex)
+    {
+        const auto& currentBuffer = buffersToFormat[bufferIndex];
+        const std::string_view intermediateSpanningTuple
+            = std::string_view(currentBuffer.buffer.getBuffer<const char>(), currentBuffer.sizeOfBufferInBytes);
+        spanningTupleString.append(intermediateSpanningTuple);
+    }
+
+    /// 3. Process the last buffer
+    const auto& lastBuffer = buffersToFormat[spanningTuple.spanEnd];
+    PRECONDITION(
+        IsFlush or (lastBuffer.offsetOfFirstTupleDelimiter < (lastBuffer.sizeOfBufferInBytes)),
+        "Non-flush buffer had tuple delimiter at {} with size {}.",
+        lastBuffer.offsetOfFirstTupleDelimiter,
+        lastBuffer.sizeOfBufferInBytes);
+    PRECONDITION(IsFlush or lastBuffer.buffer.getBuffer() != nullptr, "Non-flush buffer cannot have 'null' data.");
+    const std::string_view lastSpanningTuple
+        = std::string_view(lastBuffer.buffer.getBuffer<const char>(), lastBuffer.offsetOfFirstTupleDelimiter);
+    spanningTupleString.append(lastSpanningTuple);
+
+    /// A spanning tuple may currently be empty (the 'stop' call produces an empty tuple, if the last buffer ends in a tuple delimiter)
+    if (not spanningTupleString.empty())
+    {
+        std::vector<FieldOffsetsType> spanningTupleOffsets(numberOfFieldsInSchema + 1);
+        inputFormatter->indexTuple(spanningTupleString, spanningTupleOffsets.data(), 0);
+        spanningTupleOffsets.at(numberOfFieldsInSchema) = spanningTupleString.size();
+
+        processTuple(spanningTupleString, spanningTupleOffsets.data(), bufferProvider, formattedBuffer);
+        formattedBuffer.setNumberOfTuples(formattedBuffer.getNumberOfTuples() + 1);
+    }
+}
+
+void InputFormatterTask::stop(PipelineExecutionContext& pipelineExecutionContext)
+{
+    const auto [resultBuffers, sequenceNumberToUseForFlushedTuple] = sequenceShredder->flushFinalSpanningTuple();
+    const auto flushedBuffers = resultBuffers.stagedBuffers;
+    /// The sequence shredder injects a dummy buffer, which it always returns. Thus, a single returned buffer means no final spanning tuple.
+    if (flushedBuffers.size() == 1)
+    {
+        return;
+    }
+    /// Get the final buffer (size - 1 is dummy buffer that just contains tuple delimiter)
+    /// Allocate buffer to write formatted tuples into.
+    auto formattedBuffer = pipelineExecutionContext.getBufferManager()->getBufferBlocking();
+
+    processSpanningTuple<true>(
+        {.spanStart = 0, .spanEnd = flushedBuffers.size() - 1},
+        flushedBuffers,
+        *pipelineExecutionContext.getBufferManager(),
+        formattedBuffer);
+    /// Emit formatted buffer with single flushed tuple
+    if (formattedBuffer.getNumberOfTuples() != 0)
+    {
+        formattedBuffer.setSequenceNumber(NES::SequenceNumber(sequenceNumberToUseForFlushedTuple));
+        pipelineExecutionContext.emitBuffer(formattedBuffer, NES::PipelineExecutionContext::ContinuationPolicy::POSSIBLE);
+    }
+}
+
+void InputFormatterTask::processRawBuffer(
+    const RawBufferData& rawBufferData,
+    ChunkNumber::Underlying& runningChunkNumber,
+    FieldOffsets& fieldOffsets,
+    Memory::TupleBuffer& formattedBuffer,
+    PipelineExecutionContext& pec) const
+{
+    const auto bufferProvider = pec.getBufferManager();
+    const auto numberOfTuplesInFirstFormattedBuffer = formattedBuffer.getNumberOfTuples();
+    const size_t numberOfTuplesPerBuffer = bufferProvider->getBufferSize() / sizeOfTupleInBytes;
+    PRECONDITION(numberOfTuplesPerBuffer != 0, "The capacity of a buffer must suffice to hold at least one tuple.");
+    const auto numberOfBuffersToFill = estimateNumberOfRequiredBuffers(
+        rawBufferData.numberOfTuplesInBuffer, numberOfTuplesInFirstFormattedBuffer, numberOfTuplesPerBuffer);
+
+    /// Determine the total number of tuples to produce, including potential prior (spanning) tuples
+    /// If the first buffer is full already, the first iteration of the for loop below does 'nothing'
+    size_t numberOfFormattedTuplesToProduce = rawBufferData.numberOfTuplesInBuffer + numberOfTuplesInFirstFormattedBuffer;
+
+    /// Initialize indexes for offset buffer
+    for (size_t bufferIdx = 0; bufferIdx < numberOfBuffersToFill; ++bufferIdx)
+    {
+        /// Either fill the entire buffer, or process the leftover formatted tuples to produce
+        const size_t numberOfTuplesToRead = std::min(numberOfTuplesPerBuffer, numberOfFormattedTuplesToProduce);
+        /// If the current buffer is not the first buffer, set the meta data of the prior buffer, emit it, get a new buffer and reset the associated counters
+        if (bufferIdx != 0)
+        {
+            /// The current raw buffer produces more than one formatted buffer.
+            /// Each formatted buffer has the sequence number of the raw buffer and a chunk number that uniquely identifies it.
+            /// Only the last formatted buffer sets the 'isLastChunk' member to true.
+            formattedBuffer.setLastChunk(false);
+            formattedBuffer.setSequenceNumber(rawBufferData.buffer.getSequenceNumber());
+            formattedBuffer.setChunkNumber(ChunkNumber(runningChunkNumber++));
+            formattedBuffer.setOriginId(rawBufferData.buffer.getOriginId());
+            pec.emitBuffer(formattedBuffer, PipelineExecutionContext::ContinuationPolicy::POSSIBLE);
+            /// The 'isLastChunk' member of a new buffer is true pre default. If we don't require another buffer, the flag stays true.
+            formattedBuffer = bufferProvider->getBufferBlocking();
+        }
+
+        /// Fill current buffer until either full, or we exhausted tuples in raw buffer
+        while (formattedBuffer.getNumberOfTuples() < numberOfTuplesToRead)
+        {
+            const auto* const nextTupleOffsets = fieldOffsets.readOffsetsOfNextTuple();
+            const auto tupleStart = nextTupleOffsets[0]; ///NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            const auto tupleEnd = nextTupleOffsets[numberOfFieldsInSchema]; ///NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            const auto nextTuple = std::string_view(
+                rawBufferData.buffer.getBuffer<char>() + tupleStart, ///NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+                tupleEnd - tupleStart);
+            processTuple(nextTuple, nextTupleOffsets, *bufferProvider, formattedBuffer);
+            formattedBuffer.setNumberOfTuples(formattedBuffer.getNumberOfTuples() + 1);
+        }
+        numberOfFormattedTuplesToProduce -= formattedBuffer.getNumberOfTuples();
+    }
+}
+
 std::ostream& InputFormatterTask::toString(std::ostream& os) const
 {
     os << "InputFormatterTask: {\n";

--- a/nes-input-formatters/src/InputFormatterTask.cpp
+++ b/nes-input-formatters/src/InputFormatterTask.cpp
@@ -158,6 +158,7 @@ void InputFormatterTask::processRawBufferWithTupleDelimiter(
 
     /// 1. process leading spanning tuple if required
     auto formattedBuffer = bufferProvider->getBufferBlocking();
+    formattedBuffer.setLastChunk(false);
     if (/* hasLeadingSpanningTuple */ indexOfSequenceNumberInStagedBuffers != 0)
     {
         processSpanningTuple(
@@ -181,6 +182,7 @@ void InputFormatterTask::processRawBufferWithTupleDelimiter(
             formattedBuffer.setOriginId(rawBufferData.buffer.getOriginId());
             pec.emitBuffer(formattedBuffer, NES::PipelineExecutionContext::ContinuationPolicy::POSSIBLE);
             formattedBuffer = bufferProvider->getBufferBlocking();
+            formattedBuffer.setLastChunk(false);
         }
 
         processSpanningTuple(
@@ -192,6 +194,7 @@ void InputFormatterTask::processRawBufferWithTupleDelimiter(
     /// If a raw buffer contains exactly one delimiter, but does not complete a spanning tuple, the formatted buffer does not contain a tuple
     if (formattedBuffer.getNumberOfTuples() != 0)
     {
+        formattedBuffer.setLastChunk(true);
         formattedBuffer.setSequenceNumber(rawBufferData.buffer.getSequenceNumber());
         formattedBuffer.setChunkNumber(NES::ChunkNumber(runningChunkNumber++));
         formattedBuffer.setOriginId(rawBufferData.buffer.getOriginId());
@@ -216,6 +219,7 @@ void InputFormatterTask::processRawBufferWithoutTupleDelimiter(
     }
     /// If there is a spanning tuple, get a new buffer for formatted data and process the spanning tuples
     auto formattedBuffer = bufferProvider->getBufferBlocking();
+    formattedBuffer.setLastChunk(true);
     processSpanningTuple({.spanStart = 0, .spanEnd = stagedBuffers.size() - 1}, stagedBuffers, *bufferProvider, formattedBuffer);
 
     formattedBuffer.setSequenceNumber(rawBufferData.buffer.getSequenceNumber());
@@ -257,7 +261,6 @@ void InputFormatterTask::processTuple(
     }
 }
 
-template <bool IsFlush>
 void InputFormatterTask::processSpanningTuple(
     const SpanningTuple& spanningTuple,
     const std::vector<StagedBuffer>& buffersToFormat,
@@ -275,9 +278,9 @@ void InputFormatterTask::processSpanningTuple(
         offsetOfFirstByteInFirstBuffer);
     PRECONDITION(buffersToFormat.size() > 1, "Need at least two buffers to create a spanning tuple.");
     PRECONDITION( ///NOLINT(readability-simplify-boolean-expr)
-        IsFlush or buffersToFormat.at(1).buffer.getSequenceNumber().getRawValue() == NES::SequenceNumber::INITIAL
+        buffersToFormat.at(1).buffer.getSequenceNumber().getRawValue() == NES::SequenceNumber::INITIAL
             or firstBuffer.buffer.getBuffer() != nullptr,
-        "Non-flush and non-initial buffer cannot have 'null' data.");
+        "Non-initial buffer cannot have 'null' data.");
     const auto sizeOfLeadingSpanningTuple = firstBuffer.sizeOfBufferInBytes - (offsetOfFirstByteInFirstBuffer);
     const std::string_view firstSpanningTuple = std::string_view(
         firstBuffer.buffer.getBuffer<const char>() ///NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
@@ -296,11 +299,11 @@ void InputFormatterTask::processSpanningTuple(
     /// 3. Process the last buffer
     const auto& lastBuffer = buffersToFormat[spanningTuple.spanEnd];
     PRECONDITION(
-        IsFlush or (lastBuffer.offsetOfFirstTupleDelimiter < (lastBuffer.sizeOfBufferInBytes)),
-        "Non-flush buffer had tuple delimiter at {} with size {}.",
+        (lastBuffer.offsetOfFirstTupleDelimiter < (lastBuffer.sizeOfBufferInBytes)),
+        "Buffer had tuple delimiter at {} with size {}.",
         lastBuffer.offsetOfFirstTupleDelimiter,
         lastBuffer.sizeOfBufferInBytes);
-    PRECONDITION(IsFlush or lastBuffer.buffer.getBuffer() != nullptr, "Non-flush buffer cannot have 'null' data.");
+    PRECONDITION(lastBuffer.buffer.getBuffer() != nullptr, "Buffer cannot have 'null' data.");
     const std::string_view lastSpanningTuple
         = std::string_view(lastBuffer.buffer.getBuffer<const char>(), lastBuffer.offsetOfFirstTupleDelimiter);
     spanningTupleString.append(lastSpanningTuple);
@@ -317,30 +320,9 @@ void InputFormatterTask::processSpanningTuple(
     }
 }
 
-void InputFormatterTask::stop(PipelineExecutionContext& pipelineExecutionContext)
+void InputFormatterTask::stop(PipelineExecutionContext&)
 {
-    const auto [resultBuffers, sequenceNumberToUseForFlushedTuple] = sequenceShredder->flushFinalSpanningTuple();
-    const auto flushedBuffers = resultBuffers.stagedBuffers;
-    /// The sequence shredder injects a dummy buffer, which it always returns. Thus, a single returned buffer means no final spanning tuple.
-    if (flushedBuffers.size() == 1)
-    {
-        return;
-    }
-    /// Get the final buffer (size - 1 is dummy buffer that just contains tuple delimiter)
-    /// Allocate buffer to write formatted tuples into.
-    auto formattedBuffer = pipelineExecutionContext.getBufferManager()->getBufferBlocking();
-
-    processSpanningTuple<true>(
-        {.spanStart = 0, .spanEnd = flushedBuffers.size() - 1},
-        flushedBuffers,
-        *pipelineExecutionContext.getBufferManager(),
-        formattedBuffer);
-    /// Emit formatted buffer with single flushed tuple
-    if (formattedBuffer.getNumberOfTuples() != 0)
-    {
-        formattedBuffer.setSequenceNumber(NES::SequenceNumber(sequenceNumberToUseForFlushedTuple));
-        pipelineExecutionContext.emitBuffer(formattedBuffer, NES::PipelineExecutionContext::ContinuationPolicy::POSSIBLE);
-    }
+    sequenceShredder->validateState();
 }
 
 void InputFormatterTask::processRawBuffer(
@@ -372,13 +354,13 @@ void InputFormatterTask::processRawBuffer(
             /// The current raw buffer produces more than one formatted buffer.
             /// Each formatted buffer has the sequence number of the raw buffer and a chunk number that uniquely identifies it.
             /// Only the last formatted buffer sets the 'isLastChunk' member to true.
-            formattedBuffer.setLastChunk(false);
             formattedBuffer.setSequenceNumber(rawBufferData.buffer.getSequenceNumber());
             formattedBuffer.setChunkNumber(ChunkNumber(runningChunkNumber++));
             formattedBuffer.setOriginId(rawBufferData.buffer.getOriginId());
             pec.emitBuffer(formattedBuffer, PipelineExecutionContext::ContinuationPolicy::POSSIBLE);
             /// The 'isLastChunk' member of a new buffer is true pre default. If we don't require another buffer, the flag stays true.
             formattedBuffer = bufferProvider->getBufferBlocking();
+            formattedBuffer.setLastChunk(false);
         }
 
         /// Fill current buffer until either full, or we exhausted tuples in raw buffer

--- a/nes-input-formatters/src/RawInputDataParser.cpp
+++ b/nes-input-formatters/src/RawInputDataParser.cpp
@@ -1,0 +1,106 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <RawInputDataParser.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <string_view>
+#include <DataTypes/DataType.hpp>
+#include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/TupleBuffer.hpp>
+#include <ErrorHandling.hpp>
+
+namespace NES::InputFormatters::RawInputDataParser
+{
+
+ParseFunctionSignature getBasicStringParseFunction()
+{
+    return [](std::string_view inputString,
+              int8_t* fieldPointer,
+              Memory::AbstractBufferProvider& bufferProvider,
+              const NES::Memory::TupleBuffer& tupleBufferFormatted)
+    {
+        const auto valueLength = inputString.length();
+        auto childBuffer = bufferProvider.getUnpooledBuffer(valueLength + sizeof(uint32_t));
+        if (not childBuffer.has_value())
+        {
+            throw CannotAllocateBuffer("Could not store string, because we cannot allocate a child buffer.");
+        }
+
+        auto& childBufferVal = childBuffer.value();
+        *childBufferVal.getBuffer<uint32_t>() = valueLength;
+        std::memcpy(
+            childBufferVal.getBuffer<char>() + sizeof(uint32_t), ///NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            inputString.data(),
+            valueLength);
+        const auto indexToChildBuffer = tupleBufferFormatted.storeChildBuffer(childBufferVal);
+        auto* childBufferIndexPointer = reinterpret_cast<uint32_t*>(fieldPointer); ///NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+        *childBufferIndexPointer = indexToChildBuffer;
+    };
+}
+
+ParseFunctionSignature getBasicTypeParseFunction(const DataType::Type physicalType)
+{
+    switch (physicalType)
+    {
+        case DataType::Type::INT8: {
+            return parseFieldString<int8_t>();
+        }
+        case DataType::Type::INT16: {
+            return parseFieldString<int16_t>();
+        }
+        case DataType::Type::INT32: {
+            return parseFieldString<int32_t>();
+        }
+        case DataType::Type::INT64: {
+            return parseFieldString<int64_t>();
+        }
+        case DataType::Type::UINT8: {
+            return parseFieldString<uint8_t>();
+        }
+        case DataType::Type::UINT16: {
+            return parseFieldString<uint16_t>();
+        }
+        case DataType::Type::UINT32: {
+            return parseFieldString<uint32_t>();
+        }
+        case DataType::Type::UINT64: {
+            return parseFieldString<uint64_t>();
+        }
+        case DataType::Type::FLOAT32: {
+            return parseFieldString<float>();
+        }
+        case DataType::Type::FLOAT64: {
+            return parseFieldString<double>();
+        }
+        case DataType::Type::CHAR: {
+            return parseFieldString<char>();
+        }
+        case DataType::Type::BOOLEAN: {
+            return parseFieldString<bool>();
+        }
+        case DataType::Type::VARSIZED: {
+            return getBasicStringParseFunction();
+        }
+        case DataType::Type::VARSIZED_POINTER_REP: {
+            throw NotImplemented("Cannot parse VARSIZED_POINTER_REP type.");
+        }
+        case DataType::Type::UNDEFINED: {
+            throw NotImplemented("Cannot parse undefined type.");
+        }
+    }
+    return nullptr;
+}
+}

--- a/nes-input-formatters/src/SequenceShredder.cpp
+++ b/nes-input-formatters/src/SequenceShredder.cpp
@@ -30,7 +30,9 @@
 #include <Runtime/TupleBuffer.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
+#include <Identifiers/Identifiers.hpp>
 #include <ErrorHandling.hpp>
 
 namespace NES::InputFormatters
@@ -62,6 +64,11 @@ SequenceShredder::SequenceShredder(const size_t sizeOfTupleDelimiter, const size
            .offsetOfFirstTupleDelimiter = 0,
            .offsetOfLastTupleDelimiter = 0};
     this->stagedBufferUses[0] = 1;
+}
+
+SequenceShredder::~SequenceShredder()
+{
+    validateState();
 };
 
 bool SequenceShredder::isInRange(const SequenceNumberType sequenceNumber)
@@ -77,57 +84,95 @@ bool SequenceShredder::isInRange(const SequenceNumberType sequenceNumber)
     return false;
 }
 
-std::pair<SequenceShredder::SpanningTupleBuffers, SequenceShredder::SequenceNumberType> SequenceShredder::flushFinalSpanningTuple()
+struct CriticalSequenceNumberEntry
+{
+    SequenceShredder::SequenceNumberType sequenceNumber;
+    std::string reason;
+
+    friend std::ostream& operator<<(std::ostream& os, const CriticalSequenceNumberEntry& entry)
+    {
+        os << fmt::format("({}: {})", entry.sequenceNumber, entry.reason);
+        return os;
+    }
+};
+
+void SequenceShredder::validateState() noexcept
 {
     /// protect: write(resizeRequestCount), read(tail,numberOfBitmaps)
     {
-        std::unique_lock lock(this->readWriteMutex);
-        isLastTuple = true;
-        for (size_t offsetToTail = 1; offsetToTail <= this->numberOfBitmaps; ++offsetToTail)
+        try
         {
-            const auto bitmapIndex = (this->tail + (this->numberOfBitmaps - offsetToTail)) & this->numberOfBitmapsModulo;
-            const auto seenAndUsedBitmap = this->seenAndUsedBitmaps[bitmapIndex];
-            const auto tupleDelimiterBitmap = this->tupleDelimiterBitmaps[bitmapIndex];
-            /// Reverse-search bitmaps, until a bitmap is not 0 and therefore represents a buffer that is in the stagedBuffers vector
-            if ((seenAndUsedBitmap | tupleDelimiterBitmap) != 0)
+            const std::unique_lock lock(this->readWriteMutex);
+            std::stringstream stateStream;
+
+            const auto firstSequenceNumberInRange = this->tail * SIZE_OF_BITMAP_IN_BITS;
+            const auto lastSequenceNumberInRange = firstSequenceNumberInRange + (SIZE_OF_BITMAP_IN_BITS * numberOfBitmaps) - 1;
+
+            auto largestActiveSequenceNumber = SequenceNumber::INVALID;
+            std::vector<CriticalSequenceNumberEntry> criticalSequenceNumbers;
+            std::vector<SequenceNumberType> openSequenceNumbers;
+            for (size_t sequenceNumberOffset = 0; sequenceNumberOffset < this->stagedBuffers.size(); ++sequenceNumberOffset)
             {
-                /// If the last buffer contains a buffer that does not contain a delimiter, we need to check for a spanning tuple
-                /// We construct a dummy staged buffer and set its sequence number to exactly one higher than the largest seen sequence number.
-                /// The dummy staged buffer flushes out all prior buffers that still depended on a tuple delimiter that did not appear,
-                /// because an EOF/EOS is not a tuple delimiter.
-                const auto firstSequenceNumberOfTail = this->tail * SIZE_OF_BITMAP_IN_BITS;
-                const auto sequenceNumberOffsetOfBitmap = ((this->numberOfBitmaps - offsetToTail) & this->numberOfBitmapsModulo)
-                    << BITMAP_SIZE_BIT_SHIFT;
-                const auto firstSequenceNumberOfBitmap = firstSequenceNumberOfTail + sequenceNumberOffsetOfBitmap;
-                const auto numberOfNotSeenSequenceNumbersInBitmap = std::countl_zero(seenAndUsedBitmap | tupleDelimiterBitmap);
-                const auto offsetToNextLargerSequenceNumber = SIZE_OF_BITMAP_IN_BITS - numberOfNotSeenSequenceNumbersInBitmap;
-                const auto nextLargestSequenceNumber = firstSequenceNumberOfBitmap + offsetToNextLargerSequenceNumber;
-                auto dummyStagedBuffer = StagedBuffer{
-                    .buffer = NES::Memory::TupleBuffer{},
-                    .sizeOfBufferInBytes = 0,
-                    .offsetOfFirstTupleDelimiter = 0,
-                    .offsetOfLastTupleDelimiter = 0};
+                const auto runningSequenceNumber = firstSequenceNumberInRange + sequenceNumberOffset;
+                const auto offsetToTail = sequenceNumberOffset / SIZE_OF_BITMAP_IN_BITS;
+                const auto bitIdx = runningSequenceNumber % SIZE_OF_BITMAP_IN_BITS;
+                const auto bitmapIdx = (this->tail + offsetToTail) & this->numberOfBitmapsModulo;
+                const auto seenAndUsedBitmap = this->seenAndUsedBitmaps[bitmapIdx];
+                const auto tupleDelimiterBitmap = this->tupleDelimiterBitmaps[bitmapIdx];
+                const auto currentBit = static_cast<size_t>(1) << bitIdx;
+                const auto isSeenAndUsedBitmapSet = static_cast<bool>(seenAndUsedBitmap & currentBit);
+                const auto isTupleDelimiterBitmapSet = static_cast<bool>(tupleDelimiterBitmap & currentBit);
 
-                /// Determine whether the formatter produced a buffer using the largest sequence number already.
-                /// If that is the case, if the buffer of the largest sequence number contains a tuple delimiter and it was used alread (uses != 2)
-                const auto largestSequenceNumber = nextLargestSequenceNumber - 1;
-                const auto bitOfLastSequenceNumber = FIRST_BIT_MASK << (offsetToNextLargerSequenceNumber - 1);
-                const auto hasTupleDelimiter = static_cast<bool>(tupleDelimiterBitmap & bitOfLastSequenceNumber);
-                const auto bufferIdxOfLargestSequenceNumber = largestSequenceNumber & (this->stagedBuffers.size() - 1);
-                const auto numUsesOfLastSequenceNumber = this->stagedBufferUses[bufferIdxOfLargestSequenceNumber];
-                const auto largestSequenceNumberProducedBufferAlready = hasTupleDelimiter and numUsesOfLastSequenceNumber != 2;
-                /// We can safely use the next larger sequence number, if the there is at least one formatted buffer, with the current largest sequence number
-                const auto sequenceNumberToUseForFlushedTuple
-                    = (largestSequenceNumberProducedBufferAlready) ? nextLargestSequenceNumber : largestSequenceNumber;
-
-                lock.unlock();
-                return std::make_pair(
-                    processSequenceNumber<true>(std::move(dummyStagedBuffer), nextLargestSequenceNumber),
-                    sequenceNumberToUseForFlushedTuple);
+                const auto stagedBufferIdx = runningSequenceNumber % this->stagedBuffers.size();
+                const auto isUsed = this->stagedBufferUses[stagedBufferIdx] != 0;
+                const auto isNull = this->stagedBuffers[stagedBufferIdx].buffer.getBuffer() == nullptr;
+                const auto isInValidNotUsedState = not(isUsed) and isNull;
+                const auto isInValidUsedState = isUsed and not(isNull) and (isSeenAndUsedBitmapSet or isTupleDelimiterBitmapSet);
+                auto sequenceNumberIsOutOfRange = false;
+                if (not(isNull))
+                {
+                    const auto sequenceNumberOfBuffer = this->stagedBuffers[stagedBufferIdx].buffer.getSequenceNumber().getRawValue();
+                    sequenceNumberIsOutOfRange
+                        = sequenceNumberOfBuffer < firstSequenceNumberInRange or sequenceNumberOfBuffer > lastSequenceNumberInRange;
+                }
+                if (not(isInValidNotUsedState or isInValidUsedState) or sequenceNumberIsOutOfRange)
+                {
+                    /// Encountered critical state
+                    auto criticalSequenceNumberEntry = CriticalSequenceNumberEntry{
+                        .sequenceNumber = runningSequenceNumber,
+                        .reason = fmt::format(
+                            "isUsed: {}, isNull: {}, isTupleDelimiterBitmapSet: {}, isSeenAndUsedBitmapSet: {}",
+                            isUsed,
+                            isNull,
+                            isTupleDelimiterBitmapSet,
+                            isSeenAndUsedBitmapSet)};
+                    criticalSequenceNumbers.emplace_back(criticalSequenceNumberEntry);
+                }
+                if (isInValidUsedState)
+                {
+                    openSequenceNumbers.emplace_back(runningSequenceNumber);
+                }
+                largestActiveSequenceNumber = isInValidUsedState ? runningSequenceNumber : largestActiveSequenceNumber;
             }
+            stateStream << fmt::format(
+                "SequenceShredder State(SequenceNumberRange[{}-{}], Largest Active Sequence Number: {}, Open Sequence Numbers({}), "
+                "Critical Sequence Numbers({}))",
+                firstSequenceNumberInRange,
+                lastSequenceNumberInRange,
+                largestActiveSequenceNumber,
+                openSequenceNumbers.empty() ? "None" : fmt::format("{}", fmt::join(openSequenceNumbers, ", ")),
+                criticalSequenceNumbers.empty() ? "None" : fmt::format("{}", fmt::join(criticalSequenceNumbers, ", ")));
+            if (not criticalSequenceNumbers.empty())
+            {
+                NES_ERROR("Validation failed: {}", stateStream.str());
+            }
+            NES_DEBUG("Validation successful.");
+        }
+        catch (...)
+        {
+            NES_ERROR("Validation failed unexpectedly.");
         }
     }
-    return std::make_pair(SpanningTupleBuffers{}, 0);
 }
 
 template <bool HasTupleDelimiter>
@@ -523,6 +568,7 @@ SequenceShredder::SpanningTupleBuffers SequenceShredder::checkSpanningTupleWitho
             const auto adjustedSpanningTupleIndex = spanningTupleIndex & stagedBufferSizeModulo;
             /// A buffer with a tuple delimiter has two uses. One for starting and one for ending a SpanningTuple.
             const auto newUses = --this->stagedBufferUses[adjustedSpanningTupleIndex];
+            INVARIANT(newUses >= 0, "Uses can never be negative");
             auto returnBuffer = (newUses == 0) ? std::move(this->stagedBuffers[adjustedSpanningTupleIndex])
                                                : this->stagedBuffers[adjustedSpanningTupleIndex];
             spanningTupleBuffers.emplace_back(std::move(returnBuffer));
@@ -580,13 +626,20 @@ SequenceShredder::SpanningTupleBuffers SequenceShredder::checkSpanningTupleWithT
         if (const auto minSequenceNumber = this->tail << BITMAP_SIZE_BIT_SHIFT; sequenceNumber < minSequenceNumber)
         {
             const auto adjustedSpanningTupleIndex = sequenceNumber & stagedBufferSizeModulo;
+            /// Check if the corresponding staged buffer, if not null, still has the same sequence number
             const auto sequenceShredderStillOwnsBuffer = stagedBuffers[adjustedSpanningTupleIndex].buffer.getBuffer() != nullptr
-                and (stagedBuffers[adjustedSpanningTupleIndex].buffer.getSequenceNumber()
-                     == stagedBufferOfSequenceNumber.buffer.getSequenceNumber());
+                and (stagedBuffers[adjustedSpanningTupleIndex].buffer.getSequenceNumber().getRawValue() == sequenceNumber);
             /// If the sequence shredder still owns the 'stagedBufferOfSequenceNumber', return its ownerhip
-            auto returnBuffer = (sequenceShredderStillOwnsBuffer) ? std::move(this->stagedBuffers[adjustedSpanningTupleIndex])
-                                                                  : std::move(stagedBufferOfSequenceNumber);
-            returnBuffers.emplace_back(std::move(returnBuffer));
+            if (sequenceShredderStillOwnsBuffer)
+            {
+                returnBuffers.emplace_back(std::move(this->stagedBuffers[adjustedSpanningTupleIndex]));
+                --this->stagedBufferUses[adjustedSpanningTupleIndex];
+            }
+            else
+            {
+                returnBuffers.emplace_back(std::move(stagedBufferOfSequenceNumber));
+            }
+            INVARIANT(this->stagedBufferUses[adjustedSpanningTupleIndex] >= 0, "Uses can never be negative");
             return SpanningTupleBuffers{.indexOfProcessedSequenceNumber = 0, .stagedBuffers = std::move(returnBuffers)};
         }
         for (auto spanningTupleIndex = startIndex; spanningTupleIndex <= endIndex; ++spanningTupleIndex)

--- a/nes-input-formatters/src/SequenceShredder.cpp
+++ b/nes-input-formatters/src/SequenceShredder.cpp
@@ -12,6 +12,8 @@
     limitations under the License.
 */
 
+#include <SequenceShredder.hpp>
+
 #include <bit>
 #include <cstddef>
 #include <cstdint>
@@ -30,7 +32,6 @@
 #include <fmt/format.h>
 
 #include <ErrorHandling.hpp>
-#include <SequenceShredder.hpp>
 
 namespace NES::InputFormatters
 {
@@ -76,7 +77,7 @@ bool SequenceShredder::isInRange(const SequenceNumberType sequenceNumber)
     return false;
 }
 
-std::pair<SequenceShredder::SpanningTupleBuffers, SequenceShredder::SequenceNumberType> SequenceShredder::flushFinalPartialTuple()
+std::pair<SequenceShredder::SpanningTupleBuffers, SequenceShredder::SequenceNumberType> SequenceShredder::flushFinalSpanningTuple()
 {
     /// protect: write(resizeRequestCount), read(tail,numberOfBitmaps)
     {

--- a/nes-input-formatters/tests/UnitTests/ConcurrentSynchronizationTest.cpp
+++ b/nes-input-formatters/tests/UnitTests/ConcurrentSynchronizationTest.cpp
@@ -26,6 +26,11 @@
 #include <gtest/gtest.h>
 #include <SequenceShredder.hpp>
 
+/// Tests whether the SequenceShredder correctly finds spanning tuples given random orders of sequence numbers and random occurrences of
+/// tuple delimiters in the buffers that belong to the sequence numbers.
+/// Uses multiple threads that call the SequenceShredder to determine spanning tuples. Each thread randomly (seeded) determines whether its current
+/// request has a tuple delimiter or not, calls the 'processSequenceNumber' function of the SequenceShredder and tracks the resulting spanning tuples.
+/// We check whether the range of all produces sequence numbers matches the expected range.
 class StreamingMultiThreaderAutomatedSequenceShredderTest : public ::testing::Test
 {
 private:
@@ -116,7 +121,7 @@ public:
                 {
                 }
 
-                const auto dummyStagedBuffer = SequenceShredder::StagedBuffer{
+                const auto dummyStagedBuffer = NES::InputFormatters::StagedBuffer{
                     .buffer = NES::Memory::TupleBuffer{},
                     .sizeOfBufferInBytes = threadLocalSequenceNumber,
                     .offsetOfFirstTupleDelimiter = 0,

--- a/nes-input-formatters/tests/UnitTests/SmallFilesTest.cpp
+++ b/nes-input-formatters/tests/UnitTests/SmallFilesTest.cpp
@@ -48,28 +48,21 @@ class SmallFilesTest : public Testing::BaseUnitTest
     struct TestFile
     {
         std::string fileName;
-        bool endsWithNewline;
         std::vector<InputFormatterTestUtil::TestDataTypes> schemaFieldTypes;
     };
 
     using enum InputFormatterTestUtil::TestDataTypes;
     std::unordered_map<std::string, TestFile> testFileMap{
-        {"TwoIntegerColumns",
-         TestFile{.fileName = "TwoIntegerColumns_20_Lines.csv", .endsWithNewline = true, .schemaFieldTypes = {INT32, INT32}}},
+        {"TwoIntegerColumns", TestFile{.fileName = "TwoIntegerColumns_20_Lines.csv", .schemaFieldTypes = {INT32, INT32}}},
         {"Bimbo_1_1000", /// https://github.com/cwida/public_bi_benchmark/blob/master/benchmark/Bimbo/
          TestFile{
              .fileName = "Bimbo_1_1000_Lines.csv",
-             .endsWithNewline = true,
              .schemaFieldTypes = {INT16, INT16, INT32, INT16, FLOAT64, INT32, INT16, INT32, INT16, INT16, FLOAT64, INT16}}},
         {"Food_1", /// https://github.com/cwida/public_bi_benchmark/blob/master/benchmark/Food/
-         TestFile{
-             .fileName = "Food_1_1000_Lines.csv",
-             .endsWithNewline = true,
-             .schemaFieldTypes = {INT16, INT32, VARSIZED, VARSIZED, INT16, FLOAT64}}},
+         TestFile{.fileName = "Food_1_1000_Lines.csv", .schemaFieldTypes = {INT16, INT32, VARSIZED, VARSIZED, INT16, FLOAT64}}},
         {"Spacecraft_Telemetry", /// generated
          TestFile{
              .fileName = "Spacecraft_Telemetry_1000_Lines.csv",
-             .endsWithNewline = true,
              .schemaFieldTypes = {INT32, UINT32, BOOLEAN, CHAR, VARSIZED, FLOAT32, FLOAT64}}}};
     SourceCatalog sourceCatalog;
 
@@ -174,16 +167,8 @@ public:
                     = actualResultTestBuffer.toString(schema, Memory::MemoryLayouts::TestTupleBuffer::PrintMode::NO_HEADER_END_IN_NEWLINE);
                 out << currentBufferAsString;
             }
-            if (currentTestFile.endsWithNewline)
-            {
-                out << Memory::MemoryLayouts::TestTupleBuffer::createTestTupleBuffer(resultBufferVec.back(), schema)
-                           .toString(schema, Memory::MemoryLayouts::TestTupleBuffer::PrintMode::NO_HEADER_END_IN_NEWLINE);
-            }
-            else
-            {
-                out << Memory::MemoryLayouts::TestTupleBuffer::createTestTupleBuffer(resultBufferVec.back(), schema)
-                           .toString(schema, Memory::MemoryLayouts::TestTupleBuffer::PrintMode::NO_HEADER_END_WITHOUT_NEWLINE);
-            }
+            out << Memory::MemoryLayouts::TestTupleBuffer::createTestTupleBuffer(resultBufferVec.back(), schema)
+                       .toString(schema, Memory::MemoryLayouts::TestTupleBuffer::PrintMode::NO_HEADER_END_IN_NEWLINE);
             out.close();
             ASSERT_TRUE(InputFormatterTestUtil::compareFiles(testFilePath, resultFilePath));
             resultBuffers->clear();

--- a/nes-input-formatters/tests/UnitTests/SpecificSequenceTest.cpp
+++ b/nes-input-formatters/tests/UnitTests/SpecificSequenceTest.cpp
@@ -26,6 +26,8 @@
 namespace NES
 {
 
+/// Tests whether the SequenceShredder can handle specific sequences of input data, e.g., a single tuple without tuple delimiters, or splitting
+/// up input data and giving it to the sequence shredder in a specific order.
 class SpecificSequenceTest : public Testing::BaseUnitTest
 {
 public:
@@ -39,31 +41,15 @@ public:
     void TearDown() override { BaseUnitTest::TearDown(); }
 };
 
-TEST_F(SpecificSequenceTest, testTaskPipelineWithMultipleTasksOneRawByteBuffer)
+TEST_F(SpecificSequenceTest, oneTupleWithoutTupleDelimiters)
 {
     using namespace InputFormatterTestUtil;
     using enum TestDataTypes;
     using TestTuple = std::tuple<int32_t, int32_t>;
     runTest<TestTuple>(TestConfig<TestTuple>{
         .numRequiredBuffers = 3, /// 2 buffer for raw data, 1 buffer for results
-        .bufferSize = 16,
-        .parserConfig = {.parserType = "CSV", .tupleDelimiter = "\n", .fieldDelimiter = ","},
-        .testSchema = {INT32, INT32},
-        .expectedResults = {WorkerThreadResults<TestTuple>{{{TestTuple(123456789, 123456789)}}}},
-        .rawBytesPerThread
-        = {/* buffer 1 */ {.sequenceNumber = SequenceNumber(1), .rawBytes = "123456789,123456"},
-           /* buffer 2 */ {.sequenceNumber = SequenceNumber(2), .rawBytes = "789"}}});
-}
-
-/// Each thread should share the same InputFormatterTask, meaning that we need to check that threads don't interfere with each other's state
-TEST_F(SpecificSequenceTest, testTaskPipelineExecutingOnTwoDifferentThreads)
-{
-    using namespace InputFormatterTestUtil;
-    using enum TestDataTypes;
-    using TestTuple = std::tuple<int32_t, int32_t>;
-    runTest<TestTuple>(TestConfig<TestTuple>{
-        .numRequiredBuffers = 3, /// 2 buffers for raw data, 1 buffer for results
-        .bufferSize = 16,
+        .sizeOfRawBuffers = 16,
+        .sizeOfFormattedBuffers = 20,
         .parserConfig = {.parserType = "CSV", .tupleDelimiter = "\n", .fieldDelimiter = ","},
         .testSchema = {INT32, INT32},
         .expectedResults = {WorkerThreadResults<TestTuple>{{{TestTuple(123456789, 123456789)}}}},
@@ -73,14 +59,15 @@ TEST_F(SpecificSequenceTest, testTaskPipelineExecutingOnTwoDifferentThreads)
 }
 
 /// Threads may process buffers out of order. This test simulates a scenario where the second thread process the second buffer first.
-TEST_F(SpecificSequenceTest, testTaskPipelineExecutingOnTwoDifferentThreadsOutOfOrder)
+TEST_F(SpecificSequenceTest, testTaskPipelineExecutingOutOfOrder)
 {
     using namespace InputFormatterTestUtil;
     using enum TestDataTypes;
     using TestTuple = std::tuple<int32_t, int32_t>;
     runTest<TestTuple>(TestConfig<TestTuple>{
         .numRequiredBuffers = 3, /// 2 buffers for raw data, 1 buffer for results
-        .bufferSize = 16,
+        .sizeOfRawBuffers = 16,
+        .sizeOfFormattedBuffers = 20,
         .parserConfig = {.parserType = "CSV", .tupleDelimiter = "\n", .fieldDelimiter = ","},
         .testSchema = {INT32, INT32},
         .expectedResults = {WorkerThreadResults<TestTuple>{{{TestTuple(123456789, 123456789)}}}},
@@ -97,7 +84,8 @@ TEST_F(SpecificSequenceTest, testTwoFullTuplesInFirstAndLastBuffer)
     using TestTuple = std::tuple<int32_t, int32_t>;
     runTest<TestTuple>(TestConfig<TestTuple>{
         .numRequiredBuffers = 4, /// 2 buffers for raw data, two buffers for results
-        .bufferSize = 16,
+        .sizeOfRawBuffers = 16,
+        .sizeOfFormattedBuffers = 20, /// 8 bytes metadata, 12 bytes per formatted tuple
         .parserConfig = {.parserType = "CSV", .tupleDelimiter = "\n", .fieldDelimiter = ","},
         .testSchema = {INT32, INT32},
         .expectedResults = {WorkerThreadResults<TestTuple>{{{TestTuple(123456789, 12345)}, {TestTuple{12345, 123456789}}}}},
@@ -113,7 +101,8 @@ TEST_F(SpecificSequenceTest, testDelimiterThatIsMoreThanOneCharacter)
     using TestTuple = std::tuple<int32_t, int32_t>;
     runTest<TestTuple>(TestConfig<TestTuple>{
         .numRequiredBuffers = 4, /// 2 buffers for raw data, two buffers for results
-        .bufferSize = 16,
+        .sizeOfRawBuffers = 16,
+        .sizeOfFormattedBuffers = 20,
         .parserConfig = {.parserType = "CSV", .tupleDelimiter = "--", .fieldDelimiter = ","},
         .testSchema = {INT32, INT32},
         .expectedResults = {WorkerThreadResults<TestTuple>{{{TestTuple(123456789, 1234)}, {TestTuple{12345, 12345678}}}}},
@@ -122,14 +111,17 @@ TEST_F(SpecificSequenceTest, testDelimiterThatIsMoreThanOneCharacter)
            /* buffer 2 */ {.sequenceNumber = SequenceNumber(2), .rawBytes = "12345,12345678--"}}});
 }
 
+/// Index buffer can only represent a single tuple. Requires 7 (nested) index buffers for first buffer ("1\n2\n3\n4\n5\n6\n7\n8\n").
 TEST_F(SpecificSequenceTest, testMultipleTuplesInOneBuffer)
 {
     using namespace InputFormatterTestUtil;
     using enum TestDataTypes;
     using TestTuple = std::tuple<int32_t>;
     runTest<TestTuple>(TestConfig<TestTuple>{
-        .numRequiredBuffers = 6, /// 2 buffers for raw data, 4 buffers for results
-        .bufferSize = 16,
+        .numRequiredBuffers = 18, /// 2 buffers for raw data, 4 buffers for results
+        .sizeOfRawBuffers = 16,
+        .sizeOfFormattedBuffers
+        = 16, /// size of formatted tuple: 4 bytes, size of indexes: 8 bytes <-- 8 bytes metadata: 1 tuple per index buffer, 4 formatted buffers, 12 index buffers
         .parserConfig = {.parserType = "CSV", .tupleDelimiter = "\n", .fieldDelimiter = ","},
         .testSchema = {INT32},
         .expectedResults = {WorkerThreadResults<TestTuple>{
@@ -151,7 +143,8 @@ TEST_F(SpecificSequenceTest, triggerSpanningTupleWithThirdBufferWithoutDelimiter
     using TestTuple = std::tuple<int32_t, int32_t, int32_t, int32_t>;
     runTest<TestTuple>(TestConfig<TestTuple>{
         .numRequiredBuffers = 4, /// 3 buffers for raw data, 1 buffer from results
-        .bufferSize = 16,
+        .sizeOfRawBuffers = 16,
+        .sizeOfFormattedBuffers = 16,
         .parserConfig = {.parserType = "CSV", .tupleDelimiter = "\n", .fieldDelimiter = ","},
         .testSchema = {INT32, INT32, INT32, INT32},
         .expectedResults = {WorkerThreadResults<TestTuple>{{{TestTuple(123456789, 123456789, 123456789, 123456789)}}}},
@@ -170,7 +163,8 @@ TEST_F(SpecificSequenceTest, testMultiplePartiallyFilledBuffers)
     using TestTuple = std::tuple<int32_t, int32_t, int32_t, int32_t>;
     runTest<TestTuple>(TestConfig<TestTuple>{
         .numRequiredBuffers = 6, /// 4 buffers for raw data, 2 buffer from results
-        .bufferSize = 16,
+        .sizeOfRawBuffers = 16,
+        .sizeOfFormattedBuffers = 16,
         .parserConfig = {.parserType = "CSV", .tupleDelimiter = "\n", .fieldDelimiter = ","},
         .testSchema = {INT32, INT32, INT32, INT32},
         .expectedResults

--- a/nes-input-formatters/tests/Util/InputFormatterTestUtil.cpp
+++ b/nes-input-formatters/tests/Util/InputFormatterTestUtil.cpp
@@ -108,7 +108,7 @@ Schema createSchema(const std::vector<TestDataTypes>& testDataTypes)
 }
 
 std::function<void(OriginId, Sources::SourceReturnType::SourceReturnType)>
-getEmitFunction(ThreadSafeVector<NES::Memory::TupleBuffer>& resultBuffers)
+getEmitFunction(ThreadSafeVector<Memory::TupleBuffer>& resultBuffers)
 {
     return [&resultBuffers](const OriginId, Sources::SourceReturnType::SourceReturnType returnType)
     {
@@ -176,19 +176,14 @@ std::unique_ptr<Sources::SourceHandle> createFileSource(
     INVARIANT(sourceDescriptor.has_value(), "Test File Source couldn't be created");
     return Sources::SourceProvider::lower(NES::OriginId(1), sourceDescriptor.value(), std::move(sourceBufferPool), -1);
 }
+
 std::shared_ptr<InputFormatters::InputFormatterTask> createInputFormatterTask(const Schema& schema)
 {
     const std::unordered_map<std::string, std::string> parserConfiguration{
         {"type", "CSV"}, {"tupleDelimiter", "\n"}, {"fieldDelimiter", "|"}};
     auto validatedParserConfiguration = validateAndFormatParserConfig(parserConfiguration);
 
-    std::unique_ptr<InputFormatters::InputFormatter> inputFormatter = InputFormatters::InputFormatterProvider::provideInputFormatter(
-        validatedParserConfiguration.parserType,
-        schema,
-        validatedParserConfiguration.tupleDelimiter,
-        validatedParserConfiguration.fieldDelimiter);
-
-    return std::make_shared<InputFormatters::InputFormatterTask>(OriginId(1), std::move(inputFormatter));
+    return InputFormatters::InputFormatterProvider::provideInputFormatterTask(OriginId(0), schema, validatedParserConfiguration);
 }
 
 void waitForSource(const std::vector<NES::Memory::TupleBuffer>& resultBuffers, const size_t numExpectedBuffers)
@@ -219,14 +214,14 @@ bool compareFiles(const std::filesystem::path& file1, const std::filesystem::pat
     return std::equal(std::istreambuf_iterator(f1.rdbuf()), std::istreambuf_iterator<char>(), std::istreambuf_iterator(f2.rdbuf()));
 }
 
-TestablePipelineTask createInputFormatterTask(
+TestPipelineTask createInputFormatterTask(
     const SequenceNumber sequenceNumber,
     const WorkerThreadId workerThreadId,
     Memory::TupleBuffer taskBuffer,
     std::shared_ptr<InputFormatters::InputFormatterTask> inputFormatterTask)
 {
     taskBuffer.setSequenceNumber(sequenceNumber);
-    return TestablePipelineTask(workerThreadId, taskBuffer, std::move(inputFormatterTask));
+    return TestPipelineTask(workerThreadId, taskBuffer, std::move(inputFormatterTask));
 }
 
 }

--- a/nes-memory/TupleBuffer.cpp
+++ b/nes-memory/TupleBuffer.cpp
@@ -12,6 +12,8 @@
     limitations under the License.
 */
 
+#include <Runtime/TupleBuffer.hpp>
+
 #include <cstdint>
 #include <memory>
 #include <ostream>
@@ -19,7 +21,6 @@
 #include <utility>
 #include <Identifiers/Identifiers.hpp>
 #include <Identifiers/NESStrongTypeFormat.hpp> ///NOLINT: required for fmt
-#include <Runtime/TupleBuffer.hpp>
 #include <Time/Timestamp.hpp>
 #include <fmt/format.h>
 #include <ErrorHandling.hpp>
@@ -228,9 +229,9 @@ OriginId TupleBuffer::getOriginId() const noexcept
 {
     return controlBlock->getOriginId();
 }
-uint32_t TupleBuffer::getNumberOfChildrenBuffer() const noexcept
+uint32_t TupleBuffer::getNumberOfChildBuffers() const noexcept
 {
-    return controlBlock->getNumberOfChildrenBuffer();
+    return controlBlock->getNumberOfChildBuffers();
 }
 ChunkNumber TupleBuffer::getChunkNumber() const noexcept
 {

--- a/nes-memory/TupleBufferImpl.hpp
+++ b/nes-memory/TupleBufferImpl.hpp
@@ -111,7 +111,7 @@ public:
     [[nodiscard]] Timestamp getCreationTimestamp() const noexcept;
     [[nodiscard]] uint32_t storeChildBuffer(BufferControlBlock* control);
     [[nodiscard]] bool loadChildBuffer(uint16_t index, BufferControlBlock*& control, uint8_t*& ptr, uint32_t& size) const;
-    [[nodiscard]] uint32_t getNumberOfChildrenBuffer() const noexcept { return children.size(); }
+    [[nodiscard]] uint32_t getNumberOfChildBuffers() const noexcept { return children.size(); }
 #ifdef NES_DEBUG_TUPLE_BUFFER_LEAKS
     void dumpOwningThreadInfo();
 #endif

--- a/nes-memory/include/Runtime/TupleBuffer.hpp
+++ b/nes-memory/include/Runtime/TupleBuffer.hpp
@@ -192,7 +192,7 @@ public:
     ///@brief retrieve a child tuple buffer via its NestedTupleBufferKey
     [[nodiscard]] TupleBuffer loadChildBuffer(NestedTupleBufferKey bufferIndex) const noexcept;
 
-    [[nodiscard]] uint32_t getNumberOfChildrenBuffer() const noexcept;
+    [[nodiscard]] uint32_t getNumberOfChildBuffers() const noexcept;
 
     bool hasSpaceLeft(uint64_t used, uint64_t needed) const;
 

--- a/nes-memory/tests/TestUtils/MemoryTestUtils.cpp
+++ b/nes-memory/tests/TestUtils/MemoryTestUtils.cpp
@@ -12,13 +12,14 @@
     limitations under the License.
 */
 
+#include <MemoryTestUtils.hpp>
+
 #include <algorithm>
 #include <cstddef>
 #include <span>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
 #include <ErrorHandling.hpp>
-#include <MemoryTestUtils.hpp>
 
 namespace NES::Testing
 {
@@ -43,7 +44,7 @@ Memory::TupleBuffer copyBuffer(const Memory::TupleBuffer& buffer, Memory::Abstra
     copiedBuffer.setLastChunk(buffer.isLastChunk());
     copiedBuffer.setNumberOfTuples(buffer.getNumberOfTuples());
 
-    for (size_t childIdx = 0; childIdx < buffer.getNumberOfChildrenBuffer(); ++childIdx)
+    for (size_t childIdx = 0; childIdx < buffer.getNumberOfChildBuffers(); ++childIdx)
     {
         auto childBuffer = buffer.loadChildBuffer(childIdx);
         auto copiedChildBuffer = copyBuffer(childBuffer, provider);

--- a/nes-query-compiler/src/Phases/LowerToCompiledQueryPlanPhase.cpp
+++ b/nes-query-compiler/src/Phases/LowerToCompiledQueryPlanPhase.cpp
@@ -63,13 +63,10 @@ void LowerToCompiledQueryPlanPhase::processSource(const std::shared_ptr<Pipeline
     const auto sourceOperator = pipeline->getRootOperator().get<SourcePhysicalOperator>();
 
     const std::vector<std::shared_ptr<ExecutablePipeline>> executableSuccessorPipelines;
-    auto inputFormatter = InputFormatters::InputFormatterProvider::provideInputFormatter(
-        sourceOperator.getDescriptor().getParserConfig().parserType,
+    auto inputFormatterTask = NES::InputFormatters::InputFormatterProvider::provideInputFormatterTask(
+        sourceOperator.getOriginId(),
         *sourceOperator.getDescriptor().getLogicalSource().getSchema(),
-        sourceOperator.getDescriptor().getParserConfig().tupleDelimiter,
-        sourceOperator.getDescriptor().getParserConfig().fieldDelimiter);
-    auto inputFormatterTask
-        = std::make_unique<InputFormatters::InputFormatterTask>(sourceOperator.getOriginId(), std::move(inputFormatter));
+        sourceOperator.getDescriptor().getParserConfig());
 
     auto executableInputFormatterPipeline
         = ExecutablePipeline::create(pipeline->getPipelineId(), std::move(inputFormatterTask), executableSuccessorPipelines);

--- a/nes-sources/src/SourceThread.cpp
+++ b/nes-sources/src/SourceThread.cpp
@@ -115,9 +115,8 @@ SourceImplementationTermination dataSourceThreadRoutine(
         /// 4 Things that could happen:
         /// 1. Happy Path: Source produces a tuple buffer and emit is called. The loop continues.
         /// 2. Stop was requested by the owner of the data source. Stop is propagated to the source implementation.
-        ///    fillTupleBuffer will return false, however this is not a EndOfStream, the source simply could not produce a buffer.
         ///    The thread exits with `StopRequested`
-        /// 3. EndOfStream was signaled by the source implementation. It returned false, but the Stop Token was not triggered.
+        /// 3. EndOfStream was signaled by the source implementation. It returned 0 bytes, but the Stop Token was not triggered.
         ///    The thread exits with `EndOfStream`
         /// 4. Failure. The fillTupleBuffer method will throw an exception, the exception is propagted to the SourceThread via the return promise.
         ///    The thread exists with an exception

--- a/nes-sources/src/SourceThread.cpp
+++ b/nes-sources/src/SourceThread.cpp
@@ -121,10 +121,12 @@ SourceImplementationTermination dataSourceThreadRoutine(
         /// 4. Failure. The fillTupleBuffer method will throw an exception, the exception is propagted to the SourceThread via the return promise.
         ///    The thread exists with an exception
         auto emptyBuffer = bufferProvider.getBufferBlocking();
-        auto numReadBytes = source.fillTupleBuffer(emptyBuffer, stopToken);
+        const auto numReadBytes = source.fillTupleBuffer(emptyBuffer, stopToken);
 
         if (numReadBytes != 0)
         {
+            /// The source read in raw bytes, thus we don't know the number of tuples yet.
+            /// The InputFormatterTask expects that the source set the number of bytes this way and uses it to determine the number of tuples.
             emptyBuffer.setNumberOfTuples(numReadBytes);
             emit(emptyBuffer, true);
         }


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Prior, the CSVInputFormatter contained essentially all of the logic to parse raw input buffers. This is bad, because every new formatter needs to reimplement a lot of the logic to format input buffers. With this commit, most of the logic moves into the InputFormatterTask. InputFormatters now only need to implement two functions. One, which takes a buffer and writes all field offsets to a special data structure. A second, which parses a single spanning tuple and writes the field offsets to a pointer.

## Verifying this change
This change is tested by:
- prior InputFormatter tests
- additional SpecificSequence tests

## What components does this pull request potentially affect?
nes-input-formatters

## Documentation
- all documentation is in the code itself

## Issue Closed by this pull request:

This PR closes #679

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
