### PR TITLE
Feature(706): Extend plugin registry to return arbitrary types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@
 
 # Build files
 /build
-/build-docker
+/build-docker*
 /cmake-build*
 CMakeUserPresets.json
 debug*

--- a/cmake/PluginRegistrationUtil.cmake
+++ b/cmake/PluginRegistrationUtil.cmake
@@ -67,7 +67,7 @@ function(generate_plugin_registrar current_dir current_binary_dir plugin_registr
     set(REGISTER_FUNCTION_DECLARATIONS "")
     set(REGISTER_ALL_FUNCTION_CALLS "")
     foreach (reg_func IN LISTS plugin_registry_plugin_names_final)
-        list(APPEND REGISTER_FUNCTION_DECLARATIONS "std::unique_ptr<${plugin_registry}RegistryReturnType> Register${reg_func}${plugin_registry}(${plugin_registry}RegistryArguments)")
+        list(APPEND REGISTER_FUNCTION_DECLARATIONS "${plugin_registry}RegistryReturnType Register${reg_func}${plugin_registry}(${plugin_registry}RegistryArguments)")
         list(APPEND REGISTER_ALL_FUNCTION_CALLS "registry.addEntry(\"${reg_func}\", Register${reg_func}${plugin_registry})")
     endforeach ()
 

--- a/nes-common/include/Util/Registry.hpp
+++ b/nes-common/include/Util/Registry.hpp
@@ -84,7 +84,7 @@ class Registrar
 {
     using Tag = ConcreteRegistry;
     using KeyType = KeyTypeT;
-    using ReturnType = std::unique_ptr<ReturnTypeT>;
+    using ReturnType = ReturnTypeT;
     using CreatorFn = std::function<ReturnType(Arguments)>;
     static void registerAll(Registry<Registrar>& registry);
     template <typename Registrar>

--- a/nes-configurations/include/Configurations/Descriptor.hpp
+++ b/nes-configurations/include/Configurations/Descriptor.hpp
@@ -137,10 +137,9 @@ public:
     /// @throws If a mandatory parameter was not provided, an optional parameter was invalid, or a not-supported parameter was encountered.
     template <typename SpecificConfiguration>
     requires DescriptorConfigurationConstraints::HasParameterMap<SpecificConfiguration>
-    static std::unique_ptr<Config>
-    validateAndFormat(std::unordered_map<std::string, std::string>&& config, const std::string_view implementationName)
+    static Config validateAndFormat(std::unordered_map<std::string, std::string> config, const std::string_view implementationName)
     {
-        auto validatedConfig = std::make_unique<Config>();
+        auto validatedConfig = Config{};
 
         /// First check if all user-specified keys are valid.
         for (const auto& [key, _] : config)
@@ -160,13 +159,13 @@ public:
             const auto validatedParameter = configParameter.validate(config);
             if (validatedParameter.has_value())
             {
-                validatedConfig->emplace(key, validatedParameter.value());
+                validatedConfig.emplace(key, validatedParameter.value());
                 continue;
             }
             /// If the user did not specify a parameter that is optional, use the default value.
             if (not config.contains(key) and configParameter.getDefaultValue().has_value())
             {
-                validatedConfig->emplace(key, configParameter.getDefaultValue().value());
+                validatedConfig.emplace(key, configParameter.getDefaultValue().value());
                 continue;
             }
             throw InvalidConfigParameter(fmt::format("Failed validation of config parameter: {}, in: {}", key, implementationName));

--- a/nes-data-types/registry/include/DataTypeRegistry.hpp
+++ b/nes-data-types/registry/include/DataTypeRegistry.hpp
@@ -21,7 +21,7 @@
 namespace NES
 {
 
-using DataTypeRegistryReturnType = DataType;
+using DataTypeRegistryReturnType = std::unique_ptr<DataType>;
 struct DataTypeRegistryArguments
 {
 };

--- a/nes-data-types/src/Common/DataTypes/Boolean.cpp
+++ b/nes-data-types/src/Common/DataTypes/Boolean.cpp
@@ -43,7 +43,7 @@ std::string Boolean::toString()
     return std::string(magic_enum::enum_name(BasicType::BOOLEAN));
 }
 
-std::unique_ptr<DataTypeRegistryReturnType> DataTypeGeneratedRegistrar::RegisterBOOLEANDataType(DataTypeRegistryArguments)
+DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterBOOLEANDataType(DataTypeRegistryArguments)
 {
     return std::make_unique<Boolean>();
 }

--- a/nes-data-types/src/Common/DataTypes/Char.cpp
+++ b/nes-data-types/src/Common/DataTypes/Char.cpp
@@ -42,7 +42,7 @@ std::string Char::toString()
     return std::string(magic_enum::enum_name(BasicType::CHAR));
 }
 
-std::unique_ptr<DataTypeRegistryReturnType> DataTypeGeneratedRegistrar::RegisterCHARDataType(DataTypeRegistryArguments)
+DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterCHARDataType(DataTypeRegistryArguments)
 {
     return std::make_unique<Char>();
 }

--- a/nes-data-types/src/Common/DataTypes/Float.cpp
+++ b/nes-data-types/src/Common/DataTypes/Float.cpp
@@ -61,12 +61,12 @@ std::string Float::toString()
     return fmt::format("FLOAT{}", bits);
 }
 
-std::unique_ptr<DataTypeRegistryReturnType> DataTypeGeneratedRegistrar::RegisterFLOAT32DataType(DataTypeRegistryArguments)
+DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterFLOAT32DataType(DataTypeRegistryArguments)
 {
     return std::make_unique<Float>(32, std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max());
 }
 
-std::unique_ptr<DataTypeRegistryReturnType> DataTypeGeneratedRegistrar::RegisterFLOAT64DataType(DataTypeRegistryArguments)
+DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterFLOAT64DataType(DataTypeRegistryArguments)
 {
     return std::make_unique<Float>(64, std::numeric_limits<double>::lowest(), std::numeric_limits<double>::max());
 }

--- a/nes-data-types/src/Common/DataTypes/Integer.cpp
+++ b/nes-data-types/src/Common/DataTypes/Integer.cpp
@@ -63,42 +63,42 @@ std::string Integer::toString()
     return fmt::format("{}{}", lowerBound == 0 ? "UINT" : "INT", std::to_string(bits));
 }
 
-std::unique_ptr<DataTypeRegistryReturnType> DataTypeGeneratedRegistrar::RegisterINT8DataType(DataTypeRegistryArguments)
+DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterINT8DataType(DataTypeRegistryArguments)
 {
     return std::make_unique<Integer>(8, INT8_MIN, INT8_MAX);
 }
 
-std::unique_ptr<DataTypeRegistryReturnType> DataTypeGeneratedRegistrar::RegisterUINT8DataType(DataTypeRegistryArguments)
+DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterUINT8DataType(DataTypeRegistryArguments)
 {
     return std::make_unique<Integer>(8, 0, UINT8_MAX);
 }
 
-std::unique_ptr<DataTypeRegistryReturnType> DataTypeGeneratedRegistrar::RegisterINT16DataType(DataTypeRegistryArguments)
+DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterINT16DataType(DataTypeRegistryArguments)
 {
     return std::make_unique<Integer>(16, INT16_MIN, INT16_MAX);
 }
 
-std::unique_ptr<DataTypeRegistryReturnType> DataTypeGeneratedRegistrar::RegisterUINT16DataType(DataTypeRegistryArguments)
+DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterUINT16DataType(DataTypeRegistryArguments)
 {
     return std::make_unique<Integer>(16, 0, UINT16_MAX);
 }
 
-std::unique_ptr<DataTypeRegistryReturnType> DataTypeGeneratedRegistrar::RegisterINT32DataType(DataTypeRegistryArguments)
+DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterINT32DataType(DataTypeRegistryArguments)
 {
     return std::make_unique<Integer>(32, INT32_MIN, INT32_MAX);
 }
 
-std::unique_ptr<DataTypeRegistryReturnType> DataTypeGeneratedRegistrar::RegisterUINT32DataType(DataTypeRegistryArguments)
+DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterUINT32DataType(DataTypeRegistryArguments)
 {
     return std::make_unique<Integer>(32, 0, UINT32_MAX);
 }
 
-std::unique_ptr<DataTypeRegistryReturnType> DataTypeGeneratedRegistrar::RegisterINT64DataType(DataTypeRegistryArguments)
+DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterINT64DataType(DataTypeRegistryArguments)
 {
     return std::make_unique<Integer>(64, INT64_MIN, INT64_MAX);
 }
 
-std::unique_ptr<DataTypeRegistryReturnType> DataTypeGeneratedRegistrar::RegisterUINT64DataType(DataTypeRegistryArguments)
+DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterUINT64DataType(DataTypeRegistryArguments)
 {
     return std::make_unique<Integer>(64, 0, UINT64_MAX);
 }

--- a/nes-data-types/src/Common/DataTypes/Undefined.cpp
+++ b/nes-data-types/src/Common/DataTypes/Undefined.cpp
@@ -35,7 +35,7 @@ std::string Undefined::toString()
     return "Undefined";
 }
 
-std::unique_ptr<DataTypeRegistryReturnType> DataTypeGeneratedRegistrar::RegisterUNDEFINEDDataType(DataTypeRegistryArguments)
+DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterUNDEFINEDDataType(DataTypeRegistryArguments)
 {
     return std::make_unique<Undefined>();
 }

--- a/nes-data-types/src/Common/DataTypes/VariableSizedDataType.cpp
+++ b/nes-data-types/src/Common/DataTypes/VariableSizedDataType.cpp
@@ -37,7 +37,7 @@ std::string VariableSizedDataType::toString()
     return "VARSIZED";
 }
 
-std::unique_ptr<DataTypeRegistryReturnType> DataTypeGeneratedRegistrar::RegisterVARSIZEDDataType(DataTypeRegistryArguments)
+DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterVARSIZEDDataType(DataTypeRegistryArguments)
 {
     return std::make_unique<VariableSizedDataType>();
 }

--- a/nes-execution/registry/include/ExecutableFunctionRegistry.hpp
+++ b/nes-execution/registry/include/ExecutableFunctionRegistry.hpp
@@ -22,10 +22,10 @@
 namespace NES::Runtime::Execution::Functions
 {
 
-using ExecutableFunctionRegistryReturnType = Function;
+using ExecutableFunctionRegistryReturnType = std::unique_ptr<Function>;
 struct ExecutableFunctionRegistryArguments
 {
-    std::vector<std::unique_ptr<ExecutableFunctionRegistryReturnType>> childFunctions;
+    std::vector<ExecutableFunctionRegistryReturnType> childFunctions;
 };
 
 class ExecutableFunctionRegistry : public BaseRegistry<

--- a/nes-execution/registry/include/ExecutablePipelineProviderRegistry.hpp
+++ b/nes-execution/registry/include/ExecutablePipelineProviderRegistry.hpp
@@ -20,7 +20,7 @@
 namespace NES::Runtime::Execution
 {
 /// TODO #323: !!!IMPORTANT!!! This is not how we should use registries. We have an open issue to address this problem
-using ExecutablePipelineProviderRegistryReturnType = ExecutablePipelineProvider;
+using ExecutablePipelineProviderRegistryReturnType = std::unique_ptr<ExecutablePipelineProvider>;
 
 struct ExecutablePipelineProviderRegistryArguments
 {

--- a/nes-execution/src/Execution/Functions/ArithmeticalFunctions/ExecutableFunctionAdd.cpp
+++ b/nes-execution/src/Execution/Functions/ArithmeticalFunctions/ExecutableFunctionAdd.cpp
@@ -37,7 +37,7 @@ ExecutableFunctionAdd::ExecutableFunctionAdd(
 {
 }
 
-std::unique_ptr<ExecutableFunctionRegistryReturnType>
+ExecutableFunctionRegistryReturnType
 ExecutableFunctionGeneratedRegistrar::RegisterAddExecutableFunction(ExecutableFunctionRegistryArguments executableFunctionRegistryArguments)
 {
     PRECONDITION(executableFunctionRegistryArguments.childFunctions.size() == 2, "Add function must have exactly two sub-functions");

--- a/nes-execution/src/Execution/Functions/ArithmeticalFunctions/ExecutableFunctionDiv.cpp
+++ b/nes-execution/src/Execution/Functions/ArithmeticalFunctions/ExecutableFunctionDiv.cpp
@@ -38,7 +38,7 @@ ExecutableFunctionDiv::ExecutableFunctionDiv(
 }
 
 
-std::unique_ptr<ExecutableFunctionRegistryReturnType>
+ExecutableFunctionRegistryReturnType
 ExecutableFunctionGeneratedRegistrar::RegisterDivExecutableFunction(ExecutableFunctionRegistryArguments executableFunctionRegistryArguments)
 {
     PRECONDITION(executableFunctionRegistryArguments.childFunctions.size() == 2, "Div function must have exactly two sub-functions");

--- a/nes-execution/src/Execution/Functions/ArithmeticalFunctions/ExecutableFunctionMod.cpp
+++ b/nes-execution/src/Execution/Functions/ArithmeticalFunctions/ExecutableFunctionMod.cpp
@@ -39,7 +39,7 @@ ExecutableFunctionMod::ExecutableFunctionMod(
 }
 
 
-std::unique_ptr<ExecutableFunctionRegistryReturnType>
+ExecutableFunctionRegistryReturnType
 ExecutableFunctionGeneratedRegistrar::RegisterModExecutableFunction(ExecutableFunctionRegistryArguments executableFunctionRegistryArguments)
 {
     PRECONDITION(executableFunctionRegistryArguments.childFunctions.size() == 2, "Mod function must have exactly two sub-functions");

--- a/nes-execution/src/Execution/Functions/ArithmeticalFunctions/ExecutableFunctionMul.cpp
+++ b/nes-execution/src/Execution/Functions/ArithmeticalFunctions/ExecutableFunctionMul.cpp
@@ -38,7 +38,7 @@ ExecutableFunctionMul::ExecutableFunctionMul(
 {
 }
 
-std::unique_ptr<ExecutableFunctionRegistryReturnType>
+ExecutableFunctionRegistryReturnType
 ExecutableFunctionGeneratedRegistrar::RegisterMulExecutableFunction(ExecutableFunctionRegistryArguments executableFunctionRegistryArguments)
 {
     PRECONDITION(executableFunctionRegistryArguments.childFunctions.size() == 2, "Mul function must have exactly two sub-functions");

--- a/nes-execution/src/Execution/Functions/ArithmeticalFunctions/ExecutableFunctionSub.cpp
+++ b/nes-execution/src/Execution/Functions/ArithmeticalFunctions/ExecutableFunctionSub.cpp
@@ -37,7 +37,7 @@ ExecutableFunctionSub::ExecutableFunctionSub(
 {
 }
 
-std::unique_ptr<ExecutableFunctionRegistryReturnType>
+ExecutableFunctionRegistryReturnType
 ExecutableFunctionGeneratedRegistrar::RegisterSubExecutableFunction(ExecutableFunctionRegistryArguments executableFunctionRegistryArguments)
 {
     PRECONDITION(executableFunctionRegistryArguments.childFunctions.size() == 2, "Sub function must have exactly two sub-functions");

--- a/nes-execution/src/Execution/Functions/Comparison/ExecutableFunctionGreater.cpp
+++ b/nes-execution/src/Execution/Functions/Comparison/ExecutableFunctionGreater.cpp
@@ -40,7 +40,7 @@ ExecutableFunctionGreater::ExecutableFunctionGreater(
 {
 }
 
-std::unique_ptr<ExecutableFunctionRegistryReturnType> ExecutableFunctionGeneratedRegistrar::RegisterGreaterExecutableFunction(
+ExecutableFunctionRegistryReturnType ExecutableFunctionGeneratedRegistrar::RegisterGreaterExecutableFunction(
     ExecutableFunctionRegistryArguments executableFunctionRegistryArguments)
 {
     PRECONDITION(executableFunctionRegistryArguments.childFunctions.size() == 2, "Greater function must have exactly two sub-functions");

--- a/nes-execution/src/Execution/Functions/Comparison/ExecutableFunctionGreaterEquals.cpp
+++ b/nes-execution/src/Execution/Functions/Comparison/ExecutableFunctionGreaterEquals.cpp
@@ -40,7 +40,7 @@ ExecutableFunctionGreaterEquals::ExecutableFunctionGreaterEquals(
 {
 }
 
-std::unique_ptr<ExecutableFunctionRegistryReturnType> ExecutableFunctionGeneratedRegistrar::RegisterGreaterEqualsExecutableFunction(
+ExecutableFunctionRegistryReturnType ExecutableFunctionGeneratedRegistrar::RegisterGreaterEqualsExecutableFunction(
     ExecutableFunctionRegistryArguments executableFunctionRegistryArguments)
 {
     PRECONDITION(

--- a/nes-execution/src/Execution/Functions/Comparison/ExecutableFunctionLess.cpp
+++ b/nes-execution/src/Execution/Functions/Comparison/ExecutableFunctionLess.cpp
@@ -40,7 +40,7 @@ ExecutableFunctionLess::ExecutableFunctionLess(
 {
 }
 
-std::unique_ptr<ExecutableFunctionRegistryReturnType> ExecutableFunctionGeneratedRegistrar::RegisterLessExecutableFunction(
+ExecutableFunctionRegistryReturnType ExecutableFunctionGeneratedRegistrar::RegisterLessExecutableFunction(
     ExecutableFunctionRegistryArguments executableFunctionRegistryArguments)
 {
     PRECONDITION(executableFunctionRegistryArguments.childFunctions.size() == 2, "Less function must have exactly two sub-functions");

--- a/nes-execution/src/Execution/Functions/Comparison/ExecutableFunctionLessEquals.cpp
+++ b/nes-execution/src/Execution/Functions/Comparison/ExecutableFunctionLessEquals.cpp
@@ -40,7 +40,7 @@ ExecutableFunctionLessEquals::ExecutableFunctionLessEquals(
 {
 }
 
-std::unique_ptr<ExecutableFunctionRegistryReturnType> ExecutableFunctionGeneratedRegistrar::RegisterLessEqualsExecutableFunction(
+ExecutableFunctionRegistryReturnType ExecutableFunctionGeneratedRegistrar::RegisterLessEqualsExecutableFunction(
     ExecutableFunctionRegistryArguments executableFunctionRegistryArguments)
 {
     PRECONDITION(executableFunctionRegistryArguments.childFunctions.size() == 2, "LessEquals function must have exactly two sub-functions");

--- a/nes-execution/src/Execution/Functions/ExecutableFunctionConcat.cpp
+++ b/nes-execution/src/Execution/Functions/ExecutableFunctionConcat.cpp
@@ -51,7 +51,7 @@ VarVal ExecutableFunctionConcat::execute(const Record& record, ArenaRef& arena) 
     return newVarSizeData;
 }
 
-std::unique_ptr<ExecutableFunctionRegistryReturnType> ExecutableFunctionGeneratedRegistrar::RegisterConcatExecutableFunction(
+ExecutableFunctionRegistryReturnType ExecutableFunctionGeneratedRegistrar::RegisterConcatExecutableFunction(
     ExecutableFunctionRegistryArguments executableFunctionRegistryArguments)
 {
     PRECONDITION(executableFunctionRegistryArguments.childFunctions.size() == 2, "And function must have exactly two sub-functions");

--- a/nes-execution/src/Execution/Functions/LogicalFunctions/ExecutableFunctionAnd.cpp
+++ b/nes-execution/src/Execution/Functions/LogicalFunctions/ExecutableFunctionAnd.cpp
@@ -40,7 +40,7 @@ ExecutableFunctionAnd::ExecutableFunctionAnd(
 {
 }
 
-std::unique_ptr<ExecutableFunctionRegistryReturnType>
+ExecutableFunctionRegistryReturnType
 ExecutableFunctionGeneratedRegistrar::RegisterAndExecutableFunction(ExecutableFunctionRegistryArguments executableFunctionRegistryArguments)
 {
     PRECONDITION(executableFunctionRegistryArguments.childFunctions.size() == 2, "And function must have exactly two sub-functions");

--- a/nes-execution/src/Execution/Functions/LogicalFunctions/ExecutableFunctionEquals.cpp
+++ b/nes-execution/src/Execution/Functions/LogicalFunctions/ExecutableFunctionEquals.cpp
@@ -46,7 +46,7 @@ ExecutableFunctionEquals::ExecutableFunctionEquals(
 {
 }
 
-std::unique_ptr<ExecutableFunctionRegistryReturnType> ExecutableFunctionGeneratedRegistrar::RegisterEqualsExecutableFunction(
+ExecutableFunctionRegistryReturnType ExecutableFunctionGeneratedRegistrar::RegisterEqualsExecutableFunction(
     ExecutableFunctionRegistryArguments executableFunctionRegistryArguments)
 {
     PRECONDITION(executableFunctionRegistryArguments.childFunctions.size() == 2, "Equals function must have exactly two sub-functions");

--- a/nes-execution/src/Execution/Functions/LogicalFunctions/ExecutableFunctionNegate.cpp
+++ b/nes-execution/src/Execution/Functions/LogicalFunctions/ExecutableFunctionNegate.cpp
@@ -34,7 +34,7 @@ ExecutableFunctionNegate::ExecutableFunctionNegate(std::unique_ptr<Function> chi
 }
 
 
-std::unique_ptr<ExecutableFunctionRegistryReturnType> ExecutableFunctionGeneratedRegistrar::RegisterNegateExecutableFunction(
+ExecutableFunctionRegistryReturnType ExecutableFunctionGeneratedRegistrar::RegisterNegateExecutableFunction(
     ExecutableFunctionRegistryArguments executableFunctionRegistryArguments)
 {
     PRECONDITION(executableFunctionRegistryArguments.childFunctions.size() == 1, "Negate function must have exactly one sub-function");

--- a/nes-execution/src/Execution/Functions/LogicalFunctions/ExecutableFunctionOr.cpp
+++ b/nes-execution/src/Execution/Functions/LogicalFunctions/ExecutableFunctionOr.cpp
@@ -39,7 +39,7 @@ ExecutableFunctionOr::ExecutableFunctionOr(
 {
 }
 
-std::unique_ptr<ExecutableFunctionRegistryReturnType>
+ExecutableFunctionRegistryReturnType
 ExecutableFunctionGeneratedRegistrar::RegisterOrExecutableFunction(ExecutableFunctionRegistryArguments executableFunctionRegistryArguments)
 {
     PRECONDITION(executableFunctionRegistryArguments.childFunctions.size() == 2, "Or function must have exactly two sub-functions");

--- a/nes-execution/src/Execution/Pipelines/CMakeLists.txt
+++ b/nes-execution/src/Execution/Pipelines/CMakeLists.txt
@@ -16,5 +16,5 @@ add_source_files(nes-execution
 )
 
 # Register plugins
-add_plugin(compiler ExecutablePipelineProvider nes-execution CompilationPipelineProvider.cpp)
-add_plugin(interpreter ExecutablePipelineProvider nes-execution InterpretationPipelineProvider.cpp)
+add_plugin(Compiler ExecutablePipelineProvider nes-execution CompilationPipelineProvider.cpp)
+add_plugin(Interpreter ExecutablePipelineProvider nes-execution InterpretationPipelineProvider.cpp)

--- a/nes-execution/src/Execution/Pipelines/CompilationPipelineProvider.cpp
+++ b/nes-execution/src/Execution/Pipelines/CompilationPipelineProvider.cpp
@@ -36,8 +36,8 @@ std::unique_ptr<ExecutablePipelineStage> CompilationPipelineProvider::create(
     return std::make_unique<CompiledExecutablePipelineStage>(pipeline, std::move(operatorHandlers), options);
 }
 
-std::unique_ptr<ExecutablePipelineProviderRegistryReturnType>
-ExecutablePipelineProviderGeneratedRegistrar::RegistercompilerExecutablePipelineProvider(ExecutablePipelineProviderRegistryArguments)
+ExecutablePipelineProviderRegistryReturnType
+ExecutablePipelineProviderGeneratedRegistrar::RegisterCompilerExecutablePipelineProvider(ExecutablePipelineProviderRegistryArguments)
 {
     return std::make_unique<CompilationPipelineProvider>();
 }

--- a/nes-execution/src/Execution/Pipelines/InterpretationPipelineProvider.cpp
+++ b/nes-execution/src/Execution/Pipelines/InterpretationPipelineProvider.cpp
@@ -35,8 +35,8 @@ std::unique_ptr<ExecutablePipelineStage> InterpretationPipelineProvider::create(
     return std::make_unique<CompiledExecutablePipelineStage>(pipeline, std::move(operatorHandlers), options);
 }
 
-std::unique_ptr<ExecutablePipelineProviderRegistryReturnType>
-ExecutablePipelineProviderGeneratedRegistrar::RegisterinterpreterExecutablePipelineProvider(ExecutablePipelineProviderRegistryArguments)
+ExecutablePipelineProviderRegistryReturnType
+ExecutablePipelineProviderGeneratedRegistrar::RegisterInterpreterExecutablePipelineProvider(ExecutablePipelineProviderRegistryArguments)
 {
     return std::make_unique<InterpretationPipelineProvider>();
 }

--- a/nes-execution/src/QueryCompiler/Phases/NautilusCompilationPhase.cpp
+++ b/nes-execution/src/QueryCompiler/Phases/NautilusCompilationPhase.cpp
@@ -56,10 +56,10 @@ std::string getPipelineProviderIdentifier(const Configurations::QueryCompilerCon
     switch (compilerOptions.nautilusBackend)
     {
         case Nautilus::Configurations::NautilusBackend::INTERPRETER: {
-            return "interpreter";
+            return "Interpreter";
         };
         case Nautilus::Configurations::NautilusBackend::COMPILER: {
-            return "compiler";
+            return "Compiler";
         };
         default: {
             INVARIANT(false, "Invalid backend");

--- a/nes-input-formatters/registry/include/InputFormatterRegistry.hpp
+++ b/nes-input-formatters/registry/include/InputFormatterRegistry.hpp
@@ -14,7 +14,9 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
+
 #include <API/Schema.hpp>
 #include <InputFormatters/InputFormatter.hpp>
 #include <Util/Registry.hpp>
@@ -22,7 +24,7 @@
 namespace NES::InputFormatters
 {
 
-using InputFormatterRegistryReturnType = InputFormatter;
+using InputFormatterRegistryReturnType = std::unique_ptr<InputFormatter>;
 /// A InputFormatter requires a schema, a tuple separator and a field delimiter.
 struct InputFormatterRegistryArguments
 {

--- a/nes-input-formatters/src/CSVInputFormatter.cpp
+++ b/nes-input-formatters/src/CSVInputFormatter.cpp
@@ -423,7 +423,7 @@ std::ostream& CSVInputFormatter::toString(std::ostream& str) const
     return str;
 }
 
-std::unique_ptr<InputFormatterRegistryReturnType>
+InputFormatterRegistryReturnType
 InputFormatterGeneratedRegistrar::RegisterCSVInputFormatter(InputFormatterRegistryArguments inputFormatterRegistryArguments)
 {
     return std::make_unique<CSVInputFormatter>(

--- a/nes-nebuli/src/NebuLI.cpp
+++ b/nes-nebuli/src/NebuLI.cpp
@@ -25,6 +25,7 @@
 #include <string>
 #include <utility>
 #include <API/Schema.hpp>
+#include <Configurations/ConfigurationsNames.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Operators/LogicalOperators/Sinks/SinkLogicalOperator.hpp>
 #include <Optimizer/Phases/OriginIdInferencePhase.hpp>
@@ -183,7 +184,7 @@ void validateAndSetSinkDescriptors(const QueryPlan& query, const QueryConfig& co
     PRECONDITION(not config.sinks.empty(), fmt::format("Expects at least one sink in the query config!"));
     if (const auto sink = config.sinks.find(query.getSinkOperators().at(0)->sinkName); sink != config.sinks.end())
     {
-        auto validatedSinkConfig = *Sinks::SinkDescriptor::validateAndFormatConfig(sink->second.type, sink->second.config);
+        auto validatedSinkConfig = Sinks::SinkDescriptor::validateAndFormatConfig(sink->second.type, sink->second.config);
         query.getSinkOperators().at(0)->sinkDescriptor
             = std::make_shared<Sinks::SinkDescriptor>(sink->second.type, std::move(validatedSinkConfig), false);
     }

--- a/nes-plugins/Sinks/ChecksumSink/ChecksumSink.cpp
+++ b/nes-plugins/Sinks/ChecksumSink/ChecksumSink.cpp
@@ -90,19 +90,18 @@ void ChecksumSink::execute(const Memory::TupleBuffer& inputBuffer, Runtime::Exec
     checksum.add(formatted);
 }
 
-std::unique_ptr<Configurations::DescriptorConfig::Config>
-ChecksumSink::validateAndFormat(std::unordered_map<std::string, std::string>&& config)
+Configurations::DescriptorConfig::Config ChecksumSink::validateAndFormat(std::unordered_map<std::string, std::string> config)
 {
     return Configurations::DescriptorConfig::validateAndFormat<ConfigParametersChecksum>(std::move(config), NAME);
 }
 
-std::unique_ptr<SinkValidationRegistryReturnType>
+SinkValidationRegistryReturnType
 SinkValidationGeneratedRegistrar::RegisterChecksumSinkValidation(SinkValidationRegistryArguments sinkConfig)
 {
     return ChecksumSink::validateAndFormat(std::move(sinkConfig.config));
 }
 
-std::unique_ptr<SinkRegistryReturnType> SinkGeneratedRegistrar::RegisterChecksumSink(SinkRegistryArguments sinkRegistryArguments)
+SinkRegistryReturnType SinkGeneratedRegistrar::RegisterChecksumSink(SinkRegistryArguments sinkRegistryArguments)
 {
     return std::make_unique<ChecksumSink>(sinkRegistryArguments.sinkDescriptor);
 }

--- a/nes-plugins/Sinks/ChecksumSink/ChecksumSink.hpp
+++ b/nes-plugins/Sinks/ChecksumSink/ChecksumSink.hpp
@@ -48,8 +48,7 @@ public:
     void start(Runtime::Execution::PipelineExecutionContext&) override;
     void stop(Runtime::Execution::PipelineExecutionContext&) override;
     void execute(const Memory::TupleBuffer& inputBuffer, Runtime::Execution::PipelineExecutionContext&) override;
-    static std::unique_ptr<Configurations::DescriptorConfig::Config>
-    validateAndFormat(std::unordered_map<std::string, std::string>&& config);
+    static Configurations::DescriptorConfig::Config validateAndFormat(std::unordered_map<std::string, std::string> config);
 
 protected:
     std::ostream& toString(std::ostream& os) const override { return os << "ChecksumSink"; }

--- a/nes-plugins/Sources/TCPSource/TCPSource.cpp
+++ b/nes-plugins/Sources/TCPSource/TCPSource.cpp
@@ -262,8 +262,7 @@ bool TCPSource::fillBuffer(NES::Memory::TupleBuffer& tupleBuffer, size_t& numRec
     return numReceivedBytes == 0 and readWasValid;
 }
 
-std::unique_ptr<NES::Configurations::DescriptorConfig::Config>
-TCPSource::validateAndFormat(std::unordered_map<std::string, std::string> config)
+NES::Configurations::DescriptorConfig::Config TCPSource::validateAndFormat(std::unordered_map<std::string, std::string> config)
 {
     return Configurations::DescriptorConfig::validateAndFormat<ConfigParametersTCP>(std::move(config), name());
 }
@@ -278,13 +277,13 @@ void TCPSource::close()
     }
 }
 
-std::unique_ptr<SourceValidationRegistryReturnType>
+SourceValidationRegistryReturnType
 SourceValidationGeneratedRegistrar::RegisterTCPSourceValidation(SourceValidationRegistryArguments sourceConfig)
 {
-    return TCPSource::validateAndFormat(sourceConfig.config);
+    return TCPSource::validateAndFormat(std::move(sourceConfig.config));
 }
 
-std::unique_ptr<SourceRegistryReturnType> SourceGeneratedRegistrar::RegisterTCPSource(SourceRegistryArguments sourceRegistryArguments)
+SourceRegistryReturnType SourceGeneratedRegistrar::RegisterTCPSource(SourceRegistryArguments sourceRegistryArguments)
 {
     return std::make_unique<TCPSource>(sourceRegistryArguments.sourceDescriptor);
 }

--- a/nes-plugins/Sources/TCPSource/TCPSource.hpp
+++ b/nes-plugins/Sources/TCPSource/TCPSource.hpp
@@ -175,8 +175,7 @@ public:
     /// Close TCP connection.
     void close() override;
 
-    static std::unique_ptr<NES::Configurations::DescriptorConfig::Config>
-    validateAndFormat(std::unordered_map<std::string, std::string> config);
+    static NES::Configurations::DescriptorConfig::Config validateAndFormat(std::unordered_map<std::string, std::string> config);
 
     [[nodiscard]] std::ostream& toString(std::ostream& str) const override;
 

--- a/nes-sinks/include/Sinks/FileSink.hpp
+++ b/nes-sinks/include/Sinks/FileSink.hpp
@@ -52,8 +52,7 @@ public:
     execute(const Memory::TupleBuffer& inputTupleBuffer, Runtime::Execution::PipelineExecutionContext& pipelineExecutionContext) override;
     void stop(Runtime::Execution::PipelineExecutionContext& pipelineExecutionContext) override;
 
-    static std::unique_ptr<Configurations::DescriptorConfig::Config>
-    validateAndFormat(std::unordered_map<std::string, std::string>&& config);
+    static Configurations::DescriptorConfig::Config validateAndFormat(std::unordered_map<std::string, std::string> config);
 
 protected:
     std::ostream& toString(std::ostream& str) const override;

--- a/nes-sinks/include/Sinks/PrintSink.hpp
+++ b/nes-sinks/include/Sinks/PrintSink.hpp
@@ -50,8 +50,7 @@ public:
     execute(const Memory::TupleBuffer& inputTupleBuffer, Runtime::Execution::PipelineExecutionContext& pipelineExecutionContext) override;
     void stop(Runtime::Execution::PipelineExecutionContext& pipelineExecutionContext) override;
 
-    static std::unique_ptr<Configurations::DescriptorConfig::Config>
-    validateAndFormat(std::unordered_map<std::string, std::string>&& config);
+    static Configurations::DescriptorConfig::Config validateAndFormat(std::unordered_map<std::string, std::string> config);
 
 protected:
     std::ostream& toString(std::ostream& str) const override;

--- a/nes-sinks/include/Sinks/SinkDescriptor.hpp
+++ b/nes-sinks/include/Sinks/SinkDescriptor.hpp
@@ -30,7 +30,7 @@ struct SinkDescriptor : Configurations::Descriptor
     ~SinkDescriptor() = default;
 
     /// Iterates over all config pairs to create a DescriptorConfig::Config containing only strings.
-    static std::unique_ptr<Configurations::DescriptorConfig::Config>
+    static Configurations::DescriptorConfig::Config
     validateAndFormatConfig(const std::string& sinkType, std::unordered_map<std::string, std::string> configPairs);
 
     const std::string sinkType;

--- a/nes-sinks/registry/include/SinkRegistry.hpp
+++ b/nes-sinks/registry/include/SinkRegistry.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <Sinks/Sink.hpp>
 #include <Sinks/SinkDescriptor.hpp>
@@ -22,7 +23,7 @@
 namespace NES::Sinks
 {
 
-using SinkRegistryReturnType = Sink;
+using SinkRegistryReturnType = std::unique_ptr<Sink>;
 struct SinkRegistryArguments
 {
     SinkDescriptor sinkDescriptor;

--- a/nes-sinks/src/FileSink.cpp
+++ b/nes-sinks/src/FileSink.cpp
@@ -121,18 +121,17 @@ void FileSink::stop(Runtime::Execution::PipelineExecutionContext&)
     stream->close();
 }
 
-std::unique_ptr<Configurations::DescriptorConfig::Config> FileSink::validateAndFormat(std::unordered_map<std::string, std::string>&& config)
+Configurations::DescriptorConfig::Config FileSink::validateAndFormat(std::unordered_map<std::string, std::string> config)
 {
     return Configurations::DescriptorConfig::validateAndFormat<ConfigParametersFile>(std::move(config), NAME);
 }
 
-std::unique_ptr<SinkValidationRegistryReturnType>
-SinkValidationGeneratedRegistrar::RegisterFileSinkValidation(SinkValidationRegistryArguments sinkConfig)
+SinkValidationRegistryReturnType SinkValidationGeneratedRegistrar::RegisterFileSinkValidation(SinkValidationRegistryArguments sinkConfig)
 {
     return FileSink::validateAndFormat(std::move(sinkConfig.config));
 }
 
-std::unique_ptr<SinkRegistryReturnType> SinkGeneratedRegistrar::RegisterFileSink(SinkRegistryArguments sinkRegistryArguments)
+SinkRegistryReturnType SinkGeneratedRegistrar::RegisterFileSink(SinkRegistryArguments sinkRegistryArguments)
 {
     return std::make_unique<FileSink>(sinkRegistryArguments.sinkDescriptor);
 }

--- a/nes-sinks/src/PrintSink.cpp
+++ b/nes-sinks/src/PrintSink.cpp
@@ -69,19 +69,17 @@ std::ostream& PrintSink::toString(std::ostream& str) const
     return str;
 }
 
-std::unique_ptr<Configurations::DescriptorConfig::Config>
-PrintSink::validateAndFormat(std::unordered_map<std::string, std::string>&& config)
+Configurations::DescriptorConfig::Config PrintSink::validateAndFormat(std::unordered_map<std::string, std::string> config)
 {
     return Configurations::DescriptorConfig::validateAndFormat<ConfigParametersPrint>(std::move(config), NAME);
 }
 
-std::unique_ptr<SinkValidationRegistryReturnType>
-SinkValidationGeneratedRegistrar::RegisterPrintSinkValidation(SinkValidationRegistryArguments sinkConfig)
+SinkValidationRegistryReturnType SinkValidationGeneratedRegistrar::RegisterPrintSinkValidation(SinkValidationRegistryArguments sinkConfig)
 {
     return PrintSink::validateAndFormat(std::move(sinkConfig.config));
 }
 
-std::unique_ptr<SinkRegistryReturnType> SinkGeneratedRegistrar::RegisterPrintSink(SinkRegistryArguments sinkRegistryArguments)
+SinkRegistryReturnType SinkGeneratedRegistrar::RegisterPrintSink(SinkRegistryArguments sinkRegistryArguments)
 {
     return std::make_unique<PrintSink>(sinkRegistryArguments.sinkDescriptor);
 }

--- a/nes-sinks/src/SinkDescriptor.cpp
+++ b/nes-sinks/src/SinkDescriptor.cpp
@@ -29,13 +29,13 @@ SinkDescriptor::SinkDescriptor(std::string sinkType, Configurations::DescriptorC
 {
 }
 
-std::unique_ptr<Configurations::DescriptorConfig::Config>
+Configurations::DescriptorConfig::Config
 SinkDescriptor::validateAndFormatConfig(const std::string& sinkType, std::unordered_map<std::string, std::string> configPairs)
 {
     auto sinkValidationRegistryArguments = NES::Sinks::SinkValidationRegistryArguments(std::move(configPairs));
     if (auto validatedConfig = SinkValidationRegistry::instance().create(sinkType, std::move(sinkValidationRegistryArguments)))
     {
-        return std::move(validatedConfig.value());
+        return validatedConfig.value();
     }
     throw UnknownSinkType(fmt::format("Cannot find sink type: {} in validation registry for sinks.", sinkType));
 }

--- a/nes-sources/private/FileSource.hpp
+++ b/nes-sources/private/FileSource.hpp
@@ -51,8 +51,7 @@ public:
     void close() override;
 
     /// validates and formats a string to string configuration
-    static std::unique_ptr<NES::Configurations::DescriptorConfig::Config>
-    validateAndFormat(std::unordered_map<std::string, std::string> config);
+    static NES::Configurations::DescriptorConfig::Config validateAndFormat(std::unordered_map<std::string, std::string> config);
 
     [[nodiscard]] std::ostream& toString(std::ostream& str) const override;
 

--- a/nes-sources/registry/include/SourceRegistry.hpp
+++ b/nes-sources/registry/include/SourceRegistry.hpp
@@ -14,7 +14,9 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
+
 #include <Sources/Source.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Util/Registry.hpp>
@@ -22,7 +24,7 @@
 namespace NES::Sources
 {
 
-using SourceRegistryReturnType = Source;
+using SourceRegistryReturnType = std::unique_ptr<Source>;
 struct SourceRegistryArguments
 {
     SourceDescriptor sourceDescriptor;

--- a/nes-sources/src/FileSource.cpp
+++ b/nes-sources/src/FileSource.cpp
@@ -61,8 +61,7 @@ size_t FileSource::fillTupleBuffer(NES::Memory::TupleBuffer& tupleBuffer, const 
     return numBytesRead;
 }
 
-std::unique_ptr<NES::Configurations::DescriptorConfig::Config>
-FileSource::validateAndFormat(std::unordered_map<std::string, std::string> config)
+NES::Configurations::DescriptorConfig::Config FileSource::validateAndFormat(std::unordered_map<std::string, std::string> config)
 {
     return Configurations::DescriptorConfig::validateAndFormat<ConfigParametersCSV>(std::move(config), NAME);
 }
@@ -73,13 +72,13 @@ std::ostream& FileSource::toString(std::ostream& str) const
     return str;
 }
 
-std::unique_ptr<SourceValidationRegistryReturnType>
+SourceValidationRegistryReturnType
 SourceValidationGeneratedRegistrar::RegisterFileSourceValidation(SourceValidationRegistryArguments sourceConfig)
 {
-    return FileSource::validateAndFormat(sourceConfig.config);
+    return FileSource::validateAndFormat(std::move(sourceConfig.config));
 }
 
-std::unique_ptr<SourceRegistryReturnType> SourceGeneratedRegistrar::RegisterFileSource(SourceRegistryArguments sourceRegistryArguments)
+SourceRegistryReturnType SourceGeneratedRegistrar::RegisterFileSource(SourceRegistryArguments sourceRegistryArguments)
 {
     return std::make_unique<FileSource>(sourceRegistryArguments.sourceDescriptor);
 }

--- a/nes-sources/src/SourceProvider.cpp
+++ b/nes-sources/src/SourceProvider.cpp
@@ -26,23 +26,23 @@
 namespace NES::Sources
 {
 
-std::unique_ptr<Sources::SourceProvider> SourceProvider::create()
+std::unique_ptr<SourceProvider> SourceProvider::create()
 {
     return std::make_unique<SourceProvider>();
 }
 
-std::unique_ptr<SourceHandle> SourceProvider::lower(
-    OriginId originId, const SourceDescriptor& sourceDescriptor, std::shared_ptr<NES::Memory::AbstractPoolProvider> bufferPool)
+std::unique_ptr<SourceHandle>
+SourceProvider::lower(OriginId originId, const SourceDescriptor& sourceDescriptor, std::shared_ptr<Memory::AbstractPoolProvider> bufferPool)
 {
     /// Todo #241: Get the new source identfier from the source descriptor and pass it to SourceHandle.
     /// Todo #495: If we completely move the InputFormatter out of the sources, we get rid of constructing the parser here.
-    auto inputFormatter = NES::InputFormatters::InputFormatterProvider::provideInputFormatter(
+    auto inputFormatter = InputFormatters::InputFormatterProvider::provideInputFormatter(
         sourceDescriptor.parserConfig.parserType,
         *sourceDescriptor.schema,
         sourceDescriptor.parserConfig.tupleDelimiter,
         sourceDescriptor.parserConfig.fieldDelimiter);
 
-    auto sourceArguments = NES::Sources::SourceRegistryArguments(sourceDescriptor);
+    auto sourceArguments = SourceRegistryArguments(sourceDescriptor);
     if (auto source = SourceRegistry::instance().create(sourceDescriptor.sourceType, sourceArguments))
     {
         return std::make_unique<SourceHandle>(

--- a/nes-sources/src/SourceValidationProvider.cpp
+++ b/nes-sources/src/SourceValidationProvider.cpp
@@ -29,7 +29,7 @@ provide(const std::string& sourceType, std::unordered_map<std::string, std::stri
     auto sourceValidationRegistryArguments = SourceValidationRegistryArguments(std::move(stringConfig));
     if (const auto validConfig = SourceValidationRegistry::instance().create(sourceType, std::move(sourceValidationRegistryArguments)))
     {
-        return std::move(*validConfig.value());
+        return std::move(validConfig.value());
     }
     throw UnknownSourceType("We don't support the source type: {}", sourceType);
 }


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR modifies the way in which `Registrar` types are generated, by removing each type that a specific `Registry` returns to be wrapped in an `std::unique_ptr`. 
This way, the different registries can decide to return a `unique_ptr`, `shared_ptr`, `variant`, `optional`, etc.

From now on in each registry, we need to write out the exact type that our registry returns, instead of just using the raw type:
`using MyRegistryReturnType = std::unique_ptr<MyRegistryType>;`


## Verifying this change
This change is tested by:
- All tests

## What components does this pull request potentially affect?
- `PluginRegistrationUtil.cmake` (remove hard-coded unique_ptr wrapping)
- nes-sources (registration functions, source registry)
- nes-plugins (TCPSource and its validation)
- nes-sinks (registration functions, sink registry)
- nes-execution (registration functions, function and pipeline registry)
- nes-common (`Registry.hpp`)
- nes-configuration (`Descriptor.hpp`)
- nes-nebuli (config returned for validation)
- nes-input-formatters (registration functions, formatter registry)

## Issue Closed by this pull request:
This PR closes #706 
