### PR TITLE
Remove unused BufferProvider from NLJOperatorHandler

### DIFF
--- a/nes-execution/include/Execution/Operators/Streaming/Aggregation/AggregationOperatorHandler.hpp
+++ b/nes-execution/include/Execution/Operators/Streaming/Aggregation/AggregationOperatorHandler.hpp
@@ -23,7 +23,6 @@
 #include <Execution/Operators/Streaming/WindowBasedOperatorHandler.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Nautilus/Interface/HashMap/HashMap.hpp>
-#include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Util/Execution.hpp>
 
@@ -54,8 +53,7 @@ public:
     /// TODO #409 This might change after the [DD] Operator Representations  has been implemented
     void setHashMapParams(uint64_t keySize, uint64_t valueSize, uint64_t pageSize, uint64_t numberOfBuckets);
 
-    std::function<std::vector<std::shared_ptr<Slice>>(SliceStart, SliceEnd)>
-    getCreateNewSlicesFunction(const Memory::AbstractBufferProvider* bufferProvider) const override;
+    [[nodiscard]] std::function<std::vector<std::shared_ptr<Slice>>(SliceStart, SliceEnd)> getCreateNewSlicesFunction() const override;
 
 protected:
     void triggerSlices(

--- a/nes-execution/include/Execution/Operators/Streaming/Join/NestedLoopJoin/NLJOperatorHandler.hpp
+++ b/nes-execution/include/Execution/Operators/Streaming/Join/NestedLoopJoin/NLJOperatorHandler.hpp
@@ -17,17 +17,14 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
-#include <utility>
 #include <vector>
 #include <Execution/Operators/SliceStore/Slice.hpp>
 #include <Execution/Operators/SliceStore/WindowSlicesStoreInterface.hpp>
 #include <Execution/Operators/Streaming/Join/NestedLoopJoin/NLJSlice.hpp>
 #include <Execution/Operators/Streaming/Join/StreamJoinOperatorHandler.hpp>
-#include <Execution/Operators/Streaming/Join/StreamJoinUtil.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
 #include <Nautilus/Interface/PagedVector/PagedVector.hpp>
-#include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Util/Execution.hpp>
 #include <folly/Synchronized.h>
@@ -53,8 +50,7 @@ public:
         const std::shared_ptr<Nautilus::Interface::MemoryProvider::TupleBufferMemoryProvider>& leftMemoryProvider,
         const std::shared_ptr<Nautilus::Interface::MemoryProvider::TupleBufferMemoryProvider>& rightMemoryProvider);
 
-    std::function<std::vector<std::shared_ptr<Slice>>(SliceStart, SliceEnd)>
-    getCreateNewSlicesFunction(const Memory::AbstractBufferProvider* bufferProvider) const override;
+    [[nodiscard]] std::function<std::vector<std::shared_ptr<Slice>>(SliceStart, SliceEnd)> getCreateNewSlicesFunction() const override;
 
 private:
     void emitSliceIdsToProbe(

--- a/nes-execution/include/Execution/Operators/Streaming/WindowBasedOperatorHandler.hpp
+++ b/nes-execution/include/Execution/Operators/Streaming/WindowBasedOperatorHandler.hpp
@@ -24,9 +24,7 @@
 #include <Runtime/Execution/OperatorHandler.hpp>
 
 #include <Execution/Operators/SliceStore/Slice.hpp>
-#include <Execution/Operators/Streaming/Join/StreamJoinUtil.hpp>
 #include <Identifiers/Identifiers.hpp>
-#include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/QueryTerminationType.hpp>
 #include <Util/Execution.hpp>
 
@@ -65,8 +63,7 @@ public:
 
     /// Gives the specific operator handler the chance to provide a function that creates new slices
     /// This method is being called whenever a new slice is needed, e.g., receiving a timestamp that is not yet in the slice store.
-    virtual std::function<std::vector<std::shared_ptr<Slice>>(SliceStart, SliceEnd)>
-    getCreateNewSlicesFunction(const Memory::AbstractBufferProvider* bufferProvider) const = 0;
+    [[nodiscard]] virtual std::function<std::vector<std::shared_ptr<Slice>>(SliceStart, SliceEnd)> getCreateNewSlicesFunction() const = 0;
 
 protected:
     /// Gets called if slices should be triggered once a window is ready to be emitted.

--- a/nes-execution/src/Execution/Operators/Streaming/Aggregation/AggregationBuild.cpp
+++ b/nes-execution/src/Execution/Operators/Streaming/Aggregation/AggregationBuild.cpp
@@ -38,16 +38,12 @@
 namespace NES::Runtime::Execution::Operators
 {
 
-Interface::HashMap* getHashMapProxy(
-    const AggregationOperatorHandler* operatorHandler,
-    const Timestamp timestamp,
-    const WorkerThreadId workerThreadId,
-    const Memory::AbstractBufferProvider* bufferProvider)
+Interface::HashMap*
+getHashMapProxy(const AggregationOperatorHandler* operatorHandler, const Timestamp timestamp, const WorkerThreadId workerThreadId)
 {
     PRECONDITION(operatorHandler != nullptr, "The operator handler should not be null");
-    PRECONDITION(bufferProvider != nullptr, "The buffer provider should not be null");
 
-    const auto createFunction = operatorHandler->getCreateNewSlicesFunction(bufferProvider);
+    const auto createFunction = operatorHandler->getCreateNewSlicesFunction();
     const auto hashMap = operatorHandler->getSliceAndWindowStore().getSlicesOrCreate(timestamp, createFunction);
     INVARIANT(
         hashMap.size() == 1,
@@ -64,12 +60,7 @@ void AggregationBuild::execute(ExecutionContext& ctx, Record& record) const
 {
     /// Getting the correspinding slice so that we can update the aggregation states
     const auto timestamp = timeFunction->getTs(ctx, record);
-    const auto hashMapPtr = invoke(
-        getHashMapProxy,
-        ctx.getGlobalOperatorHandler(operatorHandlerIndex),
-        timestamp,
-        ctx.getWorkerThreadId(),
-        ctx.pipelineMemoryProvider.bufferProvider);
+    const auto hashMapPtr = invoke(getHashMapProxy, ctx.getGlobalOperatorHandler(operatorHandlerIndex), timestamp, ctx.getWorkerThreadId());
     Interface::ChainedHashMapRef hashMap(hashMapPtr, fieldKeys, fieldValues, entriesPerPage, entrySize);
 
     /// Calling the key functions to add/update the keys to the record

--- a/nes-execution/src/Execution/Operators/Streaming/Aggregation/AggregationOperatorHandler.cpp
+++ b/nes-execution/src/Execution/Operators/Streaming/Aggregation/AggregationOperatorHandler.cpp
@@ -53,8 +53,7 @@ void AggregationOperatorHandler::setHashMapParams(
     this->numberOfBuckets = numberOfBuckets;
 }
 
-std::function<std::vector<std::shared_ptr<Slice>>(SliceStart, SliceEnd)>
-AggregationOperatorHandler::getCreateNewSlicesFunction(const Memory::AbstractBufferProvider*) const
+std::function<std::vector<std::shared_ptr<Slice>>(SliceStart, SliceEnd)> AggregationOperatorHandler::getCreateNewSlicesFunction() const
 {
     PRECONDITION(
         numberOfWorkerThreads > 0, "Number of worker threads not set for window based operator. Was setWorkerThreads() being called?");


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This pull request removes unused code in `NLJOperatorHandler`.

## Verifying this change
This change is tested by
- existing system level test

## Documentation
- All necessary methods (no getter, setter, or constructor) have a documentation.