### PR TITLE
#710: Removed upper and lower bound attribute of Numeric Classes

### DIFF
--- a/grpc/SerializableDataType.proto
+++ b/grpc/SerializableDataType.proto
@@ -44,8 +44,7 @@ message SerializableDataType{
    */
   message IntegerDetails{
     uint64 bits = 1;
-    uint64 upperBound = 2;
-    int64 lowerBound = 3;
+    bool isSigned = 2;
   }
 
   /**
@@ -53,8 +52,6 @@ message SerializableDataType{
   */
   message FloatDetails{
     uint64 bits = 1;
-    double upperBound = 2;
-    double lowerBound = 3;
   }
 
   /**

--- a/nes-data-types/include/Common/DataTypes/Float.hpp
+++ b/nes-data-types/include/Common/DataTypes/Float.hpp
@@ -34,9 +34,7 @@ public:
      * @param lowerBound the lower bound, which is contained in that float.
      * @param upperBound the upper bound, which is contained in that float.
      */
-    inline Float(int8_t bits, double lowerBound, double upperBound) noexcept : Numeric(bits), lowerBound(lowerBound), upperBound(upperBound)
-    {
-    }
+    explicit Float(int8_t bits) noexcept : Numeric(bits) { }
 
     ~Float() override = default;
 
@@ -52,9 +50,5 @@ public:
     std::shared_ptr<DataType> join(std::shared_ptr<DataType> otherDataType) override;
 
     std::string toString() override;
-
-    double lowerBound;
-    double upperBound;
 };
-
 }

--- a/nes-data-types/include/Common/DataTypes/Integer.hpp
+++ b/nes-data-types/include/Common/DataTypes/Integer.hpp
@@ -36,9 +36,7 @@ public:
      * @param lowerBound the lower bound, which is contained in that integer.
      * @param upperBound the upper bound, which is contained in that integer.
      */
-    Integer(int8_t bits, int64_t lowerBound, uint64_t upperBound) noexcept : Numeric(bits), lowerBound(lowerBound), upperBound(upperBound)
-    {
-    }
+    Integer(int8_t bits, bool isSigned) noexcept : Numeric(bits), isSigned(isSigned) { }
 
     ~Integer() override = default;
 
@@ -55,8 +53,10 @@ public:
 
     std::string toString() override;
 
-    int64_t lowerBound;
-    uint64_t upperBound;
+    [[nodiscard]] bool getIsSigned() const;
+
+private:
+    bool isSigned;
 };
 
 }

--- a/nes-data-types/src/Common/DataTypes/Float.cpp
+++ b/nes-data-types/src/Common/DataTypes/Float.cpp
@@ -33,7 +33,7 @@ bool Float::operator==(const NES::DataType& other) const
 {
     if (const auto otherFloat = dynamic_cast<const Float*>(&other))
     {
-        return bits == otherFloat->bits && lowerBound == otherFloat->lowerBound && upperBound == otherFloat->upperBound;
+        return bits == otherFloat->bits;
     }
     return false;
 }
@@ -42,7 +42,7 @@ std::shared_ptr<DataType> Float::join(const std::shared_ptr<DataType> otherDataT
 {
     if (NES::Util::instanceOf<Undefined>(otherDataType))
     {
-        return std::make_shared<Float>(bits, lowerBound, upperBound);
+        return std::make_shared<Float>(bits);
     }
     if (not NES::Util::instanceOf<Numeric>(otherDataType))
     {
@@ -63,12 +63,12 @@ std::string Float::toString()
 
 DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterFLOAT32DataType(DataTypeRegistryArguments)
 {
-    return std::make_unique<Float>(32, std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max());
+    return std::make_unique<Float>(32);
 }
 
 DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterFLOAT64DataType(DataTypeRegistryArguments)
 {
-    return std::make_unique<Float>(64, std::numeric_limits<double>::lowest(), std::numeric_limits<double>::max());
+    return std::make_unique<Float>(64);
 }
 
 }

--- a/nes-data-types/src/Common/DataTypes/Integer.cpp
+++ b/nes-data-types/src/Common/DataTypes/Integer.cpp
@@ -34,7 +34,7 @@ bool Integer::operator==(const NES::DataType& other) const
 {
     if (const auto otherInteger = dynamic_cast<const Integer*>(&other))
     {
-        return bits == otherInteger->bits && lowerBound == otherInteger->lowerBound && upperBound == otherInteger->upperBound;
+        return bits == otherInteger->bits && isSigned == otherInteger->getIsSigned();
     }
     return false;
 }
@@ -43,7 +43,7 @@ std::shared_ptr<DataType> Integer::join(const std::shared_ptr<DataType> otherDat
 {
     if (NES::Util::instanceOf<Undefined>(otherDataType))
     {
-        return std::make_shared<Integer>(bits, lowerBound, upperBound);
+        return std::make_shared<Integer>(bits, isSigned);
     }
 
     if (not NES::Util::instanceOf<Numeric>(otherDataType))
@@ -60,47 +60,52 @@ std::shared_ptr<DataType> Integer::join(const std::shared_ptr<DataType> otherDat
 
 std::string Integer::toString()
 {
-    return fmt::format("{}{}", lowerBound == 0 ? "UINT" : "INT", std::to_string(bits));
+    return fmt::format("{}{}", isSigned ? "INT" : "UINT", std::to_string(bits));
+}
+
+bool Integer::getIsSigned() const
+{
+    return isSigned;
 }
 
 DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterINT8DataType(DataTypeRegistryArguments)
 {
-    return std::make_unique<Integer>(8, INT8_MIN, INT8_MAX);
+    return std::make_unique<Integer>(8, true);
 }
 
 DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterUINT8DataType(DataTypeRegistryArguments)
 {
-    return std::make_unique<Integer>(8, 0, UINT8_MAX);
+    return std::make_unique<Integer>(8, false);
 }
 
 DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterINT16DataType(DataTypeRegistryArguments)
 {
-    return std::make_unique<Integer>(16, INT16_MIN, INT16_MAX);
+    return std::make_unique<Integer>(16, true);
 }
 
 DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterUINT16DataType(DataTypeRegistryArguments)
 {
-    return std::make_unique<Integer>(16, 0, UINT16_MAX);
+    return std::make_unique<Integer>(16, false);
 }
 
 DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterINT32DataType(DataTypeRegistryArguments)
 {
-    return std::make_unique<Integer>(32, INT32_MIN, INT32_MAX);
+    return std::make_unique<Integer>(32, true);
 }
 
 DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterUINT32DataType(DataTypeRegistryArguments)
 {
-    return std::make_unique<Integer>(32, 0, UINT32_MAX);
+    return std::make_unique<Integer>(32, false);
 }
 
 DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterINT64DataType(DataTypeRegistryArguments)
 {
-    return std::make_unique<Integer>(64, INT64_MIN, INT64_MAX);
+    return std::make_unique<Integer>(64, true);
 }
 
 DataTypeRegistryReturnType DataTypeGeneratedRegistrar::RegisterUINT64DataType(DataTypeRegistryArguments)
 {
-    return std::make_unique<Integer>(64, 0, UINT64_MAX);
+    return std::make_unique<Integer>(64, false);
 }
 
 }

--- a/nes-data-types/src/Common/DataTypes/Numeric.cpp
+++ b/nes-data-types/src/Common/DataTypes/Numeric.cpp
@@ -73,8 +73,8 @@ std::optional<std::shared_ptr<DataType>> Numeric::inferDataType(const Numeric& l
         /// We need to still cast here to an integer, as the lowerBound is a member of Integer and not of Numeric
         const auto leftInt = Util::as<const Integer>(left);
         const auto rightInt = Util::as<const Integer>(right);
-        const auto leftSign = leftInt.lowerBound < 0;
-        const auto rightSign = rightInt.lowerBound < 0;
+        const auto leftSign = leftInt.getIsSigned();
+        const auto rightSign = rightInt.getIsSigned();
         const auto leftBits = leftInt.getBits();
         const auto rightBits = rightInt.getBits();
         if (leftBits < sizeOfIntInBits && rightBits < sizeOfIntInBits)

--- a/nes-data-types/src/Common/PhysicalTypes/DefaultPhysicalTypeFactory.cpp
+++ b/nes-data-types/src/Common/PhysicalTypes/DefaultPhysicalTypeFactory.cpp
@@ -61,7 +61,7 @@ std::shared_ptr<PhysicalType> DefaultPhysicalTypeFactory::getPhysicalType(std::s
 std::shared_ptr<PhysicalType> DefaultPhysicalTypeFactory::getPhysicalType(const std::shared_ptr<Integer>& integer)
 {
     using enum NES::BasicPhysicalType::NativeType;
-    if (integer->lowerBound >= 0)
+    if (!integer->getIsSigned())
     {
         if (integer->getBits() <= 8)
         {

--- a/nes-data-types/src/Serialization/DataTypeSerializationUtil.cpp
+++ b/nes-data-types/src/Serialization/DataTypeSerializationUtil.cpp
@@ -45,8 +45,7 @@ DataTypeSerializationUtil::serializeDataType(const std::shared_ptr<DataType>& da
         auto intDataType = DataType::as<Integer>(dataType);
         auto serializedInteger = SerializableDataType_IntegerDetails();
         serializedInteger.set_bits(intDataType->getBits());
-        serializedInteger.set_lowerbound(intDataType->lowerBound);
-        serializedInteger.set_upperbound(intDataType->upperBound);
+        serializedInteger.set_issigned(intDataType->getIsSigned());
         serializedDataType->mutable_details()->PackFrom(serializedInteger);
         serializedDataType->set_type(SerializableDataType_Type_INTEGER);
     }
@@ -55,8 +54,6 @@ DataTypeSerializationUtil::serializeDataType(const std::shared_ptr<DataType>& da
         auto floatDataType = DataType::as<Float>(dataType);
         auto serializableFloat = SerializableDataType_FloatDetails();
         serializableFloat.set_bits(floatDataType->getBits());
-        serializableFloat.set_lowerbound(floatDataType->lowerBound);
-        serializableFloat.set_upperbound(floatDataType->upperBound);
         serializedDataType->mutable_details()->PackFrom(serializableFloat);
         serializedDataType->set_type(SerializableDataType_Type_FLOAT);
     }
@@ -95,7 +92,7 @@ std::shared_ptr<DataType> DataTypeSerializationUtil::deserializeDataType(const S
     {
         auto integerDetails = SerializableDataType_IntegerDetails();
         serializedDataType.details().UnpackTo(&integerDetails);
-        if (integerDetails.lowerbound() < 0)
+        if (integerDetails.issigned())
         {
             return DataTypeProvider::provideDataType("INT" + std::to_string(integerDetails.bits()));
         }

--- a/nes-operators/src/Operators/LogicalOperators/Windows/Aggregations/AvgAggregationDescriptor.cpp
+++ b/nes-operators/src/Operators/LogicalOperators/Windows/Aggregations/AvgAggregationDescriptor.cpp
@@ -69,7 +69,7 @@ void AvgAggregationDescriptor::inferStamp(const Schema& schema)
     /// As we are performing essentially a sum and a count, we need to cast the sum to either uint64_t, int64_t or double to avoid overflow
     if (const auto integerDataType = NES::Util::as_if<Integer>(onField->getStamp()); integerDataType)
     {
-        if (integerDataType->lowerBound < 0)
+        if (integerDataType->getIsSigned())
         {
             onField->setStamp(DataTypeProvider::provideDataType(LogicalType::INT64));
         }


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This pull request removes the attributes `lowerBound` and `upperBound` of our `Integer` and `Float` classes. Currently, the bounds are only used for the `equals` methods of the classes and to check, if the integer is signed. 

Since pull request #697, we only support floats and integers of predetermined bit-sizes; Therefore, it suffices to compare the bit size (and compare, if two integers are signed or unsigned) to check for equality of two numeric types. For this purpose, a `isSigned` boolean attribute has been added for the `Integer` class.

### Brief change log

- Removed  `lowerBound` and `upperBound` of our `Integer` and `Float` classes
- Added `isSigned` attribute to `Integer` class
- Adjusted the serialization of the affected classes to this change

## Verifying this change
This change is covered by existing tests.

## What components does this pull request potentially affect?

- nes-data-types

## Issue Closed by this pull request:

This PR closes issue #710.
