### PR TITLE
Improve legibility by printing stacktrace with color

### DIFF
--- a/nes-common/src/ErrorHandling.cpp
+++ b/nes-common/src/ErrorHandling.cpp
@@ -84,6 +84,7 @@ std::string formatLogMessage(const Exception& e)
         auto exceptionLocation = e.where().value();
         if constexpr (logWithStacktrace)
         {
+            constexpr auto ANSI_COLOR_RESET = "\u001B[0m";
             return fmt::format(
                 "failed to process with error code ({}) : {}\n{}:{}:{} in function `{}`\n\n{}\n",
                 e.code(),
@@ -92,7 +93,7 @@ std::string formatLogMessage(const Exception& e)
                 exceptionLocation.line,
                 exceptionLocation.column,
                 exceptionLocation.symbol,
-                e.trace().to_string());
+                ANSI_COLOR_RESET + e.trace().to_string(true));
         }
         return fmt::format(
             "failed to process with error code ({}) : {}\n{}:{}:{} in function `{}`\n",


### PR DESCRIPTION
Currently:

![image](https://github.com/user-attachments/assets/3f1464b8-5117-4a89-8494-9aaccd2e598b)

With this change:

![image](https://github.com/user-attachments/assets/f19218dd-aaca-4022-8b7b-d4b44edbda09)
