### PR TITLE
don't install clang-tidy-diff twice

### DIFF
--- a/.github/workflows/clang_tidy_diff.yml
+++ b/.github/workflows/clang_tidy_diff.yml
@@ -50,9 +50,9 @@ jobs:
       - name: Create results directory
         run: mkdir clang-tidy-result
       - name: Clang-Tidy Precheck
-        run: git diff -U0 ${{ inputs.base_sha }} -- ':!*.inc' | clang-tidy-diff.py -clang-tidy-binary clang-tidy-18 -p1 -path build -config-file .clang-tidy-pre-check -j $(nproc)
+        run: git diff -U0 ${{ inputs.base_sha }} -- ':!*.inc' | clang-tidy-diff-18.py -clang-tidy-binary clang-tidy-18 -p1 -path build -config-file .clang-tidy-pre-check -j $(nproc)
       - name: Analyze by running Clang-Tidy
-        run: git diff -U0 ${{ inputs.base_sha }} -- ':!*.inc' | clang-tidy-diff.py -clang-tidy-binary clang-tidy-18 -p1 -path build -export-fixes clang-tidy-result/fixes.yml -j $(nproc)
+        run: git diff -U0 ${{ inputs.base_sha }} -- ':!*.inc' | clang-tidy-diff-18.py -clang-tidy-binary clang-tidy-18 -p1 -path build -export-fixes clang-tidy-result/fixes.yml -j $(nproc)
       - name: Upload Clang-Tidy Results
         if: ${{ !cancelled() && !github.event.act }}
         uses: actions/upload-artifact@v4

--- a/docker/dependency/Development.dockerfile
+++ b/docker/dependency/Development.dockerfile
@@ -7,10 +7,6 @@ ARG ANTLR4_VERSION=4.13.2
 RUN apt update -y \
     && apt install clang-format-${LLVM_VERSION} clang-tidy-${LLVM_VERSION} lldb-${LLVM_VERSION} gdb jq -y
 
-# As clang-tidy-diff is not available in the apt repository, we need download it from the github repo and install it
-ADD --checksum=sha256:ec28c743ce3354df22b52db59feeac2d98556b8fc81cb7c1a877f3a862ae5726 --chmod=755 \
- https://raw.githubusercontent.com/duckdb/duckdb/52b43b166091c82b3f04bf8af15f0ace18207a64/scripts/clang-tidy-diff.py /usr/bin/
-
 RUN apt-get update && apt-get install -y \
         default-jre-headless \
         python3              \

--- a/docs/development/fix_clang_tidy_warnings.md
+++ b/docs/development/fix_clang_tidy_warnings.md
@@ -25,7 +25,7 @@ export LLVM_SYMBOLIZER_PATH=llvm-symbolizer-18 && \
     cd /tmp/nebulastream && \
     rm -rf build/ && mkdir build && \
     cmake -GNinja -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON && \
-    git diff -U0 origin/<branch name> -- ':!*.inc' | clang-tidy-diff.py -clang-tidy-binary clang-tidy-18 -p1 -path build -fix -config-file .clang-tidy -j <no. threads>
+    git diff -U0 origin/<branch name> -- ':!*.inc' | clang-tidy-diff-18.py -clang-tidy-binary clang-tidy-18 -p1 -path build -fix -config-file .clang-tidy -j <no. threads>
 ```
 Since we generate some header files in the build process, clang-tidy might complain about missing header files.
 In this case, you have to build `NebulaStream` before running the clang-tidy check to create the missing header files.
@@ -36,7 +36,7 @@ export LLVM_SYMBOLIZER_PATH=llvm-symbolizer-18 && \
     rm -rf build/ && mkdir build && \
     cmake -GNinja -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON && \
     cmake --build build -j -- -k 0 && \
-    git diff -U0 origin/<branch name> -- ':!*.inc' | clang-tidy-diff.py -clang-tidy-binary clang-tidy-18 -p1 -path build -fix -config-file .clang-tidy -j <no. threads>
+    git diff -U0 origin/<branch name> -- ':!*.inc' | clang-tidy-diff-18.py -clang-tidy-binary clang-tidy-18 -p1 -path build -fix -config-file .clang-tidy -j <no. threads>
 ```
 
 # Fixing clang-tidy warnings compared to a commit hash


### PR DESCRIPTION
Installing `clang-tidy-18` already provides `clang-tidy-diff-18.py`, thus we do not need to install it again if we change the invocation.