### PR TITLE
Check format in nightly ci

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -54,6 +54,16 @@ jobs:
       ref: ${{ needs.fetch-current-main-commit.outputs.sha }}
       dev_image_tag: ${{ needs.get-dev-images.outputs.image-tag }}
 
+  check-format:
+    needs: [ fetch-current-main-commit, get-dev-images ]
+    name: "Check format"
+    uses: ./.github/workflows/format.yml
+    with:
+      head_sha: ${{ needs.fetch-current-main-commit.outputs.sha }}
+      dev_image_tag: ${{ needs.get-dev-images.outputs.image-tag }}
+      # since there is no merge base to compare against, just check last 10 commits
+      number_of_commits: 10
+
   build-and-test:
     name: "Run build and test"
     needs: [ fetch-current-main-commit, get-dev-images ]


### PR DESCRIPTION
main is currently at 7d1695f3f3 and afaics it is not formatted correctly.

This happened since https://github.com/nebulastream/nebulastream-public/pull/734 was merged [while the CI was failing](https://github.com/nebulastream/nebulastream-public/actions/runs/13947508131/job/39038125766?pr=734). To be fair: not only formatting was failing but there was also a flaky test.

Adding the format check to nightly of course does not prevent this, but it makes it easier to verify that indeed formatting is broken in CI.