### PR TITLE
fix cmake build type

### DIFF
--- a/.github/workflows/large_test.yml
+++ b/.github/workflows/large_test.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
       - name: Configure NebulaStream
-        run: cmake -GNinja -B build -DCMAKE_RELEASE_TYPE=RelWithDebInfo -DENABLE_LARGE_TESTS=ON -DExternalData_OBJECT_STORES=/test-file-cache -DNES_LOG_LEVEL=DEBUG
+        run: cmake -GNinja -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_LARGE_TESTS=ON -DExternalData_OBJECT_STORES=/test-file-cache -DNES_LOG_LEVEL=DEBUG
       - name: Build NebulaStream
         run: cmake --build build -j
       - name: Run Large System Level Tests


### PR DESCRIPTION
Afaics there is no `CMAKE_RELEASE_TYPE` variable. I think this is meant to be `CMAKE_BUILD_TYPE`.