### PR TITLE
remove unused average number of tuples from NLJOperatorHandler

### DIFF
--- a/nes-execution/include/Execution/Operators/Streaming/Join/NestedLoopJoin/NLJOperatorHandler.hpp
+++ b/nes-execution/include/Execution/Operators/Streaming/Join/NestedLoopJoin/NLJOperatorHandler.hpp
@@ -60,9 +60,6 @@ private:
         const WindowInfo& windowInfo,
         const SequenceData& sequenceData,
         PipelineExecutionContext* pipelineCtx) override;
-
-    /// We store as a pair the average number of tuples left/right and the number of samples left/right
-    folly::Synchronized<std::pair<int64_t, int64_t>> averageNumberOfTuplesLeft, averageNumberOfTuplesRight;
 };
 
 /// Proxy function that returns the pointer to the correct PagedVector


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This pull request removes the unused average number of tuples from NLJOperatorHandler.
