### PR TITLE
feat(format): warns about double quote includes

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -92,6 +92,15 @@ then
     FAIL=1
 fi
 
+# warning: no includes with double quotes
+#
+# CLion uses double quotes when adding includes (automatically).
+# This check warns the author of a PR about includes with double quotes to avoid burdening the reviewers
+echo
+echo "New includes with double quotes:"
+git diff --name-only $(git merge-base HEAD origin/main 2>/dev/null) | grep -E '\.cpp$|\.hpp$' | xargs -I{} git grep -n -E -e "#include \".*\"" -- {} 2>/dev/null || echo "None found"
+echo
+
 python3 scripts/check_preamble.py || FAIL=1
 
 python3 scripts/check_todos.py || FAIL=1


### PR DESCRIPTION
# Description

We often generate includes with double quotes, because CLion uses double quotes per default when adding an include. Prior, we relied on PR reviews to catch includes with double quotes. We don't strictly enforce includes with angular brackets, so we didn't have a check that enforces it. With this PR, the format script warns (PR authors) about newly added includes with double quotes. Ideally, authors fix the problematic cases using the warnings, which means reviewers can focus on more important issues.

'Good' run:
```sh
./scripts/format.sh -i

New includes with double quotes:
None found

...
```

'Bad' run:
```sh
./scripts/format.sh -i

New includes with double quotes:
nes-input-formatters/src/CSVInputFormatter.cpp:46:#include "Common/PhysicalTypes/PhysicalType.hpp"

...
```