### PR TITLE
fix(Parser): Blacklist Keywords from Identifiers

### DIFF
--- a/nes-sql-parser/AntlrSQL.g4
+++ b/nes-sql-parser/AntlrSQL.g4
@@ -113,7 +113,7 @@ inlineTable
     ;
 
 tableAlias
-    : (AS? strictIdentifier identifierList?)?
+    : (AS? identifier identifierList?)?
     ;
 
 multipartIdentifierList
@@ -128,17 +128,11 @@ namedExpression
     : expression (AS? (name=errorCapturingIdentifier | identifierList))?
     ;
 
-identifier
-    : strictIdentifier
-    | {!SQL_standard_keyword_behavior}? strictNonReserved
-    ;
+identifier: strictIdentifier;
 
 strictIdentifier
-    : IDENTIFIER              #unquotedIdentifier
-    | quotedIdentifier        #quotedIdentifierAlternative
-    | {SQL_standard_keyword_behavior}? ansiNonReserved #unquotedIdentifier
-    | {!SQL_standard_keyword_behavior}? nonReserved    #unquotedIdentifier
-    ;
+    : IDENTIFIER #unquotedIdentifier
+    | quotedIdentifier #quotedIdentifierAlternative;
 
 quotedIdentifier
     : BACKQUOTED_IDENTIFIER
@@ -349,102 +343,6 @@ booleanValue
     : TRUE | FALSE
     ;
 
-/// can not be used as stream alias
-strictNonReserved
-    : FULL
-    | INNER
-    | JOIN
-    | LEFT
-    | NATURAL
-    | ON
-    | RIGHT
-    | UNION
-    | USING
-    ;
-
-ansiNonReserved
-///--ANSI-NON-RESERVED-START
-    : ASC
-    | AT
-    | BETWEEN
-    | BY
-    | CUBE
-    | DELETE
-    | DESC
-    | DIV
-    | DROP
-    | EXISTS
-    | FIRST
-    | GROUPING
-    | INSERT
-    | LAST
-    | LIKE
-    | LIMIT
-    | MERGE
-    | NULLS
-    | QUERY
-    | RLIKE
-    | ROLLUP
-    | SETS
-    | TRUE
-    | TYPE
-    | VALUES
-    | WINDOW
-///--ANSI-NON-RESERVED-END
-    ;
-
-nonReserved
-///--DEFAULT-NON-RESERVED-START
-    : ASC
-    | AT
-    | BETWEEN
-    | CUBE
-    | BY
-    | DELETE
-    | DESC
-    | DIV
-    | DROP
-    | EXISTS
-    | FIRST
-    | GROUPING
-    | INSERT
-    | LAST
-    | LIKE
-    | LIMIT
-    | MERGE
-    | NULLS
-    | QUERY
-    | RLIKE
-    | ROLLUP
-    | SETS
-    | TRUE
-    | TYPE
-    | VALUES
-    | WINDOW
-	| ALL
-	| AND
-	| ANY
-	| AS
-	| DISTINCT
-	| ESCAPE
-	| FALSE
-	| FROM
-	| GROUP
-	| HAVING
-	| IN
-	| INTO
-	| IS
-	| NOT
-	| NULLTOKEN
-	| OR
-	| ORDER
-	| SELECT
-	| SOME
-	| TABLE
-	| WHERE
-	| WITH
-///--DEFAULT-NON-RESERVED-END
-    ;
 
 ALL: 'ALL' | 'all';
 AND: 'AND' | 'and';
@@ -542,6 +440,8 @@ AT_LEAST_ONCE : 'AT_LEAST_ONCE';
 ///****************************
 /// End of the keywords list
 ///****************************
+
+
 
 BOOLEAN_VALUE: 'true' | 'false';
 EQ  : '=' | '==';
@@ -664,3 +564,6 @@ OCTET: [0-2][0-9]?[0-9]?;
 UNRECOGNIZED
     : .
     ;
+
+//Make sure that you add lexer rules for keywords before the identifier rule,
+//otherwise it will take priority and your grammars will not work

--- a/nes-sql-parser/tests/AntlrSQLQueryParserTest.cpp
+++ b/nes-sql-parser/tests/AntlrSQLQueryParserTest.cpp
@@ -56,9 +56,9 @@ TEST_F(AntlrSQLQueryParserTest, projectionAndMapTests)
     /// 'Query::from("window").map(Attribute("new_id").project(Attribute("new_id"))' is diffuclt/impossible to create using the SQL syntax.
     /// Given that a projection first should be more efficient, this seems to be ok for now.
     {
-        const std::string antlrQueryString = "SELECT (id*3) AS new_id FROM window INTO File";
+        const std::string antlrQueryString = "SELECT (id*3) AS new_id FROM stream INTO File";
         const auto internalLogicalQuery
-            = Query::from("window").map(Attribute("new_id") = Attribute("id") * 3).project(Attribute("new_id")).sink("File");
+            = Query::from("stream").map(Attribute("new_id") = Attribute("id") * 3).project(Attribute("new_id")).sink("File");
         EXPECT_TRUE(parseAndCompareQueryPlans(antlrQueryString, internalLogicalQuery));
     }
     /// Todo #440: the grammar currently does not support a mixture of '*' and projections.
@@ -787,4 +787,10 @@ TEST_F(AntlrSQLQueryParserTest, multipleKeyedMultipleAggFunctionsWindowTestWithH
               .selection(Attribute("average_id") > 24 && Attribute("max_id") >= 456)
               .sink("PRINT");
     EXPECT_TRUE(parseAndCompareQueryPlans(inputQueryIngestionTime, queryIngestionTime));
+}
+
+TEST_F(AntlrSQLQueryParserTest, failProjectJoinKeyword)
+{
+    const auto inputQuery = "SELECT JOIN FROM stream"s;
+    EXPECT_ANY_THROW(AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString(inputQuery));
 }


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR blacklists keywords from being used as identifiers.
For this, the grammar rule for identifiers only takes the IDENTIFIER token. 
I haven't found a way to leverage negations in the grammar, as apparently they are not permitted in sets.



## Verifying this change
All systests are running.
I added a unit test that tries to use an invalid identifier name and is expecting an exception to be thrown.

## What components does this pull request potentially affect?
AntlrSQLQueryParser

## Documentation
I added a comment to the grammar that is intended to stay at the bottom of the file informing about the autoprioritization.

## Issue Closed by this pull request:

This PR closes #744 
