### PR TITLE
fix(CI) Enables large scale tests for benchmarks

### DIFF
--- a/.github/workflows/build-and-benchmark.yml
+++ b/.github/workflows/build-and-benchmark.yml
@@ -22,6 +22,7 @@ jobs:
       image: nebulastream/nes-benchmark:${{ inputs.dev_image_tag }}
       volumes:
         - ccache:/ccache
+        - test-file-cache:/test-file-cache
       env:
         CCACHE_DIR: /ccache
         MOLD_JOBS: 1
@@ -40,7 +41,7 @@ jobs:
           ref: ${{ inputs.ref }}
       - name: build systest
         run: |
-          cmake -B build -DCMAKE_BUILD_TYPE=Release
+          cmake -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_LARGE_TESTS=ON -DExternalData_OBJECT_STORES=/test-file-cache
           cmake --build build --target systest -j -- -k 0
       - name: run Benchmarks
         run: |


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Currently the nightly ci benchmark job fails because it does not fetch large scale test data.
This PR builds with the -DENABLE_LARGE_TESTS=ON and uses the test-data-file cache

## Verifying this change
Manually triggering the nightly ci

```bash
gh workflow run .github/workflows/nightly.yml --ref fix-ci-enables-large-scale-tests-for-benchmarks --field ref="fix-ci-enables-large-scale-tests-for-benchmarks"
```

## What components does this pull request potentially affect?
- CI

## Documentation
n/a

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
