### PR TITLE
fix(Execution): Fixes race condition in SliceStore

### DIFF
--- a/nes-execution/include/Execution/Operators/SliceStore/DefaultTimeBasedSliceStore.hpp
+++ b/nes-execution/include/Execution/Operators/SliceStore/DefaultTimeBasedSliceStore.hpp
@@ -77,7 +77,8 @@ private:
 
     /// Depending on the number of origins, we have to handle the slices differently.
     /// For example, in getAllNonTriggeredSlices(), we have to wait until all origins have called this method to ensure correctness
-    std::atomic<uint64_t> numberOfActiveOrigins;
+    /// The numberOfActiveOrigins shall be guarded by the windows Mutex.
+    uint64_t numberOfActiveOrigins;
 };
 
 }

--- a/nes-execution/src/Execution/Operators/SliceStore/DefaultTimeBasedSliceStore.cpp
+++ b/nes-execution/src/Execution/Operators/SliceStore/DefaultTimeBasedSliceStore.cpp
@@ -40,9 +40,7 @@ DefaultTimeBasedSliceStore::DefaultTimeBasedSliceStore(
 }
 
 DefaultTimeBasedSliceStore::DefaultTimeBasedSliceStore(const DefaultTimeBasedSliceStore& other)
-    : sliceAssigner(other.sliceAssigner)
-    , sequenceNumber(other.sequenceNumber.load())
-    , numberOfActiveOrigins(other.numberOfActiveOrigins.load())
+    : sliceAssigner(other.sliceAssigner), sequenceNumber(other.sequenceNumber.load()), numberOfActiveOrigins(other.numberOfActiveOrigins)
 {
     auto [slicesWriteLocked, windowsWriteLocked] = acquireLocked(slices, windows);
     auto [otherSlicesReadLocked, otherWindowsReadLocked] = acquireLocked(other.slices, other.windows);
@@ -53,7 +51,7 @@ DefaultTimeBasedSliceStore::DefaultTimeBasedSliceStore(const DefaultTimeBasedSli
 DefaultTimeBasedSliceStore::DefaultTimeBasedSliceStore(DefaultTimeBasedSliceStore&& other) noexcept
     : sliceAssigner(std::move(other.sliceAssigner))
     , sequenceNumber(std::move(other.sequenceNumber.load()))
-    , numberOfActiveOrigins(std::move(other.numberOfActiveOrigins.load()))
+    , numberOfActiveOrigins(std::move(other.numberOfActiveOrigins))
 {
     auto [slicesWriteLocked, windowsWriteLocked] = acquireLocked(slices, windows);
     auto [otherSlicesWriteLocked, otherWindowsWriteLocked] = acquireLocked(other.slices, other.windows);
@@ -70,7 +68,7 @@ DefaultTimeBasedSliceStore& DefaultTimeBasedSliceStore::operator=(const DefaultT
 
     sliceAssigner = other.sliceAssigner;
     sequenceNumber = other.sequenceNumber.load();
-    numberOfActiveOrigins = other.numberOfActiveOrigins.load();
+    numberOfActiveOrigins = other.numberOfActiveOrigins;
     return *this;
 }
 
@@ -83,7 +81,7 @@ DefaultTimeBasedSliceStore& DefaultTimeBasedSliceStore::operator=(DefaultTimeBas
 
     sliceAssigner = std::move(other.sliceAssigner);
     sequenceNumber = std::move(other.sequenceNumber.load());
-    numberOfActiveOrigins = std::move(other.numberOfActiveOrigins.load());
+    numberOfActiveOrigins = std::move(other.numberOfActiveOrigins);
     return *this;
 }
 
@@ -188,12 +186,13 @@ std::optional<std::shared_ptr<Slice>> DefaultTimeBasedSliceStore::getSliceBySlic
 
 std::map<WindowInfoAndSequenceNumber, std::vector<std::shared_ptr<Slice>>> DefaultTimeBasedSliceStore::getAllNonTriggeredSlices()
 {
+    /// Acquiring a lock for the windows, as we have to iterate over all windows and trigger all non-triggered windows
+    const auto windowsWriteLocked = windows.wlock();
+
+    /// numberOfActiveOrigins is guarded by the windows lock.
     /// If this method gets called, we know that an origin has terminated.
     INVARIANT(numberOfActiveOrigins > 0, "Method should not be called if all origin have terminated.");
     --numberOfActiveOrigins;
-
-    /// Acquiring a lock for the windows, as we have to iterate over all windows and trigger all non-triggered windows
-    const auto windowsWriteLocked = windows.wlock();
 
     /// Creating a lambda to add all slices to the return map windowsToSlices
     std::map<WindowInfoAndSequenceNumber, std::vector<std::shared_ptr<Slice>>> windowsToSlices;
@@ -222,7 +221,7 @@ std::map<WindowInfoAndSequenceNumber, std::vector<std::shared_ptr<Slice>>> Defau
                     NES_TRACE(
                         "Waiting on termination for window end {} and number of origins terminated {}",
                         windowInfo.windowEnd,
-                        numberOfActiveOrigins.load());
+                        numberOfActiveOrigins);
                     break;
                 }
                 addAllSlicesToReturnMap(windowInfo, windowSlicesAndState);
@@ -233,7 +232,7 @@ std::map<WindowInfoAndSequenceNumber, std::vector<std::shared_ptr<Slice>>> Defau
                 NES_TRACE(
                     "Checking if all origins have terminated for window with window end {} and number of origins terminated {}",
                     windowInfo.windowEnd,
-                    numberOfActiveOrigins.load());
+                    numberOfActiveOrigins);
                 if (numberOfActiveOrigins > 0)
                 {
                     continue;


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR fixes a race condition in the SliceStore cleanup which is supposed
to trigger all windows if the pipeline is terminated. 

The issue was caused by reducing the number of active producer without holding
the lock, which caused buffer to be emitted to early.

The issues manifested itself by in-frequent crashes or terminate caused by an 
empty optional.

## Verifying this change
- Covered by existing testss

## What components does this pull request potentially affect?
- SliceStore

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
