### PR TITLE
Simplify engine log level configuration 

### DIFF
--- a/nes-query-engine/CMakeLists.txt
+++ b/nes-query-engine/CMakeLists.txt
@@ -16,7 +16,13 @@ target_include_directories(nes-query-engine
         PRIVATE .
 )
 
-target_compile_definitions(nes-query-engine PRIVATE ENGINE_LOG_LEVEL_ERROR)
+# Set default ENGINE_LOG_LEVEL to ERROR if not specified. Set via: -DENGINE_LOG_LEVEL=TRACE
+if(NOT DEFINED ENGINE_LOG_LEVEL)
+    set(ENGINE_LOG_LEVEL "ERROR" CACHE STRING "Log level for query engine (TRACE, DEBUG, INFO, WARNING, ERROR)")
+endif()
+
+# Add definition to the target
+target_compile_definitions(nes-query-engine PRIVATE ENGINE_LOG_LEVEL_${ENGINE_LOG_LEVEL})
 
 find_package(folly CONFIG REQUIRED)
 target_link_libraries(nes-query-engine


### PR DESCRIPTION
Allows to set the engine log level via `-DENGINE_LOG_LEVEL=TRACE`.

Previously, it was hard-coded in the cmake.