### PR TITLE
fix(Development Docker) Fixed use of perf in docker.

### DIFF
--- a/docker/dependency/Development.dockerfile
+++ b/docker/dependency/Development.dockerfile
@@ -10,10 +10,8 @@ RUN apt-get update -y && apt-get install -y \
         lldb-${LLVM_TOOLCHAIN_VERSION} \
         gdb \
         jq \
-        python3 \
         python3-venv \
-        python3-bs4 \
-        linux-tools-generic
+        python3-bs4
 
 # install alternative more recent JRE until 21.0.7 is packaged for Noble 24.04
 # then it should be replaced with openjdk-21-jre-headless

--- a/docker/dependency/DevelopmentLocal.dockerfile
+++ b/docker/dependency/DevelopmentLocal.dockerfile
@@ -8,6 +8,22 @@ ARG UID=1000
 ARG GID=1000
 ARG USERNAME=ubuntu
 ARG ROOTLESS=false
+
+# Installing perf version corresponding to the hosts kernel
+RUN apt update && apt install -y \
+    python3\
+    python3-dev\
+    libdw-dev\
+    libunwind-dev\
+    flex\
+    bison\
+    git\
+    pkg-config\
+    libelf-dev\
+    linux-tools-common \
+    linux-tools-`uname -r`
+
+
 RUN (${ROOTLESS} || (echo "uid: ${UID} gid ${GID} username ${USERNAME}" && \
     (delgroup ubuntu || true) && \
     (deluser ubuntu || true) && \


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
The problem was that perf expects the same kernel version as the host. As we were installing perf on a different server that has a different kernel version than other systems, e.g., mine or @HerrTumorius

## Verifying this change
This change is tested by building the docker image locally via `./scripts/install-local-docker-environment.sh --libstdcxx -l` and then running the profiler in Clion.

## What components does this pull request potentially affect?
*(for example:)*
- Dependencies 
