### PR TITLE
fix(CI): Retag Images to Latest on merge

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -38,12 +38,12 @@ jobs:
       - name: Retag Specialized Images
         run: |
           # Iterate through each image type
-          for image_tag in development-dependency development ci benchmark; do
+          for image_tag in development-dependency development ci; do
             docker buildx imagetools create -t nebulastream/nes-$image_tag:latest \
               nebulastream/nes-$image_tag:${{ github.head_ref }}
           
             docker buildx imagetools create -t nebulastream/nes-$image_tag:latest-libcxx \
-              nebulastream/nes-$image_tag:${{ github.head_ref }}-libcxx
+              nebulastream/nes-$image_tag:${{ github.head_ref }}-libcxx-none
           
             for stdlib in libcxx libstdcxx; do
               for sanitizer in none address thread undefined; do
@@ -58,10 +58,13 @@ jobs:
               done
             done
           done
+          
+          docker buildx imagetools create -t nebulastream/nes-benchmark:latest \
+            nebulastream/nes-benchmark:${{ github.head_ref }}
 
       - name: Update Cache Images
         run: |
-          for image_tag in development-dependency development ci benchmark; do
+          for image_tag in development-dependency development; do
             for arch in x64 arm64; do
               for stdlib in libcxx libstdcxx; do
                 if [[ "$arch" == "arm64" && "$stdlib" == "libstdcxx" ]]; then


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Currently the job to merge development images after a pr has updated them fails.
This pr fixes the merge workflow.

## Verifying this change

gh act -W .github/workflows/pr-merge.yml -P self-hosted=-self-hosted pull_request -e event.json -s DOCKER_USER_NAME=USER -s DOCKER_SECRET=SECRET
event.json:
```json
{
  "pull_request": {
    "merged": true,
    "head": {
      "ref": "sanitizer"
    },
    "base": {
      "ref": "main"
    }
  }
}
```

## What components does this pull request potentially affect?
- CI


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
