### PR TITLE
chore(PluginRegistrationUtil): simplified registry creation

### DIFF
--- a/cmake/PluginRegistrationUtil.cmake
+++ b/cmake/PluginRegistrationUtil.cmake
@@ -98,3 +98,13 @@ function(generate_plugin_registrars plugin_registry_component)
         ")
     endforeach ()
 endfunction()
+
+# Provide the names of all registries that the component creates as ARGS
+# Registries are typically located in the 'registry' directory of the component, e.g., 'nes-sources/registry'
+function(create_registries_for_component)
+    get_filename_component(COMPONENT_NAME "${CMAKE_CURRENT_LIST_DIR}" NAME)
+    set(registries_library ${COMPONENT_NAME}-registry)
+    create_plugin_registry_library(${registries_library} ${COMPONENT_NAME})
+    target_link_libraries(${COMPONENT_NAME} PRIVATE ${registries_library})
+    generate_plugin_registrars(${COMPONENT_NAME} ${ARGN})
+endfunction()

--- a/nes-data-types/CMakeLists.txt
+++ b/nes-data-types/CMakeLists.txt
@@ -30,8 +30,4 @@ endif ()
 
 add_tests_if_enabled(tests)
 
-# # Create library for the registries, and privately link it against nes-data-types so that nes-data-types can access its registries
-create_plugin_registry_library(nes-data-types-registry nes-data-types)
-target_link_libraries(nes-data-types PRIVATE nes-data-types-registry)
-# Generate a registrar for every registry in nes-data-types
-generate_plugin_registrars(nes-data-types DataType)
+create_registries_for_component(DataType)

--- a/nes-execution/CMakeLists.txt
+++ b/nes-execution/CMakeLists.txt
@@ -38,8 +38,4 @@ endif ()
 
 add_tests_if_enabled(tests)
 
-# Create library for the registries, and privately link it against nes-execution so that nes-execution can access its registries
-create_plugin_registry_library(nes-execution-registry nes-execution)
-target_link_libraries(nes-execution PRIVATE nes-execution-registry)
-# Generate a registrar for each registry in nes-executions
-generate_plugin_registrars(nes-execution ExecutableFunction)
+create_registries_for_component(ExecutableFunction)

--- a/nes-input-formatters/CMakeLists.txt
+++ b/nes-input-formatters/CMakeLists.txt
@@ -33,10 +33,6 @@ if (NES_ENABLE_PRECOMPILED_HEADERS)
     target_precompile_headers(nes-input-formatters REUSE_FROM nes-common)
 endif ()
 
-# Create library for the registries, and privately link it against nes-input-formatters so that nes-input-formatters can access its registries
-create_plugin_registry_library(nes-input-formatters-registry nes-input-formatters)
-target_link_libraries(nes-input-formatters PRIVATE nes-input-formatters-registry)
-# Generate a registrar for every registry in nes-input-formatters
-generate_plugin_registrars(nes-input-formatters InputFormatter)
+create_registries_for_component(InputFormatter)
 
 add_tests_if_enabled(tests)

--- a/nes-sinks/CMakeLists.txt
+++ b/nes-sinks/CMakeLists.txt
@@ -29,8 +29,4 @@ if (NES_ENABLE_PRECOMPILED_HEADERS)
     target_precompile_headers(nes-sinks REUSE_FROM nes-common)
 endif ()
 
-# Create library for the registries, and privately link it against nes-sinks so that nes-sinks can access its registries.
-create_plugin_registry_library(nes-sinks-registry nes-sinks)
-target_link_libraries(nes-sinks PRIVATE nes-sinks-registry)
-# Generate a registrar for every registry in nes-sinks
-generate_plugin_registrars(nes-sinks Sink SinkValidation)
+create_registries_for_component(Sink SinkValidation)

--- a/nes-sources/CMakeLists.txt
+++ b/nes-sources/CMakeLists.txt
@@ -25,10 +25,6 @@ if (NES_ENABLE_PRECOMPILED_HEADERS)
     target_precompile_headers(nes-sources REUSE_FROM nes-common)
 endif ()
 
-# Create library for the registries, and privately link it against nes-sources so that nes-sources can access its registries.
-create_plugin_registry_library(nes-sources-registry nes-sources)
-target_link_libraries(nes-sources PRIVATE nes-sources-registry)
-# Generate a registrar for every registry in nes-sources
-generate_plugin_registrars(nes-sources Source SourceValidation)
+create_registries_for_component(Source SourceValidation)
 
 add_tests_if_enabled(tests)


### PR DESCRIPTION
Prior, creating registries for a component required three steps that had to be executed in order:
1. create_plugin_registry_library
2. target_link_libraries
3. generate_plugin_registrars The new function 'create_registries_for_component' in PluginRegistrationUtil.cmake combines these three steps, simplifying registry creation and making the surface for errors smaller.