### PR TITLE
Refactor add plugin function

### DIFF
--- a/nes-data-types/src/Common/DataTypes/CMakeLists.txt
+++ b/nes-data-types/src/Common/DataTypes/CMakeLists.txt
@@ -13,22 +13,24 @@
 add_source_files(nes-data-types
         Numeric.cpp
         DataTypeProvider.cpp
-        )
+)
 
-# Register plugins
-add_plugin(BOOLEAN DataType nes-data-types Boolean.cpp)
-add_plugin(CHAR DataType nes-data-types Char.cpp)
-add_plugin(FLOAT32 DataType nes-data-types Float.cpp)
-add_plugin(FLOAT64 DataType nes-data-types Float.cpp)
-add_plugin(INT8 DataType nes-data-types Integer.cpp)
-add_plugin(INT16 DataType nes-data-types Integer.cpp)
-add_plugin(INT32 DataType nes-data-types Integer.cpp)
-add_plugin(INT64 DataType nes-data-types Integer.cpp)
-add_plugin(UINT8 DataType nes-data-types Integer.cpp)
-add_plugin(UINT16 DataType nes-data-types Integer.cpp)
-add_plugin(UINT32 DataType nes-data-types Integer.cpp)
-add_plugin(UINT64 DataType nes-data-types Integer.cpp)
-add_plugin(UNDEFINED DataType nes-data-types Undefined.cpp)
-add_plugin(VARSIZED DataType nes-data-types VariableSizedDataType.cpp)
+add_source_files_as_plugins(nes-data-types
+        BOOLEAN DataType Boolean.cpp
+        CHAR DataType Char.cpp
+        FLOAT32 DataType Float.cpp
+        FLOAT64 DataType Float.cpp
+        INT8 DataType Integer.cpp
+        INT16 DataType Integer.cpp
+        INT32 DataType Integer.cpp
+        INT64 DataType Integer.cpp
+        UINT8 DataType Integer.cpp
+        UINT16 DataType Integer.cpp
+        UINT32 DataType Integer.cpp
+        UINT64 DataType Integer.cpp
+        UNDEFINED DataType Undefined.cpp
+        VARSIZED DataType VariableSizedDataType.cpp
+)
+
 
 

--- a/nes-execution/src/Execution/Functions/ArithmeticalFunctions/CMakeLists.txt
+++ b/nes-execution/src/Execution/Functions/ArithmeticalFunctions/CMakeLists.txt
@@ -10,8 +10,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_plugin(Add ExecutableFunction nes-execution ExecutableFunctionAdd.cpp)
-add_plugin(Div ExecutableFunction nes-execution ExecutableFunctionDiv.cpp)
-add_plugin(Mod ExecutableFunction nes-execution ExecutableFunctionMod.cpp)
-add_plugin(Mul ExecutableFunction nes-execution ExecutableFunctionMul.cpp)
-add_plugin(Sub ExecutableFunction nes-execution ExecutableFunctionSub.cpp)
+add_source_files_as_plugins(nes-execution
+        Add ExecutableFunction ExecutableFunctionAdd.cpp
+        Div ExecutableFunction ExecutableFunctionDiv.cpp
+        Mod ExecutableFunction ExecutableFunctionMod.cpp
+        Mul ExecutableFunction ExecutableFunctionMul.cpp
+        Sub ExecutableFunction ExecutableFunctionSub.cpp
+)

--- a/nes-execution/src/Execution/Functions/CMakeLists.txt
+++ b/nes-execution/src/Execution/Functions/CMakeLists.txt
@@ -13,9 +13,11 @@
 add_source_files(nes-execution
         ExecutableFunctionReadField.cpp
         ExecutableFunctionConstantValueVariableSize.cpp
-        )
+)
 
-add_plugin(Concat ExecutableFunction nes-execution ExecutableFunctionConcat.cpp)
+add_source_files_as_plugins(nes-execution
+        Concat ExecutableFunction ExecutableFunctionConcat.cpp
+)
 
 
 add_subdirectory(ArithmeticalFunctions)

--- a/nes-execution/src/Execution/Functions/Comparison/CMakeLists.txt
+++ b/nes-execution/src/Execution/Functions/Comparison/CMakeLists.txt
@@ -10,7 +10,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_plugin(Greater ExecutableFunction nes-execution ExecutableFunctionGreater.cpp)
-add_plugin(GreaterEquals ExecutableFunction nes-execution ExecutableFunctionGreaterEquals.cpp)
-add_plugin(Less ExecutableFunction nes-execution ExecutableFunctionLess.cpp)
-add_plugin(LessEquals ExecutableFunction nes-execution ExecutableFunctionLessEquals.cpp)
+add_source_files_as_plugins(nes-execution
+        Greater ExecutableFunction ExecutableFunctionGreater.cpp
+        GreaterEquals ExecutableFunction ExecutableFunctionGreaterEquals.cpp
+        Less ExecutableFunction ExecutableFunctionLess.cpp
+        LessEquals ExecutableFunction ExecutableFunctionLessEquals.cpp
+)
+

--- a/nes-execution/src/Execution/Functions/LogicalFunctions/CMakeLists.txt
+++ b/nes-execution/src/Execution/Functions/LogicalFunctions/CMakeLists.txt
@@ -10,7 +10,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_plugin(And ExecutableFunction nes-execution ExecutableFunctionAnd.cpp)
-add_plugin(Equals ExecutableFunction nes-execution ExecutableFunctionEquals.cpp)
-add_plugin(Negate ExecutableFunction nes-execution ExecutableFunctionNegate.cpp)
-add_plugin(Or ExecutableFunction nes-execution ExecutableFunctionOr.cpp)
+add_source_files_as_plugins(nes-execution
+        And ExecutableFunction ExecutableFunctionAnd.cpp
+        Equals ExecutableFunction ExecutableFunctionEquals.cpp
+        Negate ExecutableFunction ExecutableFunctionNegate.cpp
+        Or ExecutableFunction ExecutableFunctionOr.cpp
+)

--- a/nes-input-formatters/src/CMakeLists.txt
+++ b/nes-input-formatters/src/CMakeLists.txt
@@ -12,10 +12,10 @@
 
 add_source_files(nes-input-formatters
         InputFormatterTask.cpp
-        CSVInputFormatter.cpp
         InputFormatterProvider.cpp
         SequenceShredder.cpp
 )
 
-# Register plugins
-add_plugin(CSV InputFormatter nes-input-formatters CSVInputFormatter.cpp)
+add_source_files_as_plugins(nes-input-formatters
+        CSV InputFormatter CSVInputFormatter.cpp
+)

--- a/nes-sinks/src/CMakeLists.txt
+++ b/nes-sinks/src/CMakeLists.txt
@@ -18,8 +18,9 @@ add_source_files(nes-sinks
         SinkProvider.cpp
 )
 
-# Register plugins
-add_plugin(File Sink nes-sinks FileSink.cpp)
-add_plugin(File SinkValidation nes-sinks FileSink.cpp)
-add_plugin(Print Sink nes-sinks PrintSink.cpp)
-add_plugin(Print SinkValidation nes-sinks PrintSink.cpp)
+add_source_files_as_plugins(nes-sinks
+        File Sink FileSink.cpp
+        File SinkValidation FileSink.cpp
+        Print Sink PrintSink.cpp
+        Print SinkValidation PrintSink.cpp
+)

--- a/nes-sources/src/CMakeLists.txt
+++ b/nes-sources/src/CMakeLists.txt
@@ -19,6 +19,7 @@ add_source_files(nes-sources
         SourceValidationProvider.cpp
 )
 
-# Register plugins
-add_plugin(File Source nes-sources FileSource.cpp)
-add_plugin(File SourceValidation nes-sources FileSource.cpp)
+add_source_files_as_plugins(nes-sources
+        File Source FileSource.cpp
+        File SourceValidation FileSource.cpp
+)


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Adds a new cmake function in `PluginRegistrationUtil` that mimics the `add_source_files()` function, only that it also adds plugins to their respective registries.
Example:
```cmake
add_source_files_as_plugins(nes-sources
        File Source FileSource.cpp
        File SourceValidation FileSource.cpp
)
```
Prior, we had to call `add_plugin` for each plugin and had to specify the target/component each time. Specifying the target/component was especially confusing for people, since it suggested that it might make sense to register call `add_plugin` with targets that do not match the target of the registry.


This PR closes #858 
