### PR TITLE
ci: create clang-tidy comments also if clang-tidy encounters warnings that are considered errors

### DIFF
--- a/.github/workflows/clang_tidy_diff.yml
+++ b/.github/workflows/clang_tidy_diff.yml
@@ -63,7 +63,7 @@ jobs:
           name: clang-tidy-result
           path: clang-tidy-result
       - name: Run clang-tidy-pr-comments action
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
         # requires python3-venv
         uses: platisd/clang-tidy-pr-comments@v1
         with:


### PR DESCRIPTION
Currently, if in the `clang-tidy` check during a PR encounters violations that are considered errors, no PR comments are created.

This PR changes this, so that comments are created anyway.

Note that the clang-tidy-pr action now [highlights errors](https://github.com/platisd/clang-tidy-pr-comments/pull/92) by using :x: as the emoji.