### PR TITLE
Nightly CI fix asan & tsan

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -95,6 +95,10 @@ jobs:
         stdlib: [ libcxx, libstdcxx ]
         sanitizer: [ none, address, undefined, thread ]
         build_type: [ RelWithDebInfo, Debug ]
+        exclude:
+          # TODO #808 libc++ has to be compiled with TSAN
+          - stdlib: libcxx
+            sanitizer: thread
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Addresses the failures [from this run](https://github.com/nebulastream/nebulastream/actions/runs/15136929201/job/42551435956).

For the "weird opts" nightly test:

- disable ASAN leak detection
- disable TSAN x libc++ (c.f. #808)

---

This fixes stuff that is already fixed in the `build-and-test` workflow. Two meta thoughts on that:

-  AFAICS, we have ~5 different jobs jobs that build and test in some way (`clean-build-and-test-linux`, `build-and-test-linux`, `build-and-test-log-level`, `build-without-tests`, `test-other-configs`). I'm not sure if this should be abstracted or if github actions yaml just not expressive enough.
- I have the feeling that these would have been easier to fix if these issues would have been noticed earlier.