### PR TITLE
fix(Conbench): Fixed no results found for conbench

### DIFF
--- a/scripts/benchmarking/benchmark.py
+++ b/scripts/benchmarking/benchmark.py
@@ -60,7 +60,7 @@ class SystestAdapter(BenchmarkAdapter):
                     "unit": "B/s"
                 },
                 context={"benchmark_language": "systest"},
-                tags={"name": result["query name"] + " [B/s]"},
+                tags={"name": result["query name"] + "_Bps"},
             ))
 
         return benchmarkResults


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Fixed an error that conbench did not show any results for all benchmark query names that ended with [B/s]

## Verifying this change
This change is tested by manually updating the [conbench website](https://bench.nebula.stream/c-benchmarks/)

## What components does this pull request potentially affect?
- Benchmark Framework