### PR TITLE
chore(Codeowners): Adjust Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,28 +9,28 @@
 ## We aim for having at least two persons per folder to have a little bit of a redundancy.
 /docker/ @keyseven123 @ls-1801
 /grpc/ @ls-1801 @adrianmichalke
-/nes-common/ @keyseven123 @adrianmichalke
+/nes-common/ @alepping @adrianmichalke
 /nes-configurations/ @adrianmichalke @ls-1801
-/nes-data-types/ @alepping @adrianmichalke @ls-1801
-/nes-executable/ @alepping @keyseven123 @ls-1801
+/nes-data-types/ @alepping @ls-1801
+/nes-executable/ @keyseven123 @ls-1801
 /nes-physical-operators/ @keyseven123 @adrianmichalke
-/nes-input-formatters/ @alepping @yschroeder97 @keyseven123
-/nes-memory/ @ls-1801 @alepping @Artraxon
+/nes-input-formatters/ @alepping @yschroeder97
+/nes-memory/ @ls-1801 @Artraxon
 /nes-nautilus/ @alepping @keyseven123 @ls-1801
-/nes-nebuli/ @ls-1801 @Artraxon @alepping
-/nes-logical-operators/ @adrianmichalke @alepping @keyseven123
-/nes-query-compiler/ @alepping @keyseven123 @adrianmichalke
+/nes-nebuli/ @ls-1801 @Artraxon
+/nes-logical-operators/ @adrianmichalke @keyseven123
+/nes-query-compiler/ @keyseven123 @ls-1801
 /nes-query-optimizer/ @adrianmichalke @Artraxon
 /nes-plugins/ @alepping @yschroeder97
 /nes-query-engine/ @ls-1801 @keyseven123
-/nes-runtime/ @keyseven123 @ls-1801 @adrianmichalke
-/nes-single-node-worker/ @alepping @adrianmichalke @ls-1801
+/nes-runtime/ @ls-1801 @adrianmichalke
+/nes-single-node-worker/ @alepping @ls-1801
 /nes-sinks/ @alepping @yschroeder97
 /nes-sources/ @alepping @yschroeder97
-/nes-sql-parser/ @Artraxon @adrianmichalke @keyseven123
-/nes-systests/ @adrianmichalke @ls-1801
+/nes-sql-parser/ @Artraxon @adrianmichalke
+/nes-systests/ @adrianmichalke @alepping
 /scripts/ @keyseven123 @ls-1801
-/vcpkg/ @keyseven123 @ls-1801 @adrianmichalke
+/vcpkg/ @keyseven123 @ls-1801
 
 
 # We  set here the ownership specific files or folders. This will be populated in the future


### PR DESCRIPTION
This PR reduces the amount of code owners per top-level directory and changes ownership so that related directories have similar owners.

This PR is just a draft by @keyseven123  and me, feel free to comment here or in our internal chats.
