### PR TITLE
chore(Workflows): Reduce PR pings to once per day

### DIFF
--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -7,9 +7,6 @@ name: PR Review Reminder
 on: 
     schedule:
         - cron: '0 7 * * 1-5'
-        - cron: '45 10 * * 1-5'
-        - cron: '0 14 * * 1-5'
-
 jobs:
     remind-to-review:
         runs-on: ubuntu-latest


### PR DESCRIPTION
We get reminders 3 times per day, which is so often that everyone just ignores the pings.
Once per day makes this ping actually informative and actionable.
