### PR TITLE
Increased readability of WindowedAggregationLogicalOperator's and JoinLogicalOperator's explain output.

### DIFF
--- a/nes-logical-operators/src/Operators/ProjectionLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/ProjectionLogicalOperator.cpp
@@ -12,6 +12,8 @@
     limitations under the License.
 */
 
+#include <Operators/ProjectionLogicalOperator.hpp>
+
 #include <cstddef>
 #include <ranges>
 #include <string>
@@ -25,7 +27,6 @@
 #include <Functions/LogicalFunction.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Operators/LogicalOperator.hpp>
-#include <Operators/ProjectionLogicalOperator.hpp>
 #include <Serialization/FunctionSerializationUtil.hpp>
 #include <Serialization/SchemaSerializationUtil.hpp>
 #include <Traits/Trait.hpp>
@@ -105,7 +106,7 @@ std::string ProjectionLogicalOperator::explain(ExplainVerbosity verbosity) const
     {
         if (not outputSchema.getFieldNames().empty())
         {
-            return fmt::format("PROJECTION(opId: {}, schema={})", id, outputSchema);
+            return fmt::format("PROJECTION(opId: {}, schema: {})", id, outputSchema);
         }
         return fmt::format(
             "PROJECTION(opId: {}, fields: [{}])",

--- a/nes-logical-operators/src/Operators/Windows/JoinLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Windows/JoinLogicalOperator.cpp
@@ -12,6 +12,8 @@
     limitations under the License.
 */
 
+#include <Operators/Windows/JoinLogicalOperator.hpp>
+
 #include <memory>
 #include <string>
 #include <string_view>
@@ -27,7 +29,6 @@
 #include <Functions/LogicalFunction.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Operators/LogicalOperator.hpp>
-#include <Operators/Windows/JoinLogicalOperator.hpp>
 #include <Serialization/FunctionSerializationUtil.hpp>
 #include <Serialization/SchemaSerializationUtil.hpp>
 #include <Traits/Trait.hpp>
@@ -73,7 +74,7 @@ std::string JoinLogicalOperator::explain(ExplainVerbosity verbosity) const
     if (verbosity == ExplainVerbosity::Debug)
     {
         return fmt::format(
-            "Join({}-{}, windowType = {}, joinFunction = {}, windowStartField={}, windowEndField={})",
+            "Join(opId: {}, outputOriginIds: [{}], windowType: {}, joinFunction: {}, windowStartField: {}, windowEndField: {})",
             id,
             fmt::join(outputOriginIds, ", "),
             getWindowType()->toString(),

--- a/nes-logical-operators/src/Operators/Windows/WindowedAggregationLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Windows/WindowedAggregationLogicalOperator.cpp
@@ -12,7 +12,7 @@
     limitations under the License.
 */
 
-#include <Operators/Windows/Aggregations/WindowAggregationLogicalFunction.hpp>
+#include <Operators/Windows/WindowedAggregationLogicalOperator.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -30,7 +30,7 @@
 #include <Functions/FieldAccessLogicalFunction.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Operators/LogicalOperator.hpp>
-#include <Operators/Windows/WindowedAggregationLogicalOperator.hpp>
+#include <Operators/Windows/Aggregations/WindowAggregationLogicalFunction.hpp>
 #include <Serialization/FunctionSerializationUtil.hpp>
 #include <Serialization/SchemaSerializationUtil.hpp>
 #include <Traits/Trait.hpp>
@@ -69,7 +69,7 @@ std::string WindowedAggregationLogicalOperator::explain(ExplainVerbosity verbosi
         auto windowType = getWindowType();
         auto windowAggregation = getWindowAggregation();
         return fmt::format(
-            "WINDOW AGGREGATION({}, {}, window type: {})",
+            "WINDOW AGGREGATION(opId: {}, {}, window type: {})",
             id,
             fmt::join(std::views::transform(windowAggregation, [](const auto& agg) { return agg->toString(); }), ", "),
             windowType->toString());


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
The debug verbosity explain methods of ` WindowedAggregationLogicalOperator` and `JoinLogicalOperator` currently print the operator id and the outputOriginIds without labeling them as such, in contrary to the other explain methods, which affects the readability of the verbose debug output. This pull request adds an "opId: " /  "outputOriginIds: " label in front of the ids. 
- Changed instances of `label` = `value` prints in explain methods to `label`: `value` to insure consistency.

## Verifying this change
This change does not affect the performance of any component. 

## What components does this pull request potentially affect?
- Explain methods of the logical operators

## Documentation
- No additional documentation needed.

## Issue Closed by this pull request:
This PR closes #918 