### PR TITLE
fix(SinkDescriptor): explicitly delete default ctor in SinkDescriptor

### DIFF
--- a/nes-sinks/include/Sinks/SinkDescriptor.hpp
+++ b/nes-sinks/include/Sinks/SinkDescriptor.hpp
@@ -29,7 +29,7 @@ namespace NES::Sinks
 struct SinkDescriptor final : NES::Configurations::Descriptor
 {
     explicit SinkDescriptor(std::string sinkType, NES::Configurations::DescriptorConfig::Config&& config, bool addTimestamp);
-    explicit SinkDescriptor();
+    SinkDescriptor() = delete;
     ~SinkDescriptor() = default;
 
     /// Iterates over all config pairs to create a DescriptorConfig::Config containing only strings.


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
- Explicitly delete the default ctor in the `SinkDescriptor` that was previously declared but not defined in the cpp-file. 


## Verifying this change
This change is tested by:
- The ctor was never actually called (calling it would lead to linker errors)

## What components does this pull request potentially affect?
- nes-sinks

## Issue Closed by this pull request:

This PR closes #921.
