### PR TITLE
ci: improve 'is image on dockerhub' check

### DIFF
--- a/.github/workflows/get_dev_images.yml
+++ b/.github/workflows/get_dev_images.yml
@@ -86,34 +86,28 @@ jobs:
           echo "tag=$HASH" >> "$GITHUB_OUTPUT"
           echo "hash=$HASH" >> "$GITHUB_OUTPUT"
           
-          if docker manifest inspect nebulastream/nes-ci:$HASH; then
-            echo "build-dependency=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          
-          # Check if jq is installed
-          if ! command -v jq &> /dev/null; then
-            echo "jq is not installed."
+          # check if tag exists on dockerhub
+          DOCKERHUB_RESPONSE_CODE=$(curl --silent --output respose.txt --write-out '%{http_code}\n' "https://hub.docker.com/v2/namespaces/nebulastream/repositories/nes-ci/tags/$HASH")
+          echo dockerhub response code: $DOCKERHUB_RESPONSE_CODE
+
+          if [ "$DOCKERHUB_RESPONSE_CODE" -ge 500 ]; then
+            echo "dockerhub internal server error"
+            cat response.txt
             exit 1
-          fi
-          
-          # fetch all available tags for the nes-development image
-          DOCKERHUB_RESPONSE=$(curl -s "https://hub.docker.com/v2/namespaces/nebulastream/repositories/nes-ci/tags?page_size=1000")
-          if [ $? -ne 0 ]; then
-            echo "could not fetch tags from the docker repository"
-            exit 1
-          fi
-          
-          TAGS=$(echo $DOCKERHUB_RESPONSE | jq ".results[].name")
-          TAG_FOUND=$(echo $TAGS | jq -r "select (. == \"${HASH}\")")
-          # Check if the Docker manifest exists for the computed hash
-          if [[ "$TAG_FOUND" == "$HASH" ]]; then
+          elif [ "$DOCKERHUB_RESPONSE_CODE" -eq 403 ]; then
+            echo "dockerhub responded with 403: Forbidden?!"
+            exit 2
+          elif [ "$DOCKERHUB_RESPONSE_CODE" -eq 404 ]; then
+            echo "Development image with $HASH does not exist in the docker registry"
+            echo "build-dependency=true" >> "$GITHUB_OUTPUT"
+          elif [ "$DOCKERHUB_RESPONSE_CODE" -eq 200 ]; then
+            echo "found image $HASH"
             echo "build-dependency=false" >> "$GITHUB_OUTPUT"
-            exit 0
+          else
+            echo unexpected docker response! HTTP Status $DOCKERHUB_RESPONSE_CODE
+            cat reponse.txt
           fi
 
-          echo "Development image with $HASH does not exist in the docker registry"
-          echo "build-dependency=true" >> "$GITHUB_OUTPUT"
   build-dev-images:
     # We run the docker image build on separate machines and combine them into a single
     # multi-arch docker image in the docker-development-images job.

--- a/docker/dependency/Development.dockerfile
+++ b/docker/dependency/Development.dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update -y && apt-get install -y \
         clang-tidy-${LLVM_TOOLCHAIN_VERSION} \
         lldb-${LLVM_TOOLCHAIN_VERSION} \
         gdb \
-        jq \
         python3-venv \
         python3-bs4
 


### PR DESCRIPTION
Addresses a problem in this run: https://github.com/nebulastream/nebulastream/actions/runs/15618047064/job/44003945776

The _"is this image already on dockerhub"_ check queries dockerhub which return `500 - Internal Server Error`, which is interpreted as _"image not yet on dockerhub, let's build and push"_. I think it would be better to either retry and/or be explicit about this dockerhub fail.

![image](https://github.com/user-attachments/assets/ae418740-e2cd-4c54-a233-5ca335d807df)

This also simplifies the check: Instead of getting a list of tags and checking if it contains the one we want we directly use the corresponding dockerhub API endpoint.

---

btw afaics the build steps are then failing for an independent reason, I think this is due to `--cache-from type=registry,ref=nebulastream/nes-development-base-cache:-x64` aka the `inputs.branch-name` in `get_dev_images.yml` is somehow not set correctly.