### PR TITLE
fix(Systest): fix throughput in query performance output

### DIFF
--- a/nes-systests/systest/include/SystestRunner.hpp
+++ b/nes-systests/systest/include/SystestRunner.hpp
@@ -46,7 +46,7 @@ struct LoadedQueryPlan
     std::string queryName;
     Schema sinkSchema;
     SystestQueryId queryIdInTest;
-    std::unordered_map<SourceDescriptor, std::filesystem::path> sourcesToFilePaths;
+    std::unordered_map<SourceDescriptor, std::optional<SourceInputFile>> sourcesToFilePaths;
     std::optional<ExpectedError> expectedError;
 };
 

--- a/nes-systests/systest/include/SystestState.hpp
+++ b/nes-systests/systest/include/SystestState.hpp
@@ -80,6 +80,21 @@ struct SystestField
     bool operator!=(const SystestField& other) const = default;
 };
 
+class SourceInputFile
+{
+public:
+    using Underlying = std::filesystem::path;
+
+    explicit constexpr SourceInputFile(Underlying value) : value(std::move(value)) { }
+
+    friend std::ostream& operator<<(std::ostream& os, const SourceInputFile& timestamp) { return os << timestamp.value; }
+    [[nodiscard]] Underlying getRawValue() const { return value; }
+    friend std::strong_ordering operator<=>(const SourceInputFile& lhs, const SourceInputFile& rhs) = default;
+
+private:
+    Underlying value;
+};
+
 struct SystestQuery
 {
     static std::filesystem::path
@@ -95,7 +110,7 @@ struct SystestQuery
         SystestQueryId queryIdInFile,
         std::filesystem::path workingDir,
         const Schema& sinkSchema,
-        std::unordered_map<std::string, std::pair<std::filesystem::path, uint64_t>> sourceNamesToFilepathAndCount,
+        std::unordered_map<std::string, std::pair<std::optional<SourceInputFile>, uint64_t>> sourceNamesToFilepathAndCount,
         std::optional<ExpectedError> expectedError);
 
     [[nodiscard]] std::filesystem::path resultFile() const;
@@ -107,7 +122,7 @@ struct SystestQuery
     SystestQueryId queryIdInFile = INVALID_SYSTEST_QUERY_ID;
     std::filesystem::path workingDir;
     Schema expectedSinkSchema;
-    std::unordered_map<std::string, std::pair<std::filesystem::path, uint64_t>> sourceNamesToFilepathAndCount;
+    std::unordered_map<std::string, std::pair<std::optional<SourceInputFile>, uint64_t>> sourceNamesToFilepathAndCount;
     std::optional<ExpectedError> expectedError;
 };
 
@@ -248,7 +263,7 @@ private:
         const SystestQueryId queryIdInFile,
         std::filesystem::path workingDir,
         const Schema& sinkSchema,
-        std::unordered_map<std::string, std::pair<std::filesystem::path, uint64_t>> sourceNamesToFilepathAndCount,
+        std::unordered_map<std::string, std::pair<std::optional<SourceInputFile>, uint64_t>> sourceNamesToFilepathAndCount,
         std::optional<ExpectedError> expectedError)
     {
         if (const auto it = testFileMap.find(sqlLogicTestFile); it != testFileMap.end())

--- a/nes-systests/systest/src/SystestRunner.cpp
+++ b/nes-systests/systest/src/SystestRunner.cpp
@@ -285,10 +285,19 @@ std::vector<RunningQuery> runQueriesAndBenchmark(
         size_t tuplesProcessed = 0;
         for (const auto& [sourcePath, sourceOccurrencesInQuery] : queryToRun.sourceNamesToFilepathAndCount | std::views::values)
         {
-            bytesProcessed += (std::filesystem::file_size(sourcePath) * sourceOccurrencesInQuery);
+            if (not sourcePath.has_value()
+                or not(std::filesystem::exists(sourcePath.value().getRawValue()) and sourcePath.value().getRawValue().has_filename()))
+            {
+                NES_ERROR("Source path is empty or does not exist.");
+                bytesProcessed = 0;
+                tuplesProcessed = 0;
+                break;
+            }
+
+            bytesProcessed += (std::filesystem::file_size(sourcePath.value().getRawValue()) * sourceOccurrencesInQuery);
 
             /// Counting the lines, i.e., \n in the sourcePath
-            std::ifstream inFile(sourcePath);
+            std::ifstream inFile(sourcePath.value().getRawValue());
             tuplesProcessed
                 += std::count(std::istreambuf_iterator(inFile), std::istreambuf_iterator<char>(), '\n') * sourceOccurrencesInQuery;
         }


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This pull request fixes the throughput of the query performance message printed to stdout. 

## Verifying this change
- There is no test to verify this change, however, one can manually check the printed message
