### PR TITLE
chore(sources): add PhysicalSourceId strong type

### DIFF
--- a/nes-common/include/Identifiers/Identifiers.hpp
+++ b/nes-common/include/Identifiers/Identifiers.hpp
@@ -28,6 +28,7 @@ using OperatorId = NESStrongType<uint64_t, struct OperatorId_, 0, 1>;
 using OriginId = NESStrongType<uint64_t, struct OriginId_, 0, 1>;
 using QueryId = NESStrongType<uint64_t, struct QueryId_, 0, 1>;
 using WorkerThreadId = NESStrongType<uint32_t, struct WorkerThreadId_, UINT32_MAX, 0>;
+using PhysicalSourceId = NESStrongType<uint64_t, struct PhysicalSourceId_, 0, 1>;
 
 /// Local Identifiers: These Identifiers are unique in a local scope. E.g. the PipelineId is unique in regard to a single query plan.
 using PipelineId = NESStrongType<uint64_t, struct PipelineId_, 0, 1>;
@@ -43,6 +44,9 @@ static constexpr OperatorId INITIAL_OPERATOR_ID = INITIAL<OperatorId>;
 
 static constexpr OriginId INVALID_ORIGIN_ID = INVALID<OriginId>;
 static constexpr OriginId INITIAL_ORIGIN_ID = INITIAL<OriginId>;
+
+static constexpr PhysicalSourceId INVALID_PHYSICAL_SOURCE_ID = INVALID<PhysicalSourceId>;
+static constexpr PhysicalSourceId INITIAL_PHYSICAL_SOURCE_ID = INITIAL<PhysicalSourceId>;
 
 static constexpr PipelineId INVALID_PIPELINE_ID = INVALID<PipelineId>;
 static constexpr PipelineId INITIAL_PIPELINE_ID = INITIAL<PipelineId>;

--- a/nes-logical-operators/src/Serialization/OperatorSerializationUtil.cpp
+++ b/nes-logical-operators/src/Serialization/OperatorSerializationUtil.cpp
@@ -126,10 +126,9 @@ SourceDescriptor OperatorSerializationUtil::deserializeSourceDescriptor(const Se
     const LogicalSource logicalSource{sourceDescriptor.logicalsourcename(), std::make_shared<Schema>(schema)};
 
     /// TODO #815 the serializer would also a catalog to register/create source descriptors/logical sources
-    const auto physicalSourceId = sourceDescriptor.physicalsourceid();
+    const auto physicalSourceId = PhysicalSourceId{sourceDescriptor.physicalsourceid()};
     const auto& sourceType = sourceDescriptor.sourcetype();
-    const auto workerIdInt = sourceDescriptor.workerid();
-    const auto workerId = WorkerId{workerIdInt};
+    const auto workerId = WorkerId{sourceDescriptor.workerid()};
     const auto buffersInLocalPool = sourceDescriptor.numberofbuffersinlocalpool();
 
     /// Deserialize the parser config.

--- a/nes-sources/include/Sources/SourceCatalog.hpp
+++ b/nes-sources/include/Sources/SourceCatalog.hpp
@@ -73,7 +73,7 @@ public:
     [[nodiscard]] bool containsLogicalSource(const LogicalSource& logicalSource) const;
     [[nodiscard]] bool containsLogicalSource(const std::string& logicalSourceName) const;
 
-    [[nodiscard]] std::optional<SourceDescriptor> getPhysicalSource(uint64_t physicalSourceId) const;
+    [[nodiscard]] std::optional<SourceDescriptor> getPhysicalSource(PhysicalSourceId physicalSourceId) const;
 
     /// @brief retrieves physical sources for a logical source
     /// @returns nullopt if the logical source is not registered anymore, else the set of source descriptors associated with it
@@ -85,9 +85,9 @@ public:
 
 private:
     mutable std::recursive_mutex catalogMutex;
-    std::atomic_uint64_t nextPhysicalSourceId{0};
+    std::atomic<PhysicalSourceId::Underlying> nextPhysicalSourceId{INITIAL_PHYSICAL_SOURCE_ID.getRawValue()};
     std::unordered_map<std::string, LogicalSource> namesToLogicalSourceMapping;
-    std::unordered_map<uint64_t, SourceDescriptor> idsToPhysicalSources;
+    std::unordered_map<PhysicalSourceId, SourceDescriptor> idsToPhysicalSources;
     std::unordered_map<LogicalSource, std::unordered_set<SourceDescriptor>> logicalToPhysicalSourceMapping;
 };
 }

--- a/nes-sources/include/Sources/SourceDescriptor.hpp
+++ b/nes-sources/include/Sources/SourceDescriptor.hpp
@@ -73,7 +73,7 @@ public:
     [[nodiscard]] ParserConfig getParserConfig() const;
 
     [[nodiscard]] WorkerId getWorkerId() const;
-    [[nodiscard]] uint64_t getPhysicalSourceId() const;
+    [[nodiscard]] PhysicalSourceId getPhysicalSourceId() const;
     [[nodiscard]] int32_t getBuffersInLocalPool() const;
 
     [[nodiscard]] SerializableSourceDescriptor serialize() const;
@@ -82,7 +82,7 @@ public:
 private:
     friend class SourceCatalog;
     friend OperatorSerializationUtil;
-    uint64_t physicalSourceId;
+    PhysicalSourceId physicalSourceId;
     LogicalSource logicalSource;
     WorkerId workerId;
     std::string sourceType;
@@ -92,7 +92,7 @@ private:
     /// Used by Sources to create a valid SourceDescriptor.
     explicit SourceDescriptor(
         LogicalSource logicalSource,
-        uint64_t physicalSourceId,
+        PhysicalSourceId physicalSourceId,
         WorkerId workerId,
         std::string sourceType,
         int32_t numberOfBuffersInLocalPool,

--- a/nes-sources/src/SourceCatalog.cpp
+++ b/nes-sources/src/SourceCatalog.cpp
@@ -11,6 +11,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
+#include <Sources/SourceCatalog.hpp>
 
 #include <cstdint>
 #include <memory>
@@ -25,7 +26,6 @@
 #include <DataTypes/Schema.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Sources/LogicalSource.hpp>
-#include <Sources/SourceCatalog.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Util/Logger/Logger.hpp>
 
@@ -80,7 +80,7 @@ std::optional<SourceDescriptor> SourceCatalog::addPhysicalSource(
         return std::nullopt;
     }
 
-    auto id = nextPhysicalSourceId.fetch_add(1);
+    auto id = PhysicalSourceId{nextPhysicalSourceId.fetch_add(1)};
     SourceDescriptor descriptor{logicalSource, id, workerId, sourceType, buffersInLocalPool, (std::move(descriptorConfig)), parserConfig};
     idsToPhysicalSources.emplace(id, descriptor);
     logicalPhysicalIter->second.insert(descriptor);
@@ -119,7 +119,7 @@ bool SourceCatalog::containsLogicalSource(const std::string& logicalSourceName) 
     return namesToLogicalSourceMapping.contains(logicalSourceName);
 }
 
-std::optional<SourceDescriptor> SourceCatalog::getPhysicalSource(const uint64_t physicalSourceID) const
+std::optional<SourceDescriptor> SourceCatalog::getPhysicalSource(const PhysicalSourceId physicalSourceID) const
 {
     const std::unique_lock lock{catalogMutex};
     if (const auto physicalSourceIter = idsToPhysicalSources.find(physicalSourceID); physicalSourceIter != idsToPhysicalSources.end())

--- a/nes-sources/src/SourceDescriptor.cpp
+++ b/nes-sources/src/SourceDescriptor.cpp
@@ -69,7 +69,7 @@ ParserConfig ParserConfig::create(std::unordered_map<std::string, std::string> c
 
 SourceDescriptor::SourceDescriptor(
     LogicalSource logicalSource,
-    const uint64_t physicalSourceId,
+    const PhysicalSourceId physicalSourceId,
     const WorkerId workerId,
     std::string sourceType,
     const int numberOfBuffersInLocalPool,
@@ -105,7 +105,7 @@ WorkerId SourceDescriptor::getWorkerId() const
     return workerId;
 }
 
-uint64_t SourceDescriptor::getPhysicalSourceId() const
+PhysicalSourceId SourceDescriptor::getPhysicalSourceId() const
 {
     return physicalSourceId;
 }

--- a/nes-sources/tests/SourceCatalogTest.cpp
+++ b/nes-sources/tests/SourceCatalogTest.cpp
@@ -91,8 +91,13 @@ TEST_F(SourceCatalogTest, AddRemovePhysicalSources)
     ASSERT_TRUE(physical2Opt.has_value());
     const auto& physical2 = physical2Opt.value();
 
-    ASSERT_EQ(physical1.getPhysicalSourceId(), 0);
-    ASSERT_EQ(physical2.getPhysicalSourceId(), 1);
+    ASSERT_EQ(physical1.getPhysicalSourceId(), PhysicalSourceId{INITIAL_PHYSICAL_SOURCE_ID.getRawValue()});
+    ASSERT_EQ(physical2.getPhysicalSourceId(), PhysicalSourceId{INITIAL_PHYSICAL_SOURCE_ID.getRawValue() + 1});
+
+    ASSERT_TRUE(sourceCatalog.getPhysicalSource(physical1.getPhysicalSourceId()).has_value());
+    ASSERT_TRUE(sourceCatalog.getPhysicalSource(physical2.getPhysicalSourceId()).has_value());
+    ASSERT_EQ(sourceCatalog.getPhysicalSource(physical1.getPhysicalSourceId()).value(), physical1);
+    ASSERT_EQ(sourceCatalog.getPhysicalSource(physical2.getPhysicalSourceId()).value(), physical2);
 
     auto expectedSources = std::unordered_set{physical1, physical2};
     const auto expect12Opt = sourceCatalog.getPhysicalSources(*sourceOpt);
@@ -111,7 +116,9 @@ TEST_F(SourceCatalogTest, AddRemovePhysicalSources)
     ASSERT_TRUE(physical2Opt.has_value());
     const auto& physical3 = physical3Opt.value();
 
-    ASSERT_EQ(physical3.getPhysicalSourceId(), 2);
+    ASSERT_EQ(physical3.getPhysicalSourceId(), PhysicalSourceId{INITIAL_PHYSICAL_SOURCE_ID.getRawValue() + 2});
+    ASSERT_TRUE(sourceCatalog.getPhysicalSource(physical3.getPhysicalSourceId()).has_value());
+    ASSERT_EQ(sourceCatalog.getPhysicalSource(physical3.getPhysicalSourceId()).value(), physical3);
 
     const auto actualPhysicalSources = sourceCatalog.getPhysicalSources(*sourceOpt);
 


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR changes the physical source id in the `SinkDescriptor` from a uint64_t to a newly created `PhysicalSourceId` strong type, and also updates all of its usages. 

## Verifying this change
The code compiles, and all systests + all unit tests including the sources tests succeed.

## What components does this pull request potentially affect?
Sources, Optimizer

## Issue Closed by this pull request:

This PR closes #914