### PR TITLE
Fix Join Varsized DataTypes

### DIFF
--- a/nes-data-types/src/DataTypes/DataType.cpp
+++ b/nes-data-types/src/DataTypes/DataType.cpp
@@ -11,6 +11,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
+
 #include <DataTypes/DataType.hpp>
 
 #include <cstdint>
@@ -301,9 +302,15 @@ bool DataType::isNumeric() const
 
 std::optional<DataType> DataType::join(const DataType& otherDataType) const
 {
-    if (this->type == Type::UNDEFINED or this->type == Type::VARSIZED)
+    /// the join result of joining with undefined is undefined
+    if (this->type == Type::UNDEFINED)
     {
         return {DataTypeProvider::provideDataType(Type::UNDEFINED)};
+    }
+    /// both data types need to be varsized to join them
+    if (this->type == Type::VARSIZED)
+    {
+        return {DataTypeProvider::provideDataType((otherDataType.isType(Type::VARSIZED)) ? Type::VARSIZED : Type::UNDEFINED)};
     }
 
     if (this->isNumeric())

--- a/nes-logical-operators/src/Functions/FieldAssignmentLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/FieldAssignmentLogicalFunction.cpp
@@ -146,7 +146,7 @@ LogicalFunction FieldAssignmentLogicalFunction::withInferredDataType(const Schem
 
     if (copy.fieldAccess.getDataType().isType(DataType::Type::UNDEFINED))
     {
-        copy.fieldAccess = copy.fieldAccess.withDataType(copy.getAssignment().getDataType()).get<FieldAccessLogicalFunction>();
+        copy.fieldAccess = copy.fieldAccess.withDataType(copy.logicalFunction.getDataType()).get<FieldAccessLogicalFunction>();
     }
     else
     {
@@ -159,7 +159,7 @@ LogicalFunction FieldAssignmentLogicalFunction::withInferredDataType(const Schem
             copy.fieldAccess = copy.fieldAccess.withDataType(copy.getAssignment().getDataType()).get<FieldAccessLogicalFunction>();
         }
     }
-    copy.dataType = copy.getAssignment().getDataType();
+    copy.dataType = copy.fieldAccess.getDataType();
     return copy;
 }
 

--- a/nes-systests/function/varsized/Concat.test
+++ b/nes-systests/function/varsized/Concat.test
@@ -1,0 +1,21 @@
+# name: function/varsized/Concat.test
+# description: Simple concat of varsized data types test
+# groups: [Function, VarSized]
+
+Source streamWithText VARSIZED text1 VARSIZED text2 VARSIZED text3 INLINE
+test1.1,test2.1,+
+test1.2,test2.2,+
+
+SINK sinkStreamWithConcatedText VARSIZED concatedText
+
+# Concat two varsized fields and project onto the result
+SELECT CONCAT(text1, text2) AS concatedText FROM streamWithText INTO sinkStreamWithConcatedText
+----
+test1.1test2.1
+test1.2test2.2
+
+# Concat two varsized fields and project onto the result
+SELECT CONCAT(CONCAT(text1, text3), text2) AS concatedText FROM streamWithText INTO sinkStreamWithConcatedText
+----
+test1.1+test2.1
+test1.2+test2.2


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Prior, we did not support the following query:
```sql
SELECT CONCAT(text1, text2) AS concatedText FROM streamWithText INTO sinkStreamWithConcatedText
```

The problem was that when we joined `text1` and `text2`, which are both varsized fields, we would return UNDEFINED as the result type.
This PR changes the `join` function to return VARSIZED, if both data types are varsized.

## Verifying this change
Adds test for the specific query above (`nes-systests/function/varsized/Concat.test`)