### PR TITLE
fix(clang-tidy): Ignore expected in misc-include-cleaner

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -225,3 +225,7 @@ CheckOptions:
   readability-identifier-length.IgnoredParameterNames: 'it|bm|tb|id|os|ss|lhs|rhs|ts|op|fn'
   readability-identifier-length.IgnoredVariableNames: 'it|bm|tb|id|os|ss|lhs|rhs|ts|op|fn'
   cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor: true
+  # Workaround for header bug around std::expected
+  # It always tries to insert the libc++ implementation headers instead of the stdlib headers.
+  # Also, it sometimes even tries to remove the stdlib headers as not needed, then inserts the libc++ headers.
+  misc-include-cleaner.IgnoreHeaders: 'expected;__.*expected\.h;__.*unexpected\.h'


### PR DESCRIPTION
For some reason clang-tidy doesn't work properly with std::expected which we have started to use quite a lot.
It tries to insert the libc++ implementation headers instead of the stdlib. Also, sometimes it even removes the stdlib headers as not needed, and then inserts the libc++ header. 

This PR adds `expected;__.*expected\.h;__.*unexpected\.h` as a list of regexes to ignore for the misc-include-cleaner rule. 