### PR TITLE
chore(CI): Reduced the average artifact size 

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -134,7 +134,7 @@ jobs:
             build/**/*.stats
       - name: Upload Test Summary
         uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() && !github.event.act }}
+        if: ${{ failure() && !cancelled() && !github.event.act }}
         with:
           name: junit-${{ matrix.arch }}-${{ matrix.stdlib }}-${{ matrix.sanitizer }}-${{ matrix.build_type }}.xml
           path: /junit.xml
@@ -177,7 +177,7 @@ jobs:
           done
       - name: Upload Test Summary
         uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() && !github.event.act }}
+        if: ${{ failure() && !cancelled() && !github.event.act }}
         with:
           name: junit-${{ matrix.arch }}-${{ matrix.stdlib }}-${{ matrix.build_type }}-${{ matrix.log_level }}.xml
           path: /junit.xml

--- a/.github/workflows/clang_tidy_full.yml
+++ b/.github/workflows/clang_tidy_full.yml
@@ -52,7 +52,7 @@ jobs:
           python3 scripts/clang-tidy-summary.py .clang-tidy clang-tidy.log --summary-json clang-tidy-summary.json >> $GITHUB_STEP_SUMMARY
       - name: Upload Test Summary
         uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
+        if: ${{ failure() && !cancelled() }}
         with:
           name: clang-tidy-logs
           path: clang-tidy*

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -56,8 +56,7 @@ jobs:
           path: /tmp/cov-cache/
           key: ${{ matrix.platform }}-ref-cov-${{ inputs.base_sha }}
       - if: ${{ steps.ref-cov-cache.outputs.cache-hit != 'true' }}
-        uses:
-          AutoModality/action-clean@v1
+        uses: AutoModality/action-clean@v1
       - name: Checkout Base Branch
         if: ${{ steps.ref-cov-cache.outputs.cache-hit != 'true' }}
         uses: actions/checkout@v4
@@ -72,11 +71,6 @@ jobs:
           cmake --build build --target ccov-all-export
           mkdir -p /tmp/cov-cache/
           cp build/ccov/coverage.lcov /tmp/cov-cache/ref-coverage.lcov
-      - name: Upload code coverage for ref branch
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.platform }}-ref-cov-${{ inputs.base_sha }}.info
-          path: /tmp/cov-cache/ref-coverage.lcov
 
   build-code-coverage-pr-branch:
     container:
@@ -172,12 +166,6 @@ jobs:
         with:
           name: code-coverage-${{ matrix.platform }}
           path: /tmp/cov-cache/code-coverage/
-      - name: Upload code coverage for PR branch
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.platform }}-pr-cov-${{ inputs.head_sha }}.info
-          path: /tmp/cov-cache/pr-coverage.lcov
-  
 
   # For now, we build the code coverage for x64 only
   build-code-coverage:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -127,7 +127,7 @@ jobs:
           ctest --test-dir build -j --output-on-failure --output-junit /junit.xml --timeout 600
       - name: Upload Test Summary
         uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() && !github.event.act }}
+        if: ${{ failure() && !cancelled() && !github.event.act }}
         with:
           name: junit-${{ matrix.cmake_args.name }}-${{ matrix.stdlib }}-${{ matrix.sanitizer }}-${{ matrix.build_type }}.xml
           path: /junit.xml


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR reduces the average artifact size as we only upload artifacts if the run has failed.

## Verifying this change
This change is tested by running the CI and seeing that no artifacts have been published for the tests

## What components does this pull request potentially affect?
- CI

