### PR TITLE
Added engine to pipeline setup call

### DIFF
--- a/nes-nautilus/tests/TestUtils/include/NautilusTestUtils.hpp
+++ b/nes-nautilus/tests/TestUtils/include/NautilusTestUtils.hpp
@@ -34,7 +34,6 @@
 #include <ErrorHandling.hpp>
 #include <options.hpp>
 #include <static.hpp>
-
 namespace NES::Nautilus::TestUtils
 {
 
@@ -43,7 +42,6 @@ namespace NES::Nautilus::TestUtils
 struct RecordWithFields
 {
     RecordWithFields(const Record& record, std::vector<Record::RecordFieldIdentifier>& fields) : record(record), fields(fields) { }
-
     bool operator<(const RecordWithFields& other) const
     {
         for (const auto& fieldIdentifier : nautilus::static_iterable(fields))
@@ -67,7 +65,7 @@ struct RecordWithFields
 /// We use this information for being able to access a (pre-)compiled/traced function and not having to recompile it all the time
 struct NameAndNautilusBackend
 {
-    NameAndNautilusBackend(std::string_view functionName, const ExecutionMode backend)
+    NameAndNautilusBackend(std::string_view functionName, const Configurations::ExecutionMode backend)
         : functionName(std::move(functionName)), backend(backend)
     {
     }
@@ -91,7 +89,7 @@ struct NameAndNautilusBackend
     }
 
     std::string functionName;
-    ExecutionMode backend;
+    Configurations::ExecutionMode backend;
 };
 
 /// Struct that stores a min and max value.
@@ -102,6 +100,8 @@ struct MinMaxValue
     uint64_t max;
 };
 
+
+// TODO check if we can use the CompilationContext here
 /// Base function wrapper class
 class FunctionWrapperBase
 {
@@ -119,11 +119,11 @@ public:
         : FunctionWrapperBase(), func(std::move(function))
     {
     }
-
     ~FunctionWrapper() override = default;
     nautilus::engine::CallableFunction<R, FunctionArguments...> func;
 };
 
+// TODO check if we can use the CompilationContext here
 class NautilusTestUtils
 {
 public:
@@ -155,7 +155,7 @@ public:
 
     void compileFillBufferFunction(
         std::string_view functionName,
-        ExecutionMode backend,
+        Configurations::ExecutionMode backend,
         nautilus::engine::Options& options,
         const Schema& schema,
         const std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider>& memoryProviderInputBuffer);
@@ -186,6 +186,7 @@ protected:
     /// The idea behind this map is that we can batch/(pre-)compile and trace functions and store them in this map.
     /// Allowing us to not have to recompile/trace the same function in multiple different (parameterized) tests
     /// This map can and will be filled in this class but also in the tests themselves.
+    // TODO check if we can use the CompilationContext here
     std::map<NameAndNautilusBackend, std::unique_ptr<FunctionWrapperBase>> compiledFunctions;
 };
 

--- a/nes-physical-operators/include/Aggregation/AggregationOperatorHandler.hpp
+++ b/nes-physical-operators/include/Aggregation/AggregationOperatorHandler.hpp
@@ -52,7 +52,6 @@ public:
     [[nodiscard]] std::function<std::vector<std::shared_ptr<Slice>>(SliceStart, SliceEnd)>
     getCreateNewSlicesFunction(const CreateNewSlicesArguments& newSlicesArguments) const override;
 
-
 protected:
     void triggerSlices(
         const std::map<WindowInfoAndSequenceNumber, std::vector<std::shared_ptr<Slice>>>& slicesAndWindowInfo,

--- a/nes-physical-operators/include/Aggregation/AggregationProbePhysicalOperator.hpp
+++ b/nes-physical-operators/include/Aggregation/AggregationProbePhysicalOperator.hpp
@@ -34,7 +34,7 @@ public:
         std::vector<std::shared_ptr<AggregationPhysicalFunction>> aggregationPhysicalFunctions,
         OperatorHandlerId operatorHandlerId,
         WindowMetaData windowMetaData);
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    void open(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& recordBuffer) const override;
 
 private:
     std::vector<std::shared_ptr<AggregationPhysicalFunction>> aggregationPhysicalFunctions;

--- a/nes-physical-operators/include/EmitPhysicalOperator.hpp
+++ b/nes-physical-operators/include/EmitPhysicalOperator.hpp
@@ -34,14 +34,9 @@ class EmitPhysicalOperator final : public PhysicalOperatorConcept
 public:
     explicit EmitPhysicalOperator(
         OperatorHandlerId operatorHandlerId, std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> memoryProvider);
-
-    void setup(ExecutionContext&) const override { /*noop*/ }
-
-    void terminate(ExecutionContext&) const override { /*noop*/ }
-
-    void open(ExecutionContext& ctx, RecordBuffer& recordBuffer) const override;
-    void execute(ExecutionContext& ctx, Record& record) const override;
-    void close(ExecutionContext& ctx, RecordBuffer& recordBuffer) const override;
+    void open(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& recordBuffer) const override;
+    void execute(ExecutionContext& executionContext, CompilationContext& compilationContext, Record& record) const override;
+    void close(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& recordBuffer) const override;
     void emitRecordBuffer(
         ExecutionContext& ctx,
         RecordBuffer& recordBuffer,

--- a/nes-physical-operators/include/Join/HashJoin/HJBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJBuildPhysicalOperator.hpp
@@ -55,7 +55,7 @@ public:
         std::unique_ptr<TimeFunction> timeFunction,
         const std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider>& memoryProvider,
         HashMapOptions hashMapOptions);
-    void setup(ExecutionContext& executionCtx) const override;
+    void setup(ExecutionContext& executionCtx, const nautilus::engine::NautilusEngine& engine) const override;
     void execute(ExecutionContext& ctx, Record& record) const override;
 
 private:

--- a/nes-physical-operators/include/Join/HashJoin/HJBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJBuildPhysicalOperator.hpp
@@ -24,6 +24,7 @@
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Time/Timestamp.hpp>
 #include <Watermark/TimeFunction.hpp>
+#include <CompilationContext.hpp>
 #include <ExecutionContext.hpp>
 #include <HashMapOptions.hpp>
 
@@ -32,10 +33,11 @@ namespace NES
 class HJBuildPhysicalOperator;
 Interface::HashMap* getHashJoinHashMapProxy(
     const HJOperatorHandler* operatorHandler,
-    Timestamp timestamp,
-    WorkerThreadId workerThreadId,
-    JoinBuildSideType buildSide,
-    const HJBuildPhysicalOperator* buildOperator);
+    const Timestamp timestamp,
+    const WorkerThreadId workerThreadId,
+    const JoinBuildSideType buildSide,
+    const HJBuildPhysicalOperator* buildOperator,
+    CompiledFunctionWrapper<void, Interface::HashMap*>* cleanupState);
 
 /// This class is the first phase of the join. For both streams (left and right), the tuples are stored in a hash map of a
 /// corresponding slice one after the other. Afterward, the second phase (HJProbe) will start joining the tuples by comparing the join keys
@@ -48,15 +50,15 @@ public:
         Timestamp timestamp,
         WorkerThreadId workerThreadId,
         JoinBuildSideType buildSide,
-        const HJBuildPhysicalOperator* buildOperator);
+        const HJBuildPhysicalOperator* buildOperator,
+        CompiledFunctionWrapper<void, Interface::HashMap*>* cleanupState);
     HJBuildPhysicalOperator(
         OperatorHandlerId operatorHandlerId,
         JoinBuildSideType joinBuildSide,
         std::unique_ptr<TimeFunction> timeFunction,
         const std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider>& memoryProvider,
         HashMapOptions hashMapOptions);
-    void setup(ExecutionContext& executionCtx, const nautilus::engine::NautilusEngine& engine) const override;
-    void execute(ExecutionContext& ctx, Record& record) const override;
+    void execute(ExecutionContext& executionContext, CompilationContext& compilationContext, Record& record) const override;
 
 private:
     HashMapOptions hashMapOptions;

--- a/nes-physical-operators/include/Join/HashJoin/HJOperatorHandler.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJOperatorHandler.hpp
@@ -57,15 +57,7 @@ public:
     [[nodiscard]] std::function<std::vector<std::shared_ptr<Slice>>(SliceStart, SliceEnd)>
     getCreateNewSlicesFunction(const CreateNewSlicesArguments& newSlicesArguments) const override;
 
-    void setNautilusCleanupExec(
-        std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec> nautilusCleanupExec, const JoinBuildSideType& buildSide);
-    [[nodiscard]] std::vector<std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec>> getNautilusCleanupExec() const;
-
 private:
-    /// shared_ptr as multiple slices need access to it
-    std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec> leftCleanupStateNautilusFunction;
-    std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec> rightCleanupStateNautilusFunction;
-
     void emitSlicesToProbe(
         Slice& sliceLeft,
         Slice& sliceRight,

--- a/nes-physical-operators/include/Join/HashJoin/HJProbePhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJProbePhysicalOperator.hpp
@@ -44,7 +44,7 @@ public:
 
     /// As the second phase gets triggered by the first phase, we receive a tuple buffer containing all information for performing the probe.
     /// Thus, we start a new pipeline and therefore, we create new Records from the built-up state.
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    void open(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& recordBuffer) const override;
 
 private:
     std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> leftMemoryProvider, rightMemoryProvider;

--- a/nes-physical-operators/include/Join/NestedLoopJoin/NLJBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/NestedLoopJoin/NLJBuildPhysicalOperator.hpp
@@ -40,6 +40,6 @@ public:
 
     NLJBuildPhysicalOperator(const NLJBuildPhysicalOperator& other) = default;
 
-    void execute(ExecutionContext& executionCtx, Record& record) const override;
+    void execute(ExecutionContext& executionContext, CompilationContext& compilationContext, Record& record) const override;
 };
 }

--- a/nes-physical-operators/include/Join/NestedLoopJoin/NLJProbePhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/NestedLoopJoin/NLJProbePhysicalOperator.hpp
@@ -41,7 +41,7 @@ public:
         std::shared_ptr<TupleBufferMemoryProvider> leftMemoryProvider,
         std::shared_ptr<TupleBufferMemoryProvider> rightMemoryProvider);
 
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    void open(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& recordBuffer) const override;
 
 protected:
     void performNLJ(
@@ -50,6 +50,7 @@ protected:
         Interface::MemoryProvider::TupleBufferMemoryProvider& outerMemoryProvider,
         Interface::MemoryProvider::TupleBufferMemoryProvider& innerMemoryProvider,
         ExecutionContext& executionCtx,
+        CompilationContext& compilationContext,
         const nautilus::val<Timestamp>& windowStart,
         const nautilus::val<Timestamp>& windowEnd) const;
     std::shared_ptr<TupleBufferMemoryProvider> leftMemoryProvider;

--- a/nes-physical-operators/include/MapPhysicalOperator.hpp
+++ b/nes-physical-operators/include/MapPhysicalOperator.hpp
@@ -28,7 +28,7 @@ class MapPhysicalOperator final : public PhysicalOperatorConcept
 {
 public:
     MapPhysicalOperator(Record::RecordFieldIdentifier fieldToWriteTo, PhysicalFunction mapFunction);
-    void execute(ExecutionContext& ctx, Record& record) const override;
+    void execute(ExecutionContext& executionContext, CompilationContext& compilationContext, Record& record) const override;
 
     [[nodiscard]] std::optional<PhysicalOperator> getChild() const override;
     void setChild(PhysicalOperator child) override;

--- a/nes-physical-operators/include/PhysicalOperator.hpp
+++ b/nes-physical-operators/include/PhysicalOperator.hpp
@@ -31,6 +31,7 @@
 #include <Util/Logger/Formatter.hpp>
 #include <Util/PlanRenderer.hpp>
 #include <boost/core/demangle.hpp>
+#include <Engine.hpp>
 #include <ErrorHandling.hpp>
 
 namespace NES
@@ -59,7 +60,8 @@ struct PhysicalOperatorConcept
     virtual void setChild(struct PhysicalOperator child) = 0;
 
     /// This is called once before the operator starts processing records.
-    virtual void setup(ExecutionContext& executionCtx) const;
+    /// We pass the nautilus::engine  give the possibility to the operator to create custom executable nautilus functions
+    virtual void setup(ExecutionContext& executionCtx, const nautilus::engine::NautilusEngine& engine) const;
 
     /// Opens the operator for processing records.
     /// This is called before each batch of records is processed.
@@ -81,7 +83,7 @@ struct PhysicalOperatorConcept
 
 protected:
     /// Helper classes to propagate to the child
-    void setupChild(ExecutionContext& executionCtx) const;
+    void setupChild(ExecutionContext& executionCtx, const nautilus::engine::NautilusEngine& engine) const;
     void openChild(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
     void closeChild(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
     void executeChild(ExecutionContext& executionCtx, Record& record) const;
@@ -117,7 +119,7 @@ struct PhysicalOperator
     [[nodiscard]] std::optional<PhysicalOperator> getChild() const;
     [[nodiscard]] PhysicalOperator withChild(PhysicalOperator child) const;
 
-    void setup(ExecutionContext& executionCtx) const;
+    void setup(ExecutionContext& executionCtx, const nautilus::engine::NautilusEngine& engine) const;
     void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
     void close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
     void terminate(ExecutionContext& executionCtx) const;
@@ -185,7 +187,10 @@ private:
 
         void setChild(PhysicalOperator child) override { data.setChild(child); }
 
-        void setup(ExecutionContext& executionCtx) const override { data.setup(executionCtx); }
+        void setup(ExecutionContext& executionCtx, const nautilus::engine::NautilusEngine& engine) const override
+        {
+            data.setup(executionCtx, engine);
+        }
 
         void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override { data.open(executionCtx, recordBuffer); }
 

--- a/nes-physical-operators/include/ScanPhysicalOperator.hpp
+++ b/nes-physical-operators/include/ScanPhysicalOperator.hpp
@@ -37,7 +37,7 @@ public:
         std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> memoryProvider,
         std::vector<Record::RecordFieldIdentifier> projections);
 
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    void open(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& recordBuffer) const override;
     [[nodiscard]] std::optional<PhysicalOperator> getChild() const override;
     void setChild(PhysicalOperator child) override;
 

--- a/nes-physical-operators/include/SelectionPhysicalOperator.hpp
+++ b/nes-physical-operators/include/SelectionPhysicalOperator.hpp
@@ -27,7 +27,7 @@ class SelectionPhysicalOperator final : public PhysicalOperatorConcept
 {
 public:
     explicit SelectionPhysicalOperator(PhysicalFunction function) : function(std::move(std::move(function))) { };
-    void execute(ExecutionContext& ctx, Record& record) const override;
+    void execute(ExecutionContext& executionContext, CompilationContext& compilationContext, Record& record) const override;
 
     [[nodiscard]] std::optional<PhysicalOperator> getChild() const override;
     void setChild(PhysicalOperator child) override;

--- a/nes-physical-operators/include/Watermark/EventTimeWatermarkAssignerPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Watermark/EventTimeWatermarkAssignerPhysicalOperator.hpp
@@ -27,9 +27,9 @@ class EventTimeWatermarkAssignerPhysicalOperator : public PhysicalOperatorConcep
 {
 public:
     explicit EventTimeWatermarkAssignerPhysicalOperator(EventTimeFunction timeFunction);
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
-    void execute(ExecutionContext& ctx, Record& record) const override;
-    void close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    void open(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& recordBuffer) const override;
+    void execute(ExecutionContext& executionContext, CompilationContext& compilationContext, Record& record) const override;
+    void close(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& recordBuffer) const override;
     [[nodiscard]] std::optional<PhysicalOperator> getChild() const override;
     void setChild(PhysicalOperator child) override;
 

--- a/nes-physical-operators/include/Watermark/IngestionTimeWatermarkAssignerPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Watermark/IngestionTimeWatermarkAssignerPhysicalOperator.hpp
@@ -24,8 +24,8 @@ class IngestionTimeWatermarkAssignerPhysicalOperator : public PhysicalOperatorCo
 {
 public:
     explicit IngestionTimeWatermarkAssignerPhysicalOperator(IngestionTimeFunction timeFunction);
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
-    void execute(ExecutionContext& ctx, Record& record) const override;
+    void open(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& recordBuffer) const override;
+    void execute(ExecutionContext& executionContext, CompilationContext& compilationContext, Record& record) const override;
     [[nodiscard]] std::optional<PhysicalOperator> getChild() const override;
     void setChild(PhysicalOperator child) override;
 

--- a/nes-physical-operators/include/Watermark/TimeFunction.hpp
+++ b/nes-physical-operators/include/Watermark/TimeFunction.hpp
@@ -21,6 +21,7 @@
 #include <Nautilus/Interface/RecordBuffer.hpp>
 #include <Nautilus/Interface/TimestampRef.hpp>
 #include <Time/Timestamp.hpp>
+#include <CompilationContext.hpp>
 
 namespace NES
 {
@@ -37,8 +38,9 @@ using namespace Nautilus;
 class TimeFunction
 {
 public:
-    virtual void open(ExecutionContext& ctx, RecordBuffer& buffer) const = 0;
-    virtual nautilus::val<Timestamp> getTs(ExecutionContext& ctx, Record& record) const = 0;
+    virtual void open(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& buffer) const = 0;
+    virtual nautilus::val<Timestamp> getTs(ExecutionContext& executionContext, CompilationContext& compilationContext, Record& record) const
+        = 0;
     virtual ~TimeFunction() = default;
 
     [[nodiscard]] virtual std::unique_ptr<TimeFunction> clone() const = 0;
@@ -48,8 +50,8 @@ class EventTimeFunction final : public TimeFunction
 {
 public:
     explicit EventTimeFunction(PhysicalFunction timestampFunction, const Windowing::TimeUnit& unit);
-    void open(ExecutionContext& ctx, RecordBuffer& buffer) const override;
-    nautilus::val<Timestamp> getTs(ExecutionContext& ctx, Record& record) const override;
+    void open(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& buffer) const override;
+    nautilus::val<Timestamp> getTs(ExecutionContext& executionContext, CompilationContext& compilationContext, Record& record) const override;
 
     [[nodiscard]] std::unique_ptr<TimeFunction> clone() const override
     {
@@ -64,8 +66,8 @@ private:
 class IngestionTimeFunction final : public TimeFunction
 {
 public:
-    void open(ExecutionContext& ctx, RecordBuffer& buffer) const override;
-    nautilus::val<Timestamp> getTs(ExecutionContext& ctx, Record& record) const override;
+    void open(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& buffer) const override;
+    nautilus::val<Timestamp> getTs(ExecutionContext& executionContext, CompilationContext& compilationContext, Record& record) const override;
 
     [[nodiscard]] std::unique_ptr<TimeFunction> clone() const override { return std::make_unique<IngestionTimeFunction>(); }
 };

--- a/nes-physical-operators/include/WindowBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/WindowBuildPhysicalOperator.hpp
@@ -19,6 +19,7 @@
 #include <optional>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Watermark/TimeFunction.hpp>
+#include <Engine.hpp>
 #include <OperatorState.hpp>
 #include <PhysicalOperator.hpp>
 #include <val.hpp>
@@ -49,7 +50,7 @@ public:
     /// This setup function can be called in a multithreaded environment. Meaning that if
     /// multiple pipelines with the same operator (e.g. JoinBuild) have access to the same operator handler, this will lead to race conditions.
     /// Therefore, any setup to the operator handler should happen in the WindowProbePhysicalOperator.
-    void setup(ExecutionContext& executionCtx) const override;
+    void setup(ExecutionContext& executionCtx, const nautilus::engine::NautilusEngine& engine) const override;
 
     /// Initializes the time function, e.g., method that extracts the timestamp from a record
     void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;

--- a/nes-physical-operators/include/WindowBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/WindowBuildPhysicalOperator.hpp
@@ -19,6 +19,7 @@
 #include <optional>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Watermark/TimeFunction.hpp>
+#include <CompilationContext.hpp>
 #include <Engine.hpp>
 #include <OperatorState.hpp>
 #include <PhysicalOperator.hpp>
@@ -50,16 +51,16 @@ public:
     /// This setup function can be called in a multithreaded environment. Meaning that if
     /// multiple pipelines with the same operator (e.g. JoinBuild) have access to the same operator handler, this will lead to race conditions.
     /// Therefore, any setup to the operator handler should happen in the WindowProbePhysicalOperator.
-    void setup(ExecutionContext& executionCtx, const nautilus::engine::NautilusEngine& engine) const override;
+    void setup(ExecutionContext& executionContext, CompilationContext& compilationContext) const override;
 
     /// Initializes the time function, e.g., method that extracts the timestamp from a record
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    void open(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& recordBuffer) const override;
 
     /// Passes emits slices that are ready to the second phase (probe) for further processing
-    void close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    void close(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& recordBuffer) const override;
 
     /// Emits/Flushes all slices and windows, as the query will be terminated
-    void terminate(ExecutionContext& executionCtx) const override;
+    void terminate(ExecutionContext& executionContext) const override;
 
     [[nodiscard]] std::optional<PhysicalOperator> getChild() const override;
     void setChild(PhysicalOperator child) override;

--- a/nes-physical-operators/include/WindowProbePhysicalOperator.hpp
+++ b/nes-physical-operators/include/WindowProbePhysicalOperator.hpp
@@ -33,7 +33,7 @@ public:
     /// The setup method is called for each pipeline during the query initialization procedure. Meaning that if
     /// multiple pipelines with the same operator (e.g. JoinBuild) have access to the same operator handler, this will lead to race conditions.
     /// Therefore, any setup to the operator handler should ONLY happen in the WindowProbePhysicalOperator.
-    void setup(ExecutionContext& executionCtx) const override;
+    void setup(ExecutionContext& executionCtx, const nautilus::engine::NautilusEngine& engine) const override;
 
     /// Checks the current watermark and then deletes all slices and windows that are not valid anymore
     void close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;

--- a/nes-physical-operators/include/WindowProbePhysicalOperator.hpp
+++ b/nes-physical-operators/include/WindowProbePhysicalOperator.hpp
@@ -33,10 +33,10 @@ public:
     /// The setup method is called for each pipeline during the query initialization procedure. Meaning that if
     /// multiple pipelines with the same operator (e.g. JoinBuild) have access to the same operator handler, this will lead to race conditions.
     /// Therefore, any setup to the operator handler should ONLY happen in the WindowProbePhysicalOperator.
-    void setup(ExecutionContext& executionCtx, const nautilus::engine::NautilusEngine& engine) const override;
+    void setup(ExecutionContext& executionContext, CompilationContext& compilationContext) const override;
 
     /// Checks the current watermark and then deletes all slices and windows that are not valid anymore
-    void close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    void close(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& recordBuffer) const override;
 
     void terminate(ExecutionContext& executionCtx) const override;
 

--- a/nes-physical-operators/src/HashMapSlice.cpp
+++ b/nes-physical-operators/src/HashMapSlice.cpp
@@ -58,7 +58,7 @@ HashMapSlice::~HashMapSlice()
         if (hashMaps[i] and hashMaps[i]->getNumberOfTuples() > 0)
         {
             /// Calling the compiled nautilus function
-            createNewHashMapSliceArgs.nautilusCleanup[i / numberOfHashMapsPerInputStream]->operator()(hashMaps[i].get());
+            createNewHashMapSliceArgs.nautilusCleanup[i / numberOfHashMapsPerInputStream]->callCompiledFunction(hashMaps[i].get());
         }
     }
 

--- a/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
@@ -73,52 +73,42 @@ Interface::HashMap* getHashJoinHashMapProxy(
     return hjSlice->getHashMapPtrOrCreate(workerThreadId, buildSide);
 }
 
-void HJBuildPhysicalOperator::setup(ExecutionContext& executionCtx) const
+void HJBuildPhysicalOperator::setup(ExecutionContext& executionCtx, const nautilus::engine::NautilusEngine& engine) const
 {
-    StreamJoinBuildPhysicalOperator::setup(executionCtx);
+    StreamJoinBuildPhysicalOperator::setup(executionCtx, engine);
 
     /// Creating the cleanup function for the slice of current stream
-    nautilus::invoke(
-        +[](HJOperatorHandler* operatorHandler, const HJBuildPhysicalOperator* buildOperator, const JoinBuildSideType buildSide)
-        {
-            nautilus::engine::Options options;
-            options.setOption("engine.Compilation", true);
-            const nautilus::engine::NautilusEngine nautilusEngine(options);
-
-            /// We are not allowed to use const or const references for the lambda function params, as nautilus does not support this in the registerFunction method.
-            /// ReSharper disable once CppPassValueParameterByConstReference
-            /// NOLINTBEGIN(performance-unnecessary-value-param)
-            const auto cleanupStateNautilusFunction
-                = std::make_shared<CreateNewHashMapSliceArgs::NautilusCleanupExec>(nautilusEngine.registerFunction(std::function(
-                    [copyOfFieldKeys = buildOperator->hashMapOptions.fieldKeys,
-                     copyOfFieldValues = buildOperator->hashMapOptions.fieldValues,
-                     copyOfEntriesPerPage = buildOperator->hashMapOptions.entriesPerPage,
-                     copyOfEntrySize = buildOperator->hashMapOptions.entrySize](nautilus::val<Nautilus::Interface::HashMap*> hashMap)
-                    {
-                        const Interface::ChainedHashMapRef hashMapRef(
-                            hashMap, copyOfFieldKeys, copyOfFieldValues, copyOfEntriesPerPage, copyOfEntrySize);
-                        for (const auto entry : hashMapRef)
+    /// As the setup function does not get traced, we do not need to have any nautilus::invoke calls to jump to the C++ runtime
+    /// We are not allowed to use const or const references for the lambda function params, as nautilus does not support this in the registerFunction method.
+    /// ReSharper disable once CppPassValueParameterByConstReference
+    /// NOLINTBEGIN(performance-unnecessary-value-param)
+    const auto cleanupStateNautilusFunction
+        = std::make_shared<CreateNewHashMapSliceArgs::NautilusCleanupExec>(engine.registerFunction(std::function(
+            [copyOfFieldKeys = hashMapOptions.fieldKeys,
+             copyOfFieldValues = hashMapOptions.fieldValues,
+             copyOfEntriesPerPage = hashMapOptions.entriesPerPage,
+             copyOfEntrySize = hashMapOptions.entrySize](nautilus::val<Nautilus::Interface::HashMap*> hashMap)
+            {
+                const Interface::ChainedHashMapRef hashMapRef(
+                    hashMap, copyOfFieldKeys, copyOfFieldValues, copyOfEntriesPerPage, copyOfEntrySize);
+                for (const auto entry : hashMapRef)
+                {
+                    const Interface::ChainedHashMapRef::ChainedEntryRef entryRefReset(entry, hashMap, copyOfFieldKeys, copyOfFieldValues);
+                    const auto state = entryRefReset.getValueMemArea();
+                    nautilus::invoke(
+                        +[](int8_t* pagedVectorMemArea) -> void
                         {
-                            const Interface::ChainedHashMapRef::ChainedEntryRef entryRefReset(
-                                entry, hashMap, copyOfFieldKeys, copyOfFieldValues);
-                            const auto state = entryRefReset.getValueMemArea();
-                            nautilus::invoke(
-                                +[](int8_t* pagedVectorMemArea) -> void
-                                {
-                                    /// Calls the destructor of the PagedVector
-                                    /// NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-                                    auto* pagedVector = reinterpret_cast<Nautilus::Interface::PagedVector*>(pagedVectorMemArea);
-                                    pagedVector->~PagedVector();
-                                },
-                                state);
-                        }
-                    })));
-            /// NOLINTEND(performance-unnecessary-value-param)
-            operatorHandler->setNautilusCleanupExec(cleanupStateNautilusFunction, buildSide);
-        },
-        executionCtx.getGlobalOperatorHandler(operatorHandlerId),
-        nautilus::val<const HJBuildPhysicalOperator*>(this),
-        nautilus::val<JoinBuildSideType>(joinBuildSide));
+                            /// Calls the destructor of the PagedVector
+                            auto* pagedVector = reinterpret_cast<Nautilus::Interface::PagedVector*>(
+                                pagedVectorMemArea); /// NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                            pagedVector->~PagedVector();
+                        },
+                        state);
+                }
+            })));
+    /// NOLINTEND(performance-unnecessary-value-param)
+    const auto operatorHandler = dynamic_cast<HJOperatorHandler*>(executionCtx.getGlobalOperatorHandler(operatorHandlerId).value);
+    operatorHandler->setNautilusCleanupExec(cleanupStateNautilusFunction, joinBuildSide);
 }
 
 void HJBuildPhysicalOperator::execute(ExecutionContext& ctx, Record& record) const

--- a/nes-physical-operators/src/Join/HashJoin/HJOperatorHandler.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJOperatorHandler.cpp
@@ -50,26 +50,6 @@ HJOperatorHandler::getCreateNewSlicesFunction(const CreateNewSlicesArguments& ne
         });
 }
 
-void HJOperatorHandler::setNautilusCleanupExec(
-    std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec> nautilusCleanupExec, const JoinBuildSideType& buildSide)
-{
-    switch (buildSide)
-    {
-        case JoinBuildSideType::Right:
-            rightCleanupStateNautilusFunction = std::move(nautilusCleanupExec);
-            break;
-        case JoinBuildSideType::Left:
-            leftCleanupStateNautilusFunction = std::move(nautilusCleanupExec);
-            break;
-            std::unreachable();
-    }
-}
-
-std::vector<std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec>> HJOperatorHandler::getNautilusCleanupExec() const
-{
-    return {leftCleanupStateNautilusFunction, rightCleanupStateNautilusFunction};
-}
-
 void HJOperatorHandler::emitSlicesToProbe(
     Slice& sliceLeft,
     Slice& sliceRight,

--- a/nes-physical-operators/src/Join/HashJoin/HJProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJProbePhysicalOperator.cpp
@@ -64,15 +64,15 @@ Interface::HashMap* getHashMapPtrProxy(Interface::HashMap** hashMaps, const uint
 }
 }
 
-void HJProbePhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void HJProbePhysicalOperator::open(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& recordBuffer) const
 {
     /// As this operator functions as a scan, we have to set the execution context for this pipeline
-    executionCtx.watermarkTs = recordBuffer.getWatermarkTs();
-    executionCtx.sequenceNumber = recordBuffer.getSequenceNumber();
-    executionCtx.chunkNumber = recordBuffer.getChunkNumber();
-    executionCtx.lastChunk = recordBuffer.isLastChunk();
-    executionCtx.originId = recordBuffer.getOriginId();
-    StreamJoinProbePhysicalOperator::open(executionCtx, recordBuffer);
+    executionContext.watermarkTs = recordBuffer.getWatermarkTs();
+    executionContext.sequenceNumber = recordBuffer.getSequenceNumber();
+    executionContext.chunkNumber = recordBuffer.getChunkNumber();
+    executionContext.lastChunk = recordBuffer.isLastChunk();
+    executionContext.originId = recordBuffer.getOriginId();
+    StreamJoinProbePhysicalOperator::open(executionContext, compilationContext, recordBuffer);
 
     /// Getting necessary values from the record buffer
     const auto hashJoinWindowRef = static_cast<nautilus::val<EmittedHJWindowTrigger*>>(recordBuffer.getBuffer());
@@ -136,7 +136,7 @@ void HJProbePhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer&
                             const auto rightRecord = *rightIt;
                             auto joinedRecord
                                 = createJoinedRecord(leftRecord, rightRecord, windowStart, windowEnd, leftFields, rightFields);
-                            executeChild(executionCtx, joinedRecord);
+                            executeChild(executionContext, compilationContext, joinedRecord);
                         }
                     }
                 }

--- a/nes-physical-operators/src/MapPhysicalOperator.cpp
+++ b/nes-physical-operators/src/MapPhysicalOperator.cpp
@@ -27,14 +27,14 @@ MapPhysicalOperator::MapPhysicalOperator(Record::RecordFieldIdentifier fieldToWr
 {
 }
 
-void MapPhysicalOperator::execute(ExecutionContext& ctx, Record& record) const
+void MapPhysicalOperator::execute(ExecutionContext& executionContext, CompilationContext& compilationContext, Record& record) const
 {
     /// execute map function
-    const auto value = mapFunction.execute(record, ctx.pipelineMemoryProvider.arena);
+    const auto value = mapFunction.execute(record, executionContext.pipelineMemoryProvider.arena);
     /// write the result to the record
     record.write(fieldToWriteTo, value);
     /// call next operator
-    executeChild(ctx, record);
+    executeChild(executionContext, compilationContext, record);
 }
 
 std::optional<PhysicalOperator> MapPhysicalOperator::getChild() const

--- a/nes-physical-operators/src/PhysicalOperator.cpp
+++ b/nes-physical-operators/src/PhysicalOperator.cpp
@@ -11,7 +11,6 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-
 #include <PhysicalOperator.hpp>
 
 #include <memory>
@@ -27,7 +26,7 @@
 #include <Util/PlanRenderer.hpp>
 #include <fmt/format.h>
 #include <magic_enum/magic_enum.hpp>
-#include <ErrorHandling.hpp>
+#include <Engine.hpp>
 #include <ExecutionContext.hpp>
 
 namespace NES
@@ -41,59 +40,66 @@ PhysicalOperatorConcept::PhysicalOperatorConcept(OperatorId existingId) : id(exi
 {
 }
 
-void PhysicalOperatorConcept::setup(ExecutionContext& executionCtx) const
+void PhysicalOperatorConcept::setup(ExecutionContext& executionContext, CompilationContext& compilationContext) const
 {
-    setupChild(executionCtx);
+    setupChild(executionContext, compilationContext);
 }
 
-void PhysicalOperatorConcept::open(ExecutionContext& executionCtx, RecordBuffer& rb) const
+void PhysicalOperatorConcept::open(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& rb) const
 {
-    openChild(executionCtx, rb);
+    openChild(executionContext, compilationContext, rb);
 }
 
-void PhysicalOperatorConcept::close(ExecutionContext& executionCtx, RecordBuffer& rb) const
+void PhysicalOperatorConcept::close(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& rb) const
 {
-    closeChild(executionCtx, rb);
+    closeChild(executionContext, compilationContext, rb);
 }
 
-void PhysicalOperatorConcept::terminate(ExecutionContext& executionCtx) const
+void PhysicalOperatorConcept::terminate(ExecutionContext& executionContext) const
 {
-    terminateChild(executionCtx);
+    terminateChild(executionContext);
 }
 
-void PhysicalOperatorConcept::execute(ExecutionContext& executionCtx, Record& record) const
+void PhysicalOperatorConcept::execute(ExecutionContext& executionContext, CompilationContext& compilationContext, Record& record) const
 {
-    executeChild(executionCtx, record);
+    executeChild(executionContext, compilationContext, record);
 }
 
-void PhysicalOperatorConcept::setupChild(ExecutionContext& executionCtx) const
+void PhysicalOperatorConcept::setupChild(ExecutionContext& executionContext, CompilationContext& compilationContext) const
 {
-    INVARIANT(getChild().has_value(), "Child operator is not set");
-    getChild().value().setup(executionCtx);
+    if (const auto child = getChild())
+    {
+        child.value().setup(executionContext, compilationContext);
+    }
+}
+void PhysicalOperatorConcept::openChild(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& recordBuffer) const
+{
+    if (const auto child = getChild())
+    {
+        child.value().open(executionContext, compilationContext, recordBuffer);
+    }
+}
+void PhysicalOperatorConcept::closeChild(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& recordBuffer) const
+{
+    if (const auto child = getChild())
+    {
+        child.value().close(executionContext, compilationContext, recordBuffer);
+    }
+}
+void PhysicalOperatorConcept::executeChild(ExecutionContext& executionContext, CompilationContext& compilationContext, Record& record) const
+{
+    if (const auto child = getChild())
+    {
+        child.value().execute(executionContext, compilationContext, record);
+    }
 }
 
-void PhysicalOperatorConcept::openChild(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void PhysicalOperatorConcept::terminateChild(ExecutionContext& executionContext) const
 {
-    INVARIANT(getChild().has_value(), "Child operator is not set");
-    getChild().value().open(executionCtx, recordBuffer);
-}
-
-void PhysicalOperatorConcept::closeChild(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
-{
-    INVARIANT(getChild().has_value(), "Child operator is not set");
-    getChild().value().close(executionCtx, recordBuffer);
-}
-
-void PhysicalOperatorConcept::executeChild(ExecutionContext& executionCtx, Record& record) const
-{
-    INVARIANT(getChild().has_value(), "Child operator is not set");
-    getChild().value().execute(executionCtx, record);
-}
-
-void PhysicalOperatorConcept::terminateChild(ExecutionContext& executionCtx) const
-{
-    INVARIANT(getChild().has_value(), "Child operator is not set");
-    getChild().value().terminate(executionCtx);
+    if (const auto child = getChild())
+    {
+        child.value().terminate(executionContext);
+    }
 }
 
 PhysicalOperator::PhysicalOperator() = default;
@@ -116,36 +122,34 @@ std::optional<PhysicalOperator> PhysicalOperator::getChild() const
     return self->getChild();
 }
 
-PhysicalOperator PhysicalOperator::withChild(PhysicalOperator child) const
+void PhysicalOperator::setChild(PhysicalOperator child) const
 {
-    auto copy = self->clone();
-    copy->setChild(std::move(child));
-    return {copy};
+    self->setChild(std::move(child));
 }
 
-void PhysicalOperator::setup(ExecutionContext& executionCtx) const
+void PhysicalOperator::setup(ExecutionContext& executionContext, CompilationContext& compilationContext) const
 {
-    self->setup(executionCtx);
+    self->setup(executionContext, compilationContext);
 }
 
-void PhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void PhysicalOperator::open(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& recordBuffer) const
 {
-    self->open(executionCtx, recordBuffer);
+    self->open(executionContext, compilationContext, recordBuffer);
 }
 
-void PhysicalOperator::close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void PhysicalOperator::close(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& recordBuffer) const
 {
-    self->close(executionCtx, recordBuffer);
+    self->close(executionContext, compilationContext, recordBuffer);
 }
 
-void PhysicalOperator::terminate(ExecutionContext& executionCtx) const
+void PhysicalOperator::terminate(ExecutionContext& executionContext) const
 {
-    self->terminate(executionCtx);
+    self->terminate(executionContext);
 }
 
-void PhysicalOperator::execute(ExecutionContext& executionCtx, Record& record) const
+void PhysicalOperator::execute(ExecutionContext& executionContext, CompilationContext& compilationContext, Record& record) const
 {
-    self->execute(executionCtx, record);
+    self->execute(executionContext, compilationContext, record);
 }
 
 std::string PhysicalOperator::toString() const

--- a/nes-physical-operators/src/ScanPhysicalOperator.cpp
+++ b/nes-physical-operators/src/ScanPhysicalOperator.cpp
@@ -37,23 +37,23 @@ ScanPhysicalOperator::ScanPhysicalOperator(
 {
 }
 
-void ScanPhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void ScanPhysicalOperator::open(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& recordBuffer) const
 {
     /// initialize global state variables to keep track of the watermark ts and the origin id
-    executionCtx.watermarkTs = recordBuffer.getWatermarkTs();
-    executionCtx.originId = recordBuffer.getOriginId();
-    executionCtx.currentTs = recordBuffer.getCreatingTs();
-    executionCtx.sequenceNumber = recordBuffer.getSequenceNumber();
-    executionCtx.chunkNumber = recordBuffer.getChunkNumber();
-    executionCtx.lastChunk = recordBuffer.isLastChunk();
+    executionContext.watermarkTs = recordBuffer.getWatermarkTs();
+    executionContext.originId = recordBuffer.getOriginId();
+    executionContext.currentTs = recordBuffer.getCreatingTs();
+    executionContext.sequenceNumber = recordBuffer.getSequenceNumber();
+    executionContext.chunkNumber = recordBuffer.getChunkNumber();
+    executionContext.lastChunk = recordBuffer.isLastChunk();
     /// call open on all child operators
-    openChild(executionCtx, recordBuffer);
+    openChild(executionContext, compilationContext, recordBuffer);
     /// iterate over records in buffer
     auto numberOfRecords = recordBuffer.getNumRecords();
     for (nautilus::val<uint64_t> i = 0_u64; i < numberOfRecords; i = i + 1_u64)
     {
         auto record = memoryProvider->readRecord(projections, recordBuffer, i);
-        executeChild(executionCtx, record);
+        executeChild(executionContext, compilationContext, record);
     }
 }
 

--- a/nes-physical-operators/src/SelectionPhysicalOperator.cpp
+++ b/nes-physical-operators/src/SelectionPhysicalOperator.cpp
@@ -22,12 +22,12 @@
 namespace NES
 {
 
-void SelectionPhysicalOperator::execute(ExecutionContext& ctx, Record& record) const
+void SelectionPhysicalOperator::execute(ExecutionContext& executionContext, CompilationContext& compilationContext, Record& record) const
 {
     /// evaluate function and call child operator if function is valid
-    if (function.execute(record, ctx.pipelineMemoryProvider.arena))
+    if (function.execute(record, executionContext.pipelineMemoryProvider.arena))
     {
-        executeChild(ctx, record);
+        executeChild(executionContext, compilationContext, record);
     }
 }
 

--- a/nes-physical-operators/src/UnionPhysicalOperator.cpp
+++ b/nes-physical-operators/src/UnionPhysicalOperator.cpp
@@ -21,10 +21,10 @@
 namespace NES
 {
 
-void UnionPhysicalOperator::execute(ExecutionContext& ctx, Record& record) const
+void UnionPhysicalOperator::execute(ExecutionContext& executionContext, CompilationContext& compilationContext, Record& record) const
 {
     /// Path-through, will be optimized out during query compilation
-    executeChild(ctx, record);
+    executeChild(executionContext, compilationContext, record);
 }
 
 std::optional<PhysicalOperator> UnionPhysicalOperator::getChild() const

--- a/nes-physical-operators/src/Watermark/IngestionTimeWatermarkAssignerPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Watermark/IngestionTimeWatermarkAssignerPhysicalOperator.cpp
@@ -27,25 +27,25 @@ namespace NES
 IngestionTimeWatermarkAssignerPhysicalOperator::IngestionTimeWatermarkAssignerPhysicalOperator(IngestionTimeFunction timeFunction)
     : timeFunction(std::move(timeFunction)) { };
 
-void IngestionTimeWatermarkAssignerPhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void IngestionTimeWatermarkAssignerPhysicalOperator::open(ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& recordBuffer) const
 {
-    openChild(executionCtx, recordBuffer);
-    timeFunction.open(executionCtx, recordBuffer);
+    openChild(executionContext, compilationContext, recordBuffer);
+    timeFunction.open(executionContext, compilationContext, recordBuffer);
     auto emptyRecord = Record();
-    const auto tsField = [this](ExecutionContext& executionCtx)
+    const auto tsField = [this](ExecutionContext& executionContext, CompilationContext& compilationContext)
     {
         auto emptyRecord = Record();
-        return timeFunction.getTs(executionCtx, emptyRecord);
-    }(executionCtx);
-    if (const auto currentWatermark = executionCtx.watermarkTs; tsField > currentWatermark)
+        return timeFunction.getTs(executionContext, compilationContext, emptyRecord);
+    }(executionContext, compilationContext);
+    if (const auto currentWatermark = executionContext.watermarkTs; tsField > currentWatermark)
     {
-        executionCtx.watermarkTs = tsField;
+        executionContext.watermarkTs = tsField;
     }
 }
 
-void IngestionTimeWatermarkAssignerPhysicalOperator::execute(ExecutionContext& executionCtx, Record& record) const
+void IngestionTimeWatermarkAssignerPhysicalOperator::execute(ExecutionContext& executionContext, CompilationContext& compilationContext, Record& record) const
 {
-    executeChild(executionCtx, record);
+    executeChild(executionContext, compilationContext, record);
 }
 
 std::optional<PhysicalOperator> IngestionTimeWatermarkAssignerPhysicalOperator::getChild() const

--- a/nes-physical-operators/src/Watermark/TimeFunction.cpp
+++ b/nes-physical-operators/src/Watermark/TimeFunction.cpp
@@ -27,7 +27,7 @@
 namespace NES
 {
 
-void EventTimeFunction::open(ExecutionContext&, RecordBuffer&) const
+void EventTimeFunction::open(ExecutionContext&, CompilationContext&, RecordBuffer&) const
 {
     /// nop
 }
@@ -37,23 +37,25 @@ EventTimeFunction::EventTimeFunction(PhysicalFunction timestampFunction, const W
 {
 }
 
-nautilus::val<Timestamp> EventTimeFunction::getTs(ExecutionContext& ctx, Record& record) const
+nautilus::val<Timestamp>
+EventTimeFunction::getTs(ExecutionContext& executionContext, CompilationContext&, Record& record) const
 {
-    const auto ts = this->timestampFunction.execute(record, ctx.pipelineMemoryProvider.arena).cast<nautilus::val<uint64_t>>();
+    const auto ts = this->timestampFunction.execute(record, executionContext.pipelineMemoryProvider.arena).cast<nautilus::val<uint64_t>>();
     const auto timeMultiplier = nautilus::val<uint64_t>(unit.getMillisecondsConversionMultiplier());
     const auto tsInMs = nautilus::val<Timestamp>(ts * timeMultiplier);
-    ctx.currentTs = tsInMs;
+    executionContext.currentTs = tsInMs;
     return tsInMs;
 }
 
-void IngestionTimeFunction::open(ExecutionContext& ctx, RecordBuffer& buffer) const
+void IngestionTimeFunction::open(ExecutionContext& executionContext, CompilationContext&, RecordBuffer& buffer) const
 {
-    ctx.currentTs = buffer.getCreatingTs();
+    executionContext.currentTs = buffer.getCreatingTs();
 }
 
-nautilus::val<Timestamp> IngestionTimeFunction::getTs(ExecutionContext& ctx, Record&) const
+nautilus::val<Timestamp>
+IngestionTimeFunction::getTs(ExecutionContext& executionContext, CompilationContext&, Record&) const
 {
-    return ctx.currentTs;
+    return executionContext.currentTs;
 }
 
 }

--- a/nes-physical-operators/src/WindowProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/WindowProbePhysicalOperator.cpp
@@ -11,6 +11,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
+#include <WindowProbePhysicalOperator.hpp>
 
 #include <optional>
 #include <utility>
@@ -25,7 +26,6 @@
 #include <ExecutionContext.hpp>
 #include <PhysicalOperator.hpp>
 #include <WindowBasedOperatorHandler.hpp>
-#include <WindowProbePhysicalOperator.hpp>
 #include <function.hpp>
 
 namespace NES
@@ -74,10 +74,10 @@ WindowProbePhysicalOperator::WindowProbePhysicalOperator(OperatorHandlerId opera
 {
 }
 
-void WindowProbePhysicalOperator::setup(ExecutionContext& executionCtx) const
+void WindowProbePhysicalOperator::setup(ExecutionContext& executionCtx, const nautilus::engine::NautilusEngine& engine) const
 {
     /// Giving child operators the change to setup
-    setupChild(executionCtx);
+    setupChild(executionCtx, engine);
     invoke(setupProxy, executionCtx.getGlobalOperatorHandler(operatorHandlerId), executionCtx.pipelineContext);
 }
 

--- a/nes-physical-operators/src/WindowProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/WindowProbePhysicalOperator.cpp
@@ -74,28 +74,29 @@ WindowProbePhysicalOperator::WindowProbePhysicalOperator(OperatorHandlerId opera
 {
 }
 
-void WindowProbePhysicalOperator::setup(ExecutionContext& executionCtx, const nautilus::engine::NautilusEngine& engine) const
+void WindowProbePhysicalOperator::setup(ExecutionContext& executionContext, CompilationContext& compilationContext) const
 {
     /// Giving child operators the change to setup
-    setupChild(executionCtx, engine);
-    invoke(setupProxy, executionCtx.getGlobalOperatorHandler(operatorHandlerId), executionCtx.pipelineContext);
+    setupChild(executionContext, compilationContext);
+    invoke(setupProxy, executionContext.getGlobalOperatorHandler(operatorHandlerId), executionContext.pipelineContext);
 }
 
-void WindowProbePhysicalOperator::close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void WindowProbePhysicalOperator::close(
+    ExecutionContext& executionContext, CompilationContext& compilationContext, RecordBuffer& recordBuffer) const
 {
     /// Update the watermark for the probe and delete all slices that can be deleted
-    const auto operatorHandlerMemRef = executionCtx.getGlobalOperatorHandler(operatorHandlerId);
+    const auto operatorHandlerMemRef = executionContext.getGlobalOperatorHandler(operatorHandlerId);
     invoke(
         garbageCollectSlicesProxy,
         operatorHandlerMemRef,
-        executionCtx.watermarkTs,
-        executionCtx.sequenceNumber,
-        executionCtx.chunkNumber,
-        executionCtx.lastChunk,
-        executionCtx.originId);
+        executionContext.watermarkTs,
+        executionContext.sequenceNumber,
+        executionContext.chunkNumber,
+        executionContext.lastChunk,
+        executionContext.originId);
 
     /// Now close for all children
-    PhysicalOperatorConcept::close(executionCtx, recordBuffer);
+    PhysicalOperatorConcept::close(executionContext, compilationContext, recordBuffer);
 }
 
 std::optional<PhysicalOperator> WindowProbePhysicalOperator::getChild() const
@@ -108,9 +109,9 @@ void WindowProbePhysicalOperator::setChild(PhysicalOperator child)
     this->child = std::move(child);
 }
 
-void WindowProbePhysicalOperator::terminate(ExecutionContext& executionCtx) const
+void WindowProbePhysicalOperator::terminate(ExecutionContext& executionContext) const
 {
-    nautilus::invoke(terminateProxy, executionCtx.getGlobalOperatorHandler(operatorHandlerId), executionCtx.pipelineContext);
-    terminateChild(executionCtx);
+    nautilus::invoke(terminateProxy, executionContext.getGlobalOperatorHandler(operatorHandlerId), executionContext.pipelineContext);
+    terminateChild(executionContext);
 }
 }

--- a/nes-physical-operators/tests/EmitPhysicalOperatorTest.cpp
+++ b/nes-physical-operators/tests/EmitPhysicalOperatorTest.cpp
@@ -119,7 +119,7 @@ public:
         return emit;
     }
 
-    void run(const std::function<void(ExecutionContext&, RecordBuffer&)>& test, Memory::TupleBuffer buffer)
+    void run(const std::function<void(ExecutionContext&, CompilationContext&, RecordBuffer&)>& test, Memory::TupleBuffer buffer)
     {
         MockedPipelineContext pec{buffers, bm};
         pec.setOperatorHandlers(handlers);
@@ -129,9 +129,10 @@ public:
         executionContext.chunkNumber = buffer.getChunkNumber();
         executionContext.sequenceNumber = buffer.getSequenceNumber(), executionContext.lastChunk = buffer.isLastChunk();
         executionContext.originId = buffer.getOriginId();
+        CompilationContext compilationContext{std::make_shared<nautilus::engine::NautilusEngine>()};
 
         RecordBuffer recordBuffer(std::addressof(buffer));
-        test(executionContext, recordBuffer);
+        test(executionContext, compilationContext, recordBuffer);
     }
 
     ///NOLINTBEGIN(fuchsia-default-arguments-declarations)
@@ -230,10 +231,10 @@ TEST_F(EmitPhysicalOperatorTest, BasicTest)
     EmitPhysicalOperator emit = createUUT();
 
     run(
-        [&](auto& executionContext, auto& recordBuffer)
+        [&](auto& executionContext, auto& compilationContext, auto& recordBuffer)
         {
-            emit.open(executionContext, recordBuffer);
-            emit.close(executionContext, recordBuffer);
+            emit.open(executionContext, compilationContext, recordBuffer);
+            emit.close(executionContext, compilationContext, recordBuffer);
         },
         buffer);
 
@@ -260,10 +261,10 @@ TEST_F(EmitPhysicalOperatorTest, ChunkNumberTest)
         for (auto& buffer : inputBuffers)
         {
             run(
-                [&](auto& executionContext, auto& recordBuffer)
+                [&](auto& executionContext, auto& compilationContext, auto& recordBuffer)
                 {
-                    emit.open(executionContext, recordBuffer);
-                    emit.close(executionContext, recordBuffer);
+                    emit.open(executionContext, compilationContext, recordBuffer);
+                    emit.close(executionContext, compilationContext, recordBuffer);
                 },
                 buffer);
         }
@@ -306,10 +307,10 @@ TEST_F(EmitPhysicalOperatorTest, SequenceChunkNumberTest)
         for (auto& buffer : inputBuffers)
         {
             run(
-                [&](auto& executionContext, auto& recordBuffer)
+                [&](auto& executionContext, auto& compilationContext, auto& recordBuffer)
                 {
-                    emit.open(executionContext, recordBuffer);
-                    emit.close(executionContext, recordBuffer);
+                    emit.open(executionContext, compilationContext, recordBuffer);
+                    emit.close(executionContext, compilationContext, recordBuffer);
                 },
                 buffer);
         }
@@ -358,10 +359,10 @@ TEST_F(EmitPhysicalOperatorTest, ConcurrentSequenceChunkNumberTest)
                     for (size_t index = threadId; index < inputBuffers.size(); index += numberOfThreads)
                     {
                         run(
-                            [&](auto& executionContext, auto& recordBuffer)
+                            [&](auto& executionContext, auto& compilationContext, auto& recordBuffer)
                             {
-                                emit.open(executionContext, recordBuffer);
-                                emit.close(executionContext, recordBuffer);
+                                emit.open(executionContext, compilationContext, recordBuffer);
+                                emit.close(executionContext, compilationContext, recordBuffer);
                             },
                             inputBuffers.at(index));
                     }

--- a/nes-runtime/include/CompilationContext.hpp
+++ b/nes-runtime/include/CompilationContext.hpp
@@ -45,14 +45,14 @@ public:
     requires std::is_void_v<R>
     void callCompiledFunction(Args... arguments)
     {
-        func.operator()(std::forward<Args>(arguments)...);
+        func(std::forward<Args>(arguments)...);
     }
 
     template <typename... Args>
     requires (not std::is_void_v<R>)
     R callCompiledFunction(Args... arguments)
     {
-        return func.operator()(std::forward<Args>(arguments)...);
+        return func(std::forward<Args>(arguments)...);
     }
 };
 
@@ -75,7 +75,7 @@ public:
     nautilus::val<CompiledFunctionWrapper<R, FunctionArguments...>*> registerFunction(std::function<R(nautilus::val<FunctionArguments...>)> function)
     {
         /// Passing the function to the nautilus engine so that we can compile/register the function and get a callable back
-        auto compiledFunction = engine->registerFunction<R, FunctionArguments...>(function);
+        auto compiledFunction = engine->registerFunction(function);
         auto compiledFunctionInWrapper = std::make_shared<CompiledFunctionWrapper<R, FunctionArguments...>>(std::move(compiledFunction));
         compiledFunctions.emplace_back(std::move(compiledFunctionInWrapper));
         const auto compiledFunctionBack = compiledFunctions.back();

--- a/nes-runtime/include/CompilationContext.hpp
+++ b/nes-runtime/include/CompilationContext.hpp
@@ -1,0 +1,93 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <functional>
+#include <nautilus/Engine.hpp>
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+
+/// Base function wrapper class
+struct FunctionWrapperBase
+{
+    FunctionWrapperBase() = default;
+    virtual ~FunctionWrapperBase() = default;
+};
+
+/// Function wrapper class so that we can store multiple different nautilus functions in a map
+template <typename R, typename... FunctionArguments>
+class CompiledFunctionWrapper final : public FunctionWrapperBase
+{
+    nautilus::engine::CallableFunction<R, FunctionArguments...> func;
+
+public:
+    explicit CompiledFunctionWrapper(nautilus::engine::CallableFunction<R, FunctionArguments...>&& function)
+        : FunctionWrapperBase(), func(std::move(function))
+    {
+    }
+    ~CompiledFunctionWrapper() override = default;
+
+    template <typename... Args>
+    requires std::is_void_v<R>
+    void callCompiledFunction(Args... arguments)
+    {
+        func.operator()(std::forward<Args>(arguments)...);
+    }
+
+    template <typename... Args>
+    requires (not std::is_void_v<R>)
+    R callCompiledFunction(Args... arguments)
+    {
+        return func.operator()(std::forward<Args>(arguments)...);
+    }
+};
+
+
+/// Stores compiled nautilus function for this particular pipeline during the tracing of a pipeline.
+/// This class should only change its state during the tracing of a pipeline and assumes it lives as long as the pipeline.
+/// The idea behind this class is that sometimes one wants to create nautilus function that are getting called during the query lifetime at
+/// specific times. For example a cleanup function, once a slice destructor gets called.
+class CompilationContext
+{
+    std::vector<std::shared_ptr<FunctionWrapperBase>> compiledFunctions;
+    std::shared_ptr<nautilus::engine::NautilusEngine> engine;
+
+public:
+    explicit CompilationContext(std::shared_ptr<nautilus::engine::NautilusEngine> engine) : engine(std::move(engine)) { }
+
+    /// @brief Checks if the function has been seen, if not the method compiles the function and stores the compiled function into the storage
+    /// @return the compiled function
+    template <typename R, typename... FunctionArguments>
+    nautilus::val<CompiledFunctionWrapper<R, FunctionArguments...>*> registerFunction(std::function<R(nautilus::val<FunctionArguments...>)> function)
+    {
+        /// Passing the function to the nautilus engine so that we can compile/register the function and get a callable back
+        auto compiledFunction = engine->registerFunction<R, FunctionArguments...>(function);
+        auto compiledFunctionInWrapper = std::make_shared<CompiledFunctionWrapper<R, FunctionArguments...>>(std::move(compiledFunction));
+        compiledFunctions.emplace_back(std::move(compiledFunctionInWrapper));
+        const auto compiledFunctionBack = compiledFunctions.back();
+        const auto castedFunction = dynamic_cast<CompiledFunctionWrapper<R, FunctionArguments...>*>(compiledFunctionBack.get());
+        return castedFunction;
+    }
+};
+
+
+// /// Nautilus wrapper around the @class CompiledFunctionStore. In the future, we might add more functions to this class.
+// struct CompilationContext {
+//     nautilus::val<CompiledFunctionStore*> compiledFunctionStore;
+// };
+
+}

--- a/nes-runtime/include/Pipelines/CompiledExecutablePipelineStage.hpp
+++ b/nes-runtime/include/Pipelines/CompiledExecutablePipelineStage.hpp
@@ -45,7 +45,7 @@ protected:
 
 private:
     [[nodiscard]] nautilus::engine::CallableFunction<void, PipelineExecutionContext*, const Memory::TupleBuffer*, const Arena*>
-    compilePipeline() const;
+    compilePipeline(const nautilus::engine::NautilusEngine& engine) const;
     const nautilus::engine::Options options;
     nautilus::engine::CallableFunction<void, PipelineExecutionContext*, const Memory::TupleBuffer*, const Arena*> compiledPipelineFunction;
     std::unordered_map<OperatorHandlerId, std::shared_ptr<OperatorHandler>> operatorHandlers;

--- a/nes-runtime/include/Pipelines/CompiledExecutablePipelineStage.hpp
+++ b/nes-runtime/include/Pipelines/CompiledExecutablePipelineStage.hpp
@@ -20,6 +20,7 @@
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Runtime/TupleBuffer.hpp>
 #include <nautilus/Engine.hpp>
+#include <CompilationContext.hpp>
 #include <ExecutablePipelineStage.hpp>
 #include <ExecutionContext.hpp>
 #include <Pipeline.hpp>
@@ -28,7 +29,7 @@ namespace NES
 {
 class DumpHelper;
 
-/// A compiled executable pipeline stage uses nautilus-lib to compile a pipeline to a code snippet.
+/// A compiled executable pipeline stage uses nautilus-lib (https://github.com/nebulastream/nautilus) to compile a pipeline to a code snippet.
 class CompiledExecutablePipelineStage final : public ExecutablePipelineStage
 {
 public:
@@ -44,11 +45,13 @@ protected:
     std::ostream& toString(std::ostream& os) const override;
 
 private:
-    [[nodiscard]] nautilus::engine::CallableFunction<void, PipelineExecutionContext*, const Memory::TupleBuffer*, const Arena*>
-    compilePipeline(const nautilus::engine::NautilusEngine& engine) const;
-    const nautilus::engine::Options options;
-    nautilus::engine::CallableFunction<void, PipelineExecutionContext*, const Memory::TupleBuffer*, const Arena*> compiledPipelineFunction;
+    [[nodiscard]] nautilus::engine::CallableFunction<void, const PipelineExecutionContext*, const Memory::TupleBuffer*, const Arena*>
+    compilePipeline();
+    std::shared_ptr<nautilus::engine::NautilusEngine> engine;
+    nautilus::engine::CallableFunction<void, const PipelineExecutionContext*, const Memory::TupleBuffer*, const Arena*>
+        compiledPipelineFunction;
     std::unordered_map<OperatorHandlerId, std::shared_ptr<OperatorHandler>> operatorHandlers;
+    CompilationContext compilationContext;
     std::shared_ptr<Pipeline> pipeline;
 };
 

--- a/nes-runtime/include/Pipelines/CompiledExecutablePipelineStage.hpp
+++ b/nes-runtime/include/Pipelines/CompiledExecutablePipelineStage.hpp
@@ -50,8 +50,8 @@ private:
     std::shared_ptr<nautilus::engine::NautilusEngine> engine;
     nautilus::engine::CallableFunction<void, const PipelineExecutionContext*, const Memory::TupleBuffer*, const Arena*>
         compiledPipelineFunction;
-    std::unordered_map<OperatorHandlerId, std::shared_ptr<OperatorHandler>> operatorHandlers;
     CompilationContext compilationContext;
+    std::unordered_map<OperatorHandlerId, std::shared_ptr<OperatorHandler>> operatorHandlers;
     std::shared_ptr<Pipeline> pipeline;
 };
 

--- a/nes-runtime/src/CMakeLists.txt
+++ b/nes-runtime/src/CMakeLists.txt
@@ -15,6 +15,7 @@ add_subdirectory(Pipelines)
 add_subdirectory(Listeners)
 
 add_source_files(nes-runtime
+        CompilationContext.cpp
         ExecutionContext.cpp
         ExecutableQueryPlan.cpp
 )

--- a/nes-runtime/src/CompilationContext.cpp
+++ b/nes-runtime/src/CompilationContext.cpp
@@ -11,24 +11,9 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-#pragma once
 
-#include <optional>
-#include <Nautilus/Interface/Record.hpp>
-#include <PhysicalOperator.hpp>
+#include <CompilationContext.hpp>
 
-namespace NES
-{
-class UnionPhysicalOperator final : public PhysicalOperatorConcept
-{
-public:
-    explicit UnionPhysicalOperator() = default;
-    [[nodiscard]] std::optional<PhysicalOperator> getChild() const override;
-    void setChild(PhysicalOperator child) override;
+namespace NES {
 
-    void execute(ExecutionContext& executionContext, CompilationContext& compilationContext, Record& record) const override;
-
-private:
-    std::optional<PhysicalOperator> child;
-};
 }

--- a/nes-runtime/src/Pipelines/CompiledExecutablePipelineStage.cpp
+++ b/nes-runtime/src/Pipelines/CompiledExecutablePipelineStage.cpp
@@ -53,7 +53,7 @@ void CompiledExecutablePipelineStage::execute(
 }
 
 nautilus::engine::CallableFunction<void, PipelineExecutionContext*, const Memory::TupleBuffer*, const Arena*>
-CompiledExecutablePipelineStage::compilePipeline() const
+CompiledExecutablePipelineStage::compilePipeline(const nautilus::engine::NautilusEngine& engine) const
 {
     try
     {
@@ -71,8 +71,6 @@ CompiledExecutablePipelineStage::compilePipeline() const
             pipeline->getRootOperator().close(ctx, recordBuffer);
         };
         /// NOLINTEND(performance-unnecessary-value-param)
-
-        const nautilus::engine::NautilusEngine engine(options);
         return engine.registerFunction(compiledFunction);
     }
     catch (...)
@@ -101,8 +99,9 @@ void CompiledExecutablePipelineStage::start(PipelineExecutionContext& pipelineEx
     pipelineExecutionContext.setOperatorHandlers(operatorHandlers);
     Arena arena(pipelineExecutionContext.getBufferManager());
     ExecutionContext ctx(std::addressof(pipelineExecutionContext), std::addressof(arena));
-    pipeline->getRootOperator().setup(ctx);
-    compiledPipelineFunction = this->compilePipeline();
+    const nautilus::engine::NautilusEngine engine(options);
+    pipeline->getRootOperator().setup(ctx, engine);
+    compiledPipelineFunction = this->compilePipeline(engine);
 }
 
 }

--- a/nes-runtime/src/Pipelines/CompiledExecutablePipelineStage.cpp
+++ b/nes-runtime/src/Pipelines/CompiledExecutablePipelineStage.cpp
@@ -31,18 +31,18 @@
 
 namespace NES
 {
-
 CompiledExecutablePipelineStage::CompiledExecutablePipelineStage(
     std::shared_ptr<Pipeline> pipeline,
     std::unordered_map<OperatorHandlerId, std::shared_ptr<OperatorHandler>> operatorHandlers,
     nautilus::engine::Options options)
     : engine(std::make_shared<nautilus::engine::NautilusEngine>(options))
     , compiledPipelineFunction(nullptr)
-    , operatorHandlers(std::move(operatorHandlers))
     , compilationContext(engine)
+    , operatorHandlers(std::move(operatorHandlers))
     , pipeline(std::move(pipeline))
 {
 }
+
 
 void CompiledExecutablePipelineStage::execute(
     const Memory::TupleBuffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext)
@@ -50,13 +50,11 @@ void CompiledExecutablePipelineStage::execute(
     /// we call the compiled pipeline function with an input buffer and the execution context
     pipelineExecutionContext.setOperatorHandlers(operatorHandlers);
     Arena arena(pipelineExecutionContext.getBufferManager());
-    compiledPipelineFunction(
-        std::addressof(pipelineExecutionContext), std::addressof(inputTupleBuffer), std::addressof(arena));
+    compiledPipelineFunction(std::addressof(pipelineExecutionContext), std::addressof(inputTupleBuffer), std::addressof(arena));
 }
 
-nautilus::engine::
-    CallableFunction<void, const PipelineExecutionContext*, const Memory::TupleBuffer*, const Arena*>
-    CompiledExecutablePipelineStage::compilePipeline()
+nautilus::engine::CallableFunction<void, const PipelineExecutionContext*, const Memory::TupleBuffer*, const Arena*>
+CompiledExecutablePipelineStage::compilePipeline()
 {
     try
     {
@@ -64,9 +62,7 @@ nautilus::engine::
         /// Additionally, we can NOT use const or const references for the parameters of the lambda function
         /// NOLINTBEGIN(performance-unnecessary-value-param)
         const std::function<void(
-            nautilus::val<const PipelineExecutionContext*>,
-            nautilus::val<const Memory::TupleBuffer*>,
-            nautilus::val<const Arena*>)>
+            nautilus::val<const PipelineExecutionContext*>, nautilus::val<const Memory::TupleBuffer*>, nautilus::val<const Arena*>)>
             compiledFunction = [&](nautilus::val<const PipelineExecutionContext*> pipelineExecutionContext,
                                    nautilus::val<const Memory::TupleBuffer*> recordBufferRef,
                                    nautilus::val<const Arena*> arenaRef)

--- a/vcpkg/vcpkg-registry/ports/nautilus/0006_tmp_debugging.patch
+++ b/vcpkg/vcpkg-registry/ports/nautilus/0006_tmp_debugging.patch
@@ -1,0 +1,204 @@
+Index: nautilus/include/nautilus/Engine.hpp
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/nautilus/include/nautilus/Engine.hpp b/nautilus/include/nautilus/Engine.hpp
+--- a/nautilus/include/nautilus/Engine.hpp	(revision 364c89c184430e1ccd0d9422fc73b1cc54c33ca8)
++++ b/nautilus/include/nautilus/Engine.hpp	(date 1755017963490)
+@@ -65,99 +65,113 @@
+
+ 	explicit CallableFunction(std::unique_ptr<compiler::Executable>& executable)
+ 	    : func(executable->getInvocableMember<typename R::raw_type, FunctionArguments...>("execute")),
+-	      executable(std::move(executable)) {}
++	      executable(std::move(executable)) {
++	}
+
+-		CallableFunction(const CallableFunction& other) = delete;
+-		CallableFunction(CallableFunction && other) noexcept
+-		    : func(std::move(other.func)), executable(std::move(other.executable)) {
+-		}
+-		CallableFunction& operator=(const CallableFunction& other) = delete;
+-		CallableFunction& operator=(CallableFunction&& other) noexcept {
+-			if (this == &other)
+-				return *this;
+-			func = std::move(other.func);
+-			executable = std::move(other.executable);
+-			return *this;
+-		}
++	CallableFunction(const CallableFunction& other) = delete;
++	CallableFunction(CallableFunction&& other) noexcept
++	    : func(std::move(other.func)), executable(std::move(other.executable)) {
++	}
++	CallableFunction& operator=(const CallableFunction& other) = delete;
++	CallableFunction& operator=(CallableFunction&& other) noexcept {
++		if (this == &other)
++			return *this;
++		func = std::move(other.func);
++		executable = std::move(other.executable);
++		return *this;
++	}
+
+-		typename R::raw_type operator()(FunctionArguments... args) {
+-			return std::visit(
+-			    overloaded {[&](std::function<R(val<FunctionArguments>...)>& fn) -> typename R::raw_type {
+-				                return nautilus::details::RawValueResolver<typename R::raw_type>::getRawValue(
+-				                    fn(make_value(args)...));
+-			                },
+-			                [&](compiler::Executable::Invocable<typename R::raw_type, FunctionArguments...>& fn) ->
+-			                typename R::raw_type {
+-				                return fn(args...);
+-			                }},
+-			    func);
+-		}
++	typename R::raw_type operator()(FunctionArguments... args) {
++		return std::visit(
++		    overloaded {[&](std::function<R(val<FunctionArguments>...)>& fn) -> typename R::raw_type {
++			                return nautilus::details::RawValueResolver<typename R::raw_type>::getRawValue(
++			                    fn(make_value(args)...));
++		                },
++		                [&](compiler::Executable::Invocable<typename R::raw_type, FunctionArguments...>& fn) ->
++		                typename R::raw_type {
++			                return fn(args...);
++		                }},
++		    func);
++	}
+
+-	private:
+-		std::variant<std::function<R(val<FunctionArguments>...)>,
+-		             compiler::Executable::Invocable<typename R::raw_type, FunctionArguments...>>
+-		    func;
+-		std::unique_ptr<compiler::Executable> executable;
+-	};
++private:
++	std::variant<std::function<R(val<FunctionArguments>...)>,
++	             compiler::Executable::Invocable<typename R::raw_type, FunctionArguments...>>
++	    func;
++	std::unique_ptr<compiler::Executable> executable;
++};
+
+-	/// Specialization for void return type
+-	template <typename... FunctionArguments>
+-	class CallableFunction<void, FunctionArguments...> {
+-	public:
+-		explicit CallableFunction(std::function<void(val<FunctionArguments>...)> func)
+-		    : func(func), executable(nullptr) {
+-		}
++/// Specialization for void return type
++template <typename... FunctionArguments>
++class CallableFunction<void, FunctionArguments...> {
++public:
++	explicit CallableFunction(std::function<void(val<FunctionArguments>...)> func) : func(func), executable(nullptr) {
++	}
+
+-		explicit CallableFunction(std::unique_ptr<compiler::Executable>& executable)
+-		    : func(executable->getInvocableMember<void, FunctionArguments...>("execute")),
+-		      executable(std::move(executable)) {
+-		}
++	explicit CallableFunction(std::unique_ptr<compiler::Executable>& executable)
++	    : func(executable->getInvocableMember<void, FunctionArguments...>("execute")),
++	      executable(std::move(executable)) {
++	}
+
+-		auto operator()(FunctionArguments... args) {
+-			std::visit(overloaded {[&](std::function<void(val<FunctionArguments>...)>& fn) { fn(make_value(args)...); },
+-			                       [&](compiler::Executable::Invocable<void, FunctionArguments...>& fn) {
+-				                       fn(args...);
+-			                       }},
+-			           func);
+-		}
++	CallableFunction(const CallableFunction& other) = delete;
++	CallableFunction(CallableFunction&& other) noexcept
++	    : func(std::move(other.func)), executable(std::move(other.executable)) {
++	}
++	CallableFunction& operator=(const CallableFunction& other) = delete;
++	CallableFunction& operator=(CallableFunction&& other) noexcept {
++		if (this == &other)
++			return *this;
++		func = std::move(other.func);
++		executable = std::move(other.executable);
++		return *this;
++	}
++	auto operator()(FunctionArguments... args) {
++		std::visit(overloaded {[&](std::function<void(val<FunctionArguments>...)>& fn) { fn(make_value(args)...); },
++		                       [&](compiler::Executable::Invocable<void, FunctionArguments...>& fn) {
++			                       fn(args...);
++		                       }},
++		           func);
++	}
+
+-	private:
+-		std::variant<std::function<void(val<FunctionArguments>...)>,
+-		             compiler::Executable::Invocable<void, FunctionArguments...>>
+-		    func;
+-		std::unique_ptr<compiler::Executable> executable;
+-	};
++private:
++	std::variant<std::function<void(val<FunctionArguments>...)>,
++	             compiler::Executable::Invocable<void, FunctionArguments...>>
++	    func;
++	std::unique_ptr<compiler::Executable> executable;
++};
+
+-	/**
+-	 * The Nautilus Engine maintains the execution context of one or multiple nautilus functions,
+-	 * which are registered using registerFunction.
+-	 * Depending on the provided options, this functions may be compiled using a compilation backend or are executed
+-	 * directly. In general, the NautilusEngine mussed outlive any registered functions.
+-	 */
+-	class NautilusEngine {
+-	public:
+-		NautilusEngine(const Options& options = Options());
++/**
++ * The Nautilus Engine maintains the execution context of one or multiple nautilus functions,
++ * which are registered using registerFunction.
++ * Depending on the provided options, this functions may be compiled using a compilation backend or are executed
++ * directly. In general, the NautilusEngine mussed outlive any registered functions.
++ */
++class NautilusEngine {
++public:
++	NautilusEngine(const Options& options = Options());
+
+-		template <typename R, is_val... FunctionArguments>
+-		auto registerFunction(R (*fnptr)(val<FunctionArguments>...)) const {
+-			std::function<R(val<FunctionArguments>...)> inputFunction = fnptr;
+-			return registerFunction(inputFunction);
+-		}
++	template <typename R, is_val... FunctionArguments>
++	auto registerFunction(R (*fnptr)(val<FunctionArguments>...)) const {
++		std::function<R(val<FunctionArguments>...)> inputFunction = fnptr;
++		return registerFunction(inputFunction);
++	}
+
+-		template <typename R, typename... FunctionArguments>
+-		auto registerFunction(std::function<R(val<FunctionArguments>...)> func) const {
++	template <typename R, typename... FunctionArguments>
++	auto registerFunction(std::function<R(val<FunctionArguments>...)> func) const {
+ #ifdef ENABLE_TRACING
+-			if (options.getOptionOrDefault("engine.Compilation", true)) {
+-				auto wrapper = details::createFunctionWrapper(func);
+-				auto executable = jit.compile(wrapper);
+-				return CallableFunction<R, FunctionArguments...>(executable);
+-			}
++		if (options.getOptionOrDefault("engine.Compilation", true)) {
++			auto wrapper = details::createFunctionWrapper(func);
++			auto executable = jit.compile(wrapper);
++			CallableFunction<R, FunctionArguments...> callableFunction(executable);
++			return std::move(callableFunction);
++		}
+ #endif
+-			return CallableFunction<R, FunctionArguments...>(func);
+-		}
++		CallableFunction<R, FunctionArguments...> callableFunction(func);
++		return std::move(callableFunction);
++	}
+
+-	private:
+-		const compiler::JITCompiler jit;
+-		const Options options;
+-	};
++private:
++	const compiler::JITCompiler jit;
++	const Options options;
++};
+ } // namespace nautilus::engine

--- a/vcpkg/vcpkg-registry/ports/nautilus/portfile.cmake
+++ b/vcpkg/vcpkg-registry/ports/nautilus/portfile.cmake
@@ -21,6 +21,7 @@ vcpkg_from_github(
 		0003-disable-ubsan-function-call-check.patch
 		0004-disable-mlir-multithreading.patch
 		0005-clang-tidy-memory-leak.patch
+		0006_tmp_debugging.patch
 )
 
 set(ADDITIONAL_CMAKE_OPTIONS "")


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR passes the nautilus engine during the query compilation phase to the pipeline setup call. This allows any operator to query compile additional code that is not being called from a typical pipeline invocation. One example is the cleanup function for an aggregation or hash-join slice.


## Verifying this change
This change is tested by running our CI tests.

## What components does this pull request potentially affect?
- ExecutionEngine
- QueryCompiler
