### PR TITLE
test(Systest): Use serialization logic in systest

### DIFF
--- a/nes-systests/systest/src/QuerySubmitter.cpp
+++ b/nes-systests/systest/src/QuerySubmitter.cpp
@@ -24,8 +24,10 @@
 #include <Listeners/QueryLog.hpp>
 #include <Runtime/Execution/QueryStatus.hpp>
 #include <Runtime/QueryTerminationType.hpp>
+#include <Serialization/QueryPlanSerializationUtil.hpp>
 #include <grpcpp/create_channel.h>
 #include <grpcpp/security/credentials.h>
+
 #include <ErrorHandling.hpp>
 #include <SingleNodeWorkerConfiguration.hpp>
 #include <SingleNodeWorkerRPCService.pb.h>
@@ -36,7 +38,9 @@ namespace NES::Systest
 
 std::expected<QueryId, Exception> LocalWorkerQuerySubmitter::registerQuery(const LogicalPlan& plan)
 {
-    return worker.registerQuery(plan);
+    /// Make sure the queryplan is passed through serialization logic.
+    const auto serialized = QueryPlanSerializationUtil::serializeQueryPlan(plan);
+    return worker.registerQuery(QueryPlanSerializationUtil::deserializeQueryPlan(serialized));
 }
 void LocalWorkerQuerySubmitter::startQuery(QueryId query)
 {

--- a/nes-systests/systest/src/SystestStarter.cpp
+++ b/nes-systests/systest/src/SystestStarter.cpp
@@ -12,6 +12,7 @@
     limitations under the License.
 */
 
+#include <chrono>
 #include <iostream>
 #include <Util/Logger/Logger.hpp>
 #include <ErrorHandling.hpp>
@@ -20,16 +21,26 @@
 
 int main(int argc, const char** argv)
 {
+    auto startTime = std::chrono::high_resolution_clock::now();
+
     switch (const auto [returnType, outputMessage, exceptionCode] = NES::executeSystests(NES::readConfiguration(argc, argv)); returnType)
     {
         case SystestExecutorResult::ReturnType::SUCCESS: {
+            auto endTime = std::chrono::high_resolution_clock::now();
+            auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime);
             std::cout << outputMessage << '\n';
+            std::cout << "Total execution time: " << duration.count() << " ms ("
+                      << std::chrono::duration_cast<std::chrono::seconds>(duration).count() << " seconds)" << '\n';
             return 0;
         }
         case SystestExecutorResult::ReturnType::FAILED: {
+            auto endTime = std::chrono::high_resolution_clock::now();
+            auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime);
             PRECONDITION(exceptionCode, "Returning with as 'FAILED_WITH_EXCEPTION_CODE', but did not provide error code");
             NES_ERROR("{}", outputMessage);
             std::cout << outputMessage << '\n';
+            std::cout << "Total execution time: " << duration.count() << " ms ("
+                      << std::chrono::duration_cast<std::chrono::seconds>(duration).count() << " seconds)" << '\n';
             return static_cast<int>(exceptionCode.value());
         }
     }


### PR DESCRIPTION
This PR changes the localquerysubmitter to actually use the serialization logic, which catches bad serialization logic in our systests.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
