### PR TITLE
feature(adding install script)

### DIFF
--- a/docker/dependency/Base.dockerfile
+++ b/docker/dependency/Base.dockerfile
@@ -1,72 +1,23 @@
-# The Base Dockerfile installs and configures all relevant tooling to build the dependencies and NebulaStream.
-# Currently our compiler toolchain is based on llvm-18 using libc++.
-# Additionally we install a recent CMake version and the mold linker.
 FROM ubuntu:24.04
 
+# 1) Copy & run your install script
+COPY scripts/install_sys_dependencies.sh /usr/local/bin/install_script.sh
+RUN chmod +x /usr/local/bin/install_script.sh \
+ && /usr/local/bin/install_script.sh
+
 ARG LLVM_TOOLCHAIN_VERSION=19
-ARG MOLD_VERSION=2.37.1
-ARG CMAKE_VERSION=3.31.6
-ENV LLVM_TOOLCHAIN_VERSION=${LLVM_TOOLCHAIN_VERSION}
-ENV CMAKE_VERSION=${CMAKE_VERSION}
+RUN ln -sf /usr/bin/clang-${LLVM_TOOLCHAIN_VERSION}  /usr/bin/cc \
+ && ln -sf /usr/bin/clang++-${LLVM_TOOLCHAIN_VERSION} /usr/bin/c++ \
+ && update-alternatives --install /usr/bin/cc  cc  /usr/bin/clang-${LLVM_TOOLCHAIN_VERSION}  30 \
+ && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-${LLVM_TOOLCHAIN_VERSION} 30 \
+ && update-alternatives --auto cc  && update-alternatives --auto c++ \
+ && echo /usr/lib/llvm-${LLVM_TOOLCHAIN_VERSION}/lib > /etc/ld.so.conf.d/libcxx.conf \
+ && ldconfig
 
-RUN apt update -y && apt install \
-    wget \
-    zip \
-    unzip \
-    tar \
-    curl \
-    gpg \
-    git \
-    ca-certificates \
-    linux-libc-dev \
-    build-essential \
-    g++-14 \
-    make \
-    libssl-dev \
-    openssl \
-    ccache \
-    ninja-build \
-    pkg-config \
-    -y
+# 2) Install Ninja in-container
+RUN apt update -y \
+ && apt install -y ninja-build
 
-# install llvm based toolchain
-RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/keyrings/llvm-snapshot.gpg \
-    && chmod a+r /etc/apt/keyrings/llvm-snapshot.gpg \
-    && echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/"$(. /etc/os-release && echo "$VERSION_CODENAME")"/ llvm-toolchain-"$(. /etc/os-release && echo "$VERSION_CODENAME")"-${LLVM_TOOLCHAIN_VERSION} main" > /etc/apt/sources.list.d/llvm-snapshot.list \
-    && echo "deb-src [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/"$(. /etc/os-release && echo "$VERSION_CODENAME")"/ llvm-toolchain-"$(. /etc/os-release && echo "$VERSION_CODENAME")"-${LLVM_TOOLCHAIN_VERSION} main" >> /etc/apt/sources.list.d/llvm-snapshot.list \
-    && apt update -y && apt install clang-${LLVM_TOOLCHAIN_VERSION} libc++-${LLVM_TOOLCHAIN_VERSION}-dev libc++abi-${LLVM_TOOLCHAIN_VERSION}-dev libclang-rt-${LLVM_TOOLCHAIN_VERSION}-dev -y
-
-# install recent version of the mold linker
-RUN wget https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-$(uname -m)-linux.tar.gz \
-    && tar -xf mold-${MOLD_VERSION}-$(uname -m)-linux.tar.gz \
-    && cp -r mold-${MOLD_VERSION}-$(uname -m)-linux/* /usr \
-    && rm -rf mold-${MOLD_VERSION}-$(uname -m)-linux mold-${MOLD_VERSION}-$(uname -m)-linux.tar.gz \
-    && mold --version
-
-# install recent version of cmake
-RUN wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.tar.gz \
-    && tar -xf cmake-${CMAKE_VERSION}.tar.gz \
-    && cd cmake-${CMAKE_VERSION} \
-    && ./configure --parallel=$(nproc) --prefix=/usr \
-    && make install -j $(nproc)\
-    && cd .. \
-    && rm -rf cmake-${CMAKE_VERSION}.tar.gz cmake-${CMAKE_VERSION} \
-    && cmake --version
-
-# default cmake generator is ninja
+# 3) Default CMake generator and llvm toolchain version since it's only set in non-docker builds per default
 ENV CMAKE_GENERATOR=Ninja
-
-# set default compiler to clang and make libc++ available via ldconfig
-RUN ln -sf /usr/bin/clang-${LLVM_TOOLCHAIN_VERSION} /usr/bin/cc \
-    && ln -sf /usr/bin/clang++-${LLVM_TOOLCHAIN_VERSION} /usr/bin/c++ \
-    && update-alternatives --install /usr/bin/cc cc /usr/bin/clang-${LLVM_TOOLCHAIN_VERSION} 30\
-    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-${LLVM_TOOLCHAIN_VERSION} 30\
-    && update-alternatives --auto cc \
-    && update-alternatives --auto c++ \
-    && update-alternatives --display cc \
-    && update-alternatives --display c++ \
-    && echo /usr/lib/llvm-${LLVM_TOOLCHAIN_VERSION}/lib > /etc/ld.so.conf.d/libcxx.conf \
-    && ldconfig \
-    && ls -l /usr/bin/cc /usr/bin/c++ \
-    && cc --version \
-    && c++ --version
+ENV LLVM_TOOLCHAIN_VERSION=19

--- a/docker/dependency/Base.dockerfile.dockerignore
+++ b/docker/dependency/Base.dockerfile.dockerignore
@@ -1,2 +1,6 @@
 # Ignore everything
 *
+
+# Re-include the script for installing system dependencies. Also, ensure that the folder containing this installation script is re-included first
+!scripts/
+!scripts/install_sys_dependencies.sh

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -127,8 +127,9 @@ Lastly, you need to create a new CMake profile which uses the newly created dock
 
 The relevant CI Jobs will be executed in the development container. This means in order to reproduce CI results, it is
 essential to replicate the development environment built into the base docker image. Note that NebulaStream uses llvm
-for its query compilation, which will take a while to build locally. You can follow the instructions of the instructions
-of the [base.dockerfile](../docker/dependency/Base.dockerfile) to replicate on Ubuntu or Debian systems.
+for its query compilation, which will take a while to build locally. You can follow the instructions of [install-local-docker-environment.sh](../scripts/install-local-docker-environment.sh)
+or use the script under [install_sys_dependencies.sh](../scripts/install_sys_dependencies.sh). Please note that we expect Ubuntu 24.04. or newer version. 
+Some packages might not be available for older Ubuntu versions.
 
 The compiler toolchain is based on `llvm-19` and libc++-19, and we use the mold linker for its better performance.
 Follow the [llvm documentation](https://apt.llvm.org/) to install a recent toolchain via your package manager.

--- a/scripts/install_sys_dependencies.sh
+++ b/scripts/install_sys_dependencies.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# install_toolchain.sh — Install LLVM, Mold, CMake on Ubuntu 24.04
+# Usage: sudo ./install_toolchain.sh
+
+# set script to fail immediately if one command fails, treat unset vars as errors and don't mask error codes
+set -euo pipefail
+
+### Configuration (override by exporting env vars) ###
+LLVM_TOOLCHAIN_VERSION="${LLVM_TOOLCHAIN_VERSION:-19}"
+MOLD_VERSION="${MOLD_VERSION:-2.37.1}"
+CMAKE_VERSION="${CMAKE_VERSION:-3.31.6}"
+# Default CMake generator
+export CMAKE_GENERATOR="${CMAKE_GENERATOR:-Ninja}"
+
+### Ensure running as root ###
+if [ "$EUID" -ne 0 ]; then
+  echo "Please run as root or via sudo." >&2
+  exit 1
+fi
+
+echo "=== Updating apt and installing prerequisites ==="
+apt update -y
+DEBIAN_FRONTEND=noninteractive apt install -y \
+    wget zip unzip tar curl gpg git ca-certificates \
+    linux-libc-dev build-essential g++-14 make \
+    libssl-dev openssl ccache pkg-config
+
+echo "=== Adding LLVM apt repository and installing LLVM ${LLVM_TOOLCHAIN_VERSION} ==="
+# Create keyring directory if missing
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
+     | gpg --dearmor -o /etc/apt/keyrings/llvm-snapshot.gpg
+chmod a+r /etc/apt/keyrings/llvm-snapshot.gpg
+
+# Add apt sources.list for LLVM
+ARCH=$(dpkg --print-architecture)
+CODENAME=$(. /etc/os-release && echo "$VERSION_CODENAME")
+cat > /etc/apt/sources.list.d/llvm-snapshot.list <<EOF
+deb [arch=${ARCH} signed-by=/etc/apt/keyrings/llvm-snapshot.gpg] \
+    http://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-${LLVM_TOOLCHAIN_VERSION} main
+deb-src [arch=${ARCH} signed-by=/etc/apt/keyrings/llvm-snapshot.gpg] \
+    http://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-${LLVM_TOOLCHAIN_VERSION} main
+EOF
+
+apt update -y
+DEBIAN_FRONTEND=noninteractive apt install -y \
+    clang-${LLVM_TOOLCHAIN_VERSION} \
+    libc++-${LLVM_TOOLCHAIN_VERSION}-dev \
+    libc++abi-${LLVM_TOOLCHAIN_VERSION}-dev \
+    libclang-rt-${LLVM_TOOLCHAIN_VERSION}-dev
+
+echo "=== Installing Mold linker version ${MOLD_VERSION} ==="
+TMPDIR=$(mktemp -d)
+pushd "$TMPDIR"
+wget -q "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-$(uname -m)-linux.tar.gz"
+tar xf "mold-${MOLD_VERSION}-$(uname -m)-linux.tar.gz"
+cp -r "mold-${MOLD_VERSION}-$(uname -m)-linux/"* /usr/
+popd
+rm -rf "$TMPDIR"
+echo "Mold version: $(mold --version)"
+
+echo "=== Installing CMake version ${CMAKE_VERSION} ==="
+TMPDIR=$(mktemp -d)
+pushd "$TMPDIR"
+wget -q "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.tar.gz"
+tar xf "cmake-${CMAKE_VERSION}.tar.gz"
+cd "cmake-${CMAKE_VERSION}"
+./configure --parallel="$(nproc)" --prefix=/usr
+make -j"$(nproc)" install
+popd
+rm -rf "$TMPDIR"
+echo "CMake version: $(cmake --version | head -n1)"
+
+echo "=== Configuring Clang as the default compiler ==="
+# Symlink cc and c++ to clang
+ln -sf /usr/bin/clang-"${LLVM_TOOLCHAIN_VERSION}" /usr/bin/cc
+ln -sf /usr/bin/clang++-"${LLVM_TOOLCHAIN_VERSION}" /usr/bin/c++
+# Register alternatives
+update-alternatives --install /usr/bin/cc cc /usr/bin/clang-"${LLVM_TOOLCHAIN_VERSION}" 30
+update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-"${LLVM_TOOLCHAIN_VERSION}" 30
+update-alternatives --auto cc
+update-alternatives --auto c++
+
+echo "/usr/lib/llvm-${LLVM_TOOLCHAIN_VERSION}/lib" \
+     > /etc/ld.so.conf.d/libcxx.conf
+ldconfig
+
+echo "Default compiler:"
+ls -l /usr/bin/cc /usr/bin/c++
+cc --version
+c++ --version
+
+echo "=== Installation complete ==="


### PR DESCRIPTION
Adding install script

## Purpose of the Change and Brief Change Log
This change is about adding a script which separates out the installation of the dependencies from docker into a bash script so users can also install them locally.

This PR closes #985 
