### PR TITLE
chore(vcpkg): Bump baseline

### DIFF
--- a/vcpkg/vcpkg.json
+++ b/vcpkg/vcpkg.json
@@ -4,7 +4,7 @@
   "homepage": "https://nebula.stream",
   "description": "Data Management for the Internet of Things.",
 
-  "builtin-baseline": "b02e341c927f16d991edbd915d8ea43eac52096c",
+  "builtin-baseline": "16e7a3eb109cde6115b1b5126449dfdf72341dfb",
   "$comment": [
     "BEWARE: changing the baseline might change the expected ANTLR_VERSION",
     "        supplied to cmake by the antlr4 dependency." ,


### PR DESCRIPTION
Bump vcpgk baseline. This fixes a symbol clash between nlohmanjson and ANTLR.
