### PR TITLE
chore(docs): Updates readme to reflect llvm-19

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ To run the checks, you can use the target `format`.
 
 
 ## Development
-NebulaStream targets C++23 using all features implemented in both `libc++` 18 and `libstdc++` 13.2. All tests are using
-`Clang` 18.
+NebulaStream targets C++23 using all features implemented in both `libc++` 19 and `libstdc++` 14. All tests are using
+`Clang` 19.
 Follow the [development guide](docs/technical/development.md) to learn how to set up the development environment.
 To see our code of conduct, please refer to [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md).
 


### PR DESCRIPTION
The readme was outdated and still referenced clang-18
