### PR TITLE
fix QueryOptimizer.cpp filename

### DIFF
--- a/nes-query-optimizer/src/CMakeLists.txt
+++ b/nes-query-optimizer/src/CMakeLists.txt
@@ -16,4 +16,4 @@ add_subdirectory(Phases)
 
 add_source_files(nes-query-optimizer
         PhysicalPlanBuilder.cpp
-        QueryCompiler.cpp)
+        QueryOptimizer.cpp)

--- a/nes-query-optimizer/src/QueryOptimizer.cpp
+++ b/nes-query-optimizer/src/QueryOptimizer.cpp
@@ -12,10 +12,11 @@
     limitations under the License.
 */
 
+#include <QueryOptimizer.hpp>
+
 #include <Phases/LowerToPhysicalOperators.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <PhysicalPlan.hpp>
-#include <QueryOptimizer.hpp>
 
 namespace NES
 {


### PR DESCRIPTION
File contains `QueryOptimizer` and references `QueryOptimizer.hpp` but was `QueryCompiler.cpp`.

This PR fixes this.