### PR TITLE
feat(Systest): Add inline definition for GeneratorSource

### DIFF
--- a/nes-plugins/Sources/GeneratorSource/GeneratorFields.hpp
+++ b/nes-plugins/Sources/GeneratorSource/GeneratorFields.hpp
@@ -20,7 +20,10 @@
 #include <ostream>
 #include <random>
 #include <string_view>
+#include <unordered_map>
 #include <variant>
+
+#include <DataTypes/DataType.hpp>
 
 namespace NES::Sources::GeneratorFields
 {
@@ -94,5 +97,14 @@ static const std::array<FieldValidator, 2> Validators
     = {{{.identifier = SEQUENCE_IDENTIFIER, .validator = SequenceField::validate},
         {.identifier = NORMAL_DISTRIBUTION_IDENTIFIER, .validator = NormalDistributionField::validate}}};
 
-
+/// @brief Multimap containing key-value pairs of the existing generator fields and which types they accept
+/// NOLINTBEGIN(cert-err58-cpp): do not warn about static storage duration
+static const std::unordered_multimap<std::string_view, DataType::Type> FieldNameToAcceptedTypes
+    = {{SEQUENCE_IDENTIFIER, DataType::Type::UINT64},
+       {SEQUENCE_IDENTIFIER, DataType::Type::INT64},
+       {SEQUENCE_IDENTIFIER, DataType::Type::FLOAT64},
+       {SEQUENCE_IDENTIFIER, DataType::Type::FLOAT32},
+       {NORMAL_DISTRIBUTION_IDENTIFIER, DataType::Type::FLOAT64},
+       {NORMAL_DISTRIBUTION_IDENTIFIER, DataType::Type::FLOAT32}};
 }
+/// NOLINTEND(cert-err58-cpp)

--- a/nes-plugins/Sources/GeneratorSource/GeneratorSource.cpp
+++ b/nes-plugins/Sources/GeneratorSource/GeneratorSource.cpp
@@ -40,7 +40,6 @@ GeneratorSource::GeneratorSource(const SourceDescriptor& sourceDescriptor)
     : seed(sourceDescriptor.getFromConfig(ConfigParametersGenerator::SEED))
     , maxRuntime(sourceDescriptor.getFromConfig(ConfigParametersGenerator::MAX_RUNTIME_MS))
     , generatorSchemaRaw(sourceDescriptor.getFromConfig(ConfigParametersGenerator::GENERATOR_SCHEMA))
-    , generatorStartTime(std::chrono::system_clock::now())
     , generator(
           seed,
           sourceDescriptor.getFromConfig(ConfigParametersGenerator::SEQUENCE_STOPS_GENERATOR),
@@ -52,6 +51,7 @@ GeneratorSource::GeneratorSource(const SourceDescriptor& sourceDescriptor)
 
 void GeneratorSource::open()
 {
+    this->generatorStartTime = std::chrono::system_clock::now();
     NES_TRACE("Opening GeneratorSource.");
 }
 

--- a/nes-systests/sources/Generator.test
+++ b/nes-systests/sources/Generator.test
@@ -1,20 +1,25 @@
 # name: sources/Generator.test
 # description: Tests the generator source
-# groups: [Sources]
+# groups: [Sources, Generator]
 
-Source generatorDefault UINT64 id UINT64 double GENERATOR
+Source generatorDefault UINT64 id UINT64 field2 GENERATOR
 CONFIG/sources/generator_10_tuples.yaml
 
-Source generator10K UINT64 id UINT64 double GENERATOR
+Source generator10K UINT64 id UINT64 field2 GENERATOR
 CONFIG/sources/generator_10K_tuples.yaml
 
-Source generatorStopAll UINT64 id UINT64 double GENERATOR
+Source generatorStopAll UINT64 id UINT64 field2 GENERATOR
 CONFIG/sources/generator_stop_all.yaml
 
-Source generatorStopOne UINT64 id UINT64 double GENERATOR
+Source generatorStopOne UINT64 id UINT64 field2 GENERATOR
 CONFIG/sources/generator_stop_one.yaml
 
-SINK generator_sink UINT64 generatorDefault$id UINT64 generatorDefault$double
+Source generatorInline UINT64 id GENERATOR seed 1, maxRuntimeMS 1000, stopGeneratorWhenSequenceFinishes ALL
+id SEQUENCE UINT64 0 10 1
+
+SINK generator_sink UINT64 generatorDefault$id UINT64 generatorDefault$field2
+
+SINK generator_sink_inline UINT64 generatorInline$id
 
 SELECT * FROM generatorDefault INTO generator_sink
 ----
@@ -40,3 +45,16 @@ SELECT * FROM generatorStopAll INTO CHECKSUM
 SELECT * FROM generatorStopOne INTO CHECKSUM
 ----
 100 25440
+
+SELECT * FROM generatorInline INTO generator_sink_inline
+----
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9

--- a/nes-systests/systest-sources/include/SystestSources/SourceTypes.hpp
+++ b/nes-systests/systest-sources/include/SystestSources/SourceTypes.hpp
@@ -31,6 +31,12 @@ namespace NES
 
 static constexpr std::string_view SYSTEST_FILE_PATH_PARAMETER = "filePath";
 
+struct InlineGeneratorConfiguration
+{
+    std::vector<std::string> fieldSchema;
+    std::unordered_map<std::string, std::string> options;
+};
+
 enum class TestDataIngestionType : uint8_t
 {
     INLINE,
@@ -49,6 +55,7 @@ struct SystestAttachSource
     std::optional<std::vector<std::string>> tuples;
     std::optional<std::filesystem::path> fileDataPath;
     std::shared_ptr<std::vector<std::jthread>> serverThreads;
+    std::optional<InlineGeneratorConfiguration> inlineGeneratorConfiguration;
 };
 
 }

--- a/nes-systests/systest/include/SystestParser.hpp
+++ b/nes-systests/systest/include/SystestParser.hpp
@@ -180,6 +180,8 @@ private:
     [[nodiscard]] std::filesystem::path expectFilePath();
     [[nodiscard]] std::string expectQuery();
     [[nodiscard]] ErrorExpectation expectError() const;
+    [[nodiscard]] std::pair<SystestLogicalSource, std::optional<SystestAttachSource>>
+    expectInlineGeneratorSource(SystestLogicalSource& source, const std::vector<std::string>& attachSourceTokens);
 
     QueryCallback onQueryCallback;
     ResultTuplesCallback onResultTuplesCallback;

--- a/nes-systests/systest/tests/SystestParserValidTestFilesTests.cpp
+++ b/nes-systests/systest/tests/SystestParserValidTestFilesTests.cpp
@@ -60,7 +60,8 @@ TEST_F(SystestParserValidTestFileTest, ValidTestFile)
            .testDataIngestionType = TestDataIngestionType::FILE,
            .tuples = std::nullopt,
            .fileDataPath = "dummy_path.txt",
-           .serverThreads = nullptr};
+           .serverThreads = nullptr,
+           .inlineGeneratorConfiguration = std::nullopt};
     const SystestParser::SystestLogicalSource expectedLogicalSource
         = {.name = "e124", .fields = {{.type = DataTypeProvider::provideDataType(DataType::Type::INT8), .name = "i"}}};
 
@@ -114,7 +115,8 @@ TEST_F(SystestParserValidTestFileTest, Comments1TestFile)
                                        "1,8,8000",   "1,9,9000",   "1,10,10000", "1,11,11000", "1,12,12000", "1,13,13000", "1,14,14000",
                                        "1,15,15000", "1,16,16000", "1,17,17000", "1,18,18000", "1,19,19000", "1,20,20000", "1,21,21000"}},
            .fileDataPath = "null",
-           .serverThreads = nullptr};
+           .serverThreads = nullptr,
+           .inlineGeneratorConfiguration = std::nullopt};
 
     /// Expected queries and results
     const auto expectedQueries = std::to_array<std::string>(
@@ -233,7 +235,8 @@ TEST_F(SystestParserValidTestFileTest, FilterTestFile)
                                        "1,8,8000",   "1,9,9000",   "1,10,10000", "1,11,11000", "1,12,12000", "1,13,13000", "1,14,14000",
                                        "1,15,15000", "1,16,16000", "1,17,17000", "1,18,18000", "1,19,19000", "1,20,20000", "1,21,21000"}},
            .fileDataPath = "null",
-           .serverThreads = nullptr};
+           .serverThreads = nullptr,
+           .inlineGeneratorConfiguration = std::nullopt};
 
     const auto expectedQueries = std::to_array<std::string>(
         {R"(SELECT * FROM window WHERE value == UINT64(1) INTO sinkWindow)",


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR addes the ability to define a GeneratorSource within a Systest file, without needing to specific an additional config
The syntax is the following:
```
Source generatorDefault UINT64 id UINT64 double UINT64 sourceOnly GENERATOR seed 1, maxRuntimeMS 1000, stopGeneratorWhenSequenceFinishes ALL
id SEQUENCE UINT64 0 10 1
double SEQUENCE UINT64 0 5 1
```
Additionally there is logic to the catch the following wrongly defined GeneratorSources
- Number of fields defined does not match number of defined generator field schemas
- Type of generator field schema is not a type that generator field supports
- Type of field defined does not match type defined in generator field schema
- Field defined does not have an accompanying identically named generator field schema

## Verifying this change
Adding `GeneratorInline.test` which tests the inline GeneratorSource definition

This PR closes #600 
