### PR TITLE
Setup GitHub merge queue

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,7 @@ name: NES PR CI
 on:
   pull_request:
     types: [ synchronize, opened, reopened ]
+  merge_group:
 
 # cancel previous runs of same PR / branch.
 concurrency:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
 
   check-format:
     needs: [ get-dev-images ]
-    name: "Run build and test"
+    name: "run clang format"
     uses: ./.github/workflows/format.yml
     with:
       head_sha: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # decide if we can skip the CI run (e.g. if it is the first PR in merge queue)
+  evaluate-skip:
+    runs-on: ubuntu-latest
+    outputs:
+      skip-check: ${{ steps.mq-skipper.outputs.skip-check }}
+    steps:
+      - id: mq-skipper
+        uses: cariad-tech/merge-queue-ci-skipper@main
+        with:
+          secret: ${{ secrets.CI_PRIVILEGE_SECRETE }}
+
   get-dev-images:
+    if: needs.evaluate-skip.outputs.skip-check != 'true'
     uses: ./.github/workflows/get_dev_images.yml
     secrets: inherit
     with:
@@ -23,6 +35,7 @@ jobs:
       ref: ${{ github.event.pull_request.head.sha }}
 
   check-format:
+    if: needs.evaluate-skip.outputs.skip-check != 'true'
     needs: [ get-dev-images ]
     name: "run clang format"
     uses: ./.github/workflows/format.yml
@@ -32,6 +45,7 @@ jobs:
       number_of_commits: ${{ github.event.pull_request.commits }}
 
   build-and-test:
+    if: needs.evaluate-skip.outputs.skip-check != 'true'
     needs: [ get-dev-images ]
     name: "Run build and test"
     uses: ./.github/workflows/build_and_test.yml
@@ -41,6 +55,7 @@ jobs:
       ref: ${{ github.event.pull_request.head.ref }}
 
   large-tests:
+    if: needs.evaluate-skip.outputs.skip-check != 'true'
     needs: [ get-dev-images ]
     name: "Run large scale tests"
     uses: ./.github/workflows/large_test.yml
@@ -49,6 +64,7 @@ jobs:
       ref: ${{ github.event.pull_request.head.ref }}
 
   clang-tidy-report:
+    if: needs.evaluate-skip.outputs.skip-check != 'true'
     needs: [ get-dev-images ]
     name: "Run clang tidy report"
     uses: ./.github/workflows/clang_tidy_diff.yml
@@ -59,6 +75,7 @@ jobs:
       number_of_commits: ${{ github.event.pull_request.commits }}
 
   run_code_coverage:
+    if: needs.evaluate-skip.outputs.skip-check != 'true'
     needs: [ get-dev-images ]
     name: "Run Code Coverage"
     uses: ./.github/workflows/code_coverage.yml
@@ -69,6 +86,7 @@ jobs:
     secrets: inherit
 
   run_endless_mode:
+    if: needs.evaluate-skip.outputs.skip-check != 'true'
     needs: [ get-dev-images ]
     name: "Run Endless Mode"
     uses: ./.github/workflows/endless-mode.yml


### PR DESCRIPTION
[feat(CI): add PR check runs to merge_group](https://github.com/nebulastream/nebulastream/commit/0aac5ce09097015bfcba36dcfc3c596a2dc35831) 

Like this PR are not stuck anymore in the merge queue once pressing `merge when ready`

[feat(CI): skip CI runs for the merge queue PRs if possible.](https://github.com/nebulastream/nebulastream/commit/da2077abfc67554fb94f707591e32d8346b4b08c) 

This happens e.g. when all CI runs have run and no other PR is in the merge queue.
We use the action cariad-tech/merge-queue-ci-skipper for this behaviour.