### PR TITLE
refactor(LogicalOperators): enhance logical operator representations

### DIFF
--- a/nes-common/include/Util/PlanRenderer.hpp
+++ b/nes-common/include/Util/PlanRenderer.hpp
@@ -85,7 +85,7 @@ public:
 
     void dump(const Plan& plan)
     {
-        const std::vector<Operator> rootOperators = plan.rootOperators;
+        const std::vector<Operator> rootOperators = plan.getRootOperators();
         dump(rootOperators);
     }
     /// Prints a tree like graph of the queryplan to the stream this class was instatiated with.

--- a/nes-logical-operators/include/Operators/EventTimeWatermarkAssignerLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/EventTimeWatermarkAssignerLogicalOperator.hpp
@@ -45,6 +45,7 @@ public:
     [[nodiscard]] bool operator==(const LogicalOperatorConcept& rhs) const override;
     [[nodiscard]] SerializableOperator serialize() const override;
 
+    [[nodiscard]] LogicalOperator withTraitSet(TraitSet traitSet) const override;
     [[nodiscard]] TraitSet getTraitSet() const override;
 
     [[nodiscard]] LogicalOperator withChildren(std::vector<LogicalOperator> children) const override;
@@ -82,6 +83,7 @@ private:
     static constexpr std::string_view NAME = "EventTimeWatermarkAssigner";
 
     std::vector<LogicalOperator> children;
+    TraitSet traitSet;
     Schema inputSchema, outputSchema;
     std::vector<OriginId> inputOriginIds;
     std::vector<OriginId> outputOriginIds;

--- a/nes-logical-operators/include/Operators/IngestionTimeWatermarkAssignerLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/IngestionTimeWatermarkAssignerLogicalOperator.hpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
+
 #include <DataTypes/Schema.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Operators/LogicalOperator.hpp>
@@ -35,6 +36,7 @@ public:
     [[nodiscard]] bool operator==(const LogicalOperatorConcept& rhs) const override;
     [[nodiscard]] SerializableOperator serialize() const override;
 
+    [[nodiscard]] LogicalOperator withTraitSet(TraitSet traitSet) const override;
     [[nodiscard]] TraitSet getTraitSet() const override;
 
     [[nodiscard]] LogicalOperator withChildren(std::vector<LogicalOperator> children) const override;
@@ -58,6 +60,7 @@ protected:
     static constexpr std::string_view NAME = "IngestionTimeWatermarkAssigner";
 
     std::vector<LogicalOperator> children;
+    TraitSet traitSet;
     Schema inputSchema;
     Schema outputSchema;
     std::vector<OriginId> inputOriginIds;

--- a/nes-logical-operators/include/Operators/LogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/LogicalOperator.hpp
@@ -62,6 +62,9 @@ struct LogicalOperatorConcept
     /// Creates a new operator with the given children
     [[nodiscard]] virtual LogicalOperator withChildren(std::vector<LogicalOperator>) const = 0;
 
+    /// Creates a new operator with the given traits
+    [[nodiscard]] virtual LogicalOperator withTraitSet(TraitSet) const = 0;
+
     /// Compares this operator with another for equality
     [[nodiscard]] virtual bool operator==(const LogicalOperatorConcept& rhs) const = 0;
 
@@ -152,6 +155,8 @@ struct LogicalOperator
     [[nodiscard]] std::string explain(ExplainVerbosity verbosity) const;
     [[nodiscard]] std::vector<LogicalOperator> getChildren() const;
     [[nodiscard]] LogicalOperator withChildren(std::vector<LogicalOperator> children) const;
+    /// Static traits defined as member variables will be present in the new operator nonetheless
+    [[nodiscard]] LogicalOperator withTraitSet(TraitSet traitSet) const;
 
     [[nodiscard]] OperatorId getId() const;
 
@@ -195,6 +200,8 @@ private:
         {
             return data.withChildren(children);
         }
+
+        [[nodiscard]] LogicalOperator withTraitSet(TraitSet traitSet) const override { return data.withTraitSet(traitSet); }
 
         [[nodiscard]] std::string_view getName() const noexcept override { return data.getName(); }
 
@@ -251,6 +258,11 @@ inline std::ostream& operator<<(std::ostream& os, const LogicalOperator& op)
 {
     return os << op.explain(ExplainVerbosity::Short);
 }
+
+/// Adds additional traits to the given operator, returning a new operator
+/// If the same trait (with the same data) is already present, the new trait will not be added.
+LogicalOperator addAdditionalTraits(const LogicalOperator& op, const TraitSet& traitSet);
+
 }
 
 /// Hash is based solely on unique identifier (needed for e.g. unordered_set)
@@ -262,4 +274,5 @@ struct hash<NES::LogicalOperator>
     std::size_t operator()(const NES::LogicalOperator& op) const noexcept { return std::hash<NES::OperatorId>{}(op.getId()); }
 };
 }
+
 FMT_OSTREAM(NES::LogicalOperator);

--- a/nes-logical-operators/include/Operators/ProjectionLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/ProjectionLogicalOperator.hpp
@@ -52,6 +52,7 @@ public:
     [[nodiscard]] bool operator==(const LogicalOperatorConcept& rhs) const override;
     [[nodiscard]] SerializableOperator serialize() const override;
 
+    [[nodiscard]] LogicalOperator withTraitSet(TraitSet traitSet) const override;
     [[nodiscard]] TraitSet getTraitSet() const override;
 
     [[nodiscard]] LogicalOperator withChildren(std::vector<LogicalOperator> children) const override;
@@ -95,6 +96,7 @@ private:
 
     bool asterisk = false;
     std::vector<LogicalOperator> children;
+    TraitSet traitSet;
     Schema inputSchema, outputSchema;
     std::vector<OriginId> inputOriginIds;
     std::vector<OriginId> outputOriginIds;

--- a/nes-logical-operators/include/Operators/SelectionLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/SelectionLogicalOperator.hpp
@@ -42,6 +42,7 @@ public:
     [[nodiscard]] bool operator==(const LogicalOperatorConcept& rhs) const override;
     [[nodiscard]] SerializableOperator serialize() const override;
 
+    [[nodiscard]] LogicalOperator withTraitSet(TraitSet traitSet) const override;
     [[nodiscard]] TraitSet getTraitSet() const override;
 
     [[nodiscard]] LogicalOperator withChildren(std::vector<LogicalOperator> children) const override;
@@ -78,6 +79,7 @@ private:
     LogicalFunction predicate;
 
     std::vector<LogicalOperator> children;
+    TraitSet traitSet;
     Schema inputSchema, outputSchema;
     std::vector<OriginId> inputOriginIds;
     std::vector<OriginId> outputOriginIds;

--- a/nes-logical-operators/include/Operators/Sinks/SinkLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Sinks/SinkLogicalOperator.hpp
@@ -48,6 +48,7 @@ struct SinkLogicalOperator final : LogicalOperatorConcept
     [[nodiscard]] bool operator==(const LogicalOperatorConcept& rhs) const override;
     [[nodiscard]] SerializableOperator serialize() const override;
 
+    [[nodiscard]] LogicalOperator withTraitSet(TraitSet traitSet) const override;
     [[nodiscard]] TraitSet getTraitSet() const override;
 
     [[nodiscard]] LogicalOperator withChildren(std::vector<LogicalOperator> children) const override;
@@ -81,6 +82,7 @@ private:
     static constexpr std::string_view NAME = "Sink";
 
     std::vector<LogicalOperator> children;
+    TraitSet traitSet;
     std::vector<OriginId> inputOriginIds;
     std::vector<OriginId> outputOriginIds;
 };

--- a/nes-logical-operators/include/Operators/Sources/SourceDescriptorLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Sources/SourceDescriptorLogicalOperator.hpp
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <memory>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -45,6 +44,7 @@ public:
     [[nodiscard]] bool operator==(const LogicalOperatorConcept& rhs) const override;
     [[nodiscard]] SerializableOperator serialize() const override;
 
+    [[nodiscard]] LogicalOperator withTraitSet(TraitSet traitSet) const override;
     [[nodiscard]] TraitSet getTraitSet() const override;
 
     [[nodiscard]] LogicalOperator withChildren(std::vector<LogicalOperator> children) const override;
@@ -69,6 +69,7 @@ private:
     OriginIdAssignerTrait originIdTrait;
 
     std::vector<LogicalOperator> children;
+    TraitSet traitSet;
     std::vector<OriginId> sourceOriginIds;
 };
 

--- a/nes-logical-operators/include/Operators/Sources/SourceNameLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Sources/SourceNameLogicalOperator.hpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
+
 #include <DataTypes/Schema.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Operators/LogicalOperator.hpp>
@@ -48,6 +49,7 @@ public:
     [[nodiscard]] bool operator==(const LogicalOperatorConcept& rhs) const override;
     [[nodiscard]] SerializableOperator serialize() const override;
 
+    [[nodiscard]] LogicalOperator withTraitSet(TraitSet traitSet) const override;
     [[nodiscard]] TraitSet getTraitSet() const override;
 
     [[nodiscard]] LogicalOperator withChildren(std::vector<LogicalOperator> children) const override;
@@ -71,6 +73,7 @@ private:
     std::string logicalSourceName;
 
     std::vector<LogicalOperator> children;
+    TraitSet traitSet;
     Schema schema, inputSchema, outputSchema;
     std::vector<std::vector<OriginId>> inputOriginIds;
     std::vector<OriginId> outputOriginIds;

--- a/nes-logical-operators/include/Operators/UnionLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/UnionLogicalOperator.hpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
+
 #include <DataTypes/Schema.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Operators/LogicalOperator.hpp>
@@ -35,6 +36,7 @@ public:
     [[nodiscard]] bool operator==(const LogicalOperatorConcept& rhs) const override;
     [[nodiscard]] SerializableOperator serialize() const override;
 
+    [[nodiscard]] LogicalOperator withTraitSet(TraitSet traitSet) const override;
     [[nodiscard]] TraitSet getTraitSet() const override;
 
     [[nodiscard]] LogicalOperator withChildren(std::vector<LogicalOperator> children) const override;
@@ -63,6 +65,7 @@ private:
     std::vector<LogicalOperator> children;
     std::vector<Schema> inputSchemas;
     Schema outputSchema;
+    TraitSet traitSet;
     std::vector<std::vector<OriginId>> inputOriginIds;
     std::vector<OriginId> outputOriginIds;
 };

--- a/nes-logical-operators/include/Operators/Windows/JoinLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Windows/JoinLogicalOperator.hpp
@@ -61,6 +61,7 @@ public:
     [[nodiscard]] bool operator==(const LogicalOperatorConcept& rhs) const override;
     [[nodiscard]] SerializableOperator serialize() const override;
 
+    [[nodiscard]] LogicalOperator withTraitSet(TraitSet traitSet) const override;
     [[nodiscard]] TraitSet getTraitSet() const override;
 
     [[nodiscard]] LogicalOperator withChildren(std::vector<LogicalOperator> children) const override;
@@ -123,6 +124,7 @@ private:
     OriginIdAssignerTrait originIdTrait;
 
     std::vector<LogicalOperator> children;
+    TraitSet traitSet;
     std::vector<std::vector<OriginId>> inputOriginIds;
     std::vector<OriginId> outputOriginIds;
     Schema leftInputSchema, rightInputSchema, outputSchema;

--- a/nes-logical-operators/include/Operators/Windows/WindowedAggregationLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Windows/WindowedAggregationLogicalOperator.hpp
@@ -66,6 +66,7 @@ public:
     [[nodiscard]] bool operator==(const LogicalOperatorConcept& rhs) const override;
     [[nodiscard]] SerializableOperator serialize() const override;
 
+    [[nodiscard]] LogicalOperator withTraitSet(TraitSet traitSet) const override;
     [[nodiscard]] TraitSet getTraitSet() const override;
 
     [[nodiscard]] LogicalOperator withChildren(std::vector<LogicalOperator> children) const override;
@@ -133,6 +134,7 @@ private:
     OriginIdAssignerTrait originIdTrait;
 
     std::vector<LogicalOperator> children;
+    TraitSet traitSet;
     std::vector<OriginId> inputOriginIds;
     Schema inputSchema, outputSchema;
     std::vector<OriginId> outputOriginIds;

--- a/nes-logical-operators/include/Plans/LogicalPlan.hpp
+++ b/nes-logical-operators/include/Plans/LogicalPlan.hpp
@@ -38,44 +38,51 @@ public:
     LogicalPlan() = default;
     explicit LogicalPlan(LogicalOperator rootOperator);
     explicit LogicalPlan(QueryId queryId, std::vector<LogicalOperator> rootOperators);
+    explicit LogicalPlan(QueryId queryId, std::vector<LogicalOperator> rootOperators, std::string originalSql);
+
+    LogicalPlan(const LogicalPlan& other) = default;
+    LogicalPlan& operator=(const LogicalPlan& other);
+    LogicalPlan(LogicalPlan&& other) noexcept;
+    LogicalPlan& operator=(LogicalPlan&& other) noexcept;
 
     [[nodiscard]] bool operator==(const LogicalPlan& otherPlan) const;
     friend std::ostream& operator<<(std::ostream& os, const LogicalPlan& plan);
 
-    std::vector<LogicalOperator> rootOperators;
-
     [[nodiscard]] QueryId getQueryId() const;
-    [[nodiscard]] const std::string& getOriginalSql() const;
+    [[nodiscard]] std::string getOriginalSql() const;
+    [[nodiscard]] std::vector<LogicalOperator> getRootOperators() const;
+
+    [[nodiscard]] LogicalPlan withRootOperators(const std::vector<LogicalOperator>& operators) const;
 
     void setOriginalSql(const std::string& sql);
     void setQueryId(QueryId id);
 
 private:
-    /// Holds the original SQL string
-    std::string originalSql;
     QueryId queryId = INVALID_QUERY_ID;
+    std::vector<LogicalOperator> rootOperators;
+    std::string originalSql; /// Holds the original SQL string
 };
 
 /// Get all parent operators of the target operator
 [[nodiscard]] std::vector<LogicalOperator> getParents(const LogicalPlan& plan, const LogicalOperator& target);
 
 /// Replace `target` with `replacement`, keeping target's children
-[[nodiscard]] std::optional<LogicalPlan>
-replaceOperator(const LogicalPlan& plan, const LogicalOperator& target, LogicalOperator replacement);
+[[nodiscard]] std::optional<LogicalPlan> replaceOperator(const LogicalPlan& plan, OperatorId target, LogicalOperator replacement);
 
 /// Replace `target` with `replacement`, keeping the children that are already inside `replacement`
-[[nodiscard]] std::optional<LogicalPlan>
-replaceSubtree(const LogicalPlan& plan, const LogicalOperator& target, const LogicalOperator& replacement);
+[[nodiscard]] std::optional<LogicalPlan> replaceSubtree(const LogicalPlan& plan, OperatorId target, const LogicalOperator& replacement);
 
 /// Adds a new operator to the plan and promotes it as new root by reparenting existing root operators and replacing the current roots
 [[nodiscard]] LogicalPlan promoteOperatorToRoot(const LogicalPlan& plan, const LogicalOperator& newRoot);
+
+[[nodiscard]] LogicalPlan addRootOperators(const LogicalPlan& plan, const std::vector<LogicalOperator>& rootsToAdd);
 
 template <class T>
 [[nodiscard]] std::vector<T> getOperatorByType(const LogicalPlan& plan)
 {
     std::vector<T> operators;
     std::ranges::for_each(
-        plan.rootOperators,
+        plan.getRootOperators(),
         [&operators](const auto& rootOperator)
         {
             auto typedOps = BFSRange(rootOperator)
@@ -86,12 +93,14 @@ template <class T>
     return operators;
 }
 
+[[nodiscard]] std::optional<LogicalOperator> getOperatorById(const LogicalPlan& plan, OperatorId operatorId);
+
 template <typename... TraitTypes>
 [[nodiscard]] std::vector<LogicalOperator> getOperatorsByTraits(const LogicalPlan& plan)
 {
     std::vector<LogicalOperator> matchingOperators;
     std::ranges::for_each(
-        plan.rootOperators,
+        plan.getRootOperators(),
         [&matchingOperators](const auto& rootOperator)
         {
             auto ops = BFSRange(rootOperator);

--- a/nes-logical-operators/include/Plans/LogicalPlanBuilder.hpp
+++ b/nes-logical-operators/include/Plans/LogicalPlanBuilder.hpp
@@ -88,7 +88,7 @@ private:
     /// @param: leftLogicalPlan the left query plan of the binary operation
     /// @param: rightLogicalPlan the right query plan of the binary operation
     /// @return the updated queryPlan
-    static LogicalPlan
-    addBinaryOperatorAndUpdateSource(const LogicalOperator& operatorNode, LogicalPlan leftLogicalPlan, LogicalPlan rightLogicalPlan);
+    static LogicalPlan addBinaryOperatorAndUpdateSource(
+        const LogicalOperator& operatorNode, const LogicalPlan& leftLogicalPlan, const LogicalPlan& rightLogicalPlan);
 };
 }

--- a/nes-logical-operators/src/Operators/EventTimeWatermarkAssignerLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/EventTimeWatermarkAssignerLogicalOperator.cpp
@@ -11,14 +11,20 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
+
 #include <Operators/EventTimeWatermarkAssignerLogicalOperator.hpp>
 
+#include <algorithm>
 #include <cstdint>
 #include <string>
 #include <string_view>
 #include <utility>
 #include <variant>
 #include <vector>
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
 #include <Configurations/Descriptor.hpp>
 #include <DataTypes/TimeUnit.hpp>
 #include <Functions/LogicalFunction.hpp>
@@ -28,8 +34,6 @@
 #include <Serialization/SchemaSerializationUtil.hpp>
 #include <Traits/Trait.hpp>
 #include <Util/PlanRenderer.hpp>
-#include <fmt/format.h>
-#include <fmt/ranges.h>
 #include <ErrorHandling.hpp>
 #include <LogicalOperatorRegistry.hpp>
 #include <SerializableOperator.pb.h>
@@ -75,7 +79,7 @@ bool EventTimeWatermarkAssignerLogicalOperator::operator==(const LogicalOperator
     {
         return onField == rhsOperator->onField && unit == rhsOperator->unit && getOutputSchema() == rhsOperator->getOutputSchema()
             && getInputSchemas() == rhsOperator->getInputSchemas() && getInputOriginIds() == rhsOperator->getInputOriginIds()
-            && getOutputOriginIds() == rhsOperator->getOutputOriginIds();
+            && getOutputOriginIds() == rhsOperator->getOutputOriginIds() && getTraitSet() == rhsOperator->getTraitSet();
     }
     return false;
 }
@@ -102,7 +106,14 @@ LogicalOperator EventTimeWatermarkAssignerLogicalOperator::withOutputOriginIds(s
 
 TraitSet EventTimeWatermarkAssignerLogicalOperator::getTraitSet() const
 {
-    return {};
+    return traitSet;
+}
+
+LogicalOperator EventTimeWatermarkAssignerLogicalOperator::withTraitSet(TraitSet traitSet) const
+{
+    auto copy = *this;
+    copy.traitSet = traitSet;
+    return copy;
 }
 
 LogicalOperator EventTimeWatermarkAssignerLogicalOperator::withChildren(std::vector<LogicalOperator> children) const

--- a/nes-logical-operators/src/Operators/IngestionTimeWatermarkAssignerLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/IngestionTimeWatermarkAssignerLogicalOperator.cpp
@@ -12,17 +12,21 @@
     limitations under the License.
 */
 
+#include <Operators/IngestionTimeWatermarkAssignerLogicalOperator.hpp>
+
+#include <algorithm>
 #include <string>
 #include <string_view>
 #include <vector>
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
 #include <Identifiers/Identifiers.hpp>
-#include <Operators/IngestionTimeWatermarkAssignerLogicalOperator.hpp>
 #include <Operators/LogicalOperator.hpp>
 #include <Serialization/SchemaSerializationUtil.hpp>
 #include <Traits/Trait.hpp>
 #include <Util/PlanRenderer.hpp>
-#include <fmt/format.h>
-#include <fmt/ranges.h>
 #include <ErrorHandling.hpp>
 #include <LogicalOperatorRegistry.hpp>
 #include <SerializableOperator.pb.h>
@@ -56,7 +60,8 @@ bool IngestionTimeWatermarkAssignerLogicalOperator::operator==(const LogicalOper
     if (const auto* const rhsOperator = dynamic_cast<const IngestionTimeWatermarkAssignerLogicalOperator*>(&rhs))
     {
         return getOutputSchema() == rhsOperator->getOutputSchema() && getInputSchemas() == rhsOperator->getInputSchemas()
-            && getInputOriginIds() == rhsOperator->getInputOriginIds() && getOutputOriginIds() == rhsOperator->getOutputOriginIds();
+            && getInputOriginIds() == rhsOperator->getInputOriginIds() && getOutputOriginIds() == rhsOperator->getOutputOriginIds()
+            && getTraitSet() == rhsOperator->getTraitSet();
     }
     return false;
 }
@@ -73,7 +78,14 @@ LogicalOperator IngestionTimeWatermarkAssignerLogicalOperator::withInferredSchem
 
 TraitSet IngestionTimeWatermarkAssignerLogicalOperator::getTraitSet() const
 {
-    return {};
+    return traitSet;
+}
+
+LogicalOperator IngestionTimeWatermarkAssignerLogicalOperator::withTraitSet(TraitSet traitSet) const
+{
+    auto copy = *this;
+    copy.traitSet = traitSet;
+    return copy;
 }
 
 LogicalOperator IngestionTimeWatermarkAssignerLogicalOperator::withChildren(std::vector<LogicalOperator> children) const

--- a/nes-logical-operators/src/Operators/LogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/LogicalOperator.cpp
@@ -12,14 +12,15 @@
     limitations under the License.
 */
 
-#include <memory>
+#include <Operators/LogicalOperator.hpp>
+
 #include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
+
 #include <DataTypes/Schema.hpp>
 #include <Identifiers/Identifiers.hpp>
-#include <Operators/LogicalOperator.hpp>
 #include <Traits/Trait.hpp>
 #include <Util/PlanRenderer.hpp>
 #include <SerializableOperator.pb.h>
@@ -51,6 +52,11 @@ std::vector<LogicalOperator> LogicalOperator::getChildren() const
 LogicalOperator LogicalOperator::withChildren(std::vector<LogicalOperator> children) const
 {
     return self->withChildren(std::move(children));
+}
+
+LogicalOperator LogicalOperator::withTraitSet(TraitSet traitSet) const
+{
+    return self->withTraitSet(std::move(traitSet));
 }
 
 OperatorId LogicalOperator::getId() const
@@ -112,4 +118,12 @@ LogicalOperator LogicalOperator::withInferredSchema(std::vector<Schema> inputSch
 {
     return self->withInferredSchema(std::move(inputSchemas));
 }
+
+LogicalOperator addAdditionalTraits(const LogicalOperator& op, const TraitSet& traitSet)
+{
+    auto result = op.getTraitSet();
+    result.insert(traitSet.cbegin(), traitSet.cend());
+    return op.withTraitSet(std::move(result));
+}
+
 }

--- a/nes-logical-operators/src/Operators/ProjectionLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/ProjectionLogicalOperator.cpp
@@ -23,6 +23,10 @@
 #include <utility>
 #include <variant>
 #include <vector>
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
 #include <Configurations/Descriptor.hpp>
 #include <Functions/FieldAccessLogicalFunction.hpp>
 #include <Functions/LogicalFunction.hpp>
@@ -34,8 +38,6 @@
 #include <Traits/Trait.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <Util/PlanRenderer.hpp>
-#include <fmt/format.h>
-#include <fmt/ranges.h>
 #include <ErrorHandling.hpp>
 #include <LogicalOperatorRegistry.hpp>
 #include <SerializableOperator.pb.h>
@@ -99,7 +101,7 @@ bool ProjectionLogicalOperator::operator==(const LogicalOperatorConcept& rhs) co
     {
         return projections == rhsOperator->projections && getOutputSchema() == rhsOperator->getOutputSchema()
             && getInputSchemas() == rhsOperator->getInputSchemas() && getInputOriginIds() == rhsOperator->getInputOriginIds()
-            && getOutputOriginIds() == rhsOperator->getOutputOriginIds();
+            && getOutputOriginIds() == rhsOperator->getOutputOriginIds() && getTraitSet() == rhsOperator->getTraitSet();
     }
     return false;
 };
@@ -183,7 +185,14 @@ LogicalOperator ProjectionLogicalOperator::withInferredSchema(std::vector<Schema
 
 TraitSet ProjectionLogicalOperator::getTraitSet() const
 {
-    return {};
+    return traitSet;
+}
+
+LogicalOperator ProjectionLogicalOperator::withTraitSet(TraitSet traitSet) const
+{
+    auto copy = *this;
+    copy.traitSet = traitSet;
+    return copy;
 }
 
 LogicalOperator ProjectionLogicalOperator::withChildren(std::vector<LogicalOperator> children) const

--- a/nes-logical-operators/src/Operators/SelectionLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/SelectionLogicalOperator.cpp
@@ -11,14 +11,19 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
+
 #include <Operators/SelectionLogicalOperator.hpp>
 
+#include <algorithm>
 #include <cstddef>
 #include <string>
 #include <string_view>
 #include <utility>
 #include <variant>
 #include <vector>
+
+#include <fmt/format.h>
+
 #include <Configurations/Descriptor.hpp>
 #include <Functions/LogicalFunction.hpp>
 #include <Identifiers/Identifiers.hpp>
@@ -27,7 +32,6 @@
 #include <Serialization/SchemaSerializationUtil.hpp>
 #include <Traits/Trait.hpp>
 #include <Util/PlanRenderer.hpp>
-#include <fmt/format.h>
 #include <ErrorHandling.hpp>
 #include <LogicalOperatorRegistry.hpp>
 #include <SerializableOperator.pb.h>
@@ -56,7 +60,7 @@ bool SelectionLogicalOperator::operator==(const LogicalOperatorConcept& rhs) con
     {
         return predicate == rhsOperator->predicate && getOutputSchema() == rhsOperator->getOutputSchema()
             && getInputSchemas() == rhsOperator->getInputSchemas() && getInputOriginIds() == rhsOperator->getInputOriginIds()
-            && getOutputOriginIds() == rhsOperator->getOutputOriginIds();
+            && getOutputOriginIds() == rhsOperator->getOutputOriginIds() && getTraitSet() == rhsOperator->getTraitSet();
     }
     return false;
 };
@@ -96,7 +100,14 @@ LogicalOperator SelectionLogicalOperator::withInferredSchema(std::vector<Schema>
 
 TraitSet SelectionLogicalOperator::getTraitSet() const
 {
-    return {};
+    return traitSet;
+}
+
+LogicalOperator SelectionLogicalOperator::withTraitSet(TraitSet traitSet) const
+{
+    auto copy = *this;
+    copy.traitSet = traitSet;
+    return copy;
 }
 
 LogicalOperator SelectionLogicalOperator::withChildren(std::vector<LogicalOperator> children) const

--- a/nes-logical-operators/src/Operators/Sinks/SinkLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Sinks/SinkLogicalOperator.cpp
@@ -43,7 +43,7 @@ bool SinkLogicalOperator::operator==(const LogicalOperatorConcept& rhs) const
 
         return sinkName == rhsOperator->sinkName && descriptorsEqual && getOutputSchema() == rhsOperator->getOutputSchema()
             && getInputSchemas() == rhsOperator->getInputSchemas() && getInputOriginIds() == rhsOperator->getInputOriginIds()
-            && getOutputOriginIds() == rhsOperator->getOutputOriginIds();
+            && getOutputOriginIds() == rhsOperator->getOutputOriginIds() && getTraitSet() == rhsOperator->getTraitSet();
     }
     return false;
 }
@@ -85,9 +85,16 @@ LogicalOperator SinkLogicalOperator::withInferredSchema(std::vector<Schema> inpu
     return copy;
 }
 
+LogicalOperator SinkLogicalOperator::withTraitSet(TraitSet traitSet) const
+{
+    auto copy = *this;
+    copy.traitSet = traitSet;
+    return copy;
+}
+
 TraitSet SinkLogicalOperator::getTraitSet() const
 {
-    return {};
+    return traitSet;
 }
 
 LogicalOperator SinkLogicalOperator::withChildren(std::vector<LogicalOperator> children) const

--- a/nes-logical-operators/src/Operators/Sources/SourceDescriptorLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Sources/SourceDescriptorLogicalOperator.cpp
@@ -14,19 +14,20 @@
 
 #include <Operators/Sources/SourceDescriptorLogicalOperator.hpp>
 
-#include <memory>
 #include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
 #include <DataTypes/Schema.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Operators/LogicalOperator.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Traits/Trait.hpp>
 #include <Util/PlanRenderer.hpp>
-#include <fmt/format.h>
-#include <fmt/ranges.h>
 #include <ErrorHandling.hpp>
 #include <SerializableOperator.pb.h>
 
@@ -55,7 +56,7 @@ bool SourceDescriptorLogicalOperator::operator==(const LogicalOperatorConcept& r
         const bool descriptorsEqual = sourceDescriptor == rhsOperator->sourceDescriptor;
         return descriptorsEqual && getOutputSchema() == rhsOperator->getOutputSchema()
             && getInputSchemas() == rhsOperator->getInputSchemas() && getInputOriginIds() == rhsOperator->getInputOriginIds()
-            && getOutputOriginIds() == rhsOperator->getOutputOriginIds();
+            && getOutputOriginIds() == rhsOperator->getOutputOriginIds() && getTraitSet() == rhsOperator->getTraitSet();
     }
     return false;
 }
@@ -70,9 +71,18 @@ std::string SourceDescriptorLogicalOperator::explain(ExplainVerbosity verbosity)
     return fmt::format("SOURCE({})", sourceDescriptor.explain(verbosity));
 }
 
+LogicalOperator SourceDescriptorLogicalOperator::withTraitSet(TraitSet traitSet) const
+{
+    auto copy = *this;
+    copy.traitSet = traitSet;
+    return copy;
+}
+
 TraitSet SourceDescriptorLogicalOperator::getTraitSet() const
 {
-    return {originIdTrait};
+    TraitSet result = traitSet;
+    result.insert(originIdTrait);
+    return result;
 }
 
 LogicalOperator SourceDescriptorLogicalOperator::withChildren(std::vector<LogicalOperator> children) const

--- a/nes-logical-operators/src/Operators/Sources/SourceNameLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Sources/SourceNameLogicalOperator.cpp
@@ -12,19 +12,23 @@
     limitations under the License.
 */
 
+#include <Operators/Sources/SourceNameLogicalOperator.hpp>
+
+#include <algorithm>
 #include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
 #include <DataTypes/Schema.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Operators/LogicalOperator.hpp>
-#include <Operators/Sources/SourceNameLogicalOperator.hpp>
 #include <Traits/Trait.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <Util/PlanRenderer.hpp>
-#include <fmt/format.h>
-#include <fmt/ranges.h>
 #include <ErrorHandling.hpp>
 #include <SerializableOperator.pb.h>
 
@@ -46,7 +50,8 @@ bool SourceNameLogicalOperator::operator==(const LogicalOperatorConcept& rhs) co
     {
         return this->getSchema() == rhsOperator->getSchema() && this->getName() == rhsOperator->getName()
             && getOutputSchema() == rhsOperator->getOutputSchema() && getInputSchemas() == rhsOperator->getInputSchemas()
-            && getInputOriginIds() == rhsOperator->getInputOriginIds() && getOutputOriginIds() == rhsOperator->getOutputOriginIds();
+            && getInputOriginIds() == rhsOperator->getInputOriginIds() && getOutputOriginIds() == rhsOperator->getOutputOriginIds()
+            && getTraitSet() == rhsOperator->getTraitSet();
     }
     return false;
 }
@@ -86,6 +91,7 @@ Schema SourceNameLogicalOperator::getSchema() const
 {
     return schema;
 }
+
 LogicalOperator SourceNameLogicalOperator::withSchema(const Schema& schema) const
 {
     auto copy = *this;
@@ -93,9 +99,16 @@ LogicalOperator SourceNameLogicalOperator::withSchema(const Schema& schema) cons
     return copy;
 }
 
+LogicalOperator SourceNameLogicalOperator::withTraitSet(TraitSet traitSet) const
+{
+    auto copy = *this;
+    copy.traitSet = traitSet;
+    return copy;
+}
+
 TraitSet SourceNameLogicalOperator::getTraitSet() const
 {
-    return {};
+    return traitSet;
 }
 
 LogicalOperator SourceNameLogicalOperator::withChildren(std::vector<LogicalOperator> children) const

--- a/nes-logical-operators/src/Operators/UnionLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/UnionLogicalOperator.cpp
@@ -21,14 +21,16 @@
 #include <string_view>
 #include <utility>
 #include <vector>
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
 #include <DataTypes/Schema.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Operators/LogicalOperator.hpp>
 #include <Serialization/SchemaSerializationUtil.hpp>
 #include <Traits/Trait.hpp>
 #include <Util/PlanRenderer.hpp>
-#include <fmt/format.h>
-#include <fmt/ranges.h>
 #include <ErrorHandling.hpp>
 #include <LogicalOperatorRegistry.hpp>
 #include <SerializableOperator.pb.h>
@@ -48,7 +50,8 @@ bool UnionLogicalOperator::operator==(const LogicalOperatorConcept& rhs) const
     if (const auto* const rhsOperator = dynamic_cast<const UnionLogicalOperator*>(&rhs))
     {
         return getInputSchemas() == rhsOperator->getInputSchemas() && getOutputSchema() == rhsOperator->getOutputSchema()
-            && getInputOriginIds() == rhsOperator->getInputOriginIds() && getOutputOriginIds() == rhsOperator->getOutputOriginIds();
+            && getInputOriginIds() == rhsOperator->getInputOriginIds() && getOutputOriginIds() == rhsOperator->getOutputOriginIds()
+            && getTraitSet() == rhsOperator->getTraitSet();
     }
     return false;
 }
@@ -100,7 +103,14 @@ LogicalOperator UnionLogicalOperator::withInferredSchema(std::vector<Schema> inp
 
 TraitSet UnionLogicalOperator::getTraitSet() const
 {
-    return {};
+    return traitSet;
+}
+
+LogicalOperator UnionLogicalOperator::withTraitSet(TraitSet traitSet) const
+{
+    auto copy = *this;
+    copy.traitSet = traitSet;
+    return copy;
 }
 
 LogicalOperator UnionLogicalOperator::withChildren(std::vector<LogicalOperator> children) const

--- a/nes-logical-operators/src/Operators/Windows/JoinLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Windows/JoinLogicalOperator.cpp
@@ -21,6 +21,9 @@
 #include <variant>
 #include <vector>
 
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
 #include <Configurations/Descriptor.hpp>
 #include <Configurations/Enums/EnumWrapper.hpp>
 #include <DataTypes/DataType.hpp>
@@ -37,8 +40,6 @@
 #include <WindowTypes/Types/TimeBasedWindowType.hpp>
 #include <WindowTypes/Types/TumblingWindow.hpp>
 #include <WindowTypes/Types/WindowType.hpp>
-#include <fmt/format.h>
-#include <fmt/ranges.h>
 #include <ErrorHandling.hpp>
 #include <LogicalOperatorRegistry.hpp>
 #include <SerializableOperator.pb.h>
@@ -64,7 +65,7 @@ bool JoinLogicalOperator::operator==(const LogicalOperatorConcept& rhs) const
         return *getWindowType() == *rhsOperator->getWindowType() and getJoinFunction() == rhsOperator->getJoinFunction()
             and getOutputSchema() == rhsOperator->outputSchema and getRightSchema() == rhsOperator->getRightSchema()
             and getLeftSchema() == rhsOperator->getLeftSchema() and getInputOriginIds() == rhsOperator->getInputOriginIds()
-            and getOutputOriginIds() == rhsOperator->getOutputOriginIds();
+            and getOutputOriginIds() == rhsOperator->getOutputOriginIds() and getTraitSet() == rhsOperator->getTraitSet();
     }
     return false;
 }
@@ -127,9 +128,18 @@ LogicalOperator JoinLogicalOperator::withInferredSchema(std::vector<Schema> inpu
     return copy;
 }
 
+LogicalOperator JoinLogicalOperator::withTraitSet(TraitSet traitSet) const
+{
+    auto copy = *this;
+    copy.traitSet = traitSet;
+    return copy;
+}
+
 TraitSet JoinLogicalOperator::getTraitSet() const
 {
-    return {originIdTrait};
+    TraitSet result = traitSet;
+    result.insert(originIdTrait);
+    return result;
 }
 
 LogicalOperator JoinLogicalOperator::withChildren(std::vector<LogicalOperator> children) const

--- a/nes-logical-operators/src/Operators/Windows/WindowedAggregationLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Windows/WindowedAggregationLogicalOperator.cpp
@@ -24,6 +24,9 @@
 #include <variant>
 #include <vector>
 
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
 #include <Configurations/Descriptor.hpp>
 #include <DataTypes/DataType.hpp>
 #include <DataTypes/Schema.hpp>
@@ -39,8 +42,6 @@
 #include <WindowTypes/Types/TimeBasedWindowType.hpp>
 #include <WindowTypes/Types/TumblingWindow.hpp>
 #include <WindowTypes/Types/WindowType.hpp>
-#include <fmt/format.h>
-#include <fmt/ranges.h>
 #include <ErrorHandling.hpp>
 #include <LogicalOperatorRegistry.hpp>
 #include <SerializableOperator.pb.h>
@@ -116,7 +117,7 @@ bool WindowedAggregationLogicalOperator::operator==(const LogicalOperatorConcept
 
         return *windowType == *rhsOperator->getWindowType() && getOutputSchema() == rhsOperator->getOutputSchema()
             && getInputSchemas() == rhsOperator->getInputSchemas() && getInputOriginIds() == rhsOperator->getInputOriginIds()
-            && getOutputOriginIds() == rhsOperator->getOutputOriginIds();
+            && getOutputOriginIds() == rhsOperator->getOutputOriginIds() && getTraitSet() == rhsOperator->getTraitSet();
     }
     return false;
 }
@@ -182,7 +183,16 @@ LogicalOperator WindowedAggregationLogicalOperator::withInferredSchema(std::vect
 
 TraitSet WindowedAggregationLogicalOperator::getTraitSet() const
 {
-    return {originIdTrait};
+    TraitSet result = traitSet;
+    result.insert(originIdTrait);
+    return result;
+}
+
+LogicalOperator WindowedAggregationLogicalOperator::withTraitSet(TraitSet traitSet) const
+{
+    auto copy = *this;
+    copy.traitSet = traitSet;
+    return copy;
 }
 
 LogicalOperator WindowedAggregationLogicalOperator::withChildren(std::vector<LogicalOperator> children) const

--- a/nes-logical-operators/src/Serialization/FunctionSerializationUtil.cpp
+++ b/nes-logical-operators/src/Serialization/FunctionSerializationUtil.cpp
@@ -11,10 +11,12 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
+
 #include <Serialization/FunctionSerializationUtil.hpp>
 
 #include <memory>
 #include <vector>
+
 #include <Configurations/Descriptor.hpp>
 #include <Functions/FieldAccessLogicalFunction.hpp>
 #include <Functions/LogicalFunction.hpp>

--- a/nes-logical-operators/src/Serialization/OperatorSerializationUtil.cpp
+++ b/nes-logical-operators/src/Serialization/OperatorSerializationUtil.cpp
@@ -19,6 +19,7 @@
 #include <utility>
 #include <variant>
 #include <vector>
+
 #include <Configurations/Descriptor.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Operators/LogicalOperator.hpp>
@@ -185,9 +186,9 @@ OperatorSerializationUtil::deserializeSinkDescriptor(const SerializableSinkDescr
 
     /// Deserialize DescriptorSource config. Convert from protobuf variant to DescriptorSource::ConfigType.
     DescriptorConfig::Config sinkDescriptorConfig{};
-    for (const auto& [key, desciptor] : serializableSinkDescriptor.config())
+    for (const auto& [key, descriptor] : serializableSinkDescriptor.config())
     {
-        sinkDescriptorConfig[key] = protoToDescriptorConfigType(desciptor);
+        sinkDescriptorConfig[key] = protoToDescriptorConfigType(descriptor);
     }
 
     auto sinkDescriptor

--- a/nes-logical-operators/src/Serialization/QueryPlanSerializationUtil.cpp
+++ b/nes-logical-operators/src/Serialization/QueryPlanSerializationUtil.cpp
@@ -12,15 +12,17 @@
     limitations under the License.
 */
 
+#include <Serialization/QueryPlanSerializationUtil.hpp>
+
 #include <functional>
 #include <unordered_map>
 #include <utility>
 #include <vector>
+
 #include <Identifiers/Identifiers.hpp>
 #include <Iterators/BFSIterator.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <Serialization/OperatorSerializationUtil.hpp>
-#include <Serialization/QueryPlanSerializationUtil.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <ErrorHandling.hpp>
 #include <SerializableOperator.pb.h>
@@ -31,8 +33,8 @@ namespace NES
 
 SerializableQueryPlan QueryPlanSerializationUtil::serializeQueryPlan(const LogicalPlan& queryPlan)
 {
-    INVARIANT(queryPlan.rootOperators.size() == 1, "Query plan should currently have only one root operator");
-    auto rootOperator = queryPlan.rootOperators.front();
+    INVARIANT(queryPlan.getRootOperators().size() == 1, "Query plan should currently have only one root operator");
+    auto rootOperator = queryPlan.getRootOperators().front();
 
     SerializableQueryPlan serializableQueryPlan;
     /// Serialize Query Plan operators

--- a/nes-nebuli/src/LegacyOptimizer/LogicalSourceExpansionRule.cpp
+++ b/nes-nebuli/src/LegacyOptimizer/LogicalSourceExpansionRule.cpp
@@ -61,7 +61,7 @@ void LogicalSourceExpansionRule::apply(LogicalPlan& queryPlan) const
             "Parent of source name operator must have exactly one child, the source itself");
 
         auto newParent = parent.withChildren({UnionLogicalOperator{}.withChildren(std::move(expandedSourceOperators))});
-        auto replaceResult = replaceSubtree(queryPlan, parent, newParent);
+        auto replaceResult = replaceSubtree(queryPlan, parent.getId(), newParent);
 
         INVARIANT(
             replaceResult.has_value(),

--- a/nes-nebuli/src/LegacyOptimizer/OriginIdInferencePhase.cpp
+++ b/nes-nebuli/src/LegacyOptimizer/OriginIdInferencePhase.cpp
@@ -74,14 +74,14 @@ void OriginIdInferencePhase::apply(LogicalPlan& queryPlan) const /// NOLINT(read
         {
             assigner = assigner.withInputOriginIds({{OriginId(++originIdCounter)}});
             auto inferredAssigner = assigner.withOutputOriginIds({OriginId(originIdCounter)});
-            auto replaceResult = replaceOperator(queryPlan, assigner, inferredAssigner);
+            auto replaceResult = replaceOperator(queryPlan, assigner.getId(), inferredAssigner);
             INVARIANT(replaceResult.has_value(), "replaceOperator failed");
             queryPlan = std::move(replaceResult.value());
         }
         else
         {
             auto inferredAssigner = assigner.withOutputOriginIds({OriginId(++originIdCounter)});
-            auto replaceResult = replaceOperator(queryPlan, assigner, inferredAssigner);
+            auto replaceResult = replaceOperator(queryPlan, assigner.getId(), inferredAssigner);
             INVARIANT(replaceResult.has_value(), "replaceOperator failed");
             queryPlan = std::move(replaceResult.value());
         }
@@ -89,11 +89,11 @@ void OriginIdInferencePhase::apply(LogicalPlan& queryPlan) const /// NOLINT(read
 
     /// propagate origin ids through the complete query plan
     std::vector<LogicalOperator> newSinks;
-    newSinks.reserve(queryPlan.rootOperators.size());
-    for (auto& sinkOperator : queryPlan.rootOperators)
+    newSinks.reserve(queryPlan.getRootOperators().size());
+    for (auto& sinkOperator : queryPlan.getRootOperators())
     {
         newSinks.push_back(propagateOriginIds(sinkOperator));
     }
-    queryPlan.rootOperators = newSinks;
+    queryPlan = queryPlan.withRootOperators(newSinks);
 }
 }

--- a/nes-nebuli/src/LegacyOptimizer/RedundantProjectionRemovalRule.cpp
+++ b/nes-nebuli/src/LegacyOptimizer/RedundantProjectionRemovalRule.cpp
@@ -38,7 +38,7 @@ void RedundantProjectionRemovalRule::apply(LogicalPlan& queryPlan) const ///NOLI
                  }))
     {
         auto child = projectionOp.getChildren().front();
-        auto replaceResult = replaceSubtree(queryPlan, projectionOp, child);
+        auto replaceResult = replaceSubtree(queryPlan, projectionOp.id, child);
         INVARIANT(replaceResult.has_value(), "Failed to replace projection with its child");
         queryPlan = std::move(replaceResult.value());
     }

--- a/nes-nebuli/src/LegacyOptimizer/RedundantUnionRemovalRule.cpp
+++ b/nes-nebuli/src/LegacyOptimizer/RedundantUnionRemovalRule.cpp
@@ -31,7 +31,7 @@ void RedundantUnionRemovalRule::apply(LogicalPlan& queryPlan) const ///NOLINT(re
              | std::views::filter([](const auto& op) { return op.getChildren().size() == 1; }))
     {
         auto child = unionOperator.getChildren().front();
-        auto replaceResult = replaceSubtree(queryPlan, unionOperator, child);
+        auto replaceResult = replaceSubtree(queryPlan, unionOperator.id, child);
         INVARIANT(replaceResult.has_value(), "Failed to replace union with its child");
         queryPlan = std::move(replaceResult.value());
     }

--- a/nes-nebuli/src/LegacyOptimizer/SourceInferencePhase.cpp
+++ b/nes-nebuli/src/LegacyOptimizer/SourceInferencePhase.cpp
@@ -57,7 +57,7 @@ void SourceInferencePhase::apply(LogicalPlan& queryPlan) const
                     throw CannotInferSchema("Could not rename non-existing field: {}", field.name);
                 }
             });
-        auto result = replaceOperator(queryPlan, source, source.withSchema(schema));
+        auto result = replaceOperator(queryPlan, source.id, source.withSchema(schema));
         INVARIANT(result.has_value(), "replaceOperator failed");
         queryPlan = std::move(*result);
     }

--- a/nes-nebuli/src/LegacyOptimizer/TypeInferencePhase.cpp
+++ b/nes-nebuli/src/LegacyOptimizer/TypeInferencePhase.cpp
@@ -47,12 +47,12 @@ static LogicalOperator propagateSchema(const LogicalOperator& op)
 void TypeInferencePhase::apply(LogicalPlan& queryPlan) const /// NOLINT(readability-convert-member-functions-to-static)
 {
     std::vector<LogicalOperator> newRoots;
-    for (const auto& sink : queryPlan.rootOperators)
+    for (const auto& sink : queryPlan.getRootOperators())
     {
         const LogicalOperator inferredRoot = propagateSchema(sink);
         newRoots.push_back(inferredRoot);
     }
-    queryPlan.rootOperators = newRoots;
+    queryPlan = queryPlan.withRootOperators(newRoots);
 }
 
 }

--- a/nes-nebuli/src/YAML/YAMLBinder.cpp
+++ b/nes-nebuli/src/YAML/YAMLBinder.cpp
@@ -207,7 +207,7 @@ BoundQueryConfig YAMLBinder::parseAndBind(std::istream& inputStream)
     {
         auto [queryString, unboundSinks, unboundLogicalSources, unboundPhysicalSources] = YAML::Load(inputStream).as<QueryConfig>();
         plan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString(queryString);
-        const auto sinkOperators = plan.rootOperators;
+        const auto sinkOperators = plan.getRootOperators();
         if (sinkOperators.size() != 1)
         {
             throw QueryInvalid(
@@ -230,7 +230,7 @@ BoundQueryConfig YAMLBinder::parseAndBind(std::istream& inputStream)
                 sinkOperator->sinkName,
                 fmt::join(std::ranges::views::keys(sinks), ","));
         }
-        plan.rootOperators.at(0) = *sinkOperator;
+        plan = plan.withRootOperators({*sinkOperator});
         logicalSources = bindRegisterLogicalSources(unboundLogicalSources);
         physicalSources = bindRegisterPhysicalSources(unboundPhysicalSources);
         return config;

--- a/nes-query-optimizer/include/Traits/OriginIdAssignerTrait.hpp
+++ b/nes-query-optimizer/include/Traits/OriginIdAssignerTrait.hpp
@@ -14,20 +14,14 @@
 
 #pragma once
 
-#include <string>
-#include <typeinfo>
 #include <Traits/Trait.hpp>
-#include <SerializableTrait.pb.h>
 
 namespace NES
 {
 
 /// Marks an operator as creator of new origin ids
-struct OriginIdAssignerTrait final : TraitConcept
+struct OriginIdAssignerTrait final : DefaultTrait<OriginIdAssignerTrait>
 {
-    bool operator==(const TraitConcept& other) const override;
-    [[nodiscard]] const std::type_info& getType() const override;
-    [[nodiscard]] SerializableTrait serialize() const override;
 };
 
 }

--- a/nes-query-optimizer/src/Phases/LowerToPhysicalOperators.cpp
+++ b/nes-query-optimizer/src/Phases/LowerToPhysicalOperators.cpp
@@ -89,8 +89,8 @@ PhysicalPlan apply(const LogicalPlan& queryPlan, const QueryExecutionConfigurati
 {
     const auto registryArgument = RewriteRuleRegistryArguments{conf};
     std::vector<std::shared_ptr<PhysicalOperatorWrapper>> newRootOperators;
-    newRootOperators.reserve(queryPlan.rootOperators.size());
-    for (const auto& logicalRoot : queryPlan.rootOperators)
+    newRootOperators.reserve(queryPlan.getRootOperators().size());
+    for (const auto& logicalRoot : queryPlan.getRootOperators())
     {
         newRootOperators.push_back(lowerOperatorRecursively(logicalRoot, registryArgument));
     }

--- a/nes-query-optimizer/src/Traits/OriginIdAssignerTrait.cpp
+++ b/nes-query-optimizer/src/Traits/OriginIdAssignerTrait.cpp
@@ -12,28 +12,9 @@
     limitations under the License.
 */
 
-#include <typeinfo>
 #include <Traits/OriginIdAssignerTrait.hpp>
-#include <Traits/Trait.hpp>
-#include <SerializableTrait.pb.h>
 
 namespace NES
 {
-
-bool OriginIdAssignerTrait::operator==(const TraitConcept& other) const
-{
-    return typeid(other) == typeid(*this);
-}
-
-const std::type_info& OriginIdAssignerTrait::getType() const
-{
-    return typeid(this);
-}
-
-SerializableTrait OriginIdAssignerTrait::serialize() const
-{
-    SerializableTrait trait;
-    trait.set_trait_type(getType().name());
-    return trait;
-}
+/// Required for plugin registration, no implementation necessary
 }


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This pull request enhances the logical operator representations. 
The changes will be used extensively by the upcoming distributed PR.
The change list is as follows:

**LogicalPlan**:
- Change visibility of `rootOperators` to private
- Change `replaceOperator` and `replaceSubtree` to take the id of the operator to replace for more flexibility
- Introduce `getOperatorById` to retrieve an operator
- Support immutable access patterns by adding `withRootOperators` and `withAdditionalRoots` that create a new plan
- Add convenience free function `addRootOperators` to add additional roots without affecting existing ones

**LogicalOperator**:
- Support dynamic traits by introducing a `TraitSet` to each logical operator, where optimizer passes can add traits to at the time of query planning
- Add  `addTraits` free function that returns new logical operators that adds traits to the given operator

**Trait**:
- Change `TraitSet` to use an actual `std::unordered_set` such that we avoid adding duplicate traits
- Add `DefaultTrait` that can be extended by marker traits (traits without custom data). This avoids having to implement the 4 methods (`hash`, `operator==`, `getType`, and `serialize`) for them.

## Verifying this change
This change is tested by
- Additional unit tests in `LogicalPlanTest`

## What components does this pull request potentially affect?
- LogicalOperators
- QueryOptimizer (trait extended)
- Nebuli (root operator visibility)
- Systests (root operator visibility)

## Issue Closed by this pull request:
This PR closes #922.
