### PR TITLE
Removed double insertion of runningQuery in ranQueries vector in runQueriesAndBenchmark

### DIFF
--- a/nes-systests/systest/src/SystestRunner.cpp
+++ b/nes-systests/systest/src/SystestRunner.cpp
@@ -309,7 +309,6 @@ std::vector<RunningQuery> runQueriesAndBenchmark(
             = fmt::format(" in {} ({})", ranQueries.back()->getElapsedTime(), ranQueries.back()->getThroughput());
         printQueryResultToStdOut(
             *ranQueries.back(), errorMessage.value_or(""), queryFinishedCounter, totalQueries, queryPerformanceMessage);
-        ranQueries.emplace_back(ranQueries.back());
 
         queryFinishedCounter += 1;
     }


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
The pull request fixes an oversight where each runningQuery is inserted twice into the ranQueries vector in runQueriesAndBenchmark (SystestRunner).

As a result of this, two identical results for every ran query were published to the Conbench server.

## Verifying this change
This change is tested by

- systest with -b still produces the desired BenchmarkResults.json, but without duplicates.

## What components does this pull request potentially affect?

- nes-systests

## Issue Closed by this pull request:
This PR closes #1016 
