### PR TITLE
fix(Systest): serializeExecutionResults to NAN if no value in optional

### DIFF
--- a/nes-systests/systest/src/SystestRunner.cpp
+++ b/nes-systests/systest/src/SystestRunner.cpp
@@ -227,8 +227,12 @@ std::vector<RunningQuery> serializeExecutionResults(const std::vector<RunningQue
         resultJson.push_back({
             {"query name", queryRan.systestQuery.testName},
             {"time", executionTimeInSeconds},
-            {"bytesPerSecond", static_cast<double>(queryRan.bytesProcessed.value_or(NAN)) / executionTimeInSeconds},
-            {"tuplesPerSecond", static_cast<double>(queryRan.tuplesProcessed.value_or(NAN)) / executionTimeInSeconds},
+            {"bytesPerSecond",
+             queryRan.bytesProcessed.has_value() ? static_cast<double>(queryRan.bytesProcessed.value()) / executionTimeInSeconds
+                                                 : std::numeric_limits<double>::quiet_NaN()},
+            {"tuplesPerSecond",
+             queryRan.tuplesProcessed.has_value() ? static_cast<double>(queryRan.tuplesProcessed.value()) / executionTimeInSeconds
+                                                  : std::numeric_limits<double>::quiet_NaN()},
         });
     }
     return failedQueries;


### PR DESCRIPTION
As `bytesProcessed` is an uint64_t if the optional has no value this would result in the defined NAN macro being cast to uint64_t and then being cast to double. The end result not being a NAN double. The same for `tuplesProcessed`