### PR TITLE
feat(Systest): enable differential testing

### DIFF
--- a/nes-plugins/Sources/TCPSource/TCPSource.cpp
+++ b/nes-plugins/Sources/TCPSource/TCPSource.cpp
@@ -127,8 +127,8 @@ bool TCPSource::tryToConnect(const addrinfo* result, const int flags)
         {
             close();
             /// if connection was unsuccessful, throw an exception with context using errno
-            strerror_r(errno, errBuffer.data(), errBuffer.size());
-            throw CannotOpenSource("Could not connect to: {}:{}. {}", socketHost, socketPort, errBuffer.data());
+            const auto strerrorResult = strerror_r(errno, errBuffer.data(), errBuffer.size());
+            throw CannotOpenSource("Could not connect to: {}:{}. {}", socketHost, socketPort, strerrorResult);
         }
 
         /// Set the timeout for the connect attempt
@@ -144,8 +144,8 @@ bool TCPSource::tryToConnect(const addrinfo* result, const int flags)
             /// Timeout or error
             errno = ETIMEDOUT;
             close();
-            strerror_r(errno, errBuffer.data(), errBuffer.size());
-            throw CannotOpenSource("Could not connect to: {}:{}. {}", socketHost, socketPort, errBuffer.data());
+            const auto strerrorResult = strerror_r(errno, errBuffer.data(), errBuffer.size());
+            throw CannotOpenSource("Could not connect to: {}:{}. {}", socketHost, socketPort, strerrorResult);
         }
 
         /// Check if connect succeeded
@@ -155,8 +155,8 @@ bool TCPSource::tryToConnect(const addrinfo* result, const int flags)
         {
             errno = error;
             close();
-            strerror_r(errno, errBuffer.data(), errBuffer.size());
-            throw CannotOpenSource("Could not connect to: {}:{}. {}", socketHost, socketPort, errBuffer.data());
+            const auto strerrorResult = strerror_r(errno, errBuffer.data(), errBuffer.size());
+            throw CannotOpenSource("Could not connect to: {}:{}. {}", socketHost, socketPort, strerrorResult);
         }
     }
     return true;

--- a/nes-systests/bug/NotInJoinPredicate.test.disabled
+++ b/nes-systests/bug/NotInJoinPredicate.test.disabled
@@ -1,0 +1,30 @@
+# name: bug/NotInJoinPredicate.test
+# description: Moved from 'differential/JoinEquivalence.test'. Currently we cannot handle NOT in join predicates.
+# groups: [Differential, Join]
+
+Source stream1 UINT64 key1_s1 UINT64 key2_s1 UINT64 ts GENERATOR seed 1, max_runtime_ms 1000, stop_generator_when_sequence_finishes ALL
+key1_s1 SEQUENCE UINT64 1 5 1
+key2_s1 SEQUENCE UINT64 10 14 1
+ts SEQUENCE UINT64 1000 1800 200
+
+Source stream2 UINT64 key1_s2 UINT64 key2_s2 UINT64 id2 UINT64 value2 UINT64 ts UINT64 timestamp GENERATOR seed 2, max_runtime_ms 1000, stop_generator_when_sequence_finishes ALL
+key1_s2 SEQUENCE UINT64 1 5 1
+key2_s2 SEQUENCE UINT64 10 14 1
+id2 SEQUENCE UINT64 1 5 1
+value2 SEQUENCE UINT64 100 140 10
+ts SEQUENCE UINT64 1000 1800 200
+timestamp SEQUENCE UINT64 1000 1800 200
+
+SINK sinkStream1Stream2 UINT64 stream1stream2$start UINT64 stream1stream2$end UINT64 stream1$key1_s1 UINT64 stream1$key2_s1 UINT64 stream1$ts UINT64 stream2$key1_s2 UINT64 stream2$key2_s2 UINT64 stream2$id2 UINT64 stream2$value2 UINT64 stream2$ts UINT64 stream2$timestamp
+
+SELECT * FROM (SELECT * FROM stream1)
+INNER JOIN (SELECT * FROM stream2)
+  ON key1_s1 == key1_s2 AND key2_s1 == key2_s2
+  WINDOW TUMBLING (ts, size 1 sec)
+INTO sinkStream1Stream2;
+====
+SELECT * FROM (SELECT * FROM stream1)
+INNER JOIN (SELECT * FROM stream2)
+  ON NOT (key1_s1 != key1_s2 OR key2_s1 != key2_s2)
+  WINDOW TUMBLING (ts, size 1 sec)
+INTO sinkStream1Stream2;

--- a/nes-systests/differential/AggregationEquiValence.test
+++ b/nes-systests/differential/AggregationEquiValence.test
@@ -1,0 +1,27 @@
+# name: differential/AggregationEquivalence.test
+# description: Ensure differential queries agree for logically equivalent aggregation
+# groups: [Differential, Aggregation]
+
+Source stream UINT64 id UINT64 value UINT64 timestamp GENERATOR seed 1, max_runtime_ms 1000, stop_generator_when_sequence_finishes ALL
+id SEQUENCE UINT64 1 5 1
+value SEQUENCE UINT64 10 50 10
+timestamp SEQUENCE UINT64 0 20000 5000
+
+SINK sinkStream UINT64 stream$start UINT64 stream$end UINT64 stream$id UINT64 stream$sumValue
+
+SELECT start, end, id, SUM(value) AS sumValue
+FROM (
+  SELECT id, start, SUM(value) AS value
+  FROM stream
+  GROUP BY id
+  WINDOW TUMBLING (timestamp, size 5 sec)
+)
+GROUP BY id
+WINDOW SLIDING (start, size 10 sec, advance by 5 sec)
+INTO sinkStream;
+====
+SELECT start, end, id, SUM(value) AS sumValue
+FROM stream
+GROUP BY id
+WINDOW SLIDING (timestamp, size 10 sec, advance by 5 sec)
+INTO sinkStream;

--- a/nes-systests/differential/JoinEquivalence.test
+++ b/nes-systests/differential/JoinEquivalence.test
@@ -7,6 +7,14 @@ id SEQUENCE UINT64 1 5 1
 value SEQUENCE UINT64 50 90 10
 timestamp SEQUENCE UINT64 1000 1800 200
 
+Source stream2 UINT64 key1_s2 UINT64 key2_s2 UINT64 id2 UINT64 value2 UINT64 ts UINT64 timestamp GENERATOR seed 2, max_runtime_ms 1000, stop_generator_when_sequence_finishes ALL
+key1_s2 SEQUENCE UINT64 1 5 1
+key2_s2 SEQUENCE UINT64 10 14 1
+id2 SEQUENCE UINT64 1 5 1
+value2 SEQUENCE UINT64 100 140 10
+ts SEQUENCE UINT64 1000 1800 200
+timestamp SEQUENCE UINT64 1000 1800 200
+
 Source stream4 UINT64 id4 UINT64 value4 UINT64 timestamp GENERATOR seed 4, max_runtime_ms 1000, stop_generator_when_sequence_finishes ALL
 id4 SEQUENCE UINT64 1 5 1
 value4 SEQUENCE UINT64 200 240 10

--- a/nes-systests/differential/JoinEquivalence.test
+++ b/nes-systests/differential/JoinEquivalence.test
@@ -1,0 +1,64 @@
+# name: differential/JoinEquivalence.test
+# description: Ensure differential queries agree for logically equivalent joins
+# groups: [Differential, Join]
+
+Source stream UINT64 id UINT64 value UINT64 timestamp GENERATOR seed 3, max_runtime_ms 1000, stop_generator_when_sequence_finishes ALL
+id SEQUENCE UINT64 1 5 1
+value SEQUENCE UINT64 50 90 10
+timestamp SEQUENCE UINT64 1000 1800 200
+
+Source stream4 UINT64 id4 UINT64 value4 UINT64 timestamp GENERATOR seed 4, max_runtime_ms 1000, stop_generator_when_sequence_finishes ALL
+id4 SEQUENCE UINT64 1 5 1
+value4 SEQUENCE UINT64 200 240 10
+timestamp SEQUENCE UINT64 1000 1800 200
+
+Source stream4_1 UINT64 id4_1 UINT64 value4_1 UINT64 timestamp GENERATOR seed 5, max_runtime_ms 1000, stop_generator_when_sequence_finishes ALL
+id4_1 SEQUENCE UINT64 1 5 1
+value4_1 SEQUENCE UINT64 300 340 10
+timestamp SEQUENCE UINT64 1000 1800 200
+
+SINK sinkStreamStream2Stream4Stream4_1 UINT64 streamstream2stream4stream4_1$start UINT64 streamstream2stream4stream4_1$end UINT64 streamstream2stream4$start UINT64 streamstream2stream4$end UINT64 streamstream2$start UINT64 streamstream2$end UINT64 stream$id UINT64 stream$value UINT64 stream$timestamp UINT64 stream2$key1_s2 UINT64 stream2$key2_s2 UINT64 stream2$id2 UINT64 stream2$value2 UINT64 stream2$ts UINT64 stream2$timestamp UINT64 stream4$id4 UINT64 stream4$value4 UINT64 stream4$timestamp UINT64 stream4_1$id4_1 UINT64 stream4_1$value4_1 UINT64 stream4_1$timestamp
+
+SELECT * FROM (SELECT * FROM stream)
+  INNER JOIN (SELECT * FROM stream2)
+    ON id = id2
+    WINDOW SLIDING (timestamp, size 1 sec, advance by 500 ms)
+  INNER JOIN (SELECT * FROM stream4)
+    ON id = id4
+    WINDOW SLIDING (timestamp, size 1 sec, advance by 500 ms)
+  INNER JOIN (SELECT * FROM stream4_1)
+    ON id = id4_1
+    WINDOW SLIDING (timestamp, size 1 sec, advance by 500 ms)
+INTO sinkStreamStream2Stream4Stream4_1;
+====
+SELECT * FROM (SELECT * FROM stream)
+  INNER JOIN (SELECT * FROM stream2)
+    ON NOT (id != id2)
+    WINDOW SLIDING (timestamp, size 1 sec, advance by 500 ms)
+  INNER JOIN (SELECT * FROM stream4)
+    ON NOT (id != id4)
+    WINDOW SLIDING (timestamp, size 1 sec, advance by 500 ms)
+  INNER JOIN (SELECT * FROM stream4_1)
+    ON NOT (id != id4_1)
+    WINDOW SLIDING (timestamp, size 1 sec, advance by 500 ms)
+INTO sinkStreamStream2Stream4Stream4_1;
+
+
+Source streamCSV UINT64 id UINT64 value UINT64 timestamp FILE
+TESTDATA/small/stream.csv
+
+Source streamCSV2 UINT64 id2 UINT64 value2 UINT64 timestamp FILE
+TESTDATA/small/stream2.csv
+
+SINK sinkStreamStream2 UINT64 streamCSVstreamCSV2$start UINT64 streamCSVstreamCSV2$end UINT64 streamCSV$id UINT64 streamCSV$value UINT64 streamCSV$timestamp UINT64 streamCSV2$id2 UINT64 streamCSV2$value2 UINT64 streamCSV2$timestamp
+
+SELECT *
+FROM (SELECT * FROM streamCSV) INNER JOIN (SELECT * FROM streamCSV2) ON (id = id2 AND value = value2) WINDOW TUMBLING (timestamp, size 1 sec)
+WHERE value < UINT64(15)
+INTO sinkStreamStream2;
+====
+SELECT *
+FROM
+    (SELECT * FROM (SELECT * FROM streamCSV) INNER JOIN (SELECT * FROM streamCSV2) ON (id = id2 AND value = value2) WINDOW TUMBLING (timestamp, size 1 sec))
+WHERE value < UINT64(15)
+INTO sinkStreamStream2;

--- a/nes-systests/differential/ProjectionEquivalence.test
+++ b/nes-systests/differential/ProjectionEquivalence.test
@@ -1,0 +1,14 @@
+# name: differential/ProjectionEquivalence.test
+# description: Validate differential queries produce the same results for equivalent projections.
+# groups: [Differential, Projection]
+
+Source stream UINT64 id UINT64 value UINT64 timestamp GENERATOR seed 1, max_runtime_ms 1000, stop_generator_when_sequence_finishes ALL
+id SEQUENCE UINT64 1 3 1
+value SEQUENCE UINT64 10 30 10
+timestamp SEQUENCE UINT64 1000 1002 1
+
+SINK projectionSink UINT64 out_id UINT64 out_value UINT64 out_timestamp
+
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp FROM stream INTO projectionSink;
+====
+SELECT stream.id AS out_id, stream.value AS out_value, stream.timestamp AS out_timestamp FROM stream INTO projectionSink;

--- a/nes-systests/differential/SelectionEquivalence.test
+++ b/nes-systests/differential/SelectionEquivalence.test
@@ -1,0 +1,171 @@
+# name: differential/SelectionEquivalence.test
+# description: Ensure differential queries agree for logically equivalent selections
+# groups: [Differential, Selection]
+
+Source stream UINT64 id UINT64 value UINT64 timestamp GENERATOR seed 1, max_runtime_ms 1000, stop_generator_when_sequence_finishes ALL
+id SEQUENCE UINT64 1 2001 10
+value SEQUENCE UINT64 0 1200 6
+timestamp SEQUENCE UINT64 0 1000000 5000
+
+SINK selectionSink UINT64 out_id UINT64 out_value UINT64 out_timestamp
+
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp FROM stream WHERE value >= UINT64(10) INTO selectionSink;
+====
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp FROM stream WHERE NOT (value < UINT64(10)) INTO selectionSink;
+
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE value >= UINT64(10) AND value <= UINT64(100)
+INTO selectionSink;
+====
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE NOT (value < UINT64(10) OR value > UINT64(100))
+INTO selectionSink;
+
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE value <= UINT64(20) OR value >= UINT64(80)
+INTO selectionSink;
+====
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE NOT (value > UINT64(20) AND value < UINT64(80))
+INTO selectionSink;
+
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE value != UINT64(42)
+INTO selectionSink;
+====
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE value < UINT64(42) OR value > UINT64(42)
+INTO selectionSink;
+
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE value >= UINT64(10) AND (id >= UINT64(1000) OR timestamp >= UINT64(1000000000))
+INTO selectionSink;
+====
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE (value >= UINT64(10) AND id >= UINT64(1000))
+   OR (value >= UINT64(10) AND timestamp >= UINT64(1000000000))
+INTO selectionSink;
+
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE (value >= UINT64(10) AND value <= UINT64(50))
+  AND (id >= UINT64(100) OR timestamp >= UINT64(1000000))
+INTO selectionSink;
+====
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE NOT (
+    (value < UINT64(10) OR value > UINT64(50))
+    OR (id < UINT64(100) AND timestamp < UINT64(1000000))
+)
+INTO selectionSink;
+
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE value >= UINT64(90) OR (id >= UINT64(5) AND timestamp >= UINT64(100))
+INTO selectionSink;
+====
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE (value >= UINT64(90) OR id >= UINT64(5))
+  AND (value >= UINT64(90) OR timestamp >= UINT64(100))
+INTO selectionSink;
+
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE value >= UINT64(10)
+INTO selectionSink;
+====
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE (value >= UINT64(10) AND id >= UINT64(100))
+   OR (value >= UINT64(10) AND NOT (id >= UINT64(100)))
+INTO selectionSink;
+
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE value <= UINT64(50)
+INTO selectionSink;
+====
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE value <= UINT64(50) OR (value <= UINT64(50) AND id >= UINT64(1))
+INTO selectionSink;
+
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE (value >= UINT64(10) AND id >= UINT64(100))
+   OR (value < UINT64(10) AND timestamp >= UINT64(1000))
+INTO selectionSink;
+====
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE (value >= UINT64(10) AND id >= UINT64(100))
+   OR (value < UINT64(10) AND timestamp >= UINT64(1000))
+   OR (id >= UINT64(100) AND timestamp >= UINT64(1000))
+INTO selectionSink;
+
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE id <= timestamp
+INTO selectionSink;
+====
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE NOT (id > timestamp)
+INTO selectionSink;
+
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE id != value
+INTO selectionSink;
+====
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE id < value OR id > value
+INTO selectionSink;
+
+
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE (value >= UINT64(100) AND value <= UINT64(200))
+   OR (id >= UINT64(1000) AND id <= UINT64(2000))
+   OR (timestamp >= UINT64(10000) AND timestamp <= UINT64(20000))
+INTO selectionSink;
+====
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE NOT (
+    (value < UINT64(100) OR value > UINT64(200)) AND
+    (id < UINT64(1000) OR id > UINT64(2000)) AND
+    (timestamp < UINT64(10000) OR timestamp > UINT64(20000))
+)
+INTO selectionSink;
+
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE value < UINT64(10) AND value >= UINT64(10)
+INTO selectionSink;
+====
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE id != id
+INTO selectionSink;
+
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE id = id
+INTO selectionSink;
+====
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp
+FROM stream
+WHERE value >= UINT64(0)
+INTO selectionSink;

--- a/nes-systests/systest/include/SystestParser.hpp
+++ b/nes-systests/systest/include/SystestParser.hpp
@@ -46,6 +46,9 @@ enum class TokenType : uint8_t
     QUERY,
     RESULT_DELIMITER,
     ERROR_EXPECTATION,
+    DIFF_LEFT,
+    DIFF_RIGHT,
+    DIFF_END
 };
 
 /// Assures that the number of parsed queries matches the number of parsed results
@@ -151,6 +154,8 @@ public:
     using SystestAttachSourceCallback = std::function<void(SystestAttachSource attachSource)>;
     using SystestSinkCallback = std::function<void(SystestSink&&)>;
     using ErrorExpectationCallback = std::function<void(const ErrorExpectation&, SystestQueryId correspondingQueryId)>;
+    using DifferentialQueryBlockCallback
+        = std::function<void(std::string, std::string, SystestQueryId correspondingQueryId, SystestQueryId diffQueryId)>;
 
     /// Register callbacks to be called when the respective section is parsed
     void registerOnQueryCallback(QueryCallback callback);
@@ -159,6 +164,7 @@ public:
     void registerOnSystestAttachSourceCallback(SystestAttachSourceCallback callback);
     void registerOnSystestSinkCallback(SystestSinkCallback callback);
     void registerOnErrorExpectationCallback(ErrorExpectationCallback callback);
+    void registerOnDifferentialQueryBlockCallback(DifferentialQueryBlockCallback callback);
 
     void parse();
     void parseResultLines();
@@ -183,6 +189,8 @@ private:
     [[nodiscard]] std::vector<std::string> expectTuples(bool ignoreFirst);
     [[nodiscard]] std::filesystem::path expectFilePath();
     [[nodiscard]] std::string expectQuery();
+    [[nodiscard]] std::string expectQuery(const std::unordered_set<TokenType>& stopTokens);
+    [[nodiscard]] std::pair<std::string, std::string> expectDifferentialBlock();
     [[nodiscard]] ErrorExpectation expectError() const;
     [[nodiscard]] std::pair<SystestLogicalSource, std::optional<SystestAttachSource>>
     expectInlineGeneratorSource(SystestLogicalSource& source, const std::vector<std::string>& attachSourceTokens);
@@ -193,6 +201,7 @@ private:
     SystestAttachSourceCallback onAttachSourceCallback;
     SystestSinkCallback onSystestSinkCallback;
     ErrorExpectationCallback onErrorExpectationCallback;
+    DifferentialQueryBlockCallback onDifferentialQueryBlockCallback;
 
     bool firstToken = true;
     size_t currentLine = 0;

--- a/nes-systests/systest/include/SystestParser.hpp
+++ b/nes-systests/systest/include/SystestParser.hpp
@@ -46,9 +46,7 @@ enum class TokenType : uint8_t
     QUERY,
     RESULT_DELIMITER,
     ERROR_EXPECTATION,
-    DIFF_LEFT,
-    DIFF_RIGHT,
-    DIFF_END
+    DIFFERENTIAL
 };
 
 /// Assures that the number of parsed queries matches the number of parsed results
@@ -203,7 +201,10 @@ private:
     ErrorExpectationCallback onErrorExpectationCallback;
     DifferentialQueryBlockCallback onDifferentialQueryBlockCallback;
 
+    std::optional<std::string> lastParsedQuery;
+    std::optional<SystestQueryId> lastParsedQueryId;
     bool firstToken = true;
+    bool shouldRevisitCurrentLine = false;
     size_t currentLine = 0;
     std::vector<std::string> lines;
 };

--- a/nes-systests/systest/include/SystestState.hpp
+++ b/nes-systests/systest/include/SystestState.hpp
@@ -95,6 +95,7 @@ struct SystestQuery
 
     static std::filesystem::path sourceFile(const std::filesystem::path& workingDir, std::string_view testName, uint64_t sourceId);
     [[nodiscard]] std::filesystem::path resultFile() const;
+    [[nodiscard]] std::filesystem::path resultFileForDifferentialQuery() const;
 
     TestName testName;
     SystestQueryId queryIdInFile = INVALID_SYSTEST_QUERY_ID;
@@ -114,13 +115,15 @@ struct SystestQuery
     std::expected<PlanInfo, Exception> planInfoOrException;
     std::variant<std::vector<std::string>, ExpectedError> expectedResultsOrExpectedError;
     std::shared_ptr<const std::vector<std::jthread>> additionalSourceThreads;
+    std::optional<LogicalPlan> differentialQueryPlan;
 };
 
 struct RunningQuery
 {
     SystestQuery systestQuery;
     QueryId queryId = INVALID_QUERY_ID;
-    LocalQueryStatus queryStatus;
+    std::optional<QueryId> differentialQueryPair;
+    LocalQueryStatus queryStatus{};
     std::optional<uint64_t> bytesProcessed{0};
     std::optional<uint64_t> tuplesProcessed{0};
     bool passed = false;

--- a/nes-systests/systest/src/SystestState.cpp
+++ b/nes-systests/systest/src/SystestState.cpp
@@ -84,6 +84,11 @@ std::filesystem::path SystestQuery::resultFile() const
     return resultFile(workingDir, testName, queryIdInFile);
 }
 
+std::filesystem::path SystestQuery::resultFileForDifferentialQuery() const
+{
+    return resultFile(workingDir, testName + "differential", queryIdInFile);
+}
+
 TestFileMap discoverTestsRecursively(const std::filesystem::path& path, const std::optional<std::string>& fileExtension)
 {
     TestFileMap testFiles;
@@ -281,7 +286,7 @@ std::chrono::duration<double> RunningQuery::getElapsedTime() const
     INVARIANT(queryId != INVALID_QUERY_ID, "QueryId should not be invalid");
 
     const auto stop = queryStatus.metrics.stop;
-    const auto running = queryStatus.metrics.stop;
+    const auto running = queryStatus.metrics.running;
     INVARIANT(stop.has_value() && running.has_value(), "Query {} has no timestamps attached", queryId);
     return std::chrono::duration_cast<std::chrono::duration<double>>(stop.value() - running.value());
 }

--- a/nes-systests/systest/tests/SystestParserInvalidTestFilesTests.cpp
+++ b/nes-systests/systest/tests/SystestParserInvalidTestFilesTests.cpp
@@ -106,4 +106,22 @@ TEST_F(SystestParserInvalidTestFilesTest, InvalidTokenTest)
     ASSERT_EXCEPTION_ERRORCODE({ parser.parse(); }, ErrorCode::SLTUnexpectedToken)
 }
 
+TEST_F(SystestParserInvalidTestFilesTest, InvalidDifferentialTest)
+{
+    const auto* const filename = SYSTEST_DATA_DIR "invalid_differential.dummy";
+
+    SystestParser parser{};
+    parser.registerOnSystestLogicalSourceCallback(
+        [](const SystestParser::SystestLogicalSource&)
+        {
+            /// nop
+        });
+    parser.registerOnQueryCallback([&](const std::string&, SystestQueryId) { /* nop, ensure parsing*/ });
+    parser.registerOnDifferentialQueryBlockCallback(
+        [](std::string, std::string, SystestQueryId, SystestQueryId) { /* nop, ensure parsing*/ });
+
+    ASSERT_TRUE(parser.loadFile(filename));
+    ASSERT_EXCEPTION_ERRORCODE({ parser.parse(); }, ErrorCode::SLTUnexpectedToken)
+}
+
 }

--- a/nes-systests/systest/tests/SystestRunnerTest.cpp
+++ b/nes-systests/systest/tests/SystestRunnerTest.cpp
@@ -78,7 +78,8 @@ NES::Systest::SystestQuery makeQuery(
         .queryDefinition = "SELECT * FROM test",
         .planInfoOrException = planInfoOrException,
         .expectedResultsOrExpectedError = std::move(expected),
-        .additionalSourceThreads = std::make_shared<std::vector<std::jthread>>()};
+        .additionalSourceThreads = std::make_shared<std::vector<std::jthread>>(),
+        .differentialQueryPlan = std::nullopt};
 }
 }
 

--- a/nes-systests/systest/tests/testdata/differential.dummy
+++ b/nes-systests/systest/tests/testdata/differential.dummy
@@ -1,0 +1,22 @@
+# name: differential_correct.dummy
+# description: Test file for differential query parsing.
+# groups: [Parser]
+
+# This test case verifies that the parser can correctly distinguish
+# between a main query and a differential query, which is provided
+# instead of a result set.
+
+Source stream INT64 id INT64 value INT64 timestamp INLINE
+5,1,1000
+10,1,1001
+15,1,1002
+20,2,2000
+25,19,19000
+30,20,20000
+35,21,21000
+
+SINK streamSink INT64 id INT64 stream$value INT64 stream$timestamp
+
+SELECT id * UINT32(10) AS id, value, timestamp FROM stream INTO streamSink
+====
+SELECT id * UINT32(2) * UINT32(5) AS id, value, timestamp FROM stream INTO streamSink

--- a/nes-systests/systest/tests/testdata/invalid_differential.dummy
+++ b/nes-systests/systest/tests/testdata/invalid_differential.dummy
@@ -1,0 +1,20 @@
+# name: invalid_differential.dummy
+# description: Test file for differential query parsing.
+# groups: [Parser]
+
+# Invalid because of legacy differential token
+
+Source stream INT64 id INT64 value INT64 timestamp INLINE
+5,1,1000
+10,1,1001
+15,1,1002
+20,2,2000
+25,19,19000
+30,20,20000
+35,21,21000
+
+SINK streamSink INT64 id INT64 stream$value INT64 stream$timestamp
+
+SELECT id * UINT32(10) AS id, value, timestamp FROM stream INTO streamSink
+DIFFERENTIAL
+SELECT id * UINT32(5) * UINT32(2) AS id, value, timestamp FROM stream INTO streamSink


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This pull request adds differential testing support to our systests, i.e. running two semantically equivalent queries for a certain amount of time and check for equivalent results.

Example Syntax:
```SQL
SELECT id * UINT32(10) AS id, value, timestamp FROM stream INTO streamSink
====
SELECT id * UINT32(2) * UINT32(5) AS id, value, timestamp FROM stream INTO streamSink
```

- added ability for SystestQueries to store an additional optional LogicalPlan for the second part of the differential query
- added `DIFFERENTIAL` token to avoid confusion with empty result fields for certain existing tests


## Verifying this change
This change is tested by
- InvalidDifferentialTest in SystestParserInvalidTestFilesTests.cpp using invalid_differential.dummy
- testDifferentialQueryCallbackFromFile in SystestParserTests.cpp using differential.dummy

## What components does this pull request potentially affect?
- systest

## Documentation
- Valid syntax can be derived from differential.dummy, No further documentation provided.

## Issue Closed by this pull request:

This PR closes #836
