### PR TITLE
Uploads code cov on merge

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -5,6 +5,25 @@ on:
     types: [ closed ]
 
 jobs:
+  get-dev-images:
+    if: github.event.pull_request.merged == true
+    uses: ./.github/workflows/get_dev_images.yml
+    secrets: inherit
+    with:
+      branch-name: ${{ github.head_ref }}
+      ref: ${{ github.event.pull_request.head.sha }}
+
+  run_code_coverage:
+    if: github.event.pull_request.merged == true
+    needs: [ get-dev-images ]
+    name: "Run Code Coverage"
+    uses: ./.github/workflows/code_coverage.yml
+    with:
+      head_sha: ${{ github.event.pull_request.head.sha }}
+      dev_image_tag: ${{ needs.get-dev-images.outputs.image-tag }}
+      number_of_commits: ${{ github.event.pull_request.commits }}
+    secrets: inherit
+
   check-and-update-development-images:
     # This job is executed when a PR is merged into the main branch.
     # If changes to the dependencies are detected we update the `latest`


### PR DESCRIPTION
Currently, gh will change the commit before merging into the main
branch, which causes the hash to change. This prevents codecov from
reusing the codecov of the PR as the code cov of the new main branch

## Purpose of the Change and Brief Change Log

Aparently gh changes the commit after clicking the rebase and merge button.
This causes code cov to not find the new commit hash of the new main branch.

This PR introduces a fix by rerunning the coverage upload after merging into
the main branch.

