### PR TITLE
fix(systest): large scale data path

### DIFF
--- a/nes-systests/systest/CMakeLists.txt
+++ b/nes-systests/systest/CMakeLists.txt
@@ -80,7 +80,7 @@ if (ENABLE_LARGE_TESTS)
     ExternalData_Add_Test(test-data
             NAME systest_large
             # currently, 4 worker threads perform the best on the large systests (avoids lock contention on NEXMARK Query 5)
-            COMMAND systest -n 6 --workingDir=${CMAKE_CURRENT_BINARY_DIR}/large_scale --data ${LARGE_DATA} --groups large -- --worker.defaultQueryExecution.executionMode=COMPILER --worker.queryEngine.numberOfWorkerThreads=4 --worker.numberOfBuffersInGlobalBufferManager=200000)
+            COMMAND systest -n 6 --workingDir=${CMAKE_CURRENT_BINARY_DIR}/large_scale --data ${TEST_DATA_PATH} --groups large -- --worker.defaultQueryExecution.executionMode=COMPILER --worker.queryEngine.numberOfWorkerThreads=4 --worker.numberOfBuffersInGlobalBufferManager=200000)
     message(STATUS "Large scale tests enabled")
 endif ()
 


### PR DESCRIPTION
Fixes a wrong path in the cmake for large scale systests.
I am wondering how this passed the CI?