### PR TITLE
fix(yamlbinder): fix binding of sources and sinks

### DIFF
--- a/nes-nebuli/private/YAML/YAMLBinder.hpp
+++ b/nes-nebuli/private/YAML/YAMLBinder.hpp
@@ -62,6 +62,7 @@ struct LogicalSource
 struct PhysicalSource
 {
     std::string logical;
+    std::string type;
     std::unordered_map<std::string, std::string> parserConfig;
     std::unordered_map<std::string, std::string> sourceConfig;
 };


### PR DESCRIPTION
Small hotfix that binds sinks and sources correctly from yaml files now.

One slightly bigger change is that types of physical sources are not in the top-level configuration of them, not in the sourceConfig section anymore.
