### PR TITLE
Clang tidy fixes

### DIFF
--- a/.github/workflows/clang_tidy_full.yml
+++ b/.github/workflows/clang_tidy_full.yml
@@ -33,6 +33,9 @@ jobs:
         run: cmake --build build
       - name: Run clang-tidy
         id: run-clang-tidy
+        # we explicitely set bash to have pipefail
+        # (c.f. https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#exit-codes-and-error-action-preference)
+        shell: bash
         # do not run clang-tidy on generated files, i.e. files from dirs matching .*_generated_src/
         # (c.f. https://stackoverflow.com/a/1240365 for regex explanation)
         run: run-clang-tidy-19 -p build '^(?!.*_generated_src/).+$' 2> /dev/null | tee clang-tidy.log

--- a/nes-common/tests/UnitTests/Util/NonBlockingMonotonicSeqQueueTest.cpp
+++ b/nes-common/tests/UnitTests/Util/NonBlockingMonotonicSeqQueueTest.cpp
@@ -24,7 +24,6 @@
 #include <vector>
 #include <Identifiers/Identifiers.hpp>
 #include <Identifiers/NESStrongType.hpp>
-#include <Sequencing/NonBlockingMonotonicSeqQueue.hpp>
 #include <Sequencing/SequenceData.hpp>
 #include <Time/Timestamp.hpp>
 #include <Util/Logger/LogLevel.hpp>

--- a/nes-configurations/src/Configurations/Descriptor.cpp
+++ b/nes-configurations/src/Configurations/Descriptor.cpp
@@ -21,7 +21,6 @@
 #include <type_traits>
 #include <utility>
 #include <variant>
-#include <Configurations/Descriptor.hpp>
 #include <Configurations/Enums/EnumWrapper.hpp>
 #include <fmt/format.h>
 #include <google/protobuf/json/json.h>

--- a/nes-configurations/src/Configurations/Descriptor.cpp
+++ b/nes-configurations/src/Configurations/Descriptor.cpp
@@ -25,7 +25,7 @@
 #include <fmt/format.h>
 #include <google/protobuf/json/json.h>
 #include <ErrorHandling.hpp>
-#include <ProtobufHelper.hpp> /// NOLINT
+#include <ProtobufHelper.hpp>
 #include <SerializableVariantDescriptor.pb.h>
 
 namespace NES

--- a/nes-data-types/src/DataTypes/TimeUnit.cpp
+++ b/nes-data-types/src/DataTypes/TimeUnit.cpp
@@ -17,7 +17,6 @@
 #include <cstdint>
 #include <ostream>
 #include <string>
-#include <DataTypes/TimeUnit.hpp>
 #include <fmt/format.h>
 
 namespace NES::Windowing

--- a/nes-data-types/src/Serialization/DataTypeSerializationUtil.cpp
+++ b/nes-data-types/src/Serialization/DataTypeSerializationUtil.cpp
@@ -18,7 +18,6 @@
 #include <string>
 #include <vector>
 #include <DataTypes/DataType.hpp>
-#include <Serialization/DataTypeSerializationUtil.hpp>
 #include <magic_enum/magic_enum.hpp>
 #include <SerializableDataType.pb.h>
 

--- a/nes-executable/src/Pipeline.cpp
+++ b/nes-executable/src/Pipeline.cpp
@@ -13,7 +13,6 @@
 */
 #include <Pipeline.hpp>
 
-#include <Pipeline.hpp>
 
 #include <atomic>
 #include <cstdint>

--- a/nes-physical-operators/src/Join/NestedLoopJoin/NLJSlice.cpp
+++ b/nes-physical-operators/src/Join/NestedLoopJoin/NLJSlice.cpp
@@ -20,7 +20,6 @@
 #include <numeric>
 #include <utility>
 #include <Identifiers/Identifiers.hpp>
-#include <Join/NestedLoopJoin/NLJSlice.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Nautilus/Interface/PagedVector/PagedVector.hpp>
 #include <SliceStore/Slice.hpp>

--- a/nes-query-compiler/src/PipelinedQueryPlan.cpp
+++ b/nes-query-compiler/src/PipelinedQueryPlan.cpp
@@ -13,7 +13,6 @@
 */
 #include <PipelinedQueryPlan.hpp>
 
-#include <PipelinedQueryPlan.hpp>
 
 #include <cstddef>
 #include <memory>

--- a/nes-sinks/src/PrintSink.cpp
+++ b/nes-sinks/src/PrintSink.cpp
@@ -24,7 +24,6 @@
 #include <Configurations/ConfigurationsNames.hpp>
 #include <Configurations/Descriptor.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Sinks/PrintSink.hpp>
 #include <Sinks/SinkDescriptor.hpp>
 #include <SinksParsing/CSVFormat.hpp>
 #include <fmt/format.h>

--- a/nes-sinks/src/SinkDescriptor.cpp
+++ b/nes-sinks/src/SinkDescriptor.cpp
@@ -24,7 +24,6 @@
 #include <Configurations/Descriptor.hpp>
 #include <DataTypes/Schema.hpp>
 #include <Serialization/SchemaSerializationUtil.hpp>
-#include <Sinks/SinkDescriptor.hpp>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <ErrorHandling.hpp>

--- a/nes-sinks/src/SinksParsing/CSVFormat.cpp
+++ b/nes-sinks/src/SinksParsing/CSVFormat.cpp
@@ -24,7 +24,6 @@
 #include <DataTypes/Schema.hpp>
 #include <MemoryLayout/MemoryLayout.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <SinksParsing/CSVFormat.hpp>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <magic_enum/magic_enum.hpp>

--- a/nes-sql-parser/src/AntlrSQLQueryParser.cpp
+++ b/nes-sql-parser/src/AntlrSQLQueryParser.cpp
@@ -25,7 +25,6 @@
 #include <Exceptions.h>
 #include <AntlrSQLParser/AntlrSQLQueryPlanCreator.hpp>
 #include <Plans/LogicalPlan.hpp>
-#include <SQLQueryParser/AntlrSQLQueryParser.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <ErrorHandling.hpp>
 

--- a/nes-systests/systest/src/SystestState.cpp
+++ b/nes-systests/systest/src/SystestState.cpp
@@ -55,7 +55,6 @@
 
 #include <DataTypes/DataType.hpp>
 #include <Identifiers/NESStrongType.hpp>
-#include <Sources/SourceCatalog.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <SystestSources/SourceTypes.hpp>
 #include <Util/Logger/Logger.hpp>

--- a/nes-systests/systest/tests/SystestRunnerTest.cpp
+++ b/nes-systests/systest/tests/SystestRunnerTest.cpp
@@ -69,14 +69,14 @@ NES::Systest::SystestQuery makeQuery(
     std::variant<std::vector<std::string>, NES::Systest::ExpectedError> expected)
 {
     return NES::Systest::SystestQuery{
-        "test_query",
-        NES::INVALID<NES::Systest::SystestQueryId>,
-        SYSTEST_DATA_DIR "filter.dummy",
-        NES::SystestConfiguration{}.workingDir.getValue(),
-        "SELECT * FROM test",
-        planInfoOrException,
-        std::move(expected),
-        std::make_shared<std::vector<std::jthread>>()};
+        .testName = "test_query",
+        .queryIdInFile = NES::INVALID<NES::Systest::SystestQueryId>,
+        .testFilePath = SYSTEST_DATA_DIR "filter.dummy",
+        .workingDir = NES::SystestConfiguration{}.workingDir.getValue(),
+        .queryDefinition = "SELECT * FROM test",
+        .planInfoOrException = planInfoOrException,
+        .expectedResultsOrExpectedError = std::move(expected),
+        .additionalSourceThreads = std::make_shared<std::vector<std::jthread>>()};
 }
 }
 


### PR DESCRIPTION
Ensures that clang-tidy violations fail the nightly pipeline and fixes some violations.