### PR TITLE
remove workaround for jdk bug 8345296

### DIFF
--- a/docker/dependency/Development.dockerfile
+++ b/docker/dependency/Development.dockerfile
@@ -10,15 +10,8 @@ RUN apt-get update -y && apt-get install -y \
         lldb-${LLVM_TOOLCHAIN_VERSION} \
         gdb \
         python3-venv \
-        python3-bs4
-
-# install alternative more recent JRE until 21.0.7 is packaged for Noble 24.04
-# then it should be replaced with openjdk-21-jre-headless
-# https://bugs.openjdk.org/browse/JDK-8345296
-RUN wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt-key add - \
-    && echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" > /etc/apt/sources.list.d/adoptium.list \
-    && apt-get update -y \
-    && apt-get install -y temurin-21-jre
+        python3-bs4 \
+        openjdk-21-jre-headless
 
 # The vcpkg port of antlr requires the jar to be available somewhere
 ADD --checksum=sha256:eae2dfa119a64327444672aff63e9ec35a20180dc5b8090b7a6ab85125df4d76 --chmod=744 \


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Install openjdk-21-jre-headless instead of third party version.
This reduces image size, and the workaround is no longer needed since ubuntu is now packing a newer version of openjdk than 2.0.6.

## Verifying this change
Build dev images, build nebula stream, the new jdk version should run without issues.

## What components does this pull request potentially affect?
Dev images.

## Documentation
- The change is reflected in the necessary documentation, e.g., design document, in-code documentation.
- All necessary methods (no getter, setter, or constructor) have a documentation.

## Issue Closed by this pull request:

This PR closes #1060 
