### PR TITLE
fix(Systest): wrong group declaration in source tests

### DIFF
--- a/nes-systests/sources/File_Config.test
+++ b/nes-systests/sources/File_Config.test
@@ -1,5 +1,5 @@
-# name: sources/FileSource.test
-# description: Simple map tests with an add function
+# name: sources/FileConfig.test
+# description: Forwarding queries with and without configurations
 # groups: [Sources]
 
 #==============================

--- a/nes-systests/sources/File_Multiple.test
+++ b/nes-systests/sources/File_Multiple.test
@@ -1,9 +1,6 @@
-# name: sources/FileSource.test
-# description: Simple map tests with an add function
+# name: sources/FileMultiple.test
+# description: Combine two files sources with different input formatter configurations
 # groups: [Sources]
-
-# Description:
-# Combine two files sources with different input formatter configurations
 
 Source combinedSource UINT64 id UINT64 value UINT64 timestamp
 Attach File CSV combinedSource FILE

--- a/nes-systests/sources/Mixed.test
+++ b/nes-systests/sources/Mixed.test
@@ -1,6 +1,6 @@
-# name: projection/Projection.test
-# description: Simple map tests with an add function
-# groups: [Projection]
+# name: sources/Mixed.test
+# description: Mixed sources data forwarding query
+# groups: [Sources]
 
 Source stream UINT64 id UINT64 value UINT64 timestamp
 Attach TCP CSV CONFIG/inputFormatters/csv_pipe_delimiter.yaml stream INLINE

--- a/nes-systests/sources/TCP.test
+++ b/nes-systests/sources/TCP.test
@@ -1,6 +1,6 @@
-# name: projection/Projection.test
-# description: Simple map tests with an add function
-# groups: [Projection]
+# name: sources/TCP.test
+# description: forwarding queries with mixed CSV/TCP sources
+# groups: [Sources]
 
 # Source/Sink for single TCP stream
 Source stream UINT64 id UINT64 value UINT64 timestamp


### PR DESCRIPTION
The groups/descriptions of the source tests in the SLTs are declared wrong.

## Purpose of the Change and Brief Change Log
The change list is as follows:
- Fixing group
- Adding descriptions

## Verifying this change
This change is tested by
- Running systests with `systest --exclude-groups sources` and `systest --groups sources` and observing the correct tests being run

## What components does this pull request potentially affect?
- Systests

## Issue Closed by this pull request:

This PR closes #1062 
