### PR TITLE
fix(SinkLogicalOperator): taking output schema from descriptor

### DIFF
--- a/nes-logical-operators/src/Operators/Sinks/SinkLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Sinks/SinkLogicalOperator.cpp
@@ -161,8 +161,8 @@ std::vector<Schema> SinkLogicalOperator::getInputSchemas() const
 
 Schema SinkLogicalOperator::getOutputSchema() const
 {
-    INVARIANT(!children.empty(), "Logical Sink should have at least one child");
-    return children.at(0).getOutputSchema();
+    INVARIANT(this->sinkDescriptor.has_value(), "Logical Sink must have a valid descriptor (with a schema).");
+    return *this->sinkDescriptor.value().getSchema();
 }
 
 std::vector<std::vector<OriginId>> SinkLogicalOperator::getInputOriginIds() const

--- a/nes-systests/systest/tests/SystestRunnerTest.cpp
+++ b/nes-systests/systest/tests/SystestRunnerTest.cpp
@@ -95,6 +95,9 @@ public:
     }
 
     static void TearDownTestSuite() { NES_DEBUG("Tear down SystestRunnerTest test class."); }
+
+    Sinks::SinkDescriptor dummySinkDescriptor
+        = SinkCatalog{}.addSinkDescriptor("dummySink", Schema{}, "Print", {{"inputFormat", "CSV"}}).value();
 };
 
 class MockQueryManager final : public QueryManager
@@ -139,7 +142,7 @@ TEST_F(SystestRunnerTest, RuntimeFailureWithUnexpectedCode)
     auto testPhysicalSource
         = sourceCatalog.addPhysicalSource(testLogicalSource.value(), "File", {{"filePath", "/dev/null"}}, ParserConfig{});
     auto sourceOperator = SourceDescriptorLogicalOperator{testPhysicalSource.value()}.withOutputOriginIds({OriginId{1}});
-    const LogicalPlan plan{SinkLogicalOperator{}.withChildren({sourceOperator})};
+    const LogicalPlan plan{SinkLogicalOperator{dummySinkDescriptor}.withChildren({sourceOperator})};
 
     const auto result = runQueries(
         {makeQuery(SystestQuery::PlanInfo{.queryPlan = plan, .sourcesToFilePathsAndCounts = {}, .sinkOutputSchema = Schema{}}, {})},
@@ -169,7 +172,7 @@ TEST_F(SystestRunnerTest, MissingExpectedRuntimeError)
     auto testPhysicalSource
         = sourceCatalog.addPhysicalSource(testLogicalSource.value(), "File", {{"filePath", "/dev/null"}}, ParserConfig{});
     auto sourceOperator = SourceDescriptorLogicalOperator{testPhysicalSource.value()}.withOutputOriginIds({OriginId{1}});
-    const LogicalPlan plan{SinkLogicalOperator{}.withChildren({sourceOperator})};
+    const LogicalPlan plan{SinkLogicalOperator{dummySinkDescriptor}.withChildren({sourceOperator})};
 
     const auto result = runQueries(
         {makeQuery(


### PR DESCRIPTION
Prior, 'getOutputSchema()' returned the schema of the first child operator. This could lead to errors, especially in the proof of concept branch for running NES distributed.