### PR TITLE
make folly patch macos compatible

### DIFF
--- a/vcpkg/vcpkg-registry/ports/folly/0001-Folly-Patch.patch
+++ b/vcpkg/vcpkg-registry/ports/folly/0001-Folly-Patch.patch
@@ -24,9 +24,7 @@ Subject: [PATCH] Folly Patch
  CMake/folly-deps.cmake                      |  315 -----
  CMake/libfolly.pc.in                        |   11 -
  CMakeLists.txt                              | 1237 ++++---------------
- cmake/FollyConfigChecks.cmake               |  182 +++
  cmake/config.cmake                          |    5 +
- {CMake => cmake}/folly-config.h.cmake       |   32 +-
  folly/Exception.h                           |   12 +-
  folly/Executor.cpp                          |   13 +-
  folly/Function.h                            |    8 +-
@@ -72,15 +70,12 @@ Subject: [PATCH] Folly Patch
  delete mode 100644 CMake/FindZstd.cmake
  delete mode 100644 CMake/FollyCompilerMSVC.cmake
  delete mode 100644 CMake/FollyCompilerUnix.cmake
- delete mode 100644 CMake/FollyConfigChecks.cmake
  delete mode 100644 CMake/FollyFunctions.cmake
  delete mode 100644 CMake/GenPkgConfig.cmake
  delete mode 100644 CMake/folly-config.cmake.in
  delete mode 100644 CMake/folly-deps.cmake
  delete mode 100644 CMake/libfolly.pc.in
- create mode 100644 cmake/FollyConfigChecks.cmake
  create mode 100644 cmake/config.cmake
- rename {CMake => cmake}/folly-config.h.cmake (74%)
  create mode 100644 folly/stub/logging.h
 
 diff --git a/CMake/FindCython.cmake b/CMake/FindCython.cmake
@@ -936,10 +931,9 @@ index 8dcaf141a..000000000
 -  )
 -endfunction()
 diff --git a/CMake/FollyConfigChecks.cmake b/CMake/FollyConfigChecks.cmake
-deleted file mode 100644
 index 4fec47284..000000000
 --- a/CMake/FollyConfigChecks.cmake
-+++ /dev/null
++++ b/CMake/FollyConfigChecks.cmake
 @@ -1,232 +0,0 @@
 -# Copyright (c) Facebook, Inc. and its affiliates.
 -#
@@ -1173,6 +1167,189 @@ index 4fec47284..000000000
 -    set(FOLLY_GFLAGS_NAMESPACE google)
 -  endif()
 -endif()
++# Copyright (c) Meta Platforms, Inc. and affiliates.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++include(CheckCXXSourceCompiles)
++include(CheckCXXSourceRuns)
++include(CheckFunctionExists)
++include(CheckIncludeFileCXX)
++include(CheckSymbolExists)
++include(CheckTypeSize)
++include(CheckCXXCompilerFlag)
++
++if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
++    CHECK_INCLUDE_FILE_CXX(malloc_np.h FOLLY_USE_JEMALLOC)
++else()
++    CHECK_INCLUDE_FILE_CXX(jemalloc/jemalloc.h FOLLY_USE_JEMALLOC)
++endif()
++
++if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
++    # clang only rejects unknown warning flags if -Werror=unknown-warning-option
++    # is also specified.
++    check_cxx_compiler_flag(
++            -Werror=unknown-warning-option
++            COMPILER_HAS_UNKNOWN_WARNING_OPTION)
++    if (COMPILER_HAS_UNKNOWN_WARNING_OPTION)
++        set(CMAKE_REQUIRED_FLAGS
++                "${CMAKE_REQUIRED_FLAGS} -Werror=unknown-warning-option")
++    endif()
++
++    check_cxx_compiler_flag(-Wshadow-local COMPILER_HAS_W_SHADOW_LOCAL)
++    check_cxx_compiler_flag(
++            -Wshadow-compatible-local
++            COMPILER_HAS_W_SHADOW_COMPATIBLE_LOCAL)
++    if (COMPILER_HAS_W_SHADOW_LOCAL AND COMPILER_HAS_W_SHADOW_COMPATIBLE_LOCAL)
++        set(FOLLY_HAVE_SHADOW_LOCAL_WARNINGS ON)
++        list(APPEND FOLLY_CXX_FLAGS -Wshadow-compatible-local)
++    endif()
++
++    check_cxx_compiler_flag(-Wnoexcept-type COMPILER_HAS_W_NOEXCEPT_TYPE)
++    if (COMPILER_HAS_W_NOEXCEPT_TYPE)
++        list(APPEND FOLLY_CXX_FLAGS -Wno-noexcept-type)
++    endif()
++
++    check_cxx_compiler_flag(
++            -Wnullability-completeness
++            COMPILER_HAS_W_NULLABILITY_COMPLETENESS)
++    if (COMPILER_HAS_W_NULLABILITY_COMPLETENESS)
++        list(APPEND FOLLY_CXX_FLAGS -Wno-nullability-completeness)
++    endif()
++
++    check_cxx_compiler_flag(
++            -Winconsistent-missing-override
++            COMPILER_HAS_W_INCONSISTENT_MISSING_OVERRIDE)
++    if (COMPILER_HAS_W_INCONSISTENT_MISSING_OVERRIDE)
++        list(APPEND FOLLY_CXX_FLAGS -Wno-inconsistent-missing-override)
++    endif()
++
++    check_cxx_compiler_flag(-faligned-new COMPILER_HAS_F_ALIGNED_NEW)
++    if (COMPILER_HAS_F_ALIGNED_NEW)
++        list(APPEND FOLLY_CXX_FLAGS -faligned-new)
++    endif()
++
++    check_cxx_compiler_flag(-fopenmp COMPILER_HAS_F_OPENMP)
++    if (COMPILER_HAS_F_OPENMP)
++        list(APPEND FOLLY_CXX_FLAGS -fopenmp)
++    endif()
++endif()
++
++set(FOLLY_ORIGINAL_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
++string(REGEX REPLACE
++        "-std=(c|gnu)\\+\\+.."
++        ""
++        CMAKE_REQUIRED_FLAGS
++        "${CMAKE_REQUIRED_FLAGS}")
++
++check_symbol_exists(pthread_atfork pthread.h FOLLY_HAVE_PTHREAD_ATFORK)
++
++list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
++check_symbol_exists(accept4 sys/socket.h FOLLY_HAVE_ACCEPT4)
++check_symbol_exists(getrandom sys/random.h FOLLY_HAVE_GETRANDOM)
++check_symbol_exists(preadv sys/uio.h FOLLY_HAVE_PREADV)
++check_symbol_exists(pwritev sys/uio.h FOLLY_HAVE_PWRITEV)
++check_symbol_exists(clock_gettime time.h FOLLY_HAVE_CLOCK_GETTIME)
++check_symbol_exists(pipe2 unistd.h FOLLY_HAVE_PIPE2)
++check_symbol_exists(sendmmsg sys/socket.h FOLLY_HAVE_SENDMMSG)
++check_symbol_exists(recvmmsg sys/socket.h FOLLY_HAVE_RECVMMSG)
++
++check_function_exists(malloc_usable_size FOLLY_HAVE_MALLOC_USABLE_SIZE)
++
++set(CMAKE_REQUIRED_FLAGS "${FOLLY_ORIGINAL_CMAKE_REQUIRED_FLAGS}")
++
++check_cxx_source_compiles("
++  #pragma GCC diagnostic error \"-Wattributes\"
++  extern \"C\" void (*test_ifunc(void))() { return 0; }
++  void func() __attribute__((ifunc(\"test_ifunc\")));
++  int main() { return 0; }"
++        FOLLY_HAVE_IFUNC
++)
++check_cxx_source_runs("
++  int main(int, char**) {
++    char buf[64] = {0};
++    unsigned long *ptr = (unsigned long *)(buf + 1);
++    *ptr = 0xdeadbeef;
++    return (*ptr & 0xff) == 0xef ? 0 : 1;
++  }"
++        FOLLY_HAVE_UNALIGNED_ACCESS
++)
++check_cxx_source_compiles("
++  int main(int argc, char** argv) {
++    unsigned size = argc;
++    char data[size];
++    return 0;
++  }"
++        FOLLY_HAVE_VLA
++)
++check_cxx_source_runs("
++  extern \"C\" int folly_example_undefined_weak_symbol() __attribute__((weak));
++  int main(int argc, char** argv) {
++    auto f = folly_example_undefined_weak_symbol; // null pointer
++    return f ? f() : 0; // must compile, link, and run with null pointer
++  }"
++        FOLLY_HAVE_WEAK_SYMBOLS
++)
++check_cxx_source_runs("
++  #include <dlfcn.h>
++  int main() {
++    void *h = dlopen(\"linux-vdso.so.1\", RTLD_LAZY | RTLD_LOCAL | RTLD_NOLOAD);
++    if (h == nullptr) {
++      return -1;
++    }
++    dlclose(h);
++    return 0;
++  }"
++        FOLLY_HAVE_LINUX_VDSO
++)
++
++check_cxx_source_runs("
++  #include <cstddef>
++  #include <cwchar>
++  int main(int argc, char** argv) {
++    return wcstol(L\"01\", nullptr, 10) == 1 ? 0 : 1;
++  }"
++        FOLLY_HAVE_WCHAR_SUPPORT
++)
++
++check_cxx_source_compiles("
++  #include <ext/random>
++  int main(int argc, char** argv) {
++    __gnu_cxx::sfmt19937 rng;
++    return 0;
++  }"
++        FOLLY_HAVE_EXTRANDOM_SFMT19937
++)
++
++check_cxx_source_runs("
++  #include <stdarg.h>
++  #include <stdio.h>
++
++  int call_vsnprintf(const char* fmt, ...) {
++    char buf[256];
++    va_list ap;
++    va_start(ap, fmt);
++    int result = vsnprintf(buf, sizeof(buf), fmt, ap);
++    va_end(ap);
++    return result;
++  }
++
++  int main(int argc, char** argv) {
++    return call_vsnprintf(\"%\", 1) < 0 ? 0 : 1;
++  }"
++        HAVE_VSNPRINTF_ERRORS
++)
+\ No newline at end of file
 diff --git a/CMake/FollyFunctions.cmake b/CMake/FollyFunctions.cmake
 deleted file mode 100644
 index 306df17e2..000000000
@@ -2410,7 +2587,7 @@ index fc9f56350..fc93f0c6f 100644
 -option(PYTHON_EXTENSIONS
 -  "Build Python Bindings for Folly, requires Cython and (BUILD_SHARED_LIBS=ON)"
 -  OFF
-+        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/folly-config.h.cmake
++        ${CMAKE_CURRENT_SOURCE_DIR}/CMake/folly-config.h.cmake
 +        ${CMAKE_CURRENT_BINARY_DIR}/config/folly/folly-config.h
  )
  
@@ -3050,7 +3227,7 @@ index fc9f56350..fc93f0c6f 100644
 -endif()
  
 -add_subdirectory(folly)
-+include(cmake/FollyConfigChecks.cmake)
++include(CMake/FollyConfigChecks.cmake)
 +
 +configure_package_config_file(cmake/config.cmake
 +        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake # cmake-build-debug/
@@ -3261,195 +3438,6 @@ index fc9f56350..fc93f0c6f 100644
 +install(FILES ${memory_detail} DESTINATION "${include_dest}/memory/detail")
 +install(FILES "${CMAKE_CURRENT_BINARY_DIR}/config/folly/folly-config.h" DESTINATION "${include_dest}")
 +install(FILES "folly/stub/logging.h" DESTINATION "${include_dest}/stub")
-diff --git a/cmake/FollyConfigChecks.cmake b/cmake/FollyConfigChecks.cmake
-new file mode 100644
-index 000000000..57b9e3f05
---- /dev/null
-+++ b/cmake/FollyConfigChecks.cmake
-@@ -0,0 +1,182 @@
-+# Copyright (c) Meta Platforms, Inc. and affiliates.
-+#
-+# Licensed under the Apache License, Version 2.0 (the "License");
-+# you may not use this file except in compliance with the License.
-+# You may obtain a copy of the License at
-+#
-+#     http://www.apache.org/licenses/LICENSE-2.0
-+#
-+# Unless required by applicable law or agreed to in writing, software
-+# distributed under the License is distributed on an "AS IS" BASIS,
-+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-+# See the License for the specific language governing permissions and
-+# limitations under the License.
-+
-+include(CheckCXXSourceCompiles)
-+include(CheckCXXSourceRuns)
-+include(CheckFunctionExists)
-+include(CheckIncludeFileCXX)
-+include(CheckSymbolExists)
-+include(CheckTypeSize)
-+include(CheckCXXCompilerFlag)
-+
-+if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
-+    CHECK_INCLUDE_FILE_CXX(malloc_np.h FOLLY_USE_JEMALLOC)
-+else()
-+    CHECK_INCLUDE_FILE_CXX(jemalloc/jemalloc.h FOLLY_USE_JEMALLOC)
-+endif()
-+
-+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
-+    # clang only rejects unknown warning flags if -Werror=unknown-warning-option
-+    # is also specified.
-+    check_cxx_compiler_flag(
-+            -Werror=unknown-warning-option
-+            COMPILER_HAS_UNKNOWN_WARNING_OPTION)
-+    if (COMPILER_HAS_UNKNOWN_WARNING_OPTION)
-+        set(CMAKE_REQUIRED_FLAGS
-+                "${CMAKE_REQUIRED_FLAGS} -Werror=unknown-warning-option")
-+    endif()
-+
-+    check_cxx_compiler_flag(-Wshadow-local COMPILER_HAS_W_SHADOW_LOCAL)
-+    check_cxx_compiler_flag(
-+            -Wshadow-compatible-local
-+            COMPILER_HAS_W_SHADOW_COMPATIBLE_LOCAL)
-+    if (COMPILER_HAS_W_SHADOW_LOCAL AND COMPILER_HAS_W_SHADOW_COMPATIBLE_LOCAL)
-+        set(FOLLY_HAVE_SHADOW_LOCAL_WARNINGS ON)
-+        list(APPEND FOLLY_CXX_FLAGS -Wshadow-compatible-local)
-+    endif()
-+
-+    check_cxx_compiler_flag(-Wnoexcept-type COMPILER_HAS_W_NOEXCEPT_TYPE)
-+    if (COMPILER_HAS_W_NOEXCEPT_TYPE)
-+        list(APPEND FOLLY_CXX_FLAGS -Wno-noexcept-type)
-+    endif()
-+
-+    check_cxx_compiler_flag(
-+            -Wnullability-completeness
-+            COMPILER_HAS_W_NULLABILITY_COMPLETENESS)
-+    if (COMPILER_HAS_W_NULLABILITY_COMPLETENESS)
-+        list(APPEND FOLLY_CXX_FLAGS -Wno-nullability-completeness)
-+    endif()
-+
-+    check_cxx_compiler_flag(
-+            -Winconsistent-missing-override
-+            COMPILER_HAS_W_INCONSISTENT_MISSING_OVERRIDE)
-+    if (COMPILER_HAS_W_INCONSISTENT_MISSING_OVERRIDE)
-+        list(APPEND FOLLY_CXX_FLAGS -Wno-inconsistent-missing-override)
-+    endif()
-+
-+    check_cxx_compiler_flag(-faligned-new COMPILER_HAS_F_ALIGNED_NEW)
-+    if (COMPILER_HAS_F_ALIGNED_NEW)
-+        list(APPEND FOLLY_CXX_FLAGS -faligned-new)
-+    endif()
-+
-+    check_cxx_compiler_flag(-fopenmp COMPILER_HAS_F_OPENMP)
-+    if (COMPILER_HAS_F_OPENMP)
-+        list(APPEND FOLLY_CXX_FLAGS -fopenmp)
-+    endif()
-+endif()
-+
-+set(FOLLY_ORIGINAL_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
-+string(REGEX REPLACE
-+        "-std=(c|gnu)\\+\\+.."
-+        ""
-+        CMAKE_REQUIRED_FLAGS
-+        "${CMAKE_REQUIRED_FLAGS}")
-+
-+check_symbol_exists(pthread_atfork pthread.h FOLLY_HAVE_PTHREAD_ATFORK)
-+
-+list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
-+check_symbol_exists(accept4 sys/socket.h FOLLY_HAVE_ACCEPT4)
-+check_symbol_exists(getrandom sys/random.h FOLLY_HAVE_GETRANDOM)
-+check_symbol_exists(preadv sys/uio.h FOLLY_HAVE_PREADV)
-+check_symbol_exists(pwritev sys/uio.h FOLLY_HAVE_PWRITEV)
-+check_symbol_exists(clock_gettime time.h FOLLY_HAVE_CLOCK_GETTIME)
-+check_symbol_exists(pipe2 unistd.h FOLLY_HAVE_PIPE2)
-+check_symbol_exists(sendmmsg sys/socket.h FOLLY_HAVE_SENDMMSG)
-+check_symbol_exists(recvmmsg sys/socket.h FOLLY_HAVE_RECVMMSG)
-+
-+check_function_exists(malloc_usable_size FOLLY_HAVE_MALLOC_USABLE_SIZE)
-+
-+set(CMAKE_REQUIRED_FLAGS "${FOLLY_ORIGINAL_CMAKE_REQUIRED_FLAGS}")
-+
-+check_cxx_source_compiles("
-+  #pragma GCC diagnostic error \"-Wattributes\"
-+  extern \"C\" void (*test_ifunc(void))() { return 0; }
-+  void func() __attribute__((ifunc(\"test_ifunc\")));
-+  int main() { return 0; }"
-+        FOLLY_HAVE_IFUNC
-+)
-+check_cxx_source_runs("
-+  int main(int, char**) {
-+    char buf[64] = {0};
-+    unsigned long *ptr = (unsigned long *)(buf + 1);
-+    *ptr = 0xdeadbeef;
-+    return (*ptr & 0xff) == 0xef ? 0 : 1;
-+  }"
-+        FOLLY_HAVE_UNALIGNED_ACCESS
-+)
-+check_cxx_source_compiles("
-+  int main(int argc, char** argv) {
-+    unsigned size = argc;
-+    char data[size];
-+    return 0;
-+  }"
-+        FOLLY_HAVE_VLA
-+)
-+check_cxx_source_runs("
-+  extern \"C\" int folly_example_undefined_weak_symbol() __attribute__((weak));
-+  int main(int argc, char** argv) {
-+    auto f = folly_example_undefined_weak_symbol; // null pointer
-+    return f ? f() : 0; // must compile, link, and run with null pointer
-+  }"
-+        FOLLY_HAVE_WEAK_SYMBOLS
-+)
-+check_cxx_source_runs("
-+  #include <dlfcn.h>
-+  int main() {
-+    void *h = dlopen(\"linux-vdso.so.1\", RTLD_LAZY | RTLD_LOCAL | RTLD_NOLOAD);
-+    if (h == nullptr) {
-+      return -1;
-+    }
-+    dlclose(h);
-+    return 0;
-+  }"
-+        FOLLY_HAVE_LINUX_VDSO
-+)
-+
-+check_cxx_source_runs("
-+  #include <cstddef>
-+  #include <cwchar>
-+  int main(int argc, char** argv) {
-+    return wcstol(L\"01\", nullptr, 10) == 1 ? 0 : 1;
-+  }"
-+        FOLLY_HAVE_WCHAR_SUPPORT
-+)
-+
-+check_cxx_source_compiles("
-+  #include <ext/random>
-+  int main(int argc, char** argv) {
-+    __gnu_cxx::sfmt19937 rng;
-+    return 0;
-+  }"
-+        FOLLY_HAVE_EXTRANDOM_SFMT19937
-+)
-+
-+check_cxx_source_runs("
-+  #include <stdarg.h>
-+  #include <stdio.h>
-+
-+  int call_vsnprintf(const char* fmt, ...) {
-+    char buf[256];
-+    va_list ap;
-+    va_start(ap, fmt);
-+    int result = vsnprintf(buf, sizeof(buf), fmt, ap);
-+    va_end(ap);
-+    return result;
-+  }
-+
-+  int main(int argc, char** argv) {
-+    return call_vsnprintf(\"%\", 1) < 0 ? 0 : 1;
-+  }"
-+        HAVE_VSNPRINTF_ERRORS
-+)
-\ No newline at end of file
 diff --git a/cmake/config.cmake b/cmake/config.cmake
 new file mode 100644
 index 000000000..0e267af7f
@@ -3461,60 +3449,6 @@ index 000000000..0e267af7f
 +include(${CMAKE_CURRENT_LIST_DIR}/folly-targets.cmake)
 +
 +check_required_components(folly)
-diff --git a/CMake/folly-config.h.cmake b/cmake/folly-config.h.cmake
-similarity index 74%
-rename from CMake/folly-config.h.cmake
-rename to cmake/folly-config.h.cmake
-index ec6706a45..3572d73eb 100644
---- a/CMake/folly-config.h.cmake
-+++ b/cmake/folly-config.h.cmake
-@@ -1,24 +1,24 @@
- /*
-- * Copyright (c) Facebook, Inc. and its affiliates.
-- *
-- * Licensed under the Apache License, Version 2.0 (the "License");
-- * you may not use this file except in compliance with the License.
-- * You may obtain a copy of the License at
-- *
-- *     http://www.apache.org/licenses/LICENSE-2.0
-- *
-- * Unless required by applicable law or agreed to in writing, software
-- * distributed under the License is distributed on an "AS IS" BASIS,
-- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-- * See the License for the specific language governing permissions and
-- * limitations under the License.
-- */
-+* Copyright (c) Facebook, Inc. and its affiliates.
-+*
-+* Licensed under the Apache License, Version 2.0 (the "License");
-+* you may not use this file except in compliance with the License.
-+* You may obtain a copy of the License at
-+*
-+*     http://www.apache.org/licenses/LICENSE-2.0
-+*
-+* Unless required by applicable law or agreed to in writing, software
-+* distributed under the License is distributed on an "AS IS" BASIS,
-+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-+* See the License for the specific language governing permissions and
-+* limitations under the License.
-+*/
- 
- #pragma once
- 
- #if !defined(FOLLY_MOBILE)
- #if defined(__ANDROID__) || \
--    (defined(__APPLE__) &&  \
-+(defined(__APPLE__) &&  \
-      (TARGET_IPHONE_SIMULATOR || TARGET_OS_SIMULATOR || TARGET_OS_IPHONE))
- #define FOLLY_MOBILE 1
- #else
-@@ -86,4 +86,4 @@
- 
- #cmakedefine FOLLY_SUPPORT_SHARED_LIBRARY 1
- 
--#cmakedefine01 FOLLY_HAVE_LIBRT
-+#cmakedefine01 FOLLY_HAVE_LIBRT
-\ No newline at end of file
 diff --git a/folly/Exception.h b/folly/Exception.h
 index d446e29bf..db51d0fa3 100644
 --- a/folly/Exception.h


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Fix #1070 

## Verifying this change
Apply the folly patch as described in #1070 
No errors should be reported.
Install the vcpkg dependencies by building local images, the images should complete as usual.

## What components does this pull request potentially affect?

- Dependencies 
Fixes the patch of folly port to also be compatible with macOS.

## Documentation
- No changes to document

## Issue Closed by this pull request:

This PR closes #1070 
