### PR TITLE
fix(QueryEngine): Correcter behavior for start/stopping pipelines fast

### DIFF
--- a/nes-query-engine/QueryEngine.cpp
+++ b/nes-query-engine/QueryEngine.cpp
@@ -450,7 +450,7 @@ bool ThreadPool::WorkerThread::operator()(const WorkTask& task) const
     if (terminating)
     {
         ENGINE_LOG_WARNING("Skipped Task for {}-{} during termination", task.queryId, task.pipelineId);
-        return false;
+        return true;
     }
 
     const auto taskId = TaskId(pool.taskIdCounter++);
@@ -500,7 +500,7 @@ bool ThreadPool::WorkerThread::operator()(const StartPipelineTask& startPipeline
     if (terminating)
     {
         ENGINE_LOG_WARNING("Pipeline Start {}-{} was skipped during Termination", startPipeline.queryId, startPipeline.pipelineId);
-        return false;
+        return true;
     }
 
     if (auto pipeline = startPipeline.pipeline.lock())


### PR DESCRIPTION
Fixes a bug that currently occurs regularly in the repl-test when starting and stopping queries after another really fast.

Previously, if the engine was requested to shut down, Start and Stop Pipeline tasks returned false. This prevented the onComplete handler of a task from running, which in turn prevented the query from releasing and completing.

## What components does this pull request potentially affect?
QueryEngine
