### PR TITLE
fix clang-tidy bugprone-crtp-constructor-accessibility

### DIFF
--- a/nes-input-formatters/private/FieldIndexFunction.hpp
+++ b/nes-input-formatters/private/FieldIndexFunction.hpp
@@ -73,6 +73,9 @@ public:
         const std::vector<RawValueParser::ParseFunctionSignature>& parseFunctions,
         Memory::AbstractBufferProvider& bufferProvider);
 
+    friend Derived;
+
+private:
     FieldIndexFunction()
     {
         /// Cannot use Concepts / requires because of the cyclic nature of the CRTP pattern.
@@ -80,6 +83,7 @@ public:
         static_assert(std::is_constructible_v<Derived, Memory::AbstractBufferProvider&>, "Derived class must have a default constructor");
     };
 
+public:
     ~FieldIndexFunction() = default;
 
     [[nodiscard]] FieldIndex getOffsetOfFirstTupleDelimiter() const

--- a/nes-input-formatters/private/InputFormatIndexer.hpp
+++ b/nes-input-formatters/private/InputFormatIndexer.hpp
@@ -27,7 +27,9 @@ namespace NES::InputFormatters
 template <typename T>
 class InputFormatIndexer
 {
-public:
+    friend T;
+
+private:
     /// We can't constrain 'T' using the InputFormatIndexerType concept, since it is not satisfied when the 'InputFormatIndexer' is initiated.
     /// Thus, we delay asserting the constraints of the concept by applying it in the constructor.
     InputFormatIndexer()

--- a/nes-input-formatters/src/NativeInputFormatIndexer.cpp
+++ b/nes-input-formatters/src/NativeInputFormatIndexer.cpp
@@ -23,7 +23,7 @@ namespace NES::InputFormatters
 InputFormatIndexerRegistryReturnType
 InputFormatIndexerGeneratedRegistrar::RegisterNativeInputFormatIndexer(InputFormatIndexerRegistryArguments arguments)
 {
-    return arguments.createInputFormatterTaskPipeline<NativeInputFormatIndexer>({});
+    return arguments.createInputFormatterTaskPipeline<NativeInputFormatIndexer>(NativeInputFormatIndexer());
 }
 
 }

--- a/nes-query-optimizer/include/Traits/Trait.hpp
+++ b/nes-query-optimizer/include/Traits/Trait.hpp
@@ -71,6 +71,11 @@ struct DefaultTrait : TraitConcept
         trait.set_trait_type(getType().name());
         return trait;
     }
+
+    friend Derived;
+
+private:
+    DefaultTrait() = default;
 };
 
 /// A type-erased wrapper for traits.


### PR DESCRIPTION
The check currently fails in the clang-tidy nightly run.

c.f. https://clang.llvm.org/extra/clang-tidy/checks/bugprone/crtp-constructor-accessibility.html