### PR TITLE
protobuf: serialize operators as list instead of map

### DIFF
--- a/grpc/SerializableQueryPlan.proto
+++ b/grpc/SerializableQueryPlan.proto
@@ -20,7 +20,7 @@ package NES;
 The serializable wrapper definition for query plan
  */
 message SerializableQueryPlan{
-  map<uint64, SerializableOperator> operatorMap = 1;
+  repeated SerializableOperator operators = 1;
   repeated uint64 rootOperatorIds = 2;
   optional uint64 queryId = 3;
 }

--- a/nes-logical-operators/include/Operators/EventTimeWatermarkAssignerLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/EventTimeWatermarkAssignerLogicalOperator.hpp
@@ -43,7 +43,7 @@ public:
     Windowing::TimeUnit unit;
 
     [[nodiscard]] bool operator==(const LogicalOperatorConcept& rhs) const override;
-    [[nodiscard]] SerializableOperator serialize() const override;
+    void serialize(SerializableOperator&) const override;
 
     [[nodiscard]] LogicalOperator withTraitSet(TraitSet traitSet) const override;
     [[nodiscard]] TraitSet getTraitSet() const override;

--- a/nes-logical-operators/include/Operators/IngestionTimeWatermarkAssignerLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/IngestionTimeWatermarkAssignerLogicalOperator.hpp
@@ -34,7 +34,7 @@ public:
     IngestionTimeWatermarkAssignerLogicalOperator();
 
     [[nodiscard]] bool operator==(const LogicalOperatorConcept& rhs) const override;
-    [[nodiscard]] SerializableOperator serialize() const override;
+    void serialize(SerializableOperator&) const override;
 
     [[nodiscard]] LogicalOperator withTraitSet(TraitSet traitSet) const override;
     [[nodiscard]] TraitSet getTraitSet() const override;

--- a/nes-logical-operators/include/Operators/LogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/LogicalOperator.hpp
@@ -72,7 +72,7 @@ struct LogicalOperatorConcept
     [[nodiscard]] virtual std::string_view getName() const noexcept = 0;
 
     /// Serializes the operator to a protobuf message
-    [[nodiscard]] virtual SerializableOperator serialize() const = 0;
+    virtual void serialize(SerializableOperator&) const = 0;
 
     /// Returns the trait set of the operator
     [[nodiscard]] virtual TraitSet getTraitSet() const = 0;
@@ -163,7 +163,7 @@ struct LogicalOperator
     [[nodiscard]] bool operator==(const LogicalOperator& other) const;
     [[nodiscard]] std::string_view getName() const noexcept;
 
-    [[nodiscard]] SerializableOperator serialize() const;
+    void serialize(SerializableOperator&) const;
     [[nodiscard]] TraitSet getTraitSet() const;
 
     [[nodiscard]] std::vector<Schema> getInputSchemas() const;
@@ -206,7 +206,7 @@ private:
 
         [[nodiscard]] std::string_view getName() const noexcept override { return data.getName(); }
 
-        [[nodiscard]] SerializableOperator serialize() const override { return data.serialize(); }
+        void serialize(SerializableOperator& sOp) const override { return data.serialize(sOp); }
 
         [[nodiscard]] TraitSet getTraitSet() const override { return data.getTraitSet(); }
 

--- a/nes-logical-operators/include/Operators/ProjectionLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/ProjectionLogicalOperator.hpp
@@ -52,7 +52,7 @@ public:
     [[nodiscard]] const std::vector<Projection>& getProjections() const;
 
     [[nodiscard]] bool operator==(const LogicalOperatorConcept& rhs) const override;
-    [[nodiscard]] SerializableOperator serialize() const override;
+    void serialize(SerializableOperator&) const override;
 
     [[nodiscard]] LogicalOperator withTraitSet(TraitSet traitSet) const override;
     [[nodiscard]] TraitSet getTraitSet() const override;

--- a/nes-logical-operators/include/Operators/SelectionLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/SelectionLogicalOperator.hpp
@@ -40,7 +40,7 @@ public:
     [[nodiscard]] LogicalFunction getPredicate() const;
 
     [[nodiscard]] bool operator==(const LogicalOperatorConcept& rhs) const override;
-    [[nodiscard]] SerializableOperator serialize() const override;
+    void serialize(SerializableOperator&) const override;
 
     [[nodiscard]] LogicalOperator withTraitSet(TraitSet traitSet) const override;
     [[nodiscard]] TraitSet getTraitSet() const override;

--- a/nes-logical-operators/include/Operators/Sinks/SinkLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Sinks/SinkLogicalOperator.hpp
@@ -41,7 +41,7 @@ struct SinkLogicalOperator final : LogicalOperatorConcept
     explicit SinkLogicalOperator(Sinks::SinkDescriptor sinkDescriptor);
 
     [[nodiscard]] bool operator==(const LogicalOperatorConcept& rhs) const override;
-    [[nodiscard]] SerializableOperator serialize() const override;
+    void serialize(SerializableOperator&) const override;
 
     [[nodiscard]] LogicalOperator withTraitSet(TraitSet traitSet) const override;
     [[nodiscard]] TraitSet getTraitSet() const override;

--- a/nes-logical-operators/include/Operators/Sources/SourceDescriptorLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Sources/SourceDescriptorLogicalOperator.hpp
@@ -42,7 +42,7 @@ public:
     [[nodiscard]] SourceDescriptor getSourceDescriptor() const;
 
     [[nodiscard]] bool operator==(const LogicalOperatorConcept& rhs) const override;
-    [[nodiscard]] SerializableOperator serialize() const override;
+    void serialize(SerializableOperator&) const override;
 
     [[nodiscard]] LogicalOperator withTraitSet(TraitSet traitSet) const override;
     [[nodiscard]] TraitSet getTraitSet() const override;

--- a/nes-logical-operators/include/Operators/Sources/SourceNameLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Sources/SourceNameLogicalOperator.hpp
@@ -47,7 +47,7 @@ public:
 
 
     [[nodiscard]] bool operator==(const LogicalOperatorConcept& rhs) const override;
-    [[nodiscard]] SerializableOperator serialize() const override;
+    void serialize(SerializableOperator&) const override;
 
     [[nodiscard]] LogicalOperator withTraitSet(TraitSet traitSet) const override;
     [[nodiscard]] TraitSet getTraitSet() const override;

--- a/nes-logical-operators/include/Operators/UnionLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/UnionLogicalOperator.hpp
@@ -34,7 +34,7 @@ public:
     explicit UnionLogicalOperator();
 
     [[nodiscard]] bool operator==(const LogicalOperatorConcept& rhs) const override;
-    [[nodiscard]] SerializableOperator serialize() const override;
+    void serialize(SerializableOperator&) const override;
 
     [[nodiscard]] LogicalOperator withTraitSet(TraitSet traitSet) const override;
     [[nodiscard]] TraitSet getTraitSet() const override;

--- a/nes-logical-operators/include/Operators/Windows/JoinLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Windows/JoinLogicalOperator.hpp
@@ -58,7 +58,7 @@ public:
 
 
     [[nodiscard]] bool operator==(const LogicalOperatorConcept& rhs) const override;
-    [[nodiscard]] SerializableOperator serialize() const override;
+    void serialize(SerializableOperator&) const override;
 
     [[nodiscard]] LogicalOperator withTraitSet(TraitSet traitSet) const override;
     [[nodiscard]] TraitSet getTraitSet() const override;

--- a/nes-logical-operators/include/Operators/Windows/WindowedAggregationLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Windows/WindowedAggregationLogicalOperator.hpp
@@ -64,7 +64,7 @@ public:
 
 
     [[nodiscard]] bool operator==(const LogicalOperatorConcept& rhs) const override;
-    [[nodiscard]] SerializableOperator serialize() const override;
+    void serialize(SerializableOperator&) const override;
 
     [[nodiscard]] LogicalOperator withTraitSet(TraitSet traitSet) const override;
     [[nodiscard]] TraitSet getTraitSet() const override;

--- a/nes-logical-operators/src/Operators/EventTimeWatermarkAssignerLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/EventTimeWatermarkAssignerLogicalOperator.cpp
@@ -154,7 +154,7 @@ std::vector<LogicalOperator> EventTimeWatermarkAssignerLogicalOperator::getChild
     return children;
 }
 
-SerializableOperator EventTimeWatermarkAssignerLogicalOperator::serialize() const
+void EventTimeWatermarkAssignerLogicalOperator::serialize(SerializableOperator& serializableOperator) const
 {
     SerializableLogicalOperator proto;
 
@@ -188,7 +188,6 @@ SerializableOperator EventTimeWatermarkAssignerLogicalOperator::serialize() cons
     auto* outSch = proto.mutable_output_schema();
     SchemaSerializationUtil::serializeSchema(outputSchema, outSch);
 
-    SerializableOperator serializableOperator;
     serializableOperator.set_operator_id(id.getRawValue());
     for (auto& child : getChildren())
     {
@@ -204,7 +203,6 @@ SerializableOperator EventTimeWatermarkAssignerLogicalOperator::serialize() cons
     (*serializableOperator.mutable_config())[ConfigParameters::TIME_MS] = descriptorConfigTypeToProto(timeVariant);
 
     serializableOperator.mutable_operator_()->CopyFrom(proto);
-    return serializableOperator;
 }
 
 LogicalOperatorRegistryReturnType

--- a/nes-logical-operators/src/Operators/IngestionTimeWatermarkAssignerLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/IngestionTimeWatermarkAssignerLogicalOperator.cpp
@@ -135,7 +135,7 @@ std::vector<LogicalOperator> IngestionTimeWatermarkAssignerLogicalOperator::getC
     return children;
 }
 
-SerializableOperator IngestionTimeWatermarkAssignerLogicalOperator::serialize() const
+void IngestionTimeWatermarkAssignerLogicalOperator::serialize(SerializableOperator& serializableOperator) const
 {
     SerializableLogicalOperator proto;
 
@@ -169,7 +169,6 @@ SerializableOperator IngestionTimeWatermarkAssignerLogicalOperator::serialize() 
     auto* outSch = proto.mutable_output_schema();
     SchemaSerializationUtil::serializeSchema(outputSchema, outSch);
 
-    SerializableOperator serializableOperator;
     serializableOperator.set_operator_id(id.getRawValue());
     for (auto& child : getChildren())
     {
@@ -177,7 +176,6 @@ SerializableOperator IngestionTimeWatermarkAssignerLogicalOperator::serialize() 
     }
 
     serializableOperator.mutable_operator_()->CopyFrom(proto);
-    return serializableOperator;
 }
 
 LogicalOperatorRegistryReturnType

--- a/nes-logical-operators/src/Operators/LogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/LogicalOperator.cpp
@@ -75,9 +75,9 @@ std::string_view LogicalOperator::getName() const noexcept
     return self->getName();
 }
 
-SerializableOperator LogicalOperator::serialize() const
+void LogicalOperator::serialize(SerializableOperator& sOp) const
 {
-    return self->serialize();
+    self->serialize(sOp);
 }
 
 TraitSet LogicalOperator::getTraitSet() const

--- a/nes-logical-operators/src/Operators/ProjectionLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/ProjectionLogicalOperator.cpp
@@ -242,7 +242,7 @@ std::vector<LogicalOperator> ProjectionLogicalOperator::getChildren() const
     return children;
 }
 
-SerializableOperator ProjectionLogicalOperator::serialize() const
+void ProjectionLogicalOperator::serialize(SerializableOperator& serializableOperator) const
 {
     SerializableLogicalOperator proto;
 
@@ -275,7 +275,6 @@ SerializableOperator ProjectionLogicalOperator::serialize() const
     auto* outSch = proto.mutable_output_schema();
     SchemaSerializationUtil::serializeSchema(getOutputSchema(), outSch);
 
-    SerializableOperator serializableOperator;
     serializableOperator.set_operator_id(id.getRawValue());
     for (const auto& child : getChildren())
     {
@@ -296,7 +295,6 @@ SerializableOperator ProjectionLogicalOperator::serialize() const
     (*serializableOperator.mutable_config())[ConfigParameters::ASTERISK] = descriptorConfigTypeToProto(asterisk);
 
     serializableOperator.mutable_operator_()->CopyFrom(proto);
-    return serializableOperator;
 }
 
 LogicalOperatorRegistryReturnType

--- a/nes-logical-operators/src/Operators/SelectionLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/SelectionLogicalOperator.cpp
@@ -156,7 +156,7 @@ std::vector<LogicalOperator> SelectionLogicalOperator::getChildren() const
     return children;
 }
 
-SerializableOperator SelectionLogicalOperator::serialize() const
+void SelectionLogicalOperator::serialize(SerializableOperator& serializableOperator) const
 {
     SerializableLogicalOperator proto;
 
@@ -189,7 +189,6 @@ SerializableOperator SelectionLogicalOperator::serialize() const
     auto* outSch = proto.mutable_output_schema();
     SchemaSerializationUtil::serializeSchema(outputSchema, outSch);
 
-    SerializableOperator serializableOperator;
     serializableOperator.set_operator_id(id.getRawValue());
     for (auto& child : getChildren())
     {
@@ -202,7 +201,6 @@ SerializableOperator SelectionLogicalOperator::serialize() const
     (*serializableOperator.mutable_config())[ConfigParameters::SELECTION_FUNCTION_NAME] = descriptorConfigTypeToProto(funcList);
 
     serializableOperator.mutable_operator_()->CopyFrom(proto);
-    return serializableOperator;
 }
 
 LogicalOperatorRegistryReturnType

--- a/nes-logical-operators/src/Operators/Sinks/SinkLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Sinks/SinkLogicalOperator.cpp
@@ -212,7 +212,7 @@ SinkLogicalOperator SinkLogicalOperator::withSinkDescriptor(Sinks::SinkDescripto
     return newOperator;
 }
 
-SerializableOperator SinkLogicalOperator::serialize() const
+void SinkLogicalOperator::serialize(SerializableOperator& serializableOperator) const
 {
     SerializableSinkLogicalOperator proto;
     if (sinkDescriptor)
@@ -234,7 +234,6 @@ SerializableOperator SinkLogicalOperator::serialize() const
         proto.add_output_origin_ids(outId.getRawValue());
     }
 
-    SerializableOperator serializableOperator;
     const DescriptorConfig::ConfigType timeVariant = sinkName;
     (*serializableOperator.mutable_config())[ConfigParameters::SINK_NAME] = descriptorConfigTypeToProto(timeVariant);
 
@@ -245,6 +244,5 @@ SerializableOperator SinkLogicalOperator::serialize() const
     }
 
     serializableOperator.mutable_sink()->CopyFrom(proto);
-    return serializableOperator;
 }
 }

--- a/nes-logical-operators/src/Operators/Sources/SourceDescriptorLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Sources/SourceDescriptorLogicalOperator.cpp
@@ -138,18 +138,16 @@ SourceDescriptor SourceDescriptorLogicalOperator::getSourceDescriptor() const
     return sourceDescriptor;
 }
 
-[[nodiscard]] SerializableOperator SourceDescriptorLogicalOperator::serialize() const
+void SourceDescriptorLogicalOperator::serialize(SerializableOperator& serializableOperator) const
 {
     SerializableSourceDescriptorLogicalOperator proto;
     INVARIANT(sourceOriginIds.size() == 1, "Expected one originId, got '{}' instead", sourceOriginIds.size());
     proto.set_sourceoriginid(sourceOriginIds[0].getRawValue());
     proto.mutable_sourcedescriptor()->CopyFrom(sourceDescriptor.serialize());
 
-    SerializableOperator serializableOperator;
     serializableOperator.set_operator_id(id.getRawValue());
 
     serializableOperator.mutable_source()->CopyFrom(proto);
-    return serializableOperator;
 }
 
 }

--- a/nes-logical-operators/src/Operators/Sources/SourceNameLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Sources/SourceNameLogicalOperator.cpp
@@ -160,10 +160,9 @@ std::string SourceNameLogicalOperator::getLogicalSourceName() const
     return logicalSourceName;
 }
 
-SerializableOperator SourceNameLogicalOperator::serialize() const
+void SourceNameLogicalOperator::serialize(SerializableOperator&) const
 {
     PRECONDITION(false, "no serialize for SourceNameLogicalOperator defined. Serialization happens with SourceDescriptorLogicalOperator");
-    return {};
 }
 
 }

--- a/nes-logical-operators/src/Operators/UnionLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/UnionLogicalOperator.cpp
@@ -160,7 +160,7 @@ std::vector<LogicalOperator> UnionLogicalOperator::getChildren() const
     return children;
 }
 
-SerializableOperator UnionLogicalOperator::serialize() const
+void UnionLogicalOperator::serialize(SerializableOperator& serializableOperator) const
 {
     SerializableLogicalOperator proto;
 
@@ -194,7 +194,6 @@ SerializableOperator UnionLogicalOperator::serialize() const
     auto* outSch = proto.mutable_output_schema();
     SchemaSerializationUtil::serializeSchema(outputSchema, outSch);
 
-    SerializableOperator serializableOperator;
     serializableOperator.set_operator_id(id.getRawValue());
     for (auto& child : getChildren())
     {
@@ -202,7 +201,6 @@ SerializableOperator UnionLogicalOperator::serialize() const
     }
 
     serializableOperator.mutable_operator_()->CopyFrom(proto);
-    return serializableOperator;
 }
 
 LogicalOperator UnionLogicalOperator::setInputSchemas(std::vector<Schema> inputSchemas) const

--- a/nes-logical-operators/src/Operators/Windows/JoinLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Windows/JoinLogicalOperator.cpp
@@ -227,7 +227,7 @@ LogicalFunction JoinLogicalOperator::getJoinFunction() const
     return joinFunction;
 }
 
-SerializableOperator JoinLogicalOperator::serialize() const
+void JoinLogicalOperator::serialize(SerializableOperator& serializableOperator) const
 {
     SerializableLogicalOperator proto;
 
@@ -261,7 +261,6 @@ SerializableOperator JoinLogicalOperator::serialize() const
     auto* outSch = proto.mutable_output_schema();
     SchemaSerializationUtil::serializeSchema(getOutputSchema(), outSch);
 
-    SerializableOperator serializableOperator;
     serializableOperator.set_operator_id(id.getRawValue());
     for (const auto& child : getChildren())
     {
@@ -304,7 +303,6 @@ SerializableOperator JoinLogicalOperator::serialize() const
         = descriptorConfigTypeToProto(windowMetaData.windowEndFieldName);
 
     serializableOperator.mutable_operator_()->CopyFrom(proto);
-    return serializableOperator;
 }
 
 LogicalOperatorRegistryReturnType

--- a/nes-logical-operators/src/Operators/Windows/WindowedAggregationLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Windows/WindowedAggregationLogicalOperator.cpp
@@ -288,7 +288,7 @@ const WindowMetaData& WindowedAggregationLogicalOperator::getWindowMetaData() co
     return windowMetaData;
 }
 
-SerializableOperator WindowedAggregationLogicalOperator::serialize() const
+void WindowedAggregationLogicalOperator::serialize(SerializableOperator& serializableOperator) const
 {
     SerializableLogicalOperator proto;
 
@@ -321,7 +321,6 @@ SerializableOperator WindowedAggregationLogicalOperator::serialize() const
     auto* outSch = proto.mutable_output_schema();
     SchemaSerializationUtil::serializeSchema(getOutputSchema(), outSch);
 
-    SerializableOperator serializableOperator;
     serializableOperator.set_operator_id(id.getRawValue());
     for (const auto& child : getChildren())
     {
@@ -377,7 +376,6 @@ SerializableOperator WindowedAggregationLogicalOperator::serialize() const
         = descriptorConfigTypeToProto(windowMetaData.windowEndFieldName);
 
     serializableOperator.mutable_operator_()->CopyFrom(proto);
-    return serializableOperator;
 }
 
 LogicalOperatorRegistryReturnType


### PR DESCRIPTION
Previously, the `operator_id` was stored in two places (key of `operatorMap` and as field in `SerializableOperator`), which could lead to potential conflicts / subtle errors.

Also, the deserialization order of maps is non-deterministic, which can make debugging more difficult. With `repeatable`, this is not the case.

Furthermore, a map is not of much use in our current use case, as we (de)serialize all operators in bulk.

We also change the `Operator::serialize` to make it work more elegantly the protobuf repeatable.