### PR TITLE
Handle unknown enums

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -168,6 +168,17 @@ then
     log_error "Found catch (...). Please use CPPTRACE_TRY and CPPTRACE_CATCH to preserve stacktraces.\n$(git grep -n "catch (\.\.\.)" -- ".hpp" "*.cpp" | grep -v "NOLINT(no-raw-catch-all)")"
 fi
 
+# no magic_enum::enum_value<...>
+#
+# Given e.g.  enum class Color : uint8_t { RED, GREEN, BLUE };
+# a value of this type can be an unknown enum value,
+# i.e. an uint8_t that represents none of RED, GREEN, BLUE like e.g. 42.
+if git grep "magic_enum::enum_value<" -- ".hpp" "*.cpp" > /dev/null
+then
+    log_error "Found magic_enum::enum_value<...>. This can fail if given value is out of range. Use magic_enum::enum_cast instead!\n$(git grep -n "magic_enum::enum_value<" -- ".hpp" "*.cpp")"
+fi
+
+
 python3 scripts/check_preamble.py || FAIL=1
 
 DISTANCE_MERGE_BASE=$DISTANCE_MERGE_BASE python3 scripts/check_todos.py || FAIL=1


### PR DESCRIPTION
handles unknown enum values (i.e. values that do not map to one of the declared enum values) when deserializing protobuf.

This is necessary as, according to the [docs](https://protobuf.dev/programming-guides/proto3/#enum):

> During deserialization, unrecognized enum values will be preserved in the message [...]
> In [...] C++ and Go, the unknown enum value is simply stored as its underlying integer representation.

Additionally, we add a check to `format.sh` that should prohibit using `magic_enum::enum_value`, which would crash the program (or be undefined) if an unknown enum value is enountered. Instead the check suggests `magic_enum::enum_cast` which does the required bounds check.