### PR TITLE
Fix start/stop race condition in query engine 

### DIFF
--- a/nes-common/include/ErrorHandling.hpp
+++ b/nes-common/include/ErrorHandling.hpp
@@ -59,10 +59,6 @@ public:
     Exception(std::string message, ErrorCode errorCode, cpptrace::raw_trace&& trace)
         : cpptrace::lazy_exception(std::move(trace)), message(std::move(message)), errorCode(errorCode) { };
 
-    /// copy-constructor is unsaved noexcept because of std::string copy
-    Exception(const Exception&) noexcept = default;
-    Exception& operator=(const Exception&) noexcept = default;
-
     std::string& what() noexcept;
     [[nodiscard]] const char* what() const noexcept override;
     [[nodiscard]] ErrorCode code() const noexcept;

--- a/nes-common/include/Util/TypeTraits.hpp
+++ b/nes-common/include/Util/TypeTraits.hpp
@@ -1,0 +1,30 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+#include <type_traits>
+
+namespace NES
+{
+
+template <typename...>
+inline constexpr auto UniqueTypes = std::true_type{};
+
+template <typename T, typename... Rest>
+inline constexpr auto UniqueTypes<T, Rest...> = std::bool_constant<(!std::is_same_v<T, Rest> && ...) && UniqueTypes<Rest...>>{};
+
+template <typename... Ts>
+inline constexpr auto UniqueTypesIgnoringCVRef = UniqueTypes<std::remove_cvref_t<Ts>...>;
+
+}

--- a/nes-common/tests/UnitTests/Util/CMakeLists.txt
+++ b/nes-common/tests/UnitTests/Util/CMakeLists.txt
@@ -19,6 +19,7 @@ add_nes_common_test(nes-common-tests
         "LogLevelTest.cpp"
         "BFSIteratorTest.cpp"
         "RollingAverageTest.cpp"
+        "TypeTraitsTest.cpp"
 )
 
 add_nes_test(chunk-collector-test

--- a/nes-common/tests/UnitTests/Util/TypeTraitsTest.cpp
+++ b/nes-common/tests/UnitTests/Util/TypeTraitsTest.cpp
@@ -1,0 +1,38 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Util/TypeTraits.hpp>
+
+/// Since TypeTraits only compile static type utilities, this file only has to compile
+namespace NES
+{
+static_assert(!UniqueTypes<int, int, int>);
+static_assert(UniqueTypes<int, int&>, "By default cv ref qualification should create distinct types");
+static_assert(!UniqueTypesIgnoringCVRef<int, int&>, "IgnoringCVRef should not allow cv ref qualified types");
+
+struct CustomType
+{
+};
+
+using TypeAlias = CustomType;
+
+struct CustomType1
+{
+};
+
+static_assert(!UniqueTypes<CustomType, TypeAlias>, "type alias do not create distinct types");
+static_assert(UniqueTypes<CustomType, CustomType1>, "\"equal\" types are distinct types");
+static_assert(UniqueTypes<CustomType, struct CustomType2>, "\"equal\" types are distinct types");
+
+}

--- a/nes-query-engine/Interfaces.hpp
+++ b/nes-query-engine/Interfaces.hpp
@@ -46,12 +46,11 @@ public:
         QueryId,
         const std::shared_ptr<RunningQueryPlanNode>& target,
         TupleBuffer,
-        BaseTask::onComplete,
-        BaseTask::onFailure,
+        TaskCallback,
         PipelineExecutionContext::ContinuationPolicy continuationPolicy)
         = 0;
-    virtual void emitPipelineStart(QueryId, const std::shared_ptr<RunningQueryPlanNode>&, BaseTask::onComplete, BaseTask::onFailure) = 0;
-    virtual void emitPendingPipelineStop(QueryId, std::shared_ptr<RunningQueryPlanNode>, BaseTask::onComplete, BaseTask::onFailure) = 0;
-    virtual void emitPipelineStop(QueryId, std::unique_ptr<RunningQueryPlanNode>, BaseTask::onComplete, BaseTask::onFailure) = 0;
+    virtual void emitPipelineStart(QueryId, const std::shared_ptr<RunningQueryPlanNode>&, TaskCallback) = 0;
+    virtual void emitPendingPipelineStop(QueryId, std::shared_ptr<RunningQueryPlanNode>, TaskCallback) = 0;
+    virtual void emitPipelineStop(QueryId, std::unique_ptr<RunningQueryPlanNode>, TaskCallback) = 0;
 };
 }

--- a/nes-query-engine/QueryEngine.cpp
+++ b/nes-query-engine/QueryEngine.cpp
@@ -59,15 +59,15 @@ namespace
 {
 
 /// This function is unsafe because it requires the lifetime of the RunningQueryPlanNode exceed the lifetime of the callback
-auto injectQueryFailureUnsafe(RunningQueryPlanNode* node, TaskCallback::onFailure failure)
+auto injectQueryFailureUnsafe(RunningQueryPlanNode& node, TaskCallback::onFailure failure)
 {
-    return [failure = std::move(failure), node](Exception exception) mutable
+    return [failure = std::move(failure), &node](Exception exception) mutable
     {
         if (failure)
         {
             failure(exception);
         }
-        node->fail(std::move(exception));
+        node.fail(std::move(exception));
     };
 }
 
@@ -307,7 +307,7 @@ public:
         auto wrappedCallback = TaskCallback{
             std::move(complete),
             std::move(success),
-            TaskCallback::OnFailure(injectQueryFailureUnsafe(node.get(), std::move(failure.callback))),
+            TaskCallback::OnFailure(injectQueryFailureUnsafe(*node, std::move(failure.callback))),
         };
         /// Calling the Unsafe version of injectQueryFailure is required here because the RunningQueryPlan is a unique ptr.
         /// However the StopPipelineTask takes ownership of the Node and thus guarantees that it is alive when the callback is invoked.

--- a/nes-query-engine/QueryEngine.cpp
+++ b/nes-query-engine/QueryEngine.cpp
@@ -55,6 +55,65 @@
 namespace NES
 {
 
+namespace
+{
+
+/// This function is unsafe because it requires the lifetime of the RunningQueryPlanNode exceed the lifetime of the callback
+auto injectQueryFailureUnsafe(RunningQueryPlanNode* node, TaskCallback::onFailure failure)
+{
+    return [failure = std::move(failure), node](Exception exception) mutable
+    {
+        if (failure)
+        {
+            failure(exception);
+        }
+        node->fail(std::move(exception));
+    };
+}
+
+auto injectQueryFailure(std::weak_ptr<RunningQueryPlanNode> node, TaskCallback::onFailure failure)
+{
+    return [failure = std::move(failure), node = std::move(node)](Exception exception) mutable
+    {
+        const auto strongReference = node.lock();
+        if (!strongReference)
+        {
+            ENGINE_LOG_ERROR(
+                "Query Failure could not be reported as query has already been terminated. Original Error: {}", exception.what());
+            return;
+        }
+
+        if (failure)
+        {
+            failure(exception);
+        }
+        strongReference->fail(exception);
+    };
+}
+
+auto injectReferenceCountReducer(
+    ENGINE_IF_LOG_DEBUG(QueryId qid, ) std::weak_ptr<RunningQueryPlanNode> node, TaskCallback::onComplete innerFunction)
+{
+    return [ENGINE_IF_LOG_DEBUG(qid, ) innerFunction = std::move(innerFunction), node = std::weak_ptr(std::move(node))]() mutable
+    {
+        if (innerFunction)
+        {
+            innerFunction();
+        }
+        if (auto existingNode = node.lock())
+        {
+            auto updatedCount = existingNode->pendingTasks.fetch_sub(1) - 1;
+            ENGINE_LOG_DEBUG("Decreasing number of pending tasks on pipeline {}-{} to {}", qid, existingNode->id, updatedCount);
+            INVARIANT(updatedCount >= 0, "ThreadPool returned a negative number of pending tasks.");
+        }
+        else
+        {
+            ENGINE_LOG_WARNING("Node Expired and pendingTasks could not be reduced");
+        }
+    };
+}
+
+}
 
 /// The Query has not been started yet. But a slot in the QueryCatalog has been reserved.
 struct Reserved
@@ -185,79 +244,24 @@ class ThreadPool : public WorkEmitter, public QueryLifetimeController
 public:
     void addThread();
 
-    /// This function is unsafe because it requires the lifetime of the RunningQueryPlanNode exceed the lifetime of the callback
-    std::function<void(Exception)> injectQueryFailureUnsafe(RunningQueryPlanNode* node, std::function<void(Exception)> failure)
-    {
-        return [failure, node = std::move(node)](Exception exception)
-        {
-            if (failure)
-            {
-                failure(exception);
-            }
-            node->fail(exception);
-        };
-    }
-
-    std::function<void(Exception)> injectQueryFailure(std::weak_ptr<RunningQueryPlanNode> node, std::function<void(Exception)> failure)
-    {
-        return [failure, node = std::move(node)](Exception exception)
-        {
-            const auto strongReference = node.lock();
-            if (!strongReference)
-            {
-                ENGINE_LOG_ERROR(
-                    "Query Failure could not be reported as query has already been terminated. Original Error: {}", exception.what());
-                return;
-            }
-
-            if (failure)
-            {
-                failure(exception);
-            }
-            strongReference->fail(exception);
-        };
-    }
-
-    template <typename... Args>
-    auto injectReferenceCountReducer(
-        ENGINE_IF_LOG_DEBUG(QueryId qid, ) std::weak_ptr<RunningQueryPlanNode> node, std::function<void(Args...)> innerFunction)
-    {
-        return [ENGINE_IF_LOG_DEBUG(qid, ) innerFunction = std::move(innerFunction), node = std::weak_ptr(node)](Args... args)
-        {
-            if (innerFunction)
-            {
-                innerFunction(args...);
-            }
-            if (auto existingNode = node.lock())
-            {
-                auto updatedCount = existingNode->pendingTasks.fetch_sub(1) - 1;
-                ENGINE_LOG_DEBUG("Decreasing number of pending tasks on pipeline {}-{} to {}", qid, existingNode->id, updatedCount);
-                INVARIANT(updatedCount >= 0, "ThreadPool returned a negative number of pending tasks.");
-            }
-            else
-            {
-                ENGINE_LOG_WARNING("Node Expired and pendingTasks could not be reduced");
-            }
-        };
-    }
-
     bool emitWork(
         QueryId qid,
         const std::shared_ptr<RunningQueryPlanNode>& node,
         TupleBuffer buffer,
-        BaseTask::onComplete complete,
-        BaseTask::onFailure failure,
+        TaskCallback callback,
         const PipelineExecutionContext::ContinuationPolicy continuationPolicy) override
     {
         [[maybe_unused]] auto updatedCount = node->pendingTasks.fetch_add(1) + 1;
         ENGINE_LOG_DEBUG("Increasing number of pending tasks on pipeline {}-{} to {}", qid, node->id, updatedCount);
-        auto task = WorkTask(
-            qid,
-            node->id,
-            node,
-            buffer,
-            injectReferenceCountReducer(ENGINE_IF_LOG_DEBUG(qid, ) node, std::move(complete)),
-            injectQueryFailure(node, injectReferenceCountReducer(ENGINE_IF_LOG_DEBUG(qid, ) node, std::move(failure))));
+        auto [complete, failure, success] = std::move(callback).take();
+        /// Create a new callback that wraps the reference count reducer
+        auto wrappedCallback = TaskCallback{
+            TaskCallback::OnComplete(injectReferenceCountReducer(ENGINE_IF_LOG_DEBUG(qid, ) node, std::move(complete.callback))),
+            std::move(success),
+            TaskCallback::OnFailure(injectQueryFailure(node, std::move(failure.callback))),
+        };
+
+        auto task = WorkTask(qid, node->id, node, buffer, std::move(wrappedCallback));
         if (WorkerThread::id == INVALID<WorkerThreadId>)
         {
             /// Non-WorkerThread
@@ -286,19 +290,28 @@ public:
         }
     }
 
-    void emitPipelineStart(
-        QueryId qid, const std::shared_ptr<RunningQueryPlanNode>& node, BaseTask::onComplete complete, BaseTask::onFailure failure) override
+    void emitPipelineStart(QueryId qid, const std::shared_ptr<RunningQueryPlanNode>& node, TaskCallback callback) override
     {
-        addTaskOrDoNextTask(StartPipelineTask(qid, node->id, complete, injectQueryFailure(node, failure), node));
+        auto [complete, failure, success] = std::move(callback).take();
+        auto wrappedCallback = TaskCallback{
+            std::move(complete),
+            std::move(success),
+            TaskCallback::OnFailure(injectQueryFailure(node, std::move(failure.callback))),
+        };
+        addTaskOrDoNextTask(StartPipelineTask(qid, node->id, std::move(wrappedCallback), node));
     }
 
-    void emitPipelineStop(
-        QueryId qid, std::unique_ptr<RunningQueryPlanNode> node, BaseTask::onComplete complete, BaseTask::onFailure failure) override
+    void emitPipelineStop(QueryId qid, std::unique_ptr<RunningQueryPlanNode> node, TaskCallback callback) override
     {
-        auto nodePtr = node.get();
+        auto [complete, failure, success] = std::move(callback).take();
+        auto wrappedCallback = TaskCallback{
+            std::move(complete),
+            std::move(success),
+            TaskCallback::OnFailure(injectQueryFailureUnsafe(node.get(), std::move(failure.callback))),
+        };
         /// Calling the Unsafe version of injectQueryFailure is required here because the RunningQueryPlan is a unique ptr.
         /// However the StopPipelineTask takes ownership of the Node and thus guarantees that it is alive when the callback is invoked.
-        addTaskOrDoNextTask(StopPipelineTask(qid, std::move(node), complete, injectQueryFailureUnsafe(nodePtr, failure)));
+        addTaskOrDoNextTask(StopPipelineTask(qid, std::move(node), std::move(wrappedCallback)));
     }
 
     void initializeSourceFailure(QueryId id, OriginId sourceId, std::weak_ptr<RunningSource> source, Exception exception) override
@@ -308,9 +321,9 @@ public:
             id,
             std::move(source),
             std::move(exception),
-            [id, sourceId, listener = listener]
-            { listener->logSourceTermination(id, sourceId, QueryTerminationType::Failure, std::chrono::system_clock::now()); },
-            {}});
+            TaskCallback{TaskCallback::OnSuccess(
+                [id, sourceId, listener = listener]
+                { listener->logSourceTermination(id, sourceId, QueryTerminationType::Failure, std::chrono::system_clock::now()); })}});
     }
 
     void initializeSourceStop(QueryId id, OriginId sourceId, std::weak_ptr<RunningSource> source) override
@@ -319,16 +332,15 @@ public:
         admissionQueue.blockingWrite(StopSourceTask{
             id,
             std::move(source),
-            [id, sourceId, listener = listener]
-            { listener->logSourceTermination(id, sourceId, QueryTerminationType::Graceful, std::chrono::system_clock::now()); },
-            {}});
+            TaskCallback{TaskCallback::OnSuccess(
+                [id, sourceId, listener = listener]
+                { listener->logSourceTermination(id, sourceId, QueryTerminationType::Graceful, std::chrono::system_clock::now()); })}});
     }
 
-    void emitPendingPipelineStop(
-        QueryId queryId, std::shared_ptr<RunningQueryPlanNode> node, BaseTask::onComplete complete, BaseTask::onFailure failure) override
+    void emitPendingPipelineStop(QueryId queryId, std::shared_ptr<RunningQueryPlanNode> node, TaskCallback callback) override
     {
         ENGINE_LOG_DEBUG("Inserting Pending Pipeline Stop for {}-{}", queryId, node->id);
-        addTaskOrDoNextTask(PendingPipelineStopTask{queryId, std::move(node), 0, std::move(complete), std::move(failure)});
+        addTaskOrDoNextTask(PendingPipelineStopTask{queryId, std::move(node), 0, std::move(callback)});
     }
 
     ThreadPool(
@@ -355,18 +367,19 @@ public:
     struct WorkerThread
     {
         static thread_local WorkerThreadId id;
-        /// Handler for different Pipeline Tasks
-        /// Boolean return value indicates if the onComplete should be called
-        bool operator()(const WorkTask& task) const;
-        bool operator()(const StopQueryTask& stopQuery) const;
-        bool operator()(StartQueryTask& startQuery) const;
-        bool operator()(const StartPipelineTask& startPipeline) const;
-        bool operator()(PendingPipelineStopTask pendingPipelineStop) const;
-        bool operator()(const StopPipelineTask& stopPipelineTask) const;
-        bool operator()(const StopSourceTask& stopSource) const;
-        bool operator()(const FailSourceTask& failSource) const;
 
         [[nodiscard]] WorkerThread(ThreadPool& pool, bool terminating) : pool(pool), terminating(terminating) { }
+
+        /// Handler for different Pipeline Tasks
+        /// Boolean return value indicates if the onSuccess should be called
+        bool operator()(WorkTask& task) const;
+        bool operator()(StopQueryTask& stopQuery) const;
+        bool operator()(StartQueryTask& startQuery) const;
+        bool operator()(StartPipelineTask& startPipeline) const;
+        bool operator()(PendingPipelineStopTask& pendingPipelineStop) const;
+        bool operator()(StopPipelineTask& stopPipelineTask) const;
+        bool operator()(StopSourceTask& stopSource) const;
+        bool operator()(FailSourceTask& failSource) const;
 
     private:
         ThreadPool& pool; ///NOLINT The ThreadPool will always outlive the worker and not move.
@@ -376,18 +389,8 @@ public:
 private:
     void doTaskInPlace(Task&& task)
     {
-        WorkerThread worker{*this, false};
-        try
-        {
-            if (std::visit(worker, task))
-            {
-                completeTask(task);
-            }
-        }
-        catch (const Exception& exception)
-        {
-            failTask(task, exception);
-        }
+        const WorkerThread worker{*this, false};
+        handleTask(worker, std::move(task));
     }
 
     void addTaskOrDoItInPlace(Task&& task)
@@ -446,7 +449,7 @@ private:
 /// Marks every Thread which has not explicitly been created by the ThreadPool as a non-worker thread
 thread_local WorkerThreadId ThreadPool::WorkerThread::id = INVALID<WorkerThreadId>;
 
-bool ThreadPool::WorkerThread::operator()(const WorkTask& task) const
+bool ThreadPool::WorkerThread::operator()(WorkTask& task) const
 {
     if (terminating)
     {
@@ -463,7 +466,7 @@ bool ThreadPool::WorkerThread::operator()(const WorkTask& task) const
             WorkerThread::id,
             pipeline->id,
             pool.bufferProvider,
-            [&](const TupleBuffer& tupleBuffer, auto continuationPolicy)
+            [&](const TupleBuffer& tupleBuffer, PipelineExecutionContext::ContinuationPolicy continuationPolicy)
             {
                 ENGINE_LOG_DEBUG(
                     "Task emitted tuple buffer {}-{}. Tuples: {}", task.queryId, task.pipelineId, tupleBuffer.getNumberOfTuples());
@@ -472,7 +475,7 @@ bool ThreadPool::WorkerThread::operator()(const WorkTask& task) const
                 {
                     pool.statistic->onEvent(
                         TaskEmit{id, task.queryId, pipeline->id, pipeline->id, taskId, tupleBuffer.getNumberOfTuples()});
-                    return pool.emitWork(task.queryId, pipeline, tupleBuffer, {}, {}, continuationPolicy);
+                    return pool.emitWork(task.queryId, pipeline, tupleBuffer, TaskCallback{}, continuationPolicy);
                 }
                 /// Otherwise, get the successor of the pipeline, and emit a work task for it.
                 return std::ranges::all_of(
@@ -481,7 +484,7 @@ bool ThreadPool::WorkerThread::operator()(const WorkTask& task) const
                     {
                         pool.statistic->onEvent(
                             TaskEmit{id, task.queryId, pipeline->id, successor->id, taskId, tupleBuffer.getNumberOfTuples()});
-                        return pool.emitWork(task.queryId, successor, tupleBuffer, {}, {}, continuationPolicy);
+                        return pool.emitWork(task.queryId, successor, tupleBuffer, TaskCallback{}, continuationPolicy);
                     });
             });
         pool.statistic->onEvent(TaskExecutionStart{WorkerThread::id, task.queryId, pipeline->id, taskId, task.buf.getNumberOfTuples()});
@@ -496,7 +499,7 @@ bool ThreadPool::WorkerThread::operator()(const WorkTask& task) const
     return false;
 }
 
-bool ThreadPool::WorkerThread::operator()(const StartPipelineTask& startPipeline) const
+bool ThreadPool::WorkerThread::operator()(StartPipelineTask& startPipeline) const
 {
     if (terminating)
     {
@@ -512,7 +515,7 @@ bool ThreadPool::WorkerThread::operator()(const StartPipelineTask& startPipeline
             WorkerThread::id,
             pipeline->id,
             pool.bufferProvider,
-            [](const auto&, auto)
+            [](const TupleBuffer&, PipelineExecutionContext::ContinuationPolicy)
             {
                 /// Catch Emits, that are currently not supported during pipeline stage initialization.
                 INVARIANT(
@@ -530,7 +533,7 @@ bool ThreadPool::WorkerThread::operator()(const StartPipelineTask& startPipeline
     return false;
 }
 
-bool ThreadPool::WorkerThread::operator()(PendingPipelineStopTask pendingPipelineStop) const
+bool ThreadPool::WorkerThread::operator()(PendingPipelineStopTask& pendingPipelineStop) const
 {
     INVARIANT(
         pendingPipelineStop.pipeline->pendingTasks >= 0,
@@ -570,7 +573,7 @@ bool ThreadPool::WorkerThread::operator()(PendingPipelineStopTask pendingPipelin
     return true;
 }
 
-bool ThreadPool::WorkerThread::operator()(const StopPipelineTask& stopPipelineTask) const
+bool ThreadPool::WorkerThread::operator()(StopPipelineTask& stopPipelineTask) const
 {
     ENGINE_LOG_DEBUG("Stop Pipeline Task for {}-{}", stopPipelineTask.queryId, stopPipelineTask.pipeline->id);
     DefaultPEC pec(
@@ -578,7 +581,7 @@ bool ThreadPool::WorkerThread::operator()(const StopPipelineTask& stopPipelineTa
         WorkerThread::id,
         stopPipelineTask.pipeline->id,
         pool.bufferProvider,
-        [&](const TupleBuffer& tupleBuffer, auto policy)
+        [&](const TupleBuffer& tupleBuffer, PipelineExecutionContext::ContinuationPolicy policy)
         {
             if (terminating)
             {
@@ -591,7 +594,7 @@ bool ThreadPool::WorkerThread::operator()(const StopPipelineTask& stopPipelineTa
                 /// The Termination Exceution Context appends a strong reference to the successer into the Task.
                 /// This prevents the successor nodes to be destructed before they were able process tuplebuffer generated during
                 /// pipeline termination.
-                pool.emitWork(stopPipelineTask.queryId, successor, tupleBuffer, [ref = successor] { }, {}, policy);
+                pool.emitWork(stopPipelineTask.queryId, successor, tupleBuffer, TaskCallback{}, policy);
             }
             return true;
         });
@@ -602,7 +605,7 @@ bool ThreadPool::WorkerThread::operator()(const StopPipelineTask& stopPipelineTa
     return true;
 }
 
-bool ThreadPool::WorkerThread::operator()(const StopQueryTask& stopQuery) const
+bool ThreadPool::WorkerThread::operator()(StopQueryTask& stopQuery) const
 {
     ENGINE_LOG_INFO("Terminate Query Task for Query {}", stopQuery.queryId);
     if (auto queryCatalog = stopQuery.catalog.lock())
@@ -626,7 +629,7 @@ bool ThreadPool::WorkerThread::operator()(StartQueryTask& startQuery) const
     return false;
 }
 
-bool ThreadPool::WorkerThread::operator()(const StopSourceTask& stopSource) const
+bool ThreadPool::WorkerThread::operator()(StopSourceTask& stopSource) const
 {
     if (auto source = stopSource.target.lock())
     {
@@ -634,7 +637,7 @@ bool ThreadPool::WorkerThread::operator()(const StopSourceTask& stopSource) cons
         if (!source->attemptUnregister())
         {
             ENGINE_LOG_DEBUG("Could not immediately stop source. Reattempting at a later point");
-            pool.addTaskOrDoNextTask(stopSource);
+            pool.addTaskOrDoNextTask(StopSourceTask{stopSource.queryId, stopSource.target, std::move(stopSource.callback)});
             return false;
         }
         return true;
@@ -644,7 +647,7 @@ bool ThreadPool::WorkerThread::operator()(const StopSourceTask& stopSource) cons
     return false;
 }
 
-bool ThreadPool::WorkerThread::operator()(const FailSourceTask& failSource) const
+bool ThreadPool::WorkerThread::operator()(FailSourceTask& failSource) const
 {
     if (auto source = failSource.target.lock())
     {
@@ -681,17 +684,7 @@ void ThreadPool::addThread()
                 {
                     continue;
                 }
-                try
-                {
-                    if (std::visit(worker, task))
-                    {
-                        completeTask(task);
-                    }
-                }
-                catch (const Exception& exception)
-                {
-                    failTask(task, exception);
-                }
+                handleTask(worker, std::move(task));
             }
 
             ENGINE_LOG_INFO("WorkerThread {} shutting down", id);
@@ -704,18 +697,7 @@ void ThreadPool::addThread()
                 {
                     break;
                 }
-
-                try
-                {
-                    if (std::visit(terminatingWorker, task))
-                    {
-                        completeTask(task);
-                    }
-                }
-                catch (const Exception& exception)
-                {
-                    failTask(task, exception);
-                }
+                handleTask(terminatingWorker, std::move(task));
             }
         });
 }
@@ -742,14 +724,14 @@ QueryEngine::QueryEngine(
 void QueryEngine::stop(QueryId queryId)
 {
     ENGINE_LOG_INFO("Stopping Query: {}", queryId);
-    threadPool->admissionQueue.blockingWrite(StopQueryTask{queryId, queryCatalog, {}, {}});
+    threadPool->admissionQueue.blockingWrite(StopQueryTask{queryId, queryCatalog, TaskCallback{}});
 }
 
 /// NOLINTNEXTLINE Intentionally non-const
 void QueryEngine::start(std::unique_ptr<ExecutableQueryPlan> executableQueryPlan)
 {
     threadPool->admissionQueue.blockingWrite(
-        StartQueryTask{executableQueryPlan->queryId, std::move(executableQueryPlan), queryCatalog, {}, {}});
+        StartQueryTask{executableQueryPlan->queryId, std::move(executableQueryPlan), queryCatalog, TaskCallback{}});
 }
 
 QueryEngine::~QueryEngine()
@@ -838,12 +820,12 @@ void QueryCatalog::start(
             if (const auto locked = state.lock())
             {
                 locked->transition(
-                    [](Starting&& starting)
+                    [](Starting&& starting) /// NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
                     {
                         RunningQueryPlan::dispose(std::move(starting.plan));
                         return Terminated{Terminated::Stopped};
                     },
-                    [](Running&& running)
+                    [](Running&& running) /// NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
                     {
                         RunningQueryPlan::dispose(std::move(running.plan));
                         return Terminated{Terminated::Stopped};
@@ -872,7 +854,8 @@ void QueryCatalog::start(
 
     auto [runningQueryPlan, callback] = RunningQueryPlan::start(queryId, std::move(plan), controller, emitter, queryListener);
 
-    if (state->transition([&](Reserved&&) { return Starting{std::move(runningQueryPlan)}; }))
+    if (state->transition([&](Reserved&&)
+                          { return Starting{std::move(runningQueryPlan)}; })) /// NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
     {
         listener->logQueryStatusChange(queryId, QueryState::Started, startTimestamp);
     }
@@ -882,8 +865,7 @@ void QueryCatalog::start(
         INVARIANT(
             state->is<Terminated>(),
             "Bug: There is no other option for the state. The only transition from reserved to Starting happens here. Starting will "
-            "not "
-            "transition into running until the callback is dropped.");
+            "not transition into running until the callback is dropped.");
         RunningQueryPlan::dispose(std::move(runningQueryPlan));
     }
 }
@@ -898,13 +880,13 @@ void QueryCatalog::stopQuery(QueryId id)
         {
             auto& state = *it->second;
             state.transition(
-                [&ref](Starting&& starting)
+                [&ref](Starting&& starting) /// NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
                 {
                     auto [stoppingQueryPlan, callback] = RunningQueryPlan::stop(std::move(starting.plan));
                     ref = callback;
                     return Stopping{std::move(stoppingQueryPlan)};
                 },
-                [&ref](Running&& running)
+                [&ref](Running&& running) /// NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
                 {
                     auto [stoppingQueryPlan, callback] = RunningQueryPlan::stop(std::move(running.plan));
                     ref = callback;

--- a/nes-query-engine/RunningQueryPlan.hpp
+++ b/nes-query-engine/RunningQueryPlan.hpp
@@ -172,7 +172,7 @@ struct StoppingQueryPlan
 };
 
 /// It is possible to attach callbacks to the RunningQueryPlan
-struct RunningQueryPlan
+struct RunningQueryPlan final
 {
     /// Returns a RunningQueryPlan alongside a CallbackRef.
     /// The CallbackRef prevents the RunningQueryPlan from completing its setup:
@@ -186,10 +186,9 @@ struct RunningQueryPlan
         std::shared_ptr<QueryLifetimeListener>);
 
     /// Stopping a RunningQueryPlan will:
-    /// 1. Keep all callbacks alive. Eventually onDestruction will be called.
-    /// 2. Initialize pipeline termination asynchronously.
-    /// 3. Block until all sources are terminated.
-    static std::pair<std::unique_ptr<StoppingQueryPlan>, CallbackRef> stop(std::unique_ptr<RunningQueryPlan> runningQueryPlan);
+    /// 1. Initialize pipeline termination asynchronously.
+    /// 2. Block until all sources are terminated.
+    static std::unique_ptr<StoppingQueryPlan> stop(std::unique_ptr<RunningQueryPlan> runningQueryPlan);
 
     /// Disposing a RunningQueryPlan will:
     /// 1. Not notify any listeners. `onDestruction` will not be called.

--- a/nes-query-engine/RunningSource.cpp
+++ b/nes-query-engine/RunningSource.cpp
@@ -74,8 +74,7 @@ SourceReturnType::EmitFunction emitFunction(
                             queryId,
                             successor,
                             data.buffer,
-                            [availableBuffer] { availableBuffer->release(); },
-                            {},
+                            TaskCallback{TaskCallback::OnComplete([availableBuffer] { availableBuffer->release(); })},
                             PipelineExecutionContext::ContinuationPolicy::NEVER))
                         {
                             if (stopToken.stop_requested())

--- a/nes-query-engine/Task.cpp
+++ b/nes-query-engine/Task.cpp
@@ -21,14 +21,10 @@
 
 namespace NES
 {
-StopPipelineTask::~StopPipelineTask() = default;
 
-StopPipelineTask::StopPipelineTask(StopPipelineTask&& other) noexcept = default;
-StopPipelineTask& StopPipelineTask::operator=(StopPipelineTask&& other) noexcept = default;
 
-StopPipelineTask::StopPipelineTask(
-    QueryId queryId, std::unique_ptr<RunningQueryPlanNode> pipeline, onComplete complete, onFailure failure) noexcept
-    : BaseTask(queryId, std::move(complete), std::move(failure)), pipeline(std::move(pipeline))
+StopPipelineTask::StopPipelineTask(QueryId queryId, std::unique_ptr<RunningQueryPlanNode> pipeline, TaskCallback callback) noexcept
+    : BaseTask(queryId, std::move(callback)), pipeline(std::move(pipeline))
 {
 }
 

--- a/nes-query-engine/Task.cpp
+++ b/nes-query-engine/Task.cpp
@@ -14,18 +14,166 @@
 
 #include <Task.hpp>
 
+#include <cstddef>
 #include <memory>
+#include <tuple>
 #include <utility>
+#include <variant>
 #include <Identifiers/Identifiers.hpp>
+#include <Runtime/TupleBuffer.hpp>
+#include <EngineLogger.hpp>
+#include <ErrorHandling.hpp>
+#include <ExecutableQueryPlan.hpp>
 #include <RunningQueryPlan.hpp>
 
 namespace NES
 {
 
 
+TaskCallback::OnComplete::OnComplete(onComplete callback) : callback(std::move(callback))
+{
+}
+
+TaskCallback::OnSuccess::OnSuccess(onSuccess callback) : callback(std::move(callback))
+{
+}
+
+TaskCallback::OnFailure::OnFailure(onFailure callback) : callback(std::move(callback))
+{
+}
+
+void TaskCallback::callOnComplete()
+{
+    if (onCompleteCallback)
+    {
+        ENGINE_LOG_DEBUG("TaskCallback::callOnComplete");
+        onCompleteCallback();
+    }
+}
+
+void TaskCallback::callOnSuccess()
+{
+    if (onSuccessCallback)
+    {
+        ENGINE_LOG_DEBUG("TaskCallback::callOnSuccess");
+        onSuccessCallback();
+    }
+}
+
+void TaskCallback::callOnFailure(Exception exception)
+{
+    if (onFailureCallback)
+    {
+        ENGINE_LOG_ERROR("TaskCallback::callOnFailure");
+        onFailureCallback(std::move(exception));
+    }
+}
+
+std::tuple<TaskCallback::OnComplete, TaskCallback::OnFailure, TaskCallback::OnSuccess> TaskCallback::take() &&
+{
+    auto callbacks = std::make_tuple(
+        OnComplete{std::move(onCompleteCallback)}, OnFailure{std::move(onFailureCallback)}, OnSuccess{std::move(onSuccessCallback)});
+    this->onCompleteCallback = {};
+    this->onSuccessCallback = {};
+    this->onFailureCallback = {};
+    return callbacks;
+}
+
+void TaskCallback::processArgs(OnComplete onComplete)
+{
+    onCompleteCallback = std::move(onComplete.callback);
+}
+
+void TaskCallback::processArgs(OnSuccess onSuccess)
+{
+    onSuccessCallback = std::move(onSuccess.callback);
+}
+
+void TaskCallback::processArgs(OnFailure onFailure)
+{
+    onFailureCallback = std::move(onFailure.callback);
+}
+
+BaseTask::BaseTask(QueryId queryId, TaskCallback callback) : queryId(queryId), callback(std::move(callback))
+{
+}
+
+void BaseTask::complete()
+{
+    callback.callOnComplete();
+}
+
+void BaseTask::succeed()
+{
+    callback.callOnSuccess();
+}
+
+void BaseTask::fail(Exception exception)
+{
+    callback.callOnFailure(std::move(exception));
+}
+
+WorkTask::WorkTask(
+    QueryId queryId, PipelineId pipelineId, std::weak_ptr<RunningQueryPlanNode> pipeline, TupleBuffer buf, TaskCallback callback)
+    : BaseTask(queryId, std::move(callback)), pipeline(std::move(pipeline)), pipelineId(pipelineId), buf(std::move(buf))
+{
+}
+
+StartPipelineTask::StartPipelineTask(
+    QueryId queryId, PipelineId pipelineId, TaskCallback callback, std::weak_ptr<RunningQueryPlanNode> pipeline)
+    : BaseTask(std::move(queryId), std::move(callback)), pipeline(std::move(pipeline)), pipelineId(std::move(pipelineId))
+{
+}
+
 StopPipelineTask::StopPipelineTask(QueryId queryId, std::unique_ptr<RunningQueryPlanNode> pipeline, TaskCallback callback) noexcept
     : BaseTask(queryId, std::move(callback)), pipeline(std::move(pipeline))
 {
+}
+
+StopSourceTask::StopSourceTask(QueryId queryId, std::weak_ptr<RunningSource> target, TaskCallback callback)
+    : BaseTask(queryId, std::move(callback)), target(std::move(target))
+{
+}
+
+FailSourceTask::FailSourceTask() : exception("", 0)
+{
+}
+
+FailSourceTask::FailSourceTask(QueryId queryId, std::weak_ptr<RunningSource> target, Exception exception, TaskCallback callback)
+    : BaseTask(queryId, std::move(callback)), target(std::move(target)), exception(std::move(exception))
+{
+}
+
+StopQueryTask::StopQueryTask(QueryId queryId, std::weak_ptr<QueryCatalog> catalog, TaskCallback callback)
+    : BaseTask(std::move(queryId), std::move(callback)), catalog(std::move(catalog))
+{
+}
+
+StartQueryTask::StartQueryTask(
+    QueryId queryId, std::unique_ptr<ExecutableQueryPlan> queryPlan, std::weak_ptr<QueryCatalog> catalog, TaskCallback callback)
+    : BaseTask(std::move(queryId), std::move(callback)), queryPlan(std::move(queryPlan)), catalog(std::move(catalog))
+{
+}
+
+PendingPipelineStopTask::PendingPipelineStopTask(
+    QueryId queryId, std::shared_ptr<RunningQueryPlanNode> pipeline, size_t attempts, TaskCallback callback)
+    : BaseTask(std::move(queryId), std::move(callback)), attempts(attempts), pipeline(std::move(pipeline))
+{
+}
+
+void succeedTask(Task& task)
+{
+    std::visit([](auto& specificTask) { return specificTask.succeed(); }, task);
+}
+
+void completeTask(Task& task)
+{
+    std::visit([](auto& specificTask) { return specificTask.complete(); }, task);
+}
+
+void failTask(Task& task, Exception exception)
+{
+    std::visit([&exception](auto& specificTask) { return specificTask.fail(std::move(exception)); }, task);
 }
 
 }

--- a/nes-query-engine/Task.hpp
+++ b/nes-query-engine/Task.hpp
@@ -17,11 +17,15 @@
 #include <chrono>
 #include <functional>
 #include <memory>
+#include <tuple>
 #include <utility>
 #include <variant>
 #include <Identifiers/Identifiers.hpp>
 #include <Identifiers/NESStrongType.hpp>
 #include <Runtime/TupleBuffer.hpp>
+#include <absl/functional/any_invocable.h>
+#include <cpptrace/from_current.hpp>
+#include <EngineLogger.hpp>
 #include <ErrorHandling.hpp>
 #include <ExecutableQueryPlan.hpp>
 
@@ -32,65 +36,125 @@ struct RunningQueryPlanNode;
 class RunningSource;
 class QueryCatalog;
 
+/// It is possible to register callbacks which are invoked after task execution.
+/// The complete callback is invoked regardless of the outcome of the task (even throwing an exception)
+/// The success callback is invoked if the task succeeds. It is not invoked if the task throws an exception,
+///     but could be skipped for tasks that are deemed unsuccessful, even without an exception.
+/// The failure callback is invoked if the task fails with an exception.
+/// Callbacks are move only, thus every callback is invoked at most once.
+class TaskCallback
+{
+public:
+    using onComplete = absl::AnyInvocable<void()>;
+    using onSuccess = absl::AnyInvocable<void()>;
+    using onFailure = absl::AnyInvocable<void(Exception)>;
+
+    /// Helper structs that wrap the callbacks
+    struct OnComplete
+    {
+        onComplete callback;
+
+        explicit OnComplete(onComplete callback) : callback(std::move(callback)) { }
+    };
+
+    struct OnSuccess
+    {
+        onSuccess callback;
+
+        explicit OnSuccess(onSuccess callback) : callback(std::move(callback)) { }
+    };
+
+    struct OnFailure
+    {
+        onFailure callback;
+
+        explicit OnFailure(onFailure callback) : callback(std::move(callback)) { }
+    };
+
+    TaskCallback() = default;
+
+    /// Variadic template constructor
+    template <typename... Args>
+    explicit TaskCallback(Args&&... args)
+    {
+        (processArgs(std::forward<Args>(args)), ...);
+    }
+
+    void callOnComplete()
+    {
+        if (onCompleteCallback)
+        {
+            ENGINE_LOG_DEBUG("TaskCallback::callOnComplete");
+            onCompleteCallback();
+        }
+    }
+
+    void callOnSuccess()
+    {
+        if (onSuccessCallback)
+        {
+            ENGINE_LOG_DEBUG("TaskCallback::callOnSuccess");
+            onSuccessCallback();
+        }
+    }
+
+    void callOnFailure(Exception exception)
+    {
+        if (onFailureCallback)
+        {
+            ENGINE_LOG_ERROR("TaskCallback::callOnFailure");
+            onFailureCallback(std::move(exception));
+        }
+    }
+
+    [[nodiscard]] std::tuple<onComplete, onFailure, onSuccess> take() &&
+    {
+        auto callbacks = std::make_tuple(std::move(onCompleteCallback), std::move(onFailureCallback), std::move(onSuccessCallback));
+        this->onCompleteCallback = {};
+        this->onSuccessCallback = {};
+        this->onFailureCallback = {};
+        return callbacks;
+    }
+
+private:
+    /// Process OnComplete tag and callback
+    void processArgs(OnComplete onComplete) { onCompleteCallback = std::move(onComplete.callback); }
+
+    /// Process OnSuccess tag and callback
+    void processArgs(OnSuccess onSuccess) { onSuccessCallback = std::move(onSuccess.callback); }
+
+    /// Process OnFailure tag and callback
+    void processArgs(OnFailure onFailure) { onFailureCallback = std::move(onFailure.callback); }
+
+    onComplete onCompleteCallback;
+    onSuccess onSuccessCallback;
+    onFailure onFailureCallback;
+};
+
 class BaseTask
 {
 public:
-    using onComplete = std::function<void()>;
-    using onFailure = std::function<void(Exception)>;
-
     BaseTask() = default;
 
-    BaseTask(QueryId queryId, std::function<void()> onCompletion, std::function<void(Exception)> onError)
-        : queryId(queryId), onCompletion(std::move(onCompletion)), onError(std::move(onError))
-    {
-    }
+    BaseTask(QueryId queryId, TaskCallback callback) : queryId(queryId), callback(std::move(callback)) { }
 
-    void complete() const
-    {
-        /// NOLINTNEXTLINE bugprone-assignment-in-if-condition. Does not work in the INVARIANT macro. This is equivalent to !called.exchange(true)
-        INVARIANT(!onCompletionCalled && (onCompletionCalled = true, true), "Completion callback should only be called once");
-        if (onCompletion)
-        {
-            onCompletion();
-        }
-    }
+    void complete() { callback.callOnComplete(); }
 
-    void fail(Exception exception) const
-    {
-        /// NOLINTNEXTLINE bugprone-assignment-in-if-condition
-        INVARIANT(!onErrorCalled && (onErrorCalled = true, true), "Error callback should only be called once");
-        if (onError)
-        {
-            onError(std::move(exception));
-        }
-    }
+    void succeed() { callback.callOnSuccess(); }
+
+    void fail(Exception exception) { callback.callOnFailure(std::move(exception)); }
 
     QueryId queryId = INVALID<QueryId>;
+    TaskCallback callback;
 
 private:
-#ifndef NO_ASSERT /// Only used in debug INVARIANT
-    mutable bool onCompletionCalled = false;
-    mutable bool onErrorCalled = false;
-#endif
-
-    std::chrono::high_resolution_clock::time_point creation = std::chrono::high_resolution_clock::now();
-    std::function<void()> onCompletion = [] { };
-    std::function<void(Exception)> onError = [](Exception) { };
+    /// No need for onSuccessCalled and onErrorCalled since TaskCallback handles this
 };
 
 struct WorkTask : BaseTask
 {
-    WorkTask(
-        QueryId queryId,
-        PipelineId pipelineId,
-        std::weak_ptr<RunningQueryPlanNode> pipeline,
-        TupleBuffer buf,
-        onComplete complete,
-        onFailure failure)
-        : BaseTask(queryId, std::move(complete), std::move(failure))
-        , pipeline(std::move(pipeline))
-        , pipelineId(pipelineId)
-        , buf(std::move(buf))
+    WorkTask(QueryId queryId, PipelineId pipelineId, std::weak_ptr<RunningQueryPlanNode> pipeline, TupleBuffer buf, TaskCallback callback)
+        : BaseTask(queryId, std::move(callback)), pipeline(std::move(pipeline)), pipelineId(pipelineId), buf(std::move(buf))
     {
     }
 
@@ -102,33 +166,18 @@ struct WorkTask : BaseTask
 
 struct StartPipelineTask : BaseTask
 {
-    StartPipelineTask(
-        QueryId queryId,
-        PipelineId pipelineId,
-        std::function<void()> onCompletion,
-        std::function<void(Exception)> onError,
-        std::weak_ptr<RunningQueryPlanNode> pipeline)
-        : BaseTask(std::move(queryId), std::move(onCompletion), std::move(onError))
-        , pipeline(std::move(pipeline))
-        , pipelineId(std::move(pipelineId))
+    StartPipelineTask(QueryId queryId, PipelineId pipelineId, TaskCallback callback, std::weak_ptr<RunningQueryPlanNode> pipeline)
+        : BaseTask(std::move(queryId), std::move(callback)), pipeline(std::move(pipeline)), pipelineId(std::move(pipelineId))
     {
     }
 
-    StartPipelineTask() = default;
     std::weak_ptr<RunningQueryPlanNode> pipeline;
     PipelineId pipelineId = INVALID<PipelineId>;
 };
 
 struct StopPipelineTask : BaseTask
 {
-    explicit StopPipelineTask(
-        QueryId queryId, std::unique_ptr<RunningQueryPlanNode> pipeline, onComplete complete, onFailure failure) noexcept;
-    StopPipelineTask(const StopPipelineTask& other) = delete;
-    StopPipelineTask(StopPipelineTask&& other) noexcept;
-    StopPipelineTask& operator=(const StopPipelineTask& other) = delete;
-    StopPipelineTask& operator=(StopPipelineTask&& other) noexcept;
-    ~StopPipelineTask();
-    StopPipelineTask() = default;
+    explicit StopPipelineTask(QueryId queryId, std::unique_ptr<RunningQueryPlanNode> pipeline, TaskCallback callback) noexcept;
     std::unique_ptr<RunningQueryPlanNode> pipeline;
 };
 
@@ -136,8 +185,8 @@ struct StopSourceTask : BaseTask
 {
     StopSourceTask() = default;
 
-    StopSourceTask(QueryId queryId, std::weak_ptr<RunningSource> target, onComplete onComplete, onFailure onFailure)
-        : BaseTask(queryId, std::move(onComplete), std::move(onFailure)), target(std::move(target))
+    StopSourceTask(QueryId queryId, std::weak_ptr<RunningSource> target, TaskCallback callback)
+        : BaseTask(queryId, std::move(callback)), target(std::move(target))
     {
     }
 
@@ -148,9 +197,8 @@ struct FailSourceTask : BaseTask
 {
     FailSourceTask() : exception("", 0) { }
 
-    FailSourceTask(
-        QueryId queryId, std::weak_ptr<RunningSource> target, const Exception& exception, onComplete onComplete, onFailure onFailure)
-        : BaseTask(queryId, std::move(onComplete), std::move(onFailure)), target(std::move(target)), exception(std::move(exception))
+    FailSourceTask(QueryId queryId, std::weak_ptr<RunningSource> target, const Exception& exception, TaskCallback callback)
+        : BaseTask(queryId, std::move(callback)), target(std::move(target)), exception(std::move(exception))
     {
     }
 
@@ -160,44 +208,30 @@ struct FailSourceTask : BaseTask
 
 struct StopQueryTask : BaseTask
 {
-    StopQueryTask(
-        QueryId queryId, std::weak_ptr<QueryCatalog> catalog, std::function<void()> onCompletion, std::function<void(Exception)> onError)
-        : BaseTask(std::move(queryId), std::move(onCompletion), std::move(onError)), catalog(std::move(catalog))
+    StopQueryTask(QueryId queryId, std::weak_ptr<QueryCatalog> catalog, TaskCallback callback)
+        : BaseTask(std::move(queryId), std::move(callback)), catalog(std::move(catalog))
     {
     }
 
-    StopQueryTask() = default;
     std::weak_ptr<QueryCatalog> catalog;
 };
 
 struct StartQueryTask : BaseTask
 {
     StartQueryTask(
-        QueryId queryId,
-        std::unique_ptr<ExecutableQueryPlan> queryPlan,
-        std::weak_ptr<QueryCatalog> catalog,
-        std::function<void()> onCompletion,
-        std::function<void(Exception)> onError)
-        : BaseTask(std::move(queryId), std::move(onCompletion), std::move(onError))
-        , queryPlan(std::move(queryPlan))
-        , catalog(std::move(catalog))
+        QueryId queryId, std::unique_ptr<ExecutableQueryPlan> queryPlan, std::weak_ptr<QueryCatalog> catalog, TaskCallback callback)
+        : BaseTask(std::move(queryId), std::move(callback)), queryPlan(std::move(queryPlan)), catalog(std::move(catalog))
     {
     }
 
-    StartQueryTask() = default;
     std::unique_ptr<ExecutableQueryPlan> queryPlan;
     std::weak_ptr<QueryCatalog> catalog;
 };
 
 struct PendingPipelineStopTask : BaseTask
 {
-    PendingPipelineStopTask(
-        QueryId queryId,
-        std::shared_ptr<RunningQueryPlanNode> pipeline,
-        size_t attempts,
-        std::function<void()> onCompletion,
-        std::function<void(Exception)> onError)
-        : BaseTask(std::move(queryId), std::move(onCompletion), std::move(onError)), attempts(attempts), pipeline(std::move(pipeline))
+    PendingPipelineStopTask(QueryId queryId, std::shared_ptr<RunningQueryPlanNode> pipeline, size_t attempts, TaskCallback callback)
+        : BaseTask(std::move(queryId), std::move(callback)), attempts(attempts), pipeline(std::move(pipeline))
     {
     }
 
@@ -215,14 +249,42 @@ using Task = std::variant<
     StopPipelineTask,
     StartPipelineTask>;
 
-inline void completeTask(const Task& task)
+inline void succeedTask(Task& task)
+{
+    std::visit([](auto& specificTask) { return specificTask.succeed(); }, task);
+}
+
+inline void completeTask(Task& task)
 {
     std::visit([](auto& specificTask) { return specificTask.complete(); }, task);
 }
 
-inline void failTask(const Task& task, Exception exception)
+inline void failTask(Task& task, Exception exception)
 {
     std::visit([&](auto& specificTask) { return specificTask.fail(std::move(exception)); }, task);
+}
+
+void handleTask(const auto& handler, Task task)
+{
+    CPPTRACE_TRY
+    {
+        /// if handler returns true, the task has been successfully handled, which implies that the task has not been moved
+        if (std::visit(handler, task))
+        {
+            succeedTask(task);
+        }
+    }
+    CPPTRACE_CATCH(const Exception& exception)
+    {
+        failTask(task, exception);
+    }
+    CPPTRACE_CATCH_ALT(...)
+    {
+        NES_ERROR("Worker thread produced unknown exception during processing");
+        tryLogCurrentException();
+        failTask(task, wrapExternalException());
+    }
+    completeTask(task);
 }
 
 }

--- a/nes-query-engine/Task.hpp
+++ b/nes-query-engine/Task.hpp
@@ -14,8 +14,7 @@
 
 #pragma once
 
-#include <chrono>
-#include <functional>
+#include <cstddef>
 #include <memory>
 #include <tuple>
 #include <utility>
@@ -23,9 +22,10 @@
 #include <Identifiers/Identifiers.hpp>
 #include <Identifiers/NESStrongType.hpp>
 #include <Runtime/TupleBuffer.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <Util/TypeTraits.hpp>
 #include <absl/functional/any_invocable.h>
 #include <cpptrace/from_current.hpp>
-#include <EngineLogger.hpp>
 #include <ErrorHandling.hpp>
 #include <ExecutableQueryPlan.hpp>
 
@@ -54,21 +54,21 @@ public:
     {
         onComplete callback;
 
-        explicit OnComplete(onComplete callback) : callback(std::move(callback)) { }
+        explicit OnComplete(onComplete callback);
     };
 
     struct OnSuccess
     {
         onSuccess callback;
 
-        explicit OnSuccess(onSuccess callback) : callback(std::move(callback)) { }
+        explicit OnSuccess(onSuccess callback);
     };
 
     struct OnFailure
     {
         onFailure callback;
 
-        explicit OnFailure(onFailure callback) : callback(std::move(callback)) { }
+        explicit OnFailure(onFailure callback);
     };
 
     TaskCallback() = default;
@@ -77,54 +77,27 @@ public:
     template <typename... Args>
     explicit TaskCallback(Args&&... args)
     {
+        static_assert(UniqueTypesIgnoringCVRef<Args...>, "Cannot use the same callback multiple times");
         (processArgs(std::forward<Args>(args)), ...);
     }
 
-    void callOnComplete()
-    {
-        if (onCompleteCallback)
-        {
-            ENGINE_LOG_DEBUG("TaskCallback::callOnComplete");
-            onCompleteCallback();
-        }
-    }
+    void callOnComplete();
 
-    void callOnSuccess()
-    {
-        if (onSuccessCallback)
-        {
-            ENGINE_LOG_DEBUG("TaskCallback::callOnSuccess");
-            onSuccessCallback();
-        }
-    }
+    void callOnSuccess();
 
-    void callOnFailure(Exception exception)
-    {
-        if (onFailureCallback)
-        {
-            ENGINE_LOG_ERROR("TaskCallback::callOnFailure");
-            onFailureCallback(std::move(exception));
-        }
-    }
+    void callOnFailure(Exception exception);
 
-    [[nodiscard]] std::tuple<onComplete, onFailure, onSuccess> take() &&
-    {
-        auto callbacks = std::make_tuple(std::move(onCompleteCallback), std::move(onFailureCallback), std::move(onSuccessCallback));
-        this->onCompleteCallback = {};
-        this->onSuccessCallback = {};
-        this->onFailureCallback = {};
-        return callbacks;
-    }
+    [[nodiscard]] std::tuple<OnComplete, OnFailure, OnSuccess> take() &&;
 
 private:
     /// Process OnComplete tag and callback
-    void processArgs(OnComplete onComplete) { onCompleteCallback = std::move(onComplete.callback); }
+    void processArgs(OnComplete onComplete);
 
     /// Process OnSuccess tag and callback
-    void processArgs(OnSuccess onSuccess) { onSuccessCallback = std::move(onSuccess.callback); }
+    void processArgs(OnSuccess onSuccess);
 
     /// Process OnFailure tag and callback
-    void processArgs(OnFailure onFailure) { onFailureCallback = std::move(onFailure.callback); }
+    void processArgs(OnFailure onFailure);
 
     onComplete onCompleteCallback;
     onSuccess onSuccessCallback;
@@ -136,13 +109,13 @@ class BaseTask
 public:
     BaseTask() = default;
 
-    BaseTask(QueryId queryId, TaskCallback callback) : queryId(queryId), callback(std::move(callback)) { }
+    BaseTask(QueryId queryId, TaskCallback callback);
 
-    void complete() { callback.callOnComplete(); }
+    void complete();
 
-    void succeed() { callback.callOnSuccess(); }
+    void succeed();
 
-    void fail(Exception exception) { callback.callOnFailure(std::move(exception)); }
+    void fail(Exception exception);
 
     QueryId queryId = INVALID<QueryId>;
     TaskCallback callback;
@@ -153,10 +126,7 @@ private:
 
 struct WorkTask : BaseTask
 {
-    WorkTask(QueryId queryId, PipelineId pipelineId, std::weak_ptr<RunningQueryPlanNode> pipeline, TupleBuffer buf, TaskCallback callback)
-        : BaseTask(queryId, std::move(callback)), pipeline(std::move(pipeline)), pipelineId(pipelineId), buf(std::move(buf))
-    {
-    }
+    WorkTask(QueryId queryId, PipelineId pipelineId, std::weak_ptr<RunningQueryPlanNode> pipeline, TupleBuffer buf, TaskCallback callback);
 
     WorkTask() = default;
     std::weak_ptr<RunningQueryPlanNode> pipeline;
@@ -166,10 +136,7 @@ struct WorkTask : BaseTask
 
 struct StartPipelineTask : BaseTask
 {
-    StartPipelineTask(QueryId queryId, PipelineId pipelineId, TaskCallback callback, std::weak_ptr<RunningQueryPlanNode> pipeline)
-        : BaseTask(std::move(queryId), std::move(callback)), pipeline(std::move(pipeline)), pipelineId(std::move(pipelineId))
-    {
-    }
+    StartPipelineTask(QueryId queryId, PipelineId pipelineId, TaskCallback callback, std::weak_ptr<RunningQueryPlanNode> pipeline);
 
     std::weak_ptr<RunningQueryPlanNode> pipeline;
     PipelineId pipelineId = INVALID<PipelineId>;
@@ -185,22 +152,16 @@ struct StopSourceTask : BaseTask
 {
     StopSourceTask() = default;
 
-    StopSourceTask(QueryId queryId, std::weak_ptr<RunningSource> target, TaskCallback callback)
-        : BaseTask(queryId, std::move(callback)), target(std::move(target))
-    {
-    }
+    StopSourceTask(QueryId queryId, std::weak_ptr<RunningSource> target, TaskCallback callback);
 
     std::weak_ptr<RunningSource> target;
 };
 
 struct FailSourceTask : BaseTask
 {
-    FailSourceTask() : exception("", 0) { }
+    FailSourceTask();
 
-    FailSourceTask(QueryId queryId, std::weak_ptr<RunningSource> target, const Exception& exception, TaskCallback callback)
-        : BaseTask(queryId, std::move(callback)), target(std::move(target)), exception(std::move(exception))
-    {
-    }
+    FailSourceTask(QueryId queryId, std::weak_ptr<RunningSource> target, Exception exception, TaskCallback callback);
 
     std::weak_ptr<RunningSource> target;
     Exception exception;
@@ -208,10 +169,7 @@ struct FailSourceTask : BaseTask
 
 struct StopQueryTask : BaseTask
 {
-    StopQueryTask(QueryId queryId, std::weak_ptr<QueryCatalog> catalog, TaskCallback callback)
-        : BaseTask(std::move(queryId), std::move(callback)), catalog(std::move(catalog))
-    {
-    }
+    StopQueryTask(QueryId queryId, std::weak_ptr<QueryCatalog> catalog, TaskCallback callback);
 
     std::weak_ptr<QueryCatalog> catalog;
 };
@@ -219,10 +177,7 @@ struct StopQueryTask : BaseTask
 struct StartQueryTask : BaseTask
 {
     StartQueryTask(
-        QueryId queryId, std::unique_ptr<ExecutableQueryPlan> queryPlan, std::weak_ptr<QueryCatalog> catalog, TaskCallback callback)
-        : BaseTask(std::move(queryId), std::move(callback)), queryPlan(std::move(queryPlan)), catalog(std::move(catalog))
-    {
-    }
+        QueryId queryId, std::unique_ptr<ExecutableQueryPlan> queryPlan, std::weak_ptr<QueryCatalog> catalog, TaskCallback callback);
 
     std::unique_ptr<ExecutableQueryPlan> queryPlan;
     std::weak_ptr<QueryCatalog> catalog;
@@ -230,10 +185,7 @@ struct StartQueryTask : BaseTask
 
 struct PendingPipelineStopTask : BaseTask
 {
-    PendingPipelineStopTask(QueryId queryId, std::shared_ptr<RunningQueryPlanNode> pipeline, size_t attempts, TaskCallback callback)
-        : BaseTask(std::move(queryId), std::move(callback)), attempts(attempts), pipeline(std::move(pipeline))
-    {
-    }
+    PendingPipelineStopTask(QueryId queryId, std::shared_ptr<RunningQueryPlanNode> pipeline, size_t attempts, TaskCallback callback);
 
     size_t attempts;
     std::shared_ptr<RunningQueryPlanNode> pipeline;
@@ -249,20 +201,11 @@ using Task = std::variant<
     StopPipelineTask,
     StartPipelineTask>;
 
-inline void succeedTask(Task& task)
-{
-    std::visit([](auto& specificTask) { return specificTask.succeed(); }, task);
-}
+void succeedTask(Task& task);
 
-inline void completeTask(Task& task)
-{
-    std::visit([](auto& specificTask) { return specificTask.complete(); }, task);
-}
+void completeTask(Task& task);
 
-inline void failTask(Task& task, Exception exception)
-{
-    std::visit([&](auto& specificTask) { return specificTask.fail(std::move(exception)); }, task);
-}
+void failTask(Task& task, Exception exception);
 
 void handleTask(const auto& handler, Task task)
 {

--- a/nes-query-engine/tests/QueryEngineTest.cpp
+++ b/nes-query-engine/tests/QueryEngineTest.cpp
@@ -624,6 +624,7 @@ TEST_F(QueryEngineTest, RaceBetweenFailureAndEOS)
     {
         auto queryId = query->queryId;
         test.startQuery(std::move(query));
+        ASSERT_TRUE(test.waitForQepRunning(queryId, DEFAULT_LONG_AWAIT_TIMEOUT));
         test.sourceControls[source]->injectData(identifiableData(1), 1);
         test.sourceControls[source]->injectEoS();
         ASSERT_TRUE(test.waitForQepTermination(queryId, DEFAULT_LONG_AWAIT_TIMEOUT));

--- a/nes-query-engine/tests/QueryPlanTest.cpp
+++ b/nes-query-engine/tests/QueryPlanTest.cpp
@@ -570,7 +570,7 @@ TEST_F(QueryPlanTest, RunningQueryPlanTestSourceSetup)
 
         EXPECT_TRUE(srcCtrl->waitUntilOpened());
         EXPECT_FALSE(srcCtrl->waitUntilClosed());
-        stopping = dropRef(RunningQueryPlan::stop(std::move(runningQueryPlan)));
+        stopping = RunningQueryPlan::stop(std::move(runningQueryPlan));
     }
 
     EXPECT_TRUE(terminations->handle(test.stages.at(pipeline)));
@@ -612,7 +612,7 @@ TEST_F(QueryPlanTest, RunningQueryPlanTestPartialConstruction)
         EXPECT_TRUE(setups->waitForTasks(3));
         /// Only setup the pipeline1 pipeline
         EXPECT_TRUE(setups->handle(test.stages[pipeline1]));
-        stopping = dropRef(RunningQueryPlan::stop(std::move(runningQueryPlan)));
+        stopping = RunningQueryPlan::stop(std::move(runningQueryPlan));
     }
 
     EXPECT_TRUE(terminations->handle(test.stages[pipeline1]));

--- a/nes-query-engine/tests/QueryPlanTest.cpp
+++ b/nes-query-engine/tests/QueryPlanTest.cpp
@@ -150,8 +150,7 @@ struct TestPipelineExecutionContext : PipelineExecutionContext
 struct TerminatePipelineArgs
 {
     std::unique_ptr<RunningQueryPlanNode> target;
-    BaseTask::onComplete onComplete;
-    BaseTask::onFailure onFailure;
+    TaskCallback callback;
 };
 
 template <typename Args, typename KeyT>
@@ -257,9 +256,9 @@ std::unique_ptr<Terminations> Terminations::setup(const RangeOf<ExecutablePipeli
     auto terminations = std::make_unique<Terminations>();
     for (auto* stage : stages)
     {
-        EXPECT_CALL(emitter, emitPipelineStop(::testing::_, UniquePtrStageMatcher(stage), ::testing::_, ::testing::_))
-            .WillOnce(::testing::Invoke([&terminations, stage](auto, auto termination, auto complete, auto fail)
-                                        { terminations->add(stage, std::move(termination), std::move(complete), std::move(fail)); }));
+        EXPECT_CALL(emitter, emitPipelineStop(::testing::_, UniquePtrStageMatcher(stage), ::testing::_))
+            .WillOnce(::testing::Invoke([&terminations, stage](auto, auto termination, auto callback)
+                                        { terminations->add(stage, std::move(termination), std::move(callback)); }));
     }
 
     return terminations;
@@ -273,21 +272,20 @@ template <>
     try
     {
         args.target->stage->stop(pec);
-        args.onComplete();
+        args.callback.callOnSuccess();
     }
     catch (const Exception& e)
     {
-        args.onFailure(e);
+        args.callback.callOnFailure(e);
     }
-
+    args.callback.callOnComplete();
     return ::testing::AssertionSuccess();
 }
 
 struct SetupPipelineArgs
 {
     std::weak_ptr<RunningQueryPlanNode> target;
-    BaseTask::onComplete onComplete;
-    BaseTask::onFailure onFailure;
+    TaskCallback callback;
 };
 
 using Setups = EmittedTask<SetupPipelineArgs, ExecutablePipelineStage*>;
@@ -300,9 +298,9 @@ std::unique_ptr<Setups> Setups::setup(const RangeOf<ExecutablePipelineStage*> au
     auto& emitter = std::get<0>(std::forward_as_tuple<TArgs>(args)...);
     for (auto* stage : stages)
     {
-        EXPECT_CALL(emitter, emitPipelineStart(::testing::_, StageMatcher(stage), ::testing::_, ::testing::_))
-            .WillOnce(::testing::Invoke([&setups, stage](auto, auto setup, auto complete, auto fail)
-                                        { setups->add(stage, std::move(setup), std::move(complete), std::move(fail)); }));
+        EXPECT_CALL(emitter, emitPipelineStart(::testing::_, StageMatcher(stage), ::testing::_))
+            .WillOnce(::testing::Invoke([&setups, stage](auto, const auto& setup, auto callback)
+                                        { setups->add(stage, std::move(setup), std::move(callback)); }));
     }
 
     return setups;
@@ -318,14 +316,14 @@ template <>
         if (auto strongRef = args.target.lock())
         {
             strongRef->stage->start(pec);
-            args.onComplete();
+            args.callback.callOnSuccess();
         }
     }
     catch (const Exception& e)
     {
-        args.onFailure(e);
+        args.callback.callOnFailure(e);
     }
-
+    args.callback.callOnComplete();
     return ::testing::AssertionSuccess();
 }
 

--- a/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.hpp
+++ b/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.hpp
@@ -167,25 +167,11 @@ struct TestWorkEmitter : WorkEmitter
     MOCK_METHOD(
         bool,
         emitWork,
-        (QueryId,
-         const std::shared_ptr<RunningQueryPlanNode>&,
-         TupleBuffer,
-         BaseTask::onComplete,
-         BaseTask::onFailure,
-         PipelineExecutionContext::ContinuationPolicy),
+        (QueryId, const std::shared_ptr<RunningQueryPlanNode>&, TupleBuffer, TaskCallback, PipelineExecutionContext::ContinuationPolicy),
         (override));
-    MOCK_METHOD(
-        void,
-        emitPipelineStart,
-        (QueryId, const std::shared_ptr<RunningQueryPlanNode>&, BaseTask::onComplete, BaseTask::onFailure),
-        (override));
-    MOCK_METHOD(
-        void,
-        emitPendingPipelineStop,
-        (QueryId, std::shared_ptr<RunningQueryPlanNode>, BaseTask::onComplete, BaseTask::onFailure),
-        (override));
-    MOCK_METHOD(
-        void, emitPipelineStop, (QueryId, std::unique_ptr<RunningQueryPlanNode>, BaseTask::onComplete, BaseTask::onFailure), (override));
+    MOCK_METHOD(void, emitPipelineStart, (QueryId, const std::shared_ptr<RunningQueryPlanNode>&, TaskCallback), (override));
+    MOCK_METHOD(void, emitPendingPipelineStop, (QueryId, std::shared_ptr<RunningQueryPlanNode>, TaskCallback), (override));
+    MOCK_METHOD(void, emitPipelineStop, (QueryId, std::unique_ptr<RunningQueryPlanNode>, TaskCallback), (override));
 };
 
 struct TestQueryLifetimeController : QueryLifetimeController

--- a/nes-sources/tests/Util/TestSource.hpp
+++ b/nes-sources/tests/Util/TestSource.hpp
@@ -40,6 +40,8 @@ namespace NES
 class TestSourceControl
 {
 public:
+    static constexpr size_t DEFAULT_QUEUE_SIZE = 10;
+    static constexpr size_t RETRY_MULTIPLIER_MS = 10;
     bool injectEoS();
     bool injectData(std::vector<std::byte> data, size_t numberOfTuples);
     bool injectError(std::string error);
@@ -87,7 +89,7 @@ private:
     };
 
     using ControlData = std::variant<EoS, Data, Error>;
-    folly::MPMCQueue<ControlData> queue{10};
+    folly::MPMCQueue<ControlData> queue{DEFAULT_QUEUE_SIZE};
 };
 
 class TestSource : public Source


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR addresses a race condition which could occur when a query start races with a query stop. 
The issue was caused by the pipelineSetupCallback which is used once all pipelines have been started, and is intended to start all sources, finding an already destroyed running query plan object. 
The running query plan object has been destroyed by a concurrent query stop.

The fix disables the callback (i.e. it is never called) before destroying the running query plan.
This means either the running query plan is destroyed before the callback is invoked, which will skip the callback, or the callback is invoked which will block the destructor of the running query plan until the callback completes.
The running query plan then has to stop the sources.

Additionally, this PR refactors the Task Callbacks which are invoked after a Task has been handled.
Previously, the success callback was invoked when a task was handled successfully and a failure callback was invoked when the task threw an exception.
This means that tasks that were not handled successfully, but did not throw (i.e. when the task is skipped during termination) would not call any callback.
This PR introduces a third callback `onComplete` which is called regardless, and moves most of the existing callbacks into the `onComplete` category.

## Verifying this change
- Covered by systests and the new repl-test

## What components does this pull request potentially affect?
- QueryEngine

## Documentation
- The change is reflected in the necessary documentation, e.g., design document, in-code documentation.
- All necessary methods (no getter, setter, or constructor) have a documentation.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
