### PR TITLE
Fix CodeCov using the wrong base commit

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -21,6 +21,10 @@ on:
         required: true
         type: number
         description: distance between base and head
+      branch-name:
+        required: false
+        type: string
+        description: name of the branch the coverage will be associated with, if not provided codecov will pick
 
 jobs:
   build-code-coverage-pr-branch:
@@ -52,3 +56,5 @@ jobs:
           fail_ci_if_error: true
           files: build/ccov/coverage.lcov
           token: ${{ secrets.CODECOV_TOKEN }}
+          override_branch: ${{ inputs.branch-name }}
+          override_commit: ${{ inputs.head_sha }}

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -21,6 +21,7 @@ jobs:
     with:
       head_sha: ${{ github.event.pull_request.head.sha }}
       dev_image_tag: ${{ needs.get-dev-images.outputs.image-tag }}
+      branch-name: 'main'
       number_of_commits: ${{ github.event.pull_request.commits }}
     secrets: inherit
 


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Apparently the merge pr job associated the coverage with the wrong branch.
Hopefully this PR fixes the issue, and both uses the new commit sha (the sha changes when you rebase and merge) and also uses the main branch instead of the pr branches name.

## Verifying this change
I wish you could

## What components does this pull request potentially affect?
Code coverage reporting


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
