### PR TITLE
Real Code Cov Fix

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -17,10 +17,6 @@ on:
         required: true
         type: string
         description: "Commit sha of head"
-      number_of_commits:
-        required: true
-        type: number
-        description: distance between base and head
       branch-name:
         required: false
         type: string

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -19,10 +19,9 @@ jobs:
     name: "Run Code Coverage"
     uses: ./.github/workflows/code_coverage.yml
     with:
-      head_sha: ${{ github.event.pull_request.head.sha }}
+      head_sha: ${{ github.event.pull_request.merge_commit_sha }}
       dev_image_tag: ${{ needs.get-dev-images.outputs.image-tag }}
       branch-name: 'main'
-      number_of_commits: ${{ github.event.pull_request.commits }}
     secrets: inherit
 
   check-and-update-development-images:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,7 +64,6 @@ jobs:
     with:
       head_sha: ${{ github.event.pull_request.head.sha }}
       dev_image_tag: ${{ needs.get-dev-images.outputs.image-tag }}
-      number_of_commits: ${{ github.event.pull_request.commits }}
     secrets: inherit
 
   run_endless_mode:


### PR DESCRIPTION
This time we use the `merge_commit_sha` instead of `head.sha` which would hopefully point to the actually commit hash for main

From testing with the cli:
```
gh pr view 1094 --json mergeCommit
```
points to the new main commit not the old head commit, which hopefully also applies to `merge_commit_sha`
