### PR TITLE
chore(QueryLog): remove unused support for multiple runs of the same query

### DIFF
--- a/grpc/SingleNodeWorkerRPCService.proto
+++ b/grpc/SingleNodeWorkerRPCService.proto
@@ -23,7 +23,7 @@ service WorkerRPCService {
   rpc StartQuery (StartQueryRequest) returns (google.protobuf.Empty) {}
   rpc StopQuery (StopQueryRequest) returns (google.protobuf.Empty) {}
 
-  rpc RequestQuerySummary (QuerySummaryRequest) returns (QuerySummaryReply) {}
+  rpc RequestQueryStatus (QueryStatusRequest) returns (QueryStatusReply) {}
   rpc RequestQueryLog (QueryLogRequest) returns (QueryLogReply) {}
 }
 
@@ -49,7 +49,7 @@ message StopQueryRequest {
     QueryTerminationType terminationType = 3;
 }
 
-enum QueryStatus {
+enum QueryState {
     Registered = 0;
     Started = 1;
     Running = 2;
@@ -64,21 +64,21 @@ message Error {
     string location = 4; /// currently untyped
 }
 
-message QuerySummaryRequest {
+message QueryStatusRequest {
   uint64 queryId = 1;
 }
 
-message QueryRunSummary {
-   uint64 startUnixTimeInMs = 1;
-   uint64 runningUnixTimeInMs = 2;
-   uint64 stopUnixTimeInMs = 3;
+message QueryMetrics {
+   optional uint64 startUnixTimeInMs = 1;
+   optional uint64 runningUnixTimeInMs = 2;
+   optional uint64 stopUnixTimeInMs = 3;
    optional Error error = 4;
 }
 
-message QuerySummaryReply {
+message QueryStatusReply {
     uint64 queryId = 1;
-    QueryStatus status = 2;
-    repeated QueryRunSummary runs = 3;
+    QueryState state = 2;
+    QueryMetrics metrics = 3;
 }
 
 message QueryLogRequest {
@@ -86,7 +86,7 @@ message QueryLogRequest {
 }
 
 message QueryLogEntry {
-    QueryStatus status = 1;
+    QueryState state = 1;
     uint64 unixTimeInMs = 2;
     optional Error error = 3;
 }

--- a/nes-nebuli/include/QueryManager/EmbeddedWorkerQueryManager.hpp
+++ b/nes-nebuli/include/QueryManager/EmbeddedWorkerQueryManager.hpp
@@ -31,7 +31,7 @@ public:
     std::expected<void, Exception> start(QueryId queryId) noexcept override;
     std::expected<void, Exception> stop(QueryId queryId) noexcept override;
     std::expected<void, Exception> unregister(QueryId queryId) noexcept override;
-    [[nodiscard]] std::expected<QuerySummary, Exception> status(QueryId queryId) const noexcept override;
+    [[nodiscard]] std::expected<LocalQueryStatus, Exception> status(QueryId queryId) const noexcept override;
 
 private:
     SingleNodeWorker worker;

--- a/nes-nebuli/include/QueryManager/GRPCQueryManager.hpp
+++ b/nes-nebuli/include/QueryManager/GRPCQueryManager.hpp
@@ -37,6 +37,6 @@ public:
     std::expected<void, Exception> stop(QueryId queryId) noexcept override;
     std::expected<void, Exception> start(QueryId queryId) noexcept override;
     std::expected<void, Exception> unregister(QueryId queryId) noexcept override;
-    [[nodiscard]] std::expected<QuerySummary, Exception> status(QueryId queryId) const noexcept override;
+    [[nodiscard]] std::expected<LocalQueryStatus, Exception> status(QueryId queryId) const noexcept override;
 };
 }

--- a/nes-nebuli/include/QueryManager/QueryManager.hpp
+++ b/nes-nebuli/include/QueryManager/QueryManager.hpp
@@ -40,6 +40,6 @@ public:
     virtual std::expected<void, Exception> start(QueryId queryId) noexcept = 0;
     virtual std::expected<void, Exception> stop(QueryId queryId) noexcept = 0;
     virtual std::expected<void, Exception> unregister(QueryId queryId) noexcept = 0;
-    [[nodiscard]] virtual std::expected<QuerySummary, Exception> status(QueryId queryId) const noexcept = 0;
+    [[nodiscard]] virtual std::expected<LocalQueryStatus, Exception> status(QueryId queryId) const noexcept = 0;
 };
 }

--- a/nes-nebuli/include/StatementHandler.hpp
+++ b/nes-nebuli/include/StatementHandler.hpp
@@ -88,7 +88,7 @@ struct QueryStatementResult
 
 struct ShowQueriesStatementResult
 {
-    std::unordered_map<QueryId, QuerySummary> queries;
+    std::unordered_map<QueryId, LocalQueryStatus> queries;
 };
 
 struct DropQueryStatementResult

--- a/nes-nebuli/include/StatementOutputAssembler.hpp
+++ b/nes-nebuli/include/StatementOutputAssembler.hpp
@@ -244,7 +244,7 @@ struct StatementOutputAssembler<ShowQueriesStatementResult>
         output.reserve(result.queries.size());
         for (const auto& [id, query] : result.queries)
         {
-            output.emplace_back(id, magic_enum::enum_name(query.currentStatus));
+            output.emplace_back(id, magic_enum::enum_name(query.state));
         }
         return std::make_pair(queryStatusOutputColumns, output);
     }

--- a/nes-nebuli/src/NebuLIStarter.cpp
+++ b/nes-nebuli/src/NebuLIStarter.cpp
@@ -222,8 +222,8 @@ int main(int argc, char** argv)
                 for (const auto& query : queryStatementHandler->getRunningQueries())
                 {
                     auto status = queryManager->status(query);
-                    while (status.has_value() && status.value().currentStatus != NES::QueryStatus::Stopped
-                           && status.value().currentStatus != NES::QueryStatus::Failed)
+                    while (status.has_value() && status.value().state != NES::QueryState::Stopped
+                           && status.value().state != NES::QueryState::Failed)
                     {
                         std::this_thread::sleep_for(std::chrono::milliseconds(50));
                         status = queryManager->status(query);
@@ -335,8 +335,8 @@ int main(int argc, char** argv)
             if (startedQuery.has_value())
             {
                 auto status = queryManager->status(startedQuery.value());
-                while (status.has_value() && status.value().currentStatus != NES::QueryStatus::Stopped
-                       && status.value().currentStatus != NES::QueryStatus::Failed)
+                while (status.has_value() && status.value().state != NES::QueryState::Stopped
+                       && status.value().state != NES::QueryState::Failed)
                 {
                     std::this_thread::sleep_for(std::chrono::milliseconds(50));
                     status = queryManager->status(startedQuery.value());

--- a/nes-nebuli/src/QueryManager/EmbeddedWorkerQueryManager.cpp
+++ b/nes-nebuli/src/QueryManager/EmbeddedWorkerQueryManager.cpp
@@ -47,8 +47,8 @@ std::expected<void, Exception> EmbeddedWorkerQueryManager::unregister(const Quer
     return worker.unregisterQuery(queryId);
 }
 
-std::expected<QuerySummary, Exception> EmbeddedWorkerQueryManager::status(QueryId queryId) const noexcept
+std::expected<LocalQueryStatus, Exception> EmbeddedWorkerQueryManager::status(QueryId queryId) const noexcept
 {
-    return worker.getQuerySummary(queryId);
+    return worker.getQueryStatus(queryId);
 }
 }

--- a/nes-nebuli/src/StatementHandler.cpp
+++ b/nes-nebuli/src/StatementHandler.cpp
@@ -205,7 +205,7 @@ std::expected<ShowQueriesStatementResult, Exception> QueryStatementHandler::oper
     if (not statement.id.has_value())
     {
         auto allQueryState = runningQueries | std::views::transform([this](auto queryId) { return queryManager->status(queryId); })
-            | std::views::filter([](const std::expected<QuerySummary, Exception>& statusResult) { return statusResult.has_value(); })
+            | std::views::filter([](const std::expected<LocalQueryStatus, Exception>& statusResult) { return statusResult.has_value(); })
             | std::views::transform([](const auto& statusResult) { return statusResult.value(); }) | std::ranges::to<std::vector>();
         auto newRunningQueries = allQueryState | std::views::transform([](const auto& querySummary) { return querySummary.queryId; })
             | std::ranges::to<std::vector>();
@@ -213,11 +213,11 @@ std::expected<ShowQueriesStatementResult, Exception> QueryStatementHandler::oper
         return ShowQueriesStatementResult{
             allQueryState
             | std::views::transform([](const auto& querySummary) { return std::make_pair(querySummary.queryId, querySummary); })
-            | std::ranges::to<std::unordered_map<QueryId, QuerySummary>>()};
+            | std::ranges::to<std::unordered_map<QueryId, LocalQueryStatus>>()};
     }
     if (const auto statusOpt = queryManager->status(statement.id.value()); statusOpt.has_value())
     {
-        return ShowQueriesStatementResult{std::unordered_map<QueryId, QuerySummary>{{statement.id.value(), statusOpt.value()}}};
+        return ShowQueriesStatementResult{std::unordered_map<QueryId, LocalQueryStatus>{{statement.id.value(), statusOpt.value()}}};
     }
     return ShowQueriesStatementResult{.queries = {}};
 }

--- a/nes-nebuli/test/test_repl.sh
+++ b/nes-nebuli/test/test_repl.sh
@@ -55,18 +55,22 @@ SQL_CONTENT=$(cat "$SQL_FILE" | sed "s|TESTDATA|$TESTDATA_PATH|g" | sed "s|WORKD
 echo "$SQL_CONTENT" > "$GEN_OUT_PATH"/"$(basename "$SQL_FILE" .sql)"_gen.sql
 EXPECTED_OUTPUT_1=$(cat "$EXPECTED_OUTPUT_PATH" | sed "s|TESTDATA|$TESTDATA_PATH|g" | sed "s|WORKDIR|$WORKDIR_PATH|g")
 EXPECTED_OUTPUT_2=$(cat "$EXPECTED_OUTPUT_PATH" | sed "s|TESTDATA|$TESTDATA_PATH|g" | sed "s|WORKDIR|$WORKDIR_PATH|g" | sed "s|Running|Registered|g")
-echo "$EXPECTED_OUTPUT_1" > "$GEN_OUT_PATH"/"$(basename "$EXPECTED_OUTPUT_PATH_1" .sql)"_gen.sql
-echo "$EXPECTED_OUTPUT_2" > "$GEN_OUT_PATH"/"$(basename "$EXPECTED_OUTPUT_PATH_2" .sql)"_gen.sql
+EXPECTED_OUTPUT_3=$(cat "$EXPECTED_OUTPUT_PATH" | sed "s|TESTDATA|$TESTDATA_PATH|g" | sed "s|WORKDIR|$WORKDIR_PATH|g" | sed "s|Running|Started|g")
+echo "$EXPECTED_OUTPUT_1" > "$GEN_OUT_PATH"/"$(basename "$EXPECTED_OUTPUT_PATH" .sql)"_gen1.sql
+echo "$EXPECTED_OUTPUT_2" > "$GEN_OUT_PATH"/"$(basename "$EXPECTED_OUTPUT_PATH" .sql)"_gen2.sql
+echo "$EXPECTED_OUTPUT_3" > "$GEN_OUT_PATH"/"$(basename "$EXPECTED_OUTPUT_PATH" .sql)"_gen3.sql
 
 # Run the binary and pipe the modified SQL content as stdin
 ACTUAL_OUTPUT=$(echo "$SQL_CONTENT" | "$BINARY_PATH" -w -f JSON )
 
-if [[ "$ACTUAL_OUTPUT" == "$EXPECTED_OUTPUT_1" || "$ACTUAL_OUTPUT" == "$EXPECTED_OUTPUT_2" ]]; then
+if [[ "$ACTUAL_OUTPUT" == "$EXPECTED_OUTPUT_1" || "$ACTUAL_OUTPUT" == "$EXPECTED_OUTPUT_2" || "$ACTUAL_OUTPUT" == "$EXPECTED_OUTPUT_3" ]]; then
   exit 0
 else
   echo "Actual output does not match expected, diff 1 was:"
   echo "$(diff <(echo "$EXPECTED_OUTPUT_1") <(echo "$ACTUAL_OUTPUT"))"
   echo "Actual output does not match expected, diff 2 was:"
   echo "$(diff <(echo "$EXPECTED_OUTPUT_2") <(echo "$ACTUAL_OUTPUT"))"
+  echo "Actual output does not match expected, diff 3 was:"
+  echo "$(diff <(echo "$EXPECTED_OUTPUT_3") <(echo "$ACTUAL_OUTPUT"))"
   exit 1
 fi

--- a/nes-query-engine/QueryEngine.cpp
+++ b/nes-query-engine/QueryEngine.cpp
@@ -789,7 +789,7 @@ void QueryCatalog::start(
                         return Terminated{Terminated::Failed};
                     },
                     [](Starting&& starting) { return Running{std::move(starting.plan)}; });
-                listener->logQueryStatusChange(queryId, QueryStatus::Running, timestamp);
+                listener->logQueryStatusChange(queryId, QueryState::Running, timestamp);
             }
         }
 
@@ -853,7 +853,7 @@ void QueryCatalog::start(
                         StoppingQueryPlan::dispose(std::move(stopping.plan));
                         return Terminated{Terminated::Stopped};
                     });
-                listener->logQueryStatusChange(queryId, QueryStatus::Stopped, timestamp);
+                listener->logQueryStatusChange(queryId, QueryState::Stopped, timestamp);
                 statistic->onEvent(QueryStop(ThreadPool::WorkerThread::id, queryId));
             }
         }
@@ -874,7 +874,7 @@ void QueryCatalog::start(
 
     if (state->transition([&](Reserved&&) { return Starting{std::move(runningQueryPlan)}; }))
     {
-        listener->logQueryStatusChange(queryId, QueryStatus::Started, startTimestamp);
+        listener->logQueryStatusChange(queryId, QueryState::Started, startTimestamp);
     }
     else
     {

--- a/nes-query-engine/tests/QueryEngineTest.cpp
+++ b/nes-query-engine/tests/QueryEngineTest.cpp
@@ -76,7 +76,7 @@ TEST_F(QueryEngineTest, singleQueryWithShutdown)
         ExpectStats::TaskExecutionStart(4),
         ExpectStats::TaskExecutionComplete(4));
 
-    test.expectQueryStatusEvents(queryId, {QueryStatus::Started, QueryStatus::Running});
+    test.expectQueryStatusEvents(queryId, {QueryState::Started, QueryState::Running});
 
     test.start();
     {
@@ -122,7 +122,7 @@ TEST_F(QueryEngineTest, singleQueryWithSystemShutdown)
         ExpectStats::TaskExecutionComplete(8),
         ExpectStats::TaskEmit(4));
 
-    test.expectQueryStatusEvents(id, {QueryStatus::Started, QueryStatus::Running});
+    test.expectQueryStatusEvents(id, {QueryState::Started, QueryState::Running});
 
     test.start();
     {
@@ -173,7 +173,7 @@ TEST_F(QueryEngineTest, singleQueryWithExternalStop)
         ExpectStats::TaskExecutionComplete(8),
         ExpectStats::TaskEmit(4));
 
-    test.expectQueryStatusEvents(QueryId(1), {QueryStatus::Started, QueryStatus::Running, QueryStatus::Stopped});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Stopped});
     test.expectSourceTermination(QueryId(1), source, QueryTerminationType::Graceful);
 
     test.start();
@@ -213,7 +213,7 @@ TEST_F(QueryEngineTest, singleQueryWithSystemStop)
 
     auto ctrl = test.sourceControls[source];
     auto sinkCtrl = test.sinkControls[sink];
-    test.expectQueryStatusEvents(QueryId(1), {QueryStatus::Started, QueryStatus::Running, QueryStatus::Stopped});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Stopped});
 
     /// Statistics.
     ///     Note: Pipelines are terminated because the query is gracefully stopped.
@@ -268,7 +268,7 @@ TEST_F(QueryEngineTest, singleQueryWithSourceFailure)
 
     auto ctrl = test.sourceControls[source];
     auto sinkCtrl = test.sinkControls[sink];
-    test.expectQueryStatusEvents(QueryId(1), {QueryStatus::Started, QueryStatus::Running, QueryStatus::Failed});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Failed});
     test.expectSourceTermination(QueryId(1), source, QueryTerminationType::Failure);
 
     test.start();
@@ -311,7 +311,7 @@ TEST_F(QueryEngineTest, singleQueryWithTwoSourcesShutdown)
     auto ctrl1 = test.sourceControls[source1];
     auto ctrl2 = test.sourceControls[source2];
     auto sinkCtrl = test.sinkControls[sink];
-    test.expectQueryStatusEvents(QueryId(1), {QueryStatus::Started, QueryStatus::Running});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running});
 
     /// Statistics.
     ///     Note: Pipelines are not terminated, due to system shutdown
@@ -362,7 +362,7 @@ TEST_F(QueryEngineTest, failureDuringPipelineStop)
     auto id = query->queryId;
     test.pipelineControls[failingPipeline]->failOnStop = true;
 
-    test.expectQueryStatusEvents(id, {QueryStatus::Started, QueryStatus::Running, QueryStatus::Failed});
+    test.expectQueryStatusEvents(id, {QueryState::Started, QueryState::Running, QueryState::Failed});
     test.expectSourceTermination(id, source, QueryTerminationType::Graceful);
 
     test.start();
@@ -393,7 +393,7 @@ TEST_F(QueryEngineTest, failureDuringPipelineStopMultipleSources)
     auto id = query->queryId;
     test.pipelineControls[failingPipeline]->failOnStop = true;
 
-    test.expectQueryStatusEvents(id, {QueryStatus::Started, QueryStatus::Running, QueryStatus::Failed});
+    test.expectQueryStatusEvents(id, {QueryState::Started, QueryState::Running, QueryState::Failed});
     test.expectSourceTermination(id, source1, QueryTerminationType::Graceful);
     test.expectSourceTermination(id, source2, QueryTerminationType::Graceful);
 
@@ -435,7 +435,7 @@ TEST_F(QueryEngineTest, failureDuringPipelineStartWithMultiplePipelines)
     auto id = query->queryId;
     test.pipelineControls[failingPipeline]->failOnStart = true;
 
-    test.expectQueryStatusEvents(id, {QueryStatus::Failed});
+    test.expectQueryStatusEvents(id, {QueryState::Failed});
 
     test.start();
     {
@@ -460,7 +460,7 @@ TEST_F(QueryEngineTest, failureDuringPipelineStartWithMultipleSources)
     auto id = query->queryId;
     test.pipelineControls[failingPipeline]->failOnStart = true;
 
-    test.expectQueryStatusEvents(id, {QueryStatus::Failed});
+    test.expectQueryStatusEvents(id, {QueryState::Failed});
 
     test.start();
     {
@@ -482,7 +482,7 @@ TEST_F(QueryEngineTest, singleQueryWithTwoSourcesWaitingForTwoStops)
     auto ctrl1 = test.sourceControls[source1];
     auto ctrl2 = test.sourceControls[source2];
     auto sinkCtrl = test.sinkControls[sink];
-    test.expectQueryStatusEvents(QueryId(1), {QueryStatus::Started, QueryStatus::Running, QueryStatus::Stopped});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Stopped});
     test.expectSourceTermination(QueryId(1), source1, QueryTerminationType::Graceful);
     test.expectSourceTermination(QueryId(1), source2, QueryTerminationType::Graceful);
 
@@ -547,7 +547,7 @@ TEST_F(QueryEngineTest, singleQueryWithManySources)
         });
 
     auto sinkCtrl = test.sinkControls[sink];
-    test.expectQueryStatusEvents(QueryId(1), {QueryStatus::Started, QueryStatus::Running, QueryStatus::Stopped});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Stopped});
 
     test.start();
     {
@@ -584,7 +584,7 @@ TEST_F(QueryEngineTest, singleQueryWithManySourcesOneOfThemFails)
     std::vector<std::shared_ptr<TestSourceControl>> sourcesCtrls;
     std::ranges::transform(sources, std::back_inserter(sourcesCtrls), [&](auto identifier) { return test.sourceControls[identifier]; });
 
-    test.expectQueryStatusEvents(QueryId(1), {QueryStatus::Started, QueryStatus::Running, QueryStatus::Failed});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Failed});
     /// Overwrite Source 0 to expect source failure.
     test.expectSourceTermination(QueryId(1), sources[0], QueryTerminationType::Failure);
 
@@ -618,7 +618,7 @@ TEST_F(QueryEngineTest, RaceBetweenFailureAndEOS)
 
     auto query = test.addNewQuery(std::move(builder));
     test.pipelineControls[failingPipeline]->throwOnNthInvocation = 1;
-    test.expectQueryStatusEvents(QueryId(1), {QueryStatus::Started, QueryStatus::Running, QueryStatus::Failed});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Failed});
 
     test.start();
     {
@@ -662,7 +662,7 @@ TEST_F(QueryEngineTest, ManyQueriesWithTwoSources)
         sinkCtrls.push_back(test.sinkControls[sinks[index]]);
         test.expectSourceTermination(QueryId(1 + index), sources[index * 2], QueryTerminationType::Graceful);
         test.expectSourceTermination(QueryId(1 + index), sources[(index * 2) + 1], QueryTerminationType::Graceful);
-        test.expectQueryStatusEvents(QueryId(1 + index), {QueryStatus::Started, QueryStatus::Running, QueryStatus::Stopped});
+        test.expectQueryStatusEvents(QueryId(1 + index), {QueryState::Started, QueryState::Running, QueryState::Stopped});
     }
 
     test.start();
@@ -735,13 +735,13 @@ TEST_F(QueryEngineTest, ManyQueriesWithTwoSourcesOneSourceFails)
     sourcesCtrls.push_back(test.sourceControls[sources[1]]);
     sinkCtrls.push_back(test.sinkControls[sinks[0]]);
     test.expectSourceTermination(QueryId(1), sources[0], QueryTerminationType::Failure);
-    test.expectQueryStatusEvents(QueryId(1), {QueryStatus::Started, QueryStatus::Running, QueryStatus::Failed});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Failed});
 
     /// Query 2 is terminated by an internal stop
     sourcesCtrls.push_back(test.sourceControls[sources[2]]);
     sourcesCtrls.push_back(test.sourceControls[sources[3]]);
     sinkCtrls.push_back(test.sinkControls[sinks[1]]);
-    test.expectQueryStatusEvents(QueryId(2), {QueryStatus::Started, QueryStatus::Running, QueryStatus::Stopped});
+    test.expectQueryStatusEvents(QueryId(2), {QueryState::Started, QueryState::Running, QueryState::Stopped});
 
     /// Rest of the queries are terminated by external stop via eos
     for (size_t index = 2; const auto& query : queryPlans | std::ranges::views::drop(2))
@@ -751,7 +751,7 @@ TEST_F(QueryEngineTest, ManyQueriesWithTwoSourcesOneSourceFails)
         sinkCtrls.push_back(test.sinkControls[sinks[index]]);
         test.expectSourceTermination(QueryId(1 + index), sources[index * 2], QueryTerminationType::Graceful);
         test.expectSourceTermination(QueryId(1 + index), sources[(index * 2) + 1], QueryTerminationType::Graceful);
-        test.expectQueryStatusEvents(QueryId(1 + index), {QueryStatus::Started, QueryStatus::Running, QueryStatus::Stopped});
+        test.expectQueryStatusEvents(QueryId(1 + index), {QueryState::Started, QueryState::Running, QueryState::Stopped});
         index++;
     }
 
@@ -810,7 +810,7 @@ TEST_F(QueryEngineTest, singleQueryWithTwoSourceExternalStop)
     auto sink = builder.addSink({pipeline});
     auto query = test.addNewQuery(std::move(builder));
 
-    test.expectQueryStatusEvents(QueryId(1), {QueryStatus::Started, QueryStatus::Running, QueryStatus::Stopped});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Stopped});
 
     test.start();
     {
@@ -853,7 +853,7 @@ TEST_F(QueryEngineTest, singleQueryWithSlowlyFailingSourceDuringEngineTerminatio
         ExpectStats::TaskEmit(0));
 
     test.sourceControls[source]->failDuringOpen(DEFAULT_AWAIT_TIMEOUT);
-    test.expectQueryStatusEvents(QueryId(1), {QueryStatus::Started, QueryStatus::Running});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running});
 
     test.start();
     {
@@ -886,7 +886,7 @@ TEST_F(QueryEngineTest, singleQueryWithSlowlyFailingSourceDuringQueryPlanTermina
         ExpectStats::TaskEmit(0));
 
     test.sourceControls[source]->failDuringOpen(DEFAULT_LONG_AWAIT_TIMEOUT);
-    test.expectQueryStatusEvents(query->queryId, {QueryStatus::Started, QueryStatus::Running, QueryStatus::Stopped});
+    test.expectQueryStatusEvents(query->queryId, {QueryState::Started, QueryState::Running, QueryState::Stopped});
 
     test.start();
     {
@@ -916,7 +916,7 @@ TEST_F(QueryEngineTest, singleQueryWithPipelineFailure)
     auto sink = builder.addSink({pipeline});
     auto query = test.addNewQuery(std::move(builder));
 
-    test.expectQueryStatusEvents(QueryId(1), {QueryStatus::Started, QueryStatus::Running, QueryStatus::Failed});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Failed});
     test.pipelineControls[pipeline]->throwOnNthInvocation = 2;
 
     test.start();
@@ -952,7 +952,7 @@ TEST_F(QueryEngineTest, singleSourceWithMultipleSuccessors)
     auto sink = builder.addSink({pipeline1, pipeline2, pipeline3});
 
     auto query = test.addNewQuery(std::move(builder));
-    test.expectQueryStatusEvents(QueryId(1), {QueryStatus::Started, QueryStatus::Running, QueryStatus::Stopped});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Stopped});
     test.expectSourceTermination(QueryId(1), source, QueryTerminationType::Graceful);
 
     test.start();
@@ -988,7 +988,7 @@ TEST_F(QueryEngineTest, singleSourceWithMultipleSuccessorsSourceFailure)
     auto sink = builder.addSink({pipeline1, pipeline2, pipeline3});
 
     auto query = test.addNewQuery(std::move(builder));
-    test.expectQueryStatusEvents(QueryId(1), {QueryStatus::Started, QueryStatus::Running, QueryStatus::Failed});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Failed});
     test.expectSourceTermination(QueryId(1), source, QueryTerminationType::Failure);
 
 
@@ -1082,7 +1082,7 @@ TEST_F(QueryEngineTest, ManyQueriesWithTwoSourcesAndPipelineFailures)
     sinkCtrls.push_back(test.sinkControls[sinks[0]]);
     test.expectSourceTermination(QueryId(1), sources[0], QueryTerminationType::Graceful);
     test.expectSourceTermination(QueryId(1), sources[1], QueryTerminationType::Graceful);
-    test.expectQueryStatusEvents(QueryId(1), {QueryStatus::Started, QueryStatus::Running, QueryStatus::Stopped});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Stopped});
 
     /// Rest of the queries are failing due to pipeline errors on pipeline 1
     for (size_t index = 1; const auto& query : queryPlans | std::ranges::views::drop(1))
@@ -1091,7 +1091,7 @@ TEST_F(QueryEngineTest, ManyQueriesWithTwoSourcesAndPipelineFailures)
         sourcesCtrls.push_back(test.sourceControls[sources[index * 2]]);
         sourcesCtrls.push_back(test.sourceControls[sources[(index * 2) + 1]]);
         sinkCtrls.push_back(test.sinkControls[sinks[index]]);
-        test.expectQueryStatusEvents(QueryId(1 + index), {QueryStatus::Started, QueryStatus::Running, QueryStatus::Failed});
+        test.expectQueryStatusEvents(QueryId(1 + index), {QueryState::Started, QueryState::Running, QueryState::Failed});
         index++;
     }
 

--- a/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.cpp
+++ b/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.cpp
@@ -294,23 +294,23 @@ std::unique_ptr<ExecutableQueryPlan> TestingHarness::addNewQuery(QueryPlanBuilde
     return std::move(plan);
 }
 
-void TestingHarness::expectQueryStatusEvents(QueryId id, std::initializer_list<QueryStatus> states)
+void TestingHarness::expectQueryStatusEvents(QueryId id, std::initializer_list<QueryState> states)
 {
     for (auto state : states)
     {
         switch (state)
         {
-            case QueryStatus::Registered:
-                EXPECT_CALL(*status, logQueryStatusChange(id, QueryStatus::Registered, ::testing::_)).Times(1);
+            case QueryState::Registered:
+                EXPECT_CALL(*status, logQueryStatusChange(id, QueryState::Registered, ::testing::_)).Times(1);
                 break;
-            case QueryStatus::Started:
-                EXPECT_CALL(*status, logQueryStatusChange(id, QueryStatus::Started, ::testing::_))
+            case QueryState::Started:
+                EXPECT_CALL(*status, logQueryStatusChange(id, QueryState::Started, ::testing::_))
                     .Times(1)
                     .WillOnce(::testing::Invoke([](auto, auto, auto) { return true; }));
                 break;
-            case QueryStatus::Running:
+            case QueryState::Running:
                 queryRunning.emplace(id, std::make_unique<std::promise<void>>());
-                EXPECT_CALL(*status, logQueryStatusChange(id, QueryStatus::Running, ::testing::_))
+                EXPECT_CALL(*status, logQueryStatusChange(id, QueryState::Running, ::testing::_))
                     .Times(1)
                     .WillOnce(::testing::Invoke(
                         [this](auto id, auto, auto)
@@ -319,10 +319,10 @@ void TestingHarness::expectQueryStatusEvents(QueryId id, std::initializer_list<Q
                             return true;
                         }));
                 break;
-            case QueryStatus::Stopped:
+            case QueryState::Stopped:
                 ASSERT_TRUE(queryTermination.try_emplace(id, std::make_unique<std::promise<void>>()).second)
                     << "Registered multiple query terminations";
-                EXPECT_CALL(*status, logQueryStatusChange(id, QueryStatus::Stopped, ::testing::_))
+                EXPECT_CALL(*status, logQueryStatusChange(id, QueryState::Stopped, ::testing::_))
                     .Times(1)
                     .WillOnce(::testing::Invoke(
                         [this](auto id, auto, auto)
@@ -331,7 +331,7 @@ void TestingHarness::expectQueryStatusEvents(QueryId id, std::initializer_list<Q
                             return true;
                         }));
                 break;
-            case QueryStatus::Failed:
+            case QueryState::Failed:
                 ASSERT_TRUE(queryTermination.try_emplace(id, std::make_unique<std::promise<void>>()).second)
                     << "Registered multiple query terminations";
                 EXPECT_CALL(*status, logQueryFailure(id, ::testing::_, ::testing::_))

--- a/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.hpp
+++ b/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.hpp
@@ -157,7 +157,7 @@ class QueryStatusListener final : public AbstractQueryStatusListener
 public:
     MOCK_METHOD(bool, logSourceTermination, (QueryId, OriginId, QueryTerminationType, std::chrono::system_clock::time_point), (override));
     MOCK_METHOD(bool, logQueryFailure, (QueryId, Exception, std::chrono::system_clock::time_point), (override));
-    MOCK_METHOD(bool, logQueryStatusChange, (QueryId, QueryStatus, std::chrono::system_clock::time_point), (override));
+    MOCK_METHOD(bool, logQueryStatusChange, (QueryId, QueryState, std::chrono::system_clock::time_point), (override));
 };
 
 /// Mock implementation for internal interfaces of the QueryEngine. These are used when verifying the behavior of internal
@@ -454,7 +454,7 @@ struct TestingHarness
     std::unique_ptr<ExecutableQueryPlan> addNewQuery(QueryPlanBuilder&& builder);
 
     /// List of status events to be emitted by a query with QueryId `id`
-    void expectQueryStatusEvents(QueryId id, std::initializer_list<QueryStatus> states);
+    void expectQueryStatusEvents(QueryId id, std::initializer_list<QueryState> states);
 
     /// Expects a source for a given query to be terminated (gracefully or due to a failure)
     void expectSourceTermination(QueryId id, QueryPlanBuilder::identifier_t source, QueryTerminationType type);

--- a/nes-runtime/include/Listeners/AbstractQueryStatusListener.hpp
+++ b/nes-runtime/include/Listeners/AbstractQueryStatusListener.hpp
@@ -32,6 +32,6 @@ struct AbstractQueryStatusListener
 
     virtual bool logQueryFailure(QueryId queryId, Exception exception, std::chrono::system_clock::time_point) = 0;
 
-    virtual bool logQueryStatusChange(QueryId queryId, QueryStatus status, std::chrono::system_clock::time_point) = 0;
+    virtual bool logQueryStatusChange(QueryId queryId, QueryState status, std::chrono::system_clock::time_point) = 0;
 };
 }

--- a/nes-runtime/include/Listeners/QueryLog.hpp
+++ b/nes-runtime/include/Listeners/QueryLog.hpp
@@ -29,7 +29,7 @@
 namespace NES
 {
 
-struct QueryRunSummary
+struct QueryMetrics
 {
     std::optional<std::chrono::system_clock::time_point> start;
     std::optional<std::chrono::system_clock::time_point> running;
@@ -38,46 +38,46 @@ struct QueryRunSummary
 };
 
 /// Summary structure of the query log for a query
-struct QuerySummary
+struct LocalQueryStatus
 {
-    /// In the future, this will be extended to include more information such as the query plan, etc.
     QueryId queryId = INVALID_QUERY_ID;
-    QueryStatus currentStatus;
-    std::vector<QueryRunSummary> runs;
+    QueryState state = QueryState::Registered;
+    QueryMetrics metrics{};
 };
 
 /// Struct to store the status change of a query. Initialized either with a status or an exception.
-struct QueryStatusChange
+struct QueryStateChange
 {
-    QueryStatusChange(QueryStatus state, std::chrono::system_clock::time_point timestamp) : state(state), timestamp(timestamp) { };
+    QueryStateChange(const QueryState state, const std::chrono::system_clock::time_point timestamp) : state(state), timestamp(timestamp) { }
 
-    QueryStatusChange(Exception exception, std::chrono::system_clock::time_point timestamp)
-        : state(QueryStatus::Failed), timestamp(timestamp), exception(exception) { };
+    QueryStateChange(Exception exception, std::chrono::system_clock::time_point timestamp);
 
-    friend std::ostream& operator<<(std::ostream& os, const QueryStatusChange& statusChange);
+    friend std::ostream& operator<<(std::ostream& os, const QueryStateChange& statusChange);
 
-    QueryStatus state;
+    QueryState state;
     std::chrono::system_clock::time_point timestamp;
     std::optional<Exception> exception;
 };
 
-inline std::ostream& operator<<(std::ostream& os, const QueryStatusChange& statusChange);
+inline std::ostream& operator<<(std::ostream& os, const QueryStateChange& statusChange);
 
 /// The query log keeps track of query status changes. We want to keep it as lightweight as possible to reduce overhead inflicted to
 /// the query manager.
 struct QueryLog : AbstractQueryStatusListener
 {
-    using Log = std::vector<QueryStatusChange>;
-    using QueryStatusLog = std::unordered_map<QueryId, std::vector<QueryStatusChange>>;
+    using Log = std::vector<QueryStateChange>;
+    using QueryStatusLog = std::unordered_map<QueryId, std::vector<QueryStateChange>>;
 
     /// TODO #241: we should use the new unique sourceId/hash once implemented here instead
     bool logSourceTermination(
         QueryId queryId, OriginId sourceId, QueryTerminationType, std::chrono::system_clock::time_point timestamp) override;
     bool logQueryFailure(QueryId queryId, Exception exception, std::chrono::system_clock::time_point timestamp) override;
-    bool logQueryStatusChange(QueryId queryId, QueryStatus status, std::chrono::system_clock::time_point timestamp) override;
+    bool logQueryStatusChange(QueryId queryId, QueryState status, std::chrono::system_clock::time_point timestamp) override;
 
     [[nodiscard]] std::optional<Log> getLogForQuery(QueryId queryId) const;
-    [[nodiscard]] std::optional<QuerySummary> getQuerySummary(QueryId queryId) const;
+    [[nodiscard]] std::optional<LocalQueryStatus> getQueryStatus(QueryId queryId) const;
+
+    [[nodiscard]] std::vector<LocalQueryStatus> getStatus() const;
 
 private:
     folly::Synchronized<QueryStatusLog> queryStatusLog;

--- a/nes-runtime/include/Runtime/Execution/QueryStatus.hpp
+++ b/nes-runtime/include/Runtime/Execution/QueryStatus.hpp
@@ -20,7 +20,7 @@
 
 namespace NES
 {
-enum class QueryStatus : uint8_t
+enum class QueryState : uint8_t
 {
     Registered,
     Started,
@@ -29,10 +29,10 @@ enum class QueryStatus : uint8_t
     Failed,
 };
 
-inline std::ostream& operator<<(std::ostream& ostream, const QueryStatus& status)
+inline std::ostream& operator<<(std::ostream& ostream, const QueryState& status)
 {
     return ostream << magic_enum::enum_name(status);
 }
 }
 
-FMT_OSTREAM(NES::QueryStatus);
+FMT_OSTREAM(NES::QueryState);

--- a/nes-runtime/src/Runtime/NodeEngine.cpp
+++ b/nes-runtime/src/Runtime/NodeEngine.cpp
@@ -99,7 +99,7 @@ NodeEngine::NodeEngine(
 QueryId NodeEngine::registerCompiledQueryPlan(std::unique_ptr<CompiledQueryPlan> compiledQueryPlan)
 {
     auto queryId = queryTracker->registerQuery(std::move(compiledQueryPlan));
-    queryLog->logQueryStatusChange(queryId, QueryStatus::Registered, std::chrono::system_clock::now());
+    queryLog->logQueryStatusChange(queryId, QueryState::Registered, std::chrono::system_clock::now());
     return queryId;
 }
 

--- a/nes-runtime/tests/UnitTests/Runtime/CMakeLists.txt
+++ b/nes-runtime/tests/UnitTests/Runtime/CMakeLists.txt
@@ -11,3 +11,4 @@
 # limitations under the License.
 
 add_subdirectory(MemoryLayouts)
+add_nes_runtime_test(query-log-test "QueryLogTest.cpp")

--- a/nes-runtime/tests/UnitTests/Runtime/QueryLogTest.cpp
+++ b/nes-runtime/tests/UnitTests/Runtime/QueryLogTest.cpp
@@ -1,0 +1,314 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <barrier>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <Identifiers/Identifiers.hpp>
+#include <Listeners/QueryLog.hpp>
+#include <Runtime/Execution/QueryStatus.hpp>
+#include <ErrorHandling.hpp>
+
+using namespace std::chrono_literals;
+
+namespace NES
+{
+
+class QueryLogTest : public ::testing::Test
+{
+protected:
+    void SetUp() override { queryLog = std::make_unique<QueryLog>(); }
+
+    std::unique_ptr<QueryLog> queryLog;
+    const QueryId testQueryId{42};
+    const std::chrono::system_clock::time_point testTime = std::chrono::system_clock::now();
+};
+
+/// NOLINTBEGIN(readability-magic-numbers,bugprone-unchecked-optional-access,misc-include-cleaner)
+TEST_F(QueryLogTest, LogQueryStatusChangeBasic)
+{
+    EXPECT_TRUE(queryLog->logQueryStatusChange(testQueryId, QueryState::Started, testTime));
+    EXPECT_TRUE(queryLog->logQueryStatusChange(testQueryId, QueryState::Running, testTime + 100ms));
+    EXPECT_TRUE(queryLog->logQueryStatusChange(testQueryId, QueryState::Stopped, testTime + 200ms));
+}
+
+TEST_F(QueryLogTest, GetLogForQuery)
+{
+    queryLog->logQueryStatusChange(testQueryId, QueryState::Started, testTime);
+    queryLog->logQueryStatusChange(testQueryId, QueryState::Running, testTime + 100ms);
+    queryLog->logQueryStatusChange(testQueryId, QueryState::Stopped, testTime + 200ms);
+
+    const auto log = queryLog->getLogForQuery(testQueryId);
+    ASSERT_TRUE(log.has_value());
+    EXPECT_EQ(log->size(), 3);
+
+    EXPECT_EQ(log->at(0).state, QueryState::Started);
+    EXPECT_EQ(log->at(1).state, QueryState::Running);
+    EXPECT_EQ(log->at(2).state, QueryState::Stopped);
+}
+
+TEST_F(QueryLogTest, GetLogForNonExistentQuery)
+{
+    const auto log = queryLog->getLogForQuery(QueryId{999});
+    EXPECT_FALSE(log.has_value());
+}
+
+TEST_F(QueryLogTest, GetQuerySummarySuccessfulExecution)
+{
+    queryLog->logQueryStatusChange(testQueryId, QueryState::Started, testTime);
+    queryLog->logQueryStatusChange(testQueryId, QueryState::Running, testTime + 100ms);
+    queryLog->logQueryStatusChange(testQueryId, QueryState::Stopped, testTime + 200ms);
+
+    const auto status = queryLog->getQueryStatus(testQueryId);
+    ASSERT_TRUE(status.has_value());
+
+    EXPECT_EQ(status->queryId, testQueryId);
+    EXPECT_EQ(status->state, QueryState::Stopped);
+
+    EXPECT_TRUE(status->metrics.start.has_value());
+    EXPECT_TRUE(status->metrics.running.has_value());
+    EXPECT_TRUE(status->metrics.stop.has_value());
+    EXPECT_FALSE(status->metrics.error.has_value());
+
+    EXPECT_EQ(*status->metrics.start, testTime);
+    EXPECT_EQ(*status->metrics.running, testTime + 100ms);
+    EXPECT_EQ(*status->metrics.stop, testTime + 200ms);
+}
+
+TEST_F(QueryLogTest, GetQuerySummaryWithFailure)
+{
+    const Exception testError{"Test error", 500};
+
+    queryLog->logQueryStatusChange(testQueryId, QueryState::Started, testTime);
+    queryLog->logQueryStatusChange(testQueryId, QueryState::Running, testTime + 100ms);
+    queryLog->logQueryFailure(testQueryId, testError, testTime + 200ms);
+
+    auto summary = queryLog->getQueryStatus(testQueryId);
+    ASSERT_TRUE(summary.has_value());
+
+    EXPECT_EQ(summary->queryId, testQueryId);
+    EXPECT_EQ(summary->state, QueryState::Failed);
+
+    EXPECT_TRUE(summary->metrics.start.has_value());
+    EXPECT_TRUE(summary->metrics.running.has_value());
+    EXPECT_TRUE(summary->metrics.stop.has_value());
+    EXPECT_TRUE(summary->metrics.error.has_value());
+
+    EXPECT_EQ(summary->metrics.error->code(), 500);
+    EXPECT_EQ(summary->metrics.error->what(), "Test error");
+}
+
+TEST_F(QueryLogTest, GetQuerySummaryPartialExecution)
+{
+    queryLog->logQueryStatusChange(testQueryId, QueryState::Started, testTime);
+    queryLog->logQueryStatusChange(testQueryId, QueryState::Running, testTime + 100ms);
+
+    const auto status = queryLog->getQueryStatus(testQueryId);
+    ASSERT_TRUE(status.has_value());
+
+    EXPECT_EQ(status->queryId, testQueryId);
+    EXPECT_EQ(status->state, QueryState::Running);
+
+    EXPECT_TRUE(status->metrics.start.has_value());
+    EXPECT_TRUE(status->metrics.running.has_value());
+    EXPECT_FALSE(status->metrics.stop.has_value());
+    EXPECT_FALSE(status->metrics.error.has_value());
+}
+
+TEST_F(QueryLogTest, GetQuerySummaryForNonExistentQuery)
+{
+    const auto status = queryLog->getQueryStatus(QueryId{999});
+    EXPECT_FALSE(status.has_value());
+}
+
+TEST_F(QueryLogTest, MultipleQueriesIndependentLogs)
+{
+    constexpr QueryId query1{1};
+    constexpr QueryId query2{2};
+
+    queryLog->logQueryStatusChange(query1, QueryState::Started, testTime);
+    queryLog->logQueryStatusChange(query2, QueryState::Started, testTime + 50ms);
+    queryLog->logQueryStatusChange(query1, QueryState::Running, testTime + 100ms);
+    queryLog->logQueryFailure(query2, Exception{"Query 2 failed", 400}, testTime + 150ms); /// NOLINT(*-magic-numbers)
+
+    const auto status1 = queryLog->getQueryStatus(query1);
+    const auto status2 = queryLog->getQueryStatus(query2);
+
+    ASSERT_TRUE(status1.has_value());
+    ASSERT_TRUE(status2.has_value());
+
+    EXPECT_EQ(status1->state, QueryState::Running);
+    EXPECT_EQ(status2->state, QueryState::Failed);
+
+    EXPECT_FALSE(status1->metrics.error.has_value());
+    EXPECT_TRUE(status2->metrics.error.has_value());
+    EXPECT_EQ(status2->metrics.error->code(), 400);
+}
+
+TEST_F(QueryLogTest, QueryStateChangeConstructors)
+{
+    /// Test state-only constructor
+    const QueryStateChange stateChange1(QueryState::Running, testTime);
+    EXPECT_EQ(stateChange1.state, QueryState::Running);
+    EXPECT_EQ(stateChange1.timestamp, testTime);
+    EXPECT_FALSE(stateChange1.exception.has_value());
+
+    /// Test exception constructor
+    const Exception testError{"Test exception", 404};
+    QueryStateChange stateChange2(testError, testTime);
+    EXPECT_EQ(stateChange2.state, QueryState::Failed);
+    EXPECT_EQ(stateChange2.timestamp, testTime);
+    EXPECT_TRUE(stateChange2.exception.has_value());
+    EXPECT_EQ(stateChange2.exception->code(), 404);
+}
+
+TEST_F(QueryLogTest, OutOfOrderEventsWithMonotonicTimestamps)
+{
+    /// Test that events can arrive out of order but with monotonic timestamps
+    /// Events arrive in order: Running, Started, Stopped (out of logical order)
+    /// But timestamps are monotonic: t0 <= t1 <= t2
+    const auto time0 = testTime;
+    const auto time1 = testTime + 100ms;
+    const auto time2 = testTime + 200ms;
+
+    /// Log events out of logical order but with monotonic timestamps
+    queryLog->logQueryStatusChange(testQueryId, QueryState::Running, time1);
+    queryLog->logQueryStatusChange(testQueryId, QueryState::Started, time0);
+    queryLog->logQueryStatusChange(testQueryId, QueryState::Stopped, time2);
+
+    /// Verify that the log preserves the order events were logged
+    const auto log = queryLog->getLogForQuery(testQueryId);
+    ASSERT_TRUE(log.has_value());
+    EXPECT_EQ(log->size(), 3);
+
+    /// Verify status uses the most recent state and appropriate timestamps
+    const auto status = queryLog->getQueryStatus(testQueryId);
+    ASSERT_TRUE(status.has_value());
+    EXPECT_EQ(status->state, QueryState::Stopped);
+
+    /// Metrics should reflect the actual timestamps, not arrival order
+    EXPECT_TRUE(status->metrics.start.has_value());
+    EXPECT_TRUE(status->metrics.running.has_value());
+    EXPECT_TRUE(status->metrics.stop.has_value());
+
+    EXPECT_EQ(*status->metrics.start, time0);
+    EXPECT_EQ(*status->metrics.running, time1);
+    EXPECT_EQ(*status->metrics.stop, time2);
+}
+
+TEST_F(QueryLogTest, EventsWithEqualTimestamps)
+{
+    /// Test behavior when multiple events have the same timestamp
+    const auto sameTime = testTime;
+    const Exception testError{"Test failure", 500};
+
+    queryLog->logQueryStatusChange(testQueryId, QueryState::Registered, sameTime);
+    queryLog->logQueryStatusChange(testQueryId, QueryState::Started, sameTime);
+    queryLog->logQueryStatusChange(testQueryId, QueryState::Running, sameTime);
+    queryLog->logQueryStatusChange(testQueryId, QueryState::Stopped, sameTime);
+    queryLog->logQueryFailure(testQueryId, testError, sameTime);
+
+    const auto log = queryLog->getLogForQuery(testQueryId);
+    ASSERT_TRUE(log.has_value());
+    EXPECT_EQ(log->size(), 5);
+
+    /// All events should have the same timestamp
+    for (const auto& entry : *log)
+    {
+        EXPECT_EQ(entry.timestamp, sameTime);
+    }
+
+    /// Status should show the final state (Failed)
+    const auto status = queryLog->getQueryStatus(testQueryId);
+    ASSERT_TRUE(status.has_value());
+    EXPECT_EQ(status->state, QueryState::Failed);
+
+    /// All metric timestamps should be the same
+    EXPECT_EQ(*status->metrics.start, sameTime);
+    EXPECT_EQ(*status->metrics.running, sameTime);
+    EXPECT_EQ(*status->metrics.stop, sameTime);
+
+    /// Error should be captured
+    EXPECT_TRUE(status->metrics.error.has_value());
+    EXPECT_EQ(status->metrics.error->code(), 500);
+    EXPECT_STREQ(status->metrics.error->what(), "Test failure");
+}
+
+TEST_F(QueryLogTest, MultiThreadedLogging)
+{
+    /// Test that multiple threads can safely log to the same QueryLog instance
+    constexpr uint64_t numThreads = 16;
+    constexpr uint64_t numQueries = 1'000;
+    const auto baseTime = testTime;
+
+    std::barrier barrier{numThreads};
+
+    const auto logSubmission = [this, baseTime, &barrier]
+    {
+        barrier.arrive_and_wait();
+        /// Each thread logs the same sequence of state changes for all queries
+        for (uint64_t queryId = 0; queryId < numQueries; ++queryId)
+        {
+            const auto timestamp = baseTime + std::chrono::milliseconds{queryId * 10};
+
+            queryLog->logQueryStatusChange(QueryId{queryId}, QueryState::Registered, timestamp);
+            queryLog->logQueryStatusChange(QueryId{queryId}, QueryState::Started, timestamp);
+            queryLog->logQueryStatusChange(QueryId{queryId}, QueryState::Running, timestamp);
+            queryLog->logQueryStatusChange(QueryId{queryId}, QueryState::Stopped, timestamp);
+            queryLog->logQueryFailure(QueryId{queryId}, Exception{"Test failure", 404}, timestamp);
+            queryLog->logQueryStatusChange(QueryId{queryId}, QueryState::Running, timestamp);
+        }
+    };
+
+    {
+        std::vector<std::jthread> threads;
+        threads.reserve(numThreads);
+        /// Launch multiple threads that log events for different queries
+        for (uint64_t threadId = 0; threadId < numThreads; ++threadId)
+        {
+            threads.emplace_back(logSubmission);
+        }
+    }
+
+    /// Verify that each thread's events were logged correctly
+    constexpr uint64_t eventsPerQuery = numThreads * 6;
+    for (uint64_t queryId = 0; queryId < numThreads; ++queryId)
+    {
+        const auto log = queryLog->getLogForQuery(QueryId{queryId});
+        ASSERT_TRUE(log.has_value()) << "Query " << queryId << " events not found";
+        EXPECT_EQ(log->size(), eventsPerQuery) << "Query " << queryId << " wrong event count";
+
+        const auto status = queryLog->getQueryStatus(QueryId{queryId});
+        ASSERT_TRUE(status.has_value());
+        EXPECT_EQ(status->state, QueryState::Failed);
+        EXPECT_TRUE(status->metrics.start.has_value());
+        EXPECT_TRUE(status->metrics.stop.has_value());
+        EXPECT_TRUE(status->metrics.error.has_value());
+        EXPECT_EQ(status->metrics.error->code(), 404);
+        EXPECT_STREQ(status->metrics.error->what(), "Test failure");
+    }
+
+    /// Verify that we have logs for all expected queries and no extra ones
+    const auto statusResults = queryLog->getStatus();
+    EXPECT_EQ(statusResults.size(), numQueries);
+}
+
+/// NOLINTEND(readability-magic-numbers,bugprone-unchecked-optional-access,misc-include-cleaner)
+}

--- a/nes-single-node-worker/include/GrpcService.hpp
+++ b/nes-single-node-worker/include/GrpcService.hpp
@@ -33,7 +33,7 @@ public:
 
     grpc::Status StopQuery(grpc::ServerContext*, const StopQueryRequest*, google::protobuf::Empty*) override;
 
-    grpc::Status RequestQuerySummary(grpc::ServerContext*, const QuerySummaryRequest*, QuerySummaryReply*) override;
+    grpc::Status RequestQueryStatus(grpc::ServerContext*, const QueryStatusRequest*, QueryStatusReply*) override;
 
     grpc::Status RequestQueryLog(grpc::ServerContext* context, const QueryLogRequest* request, QueryLogReply* response) override;
 

--- a/nes-single-node-worker/include/SingleNodeWorker.hpp
+++ b/nes-single-node-worker/include/SingleNodeWorker.hpp
@@ -80,6 +80,6 @@ public:
     /// Complete history of query status changes.
     [[nodiscard]] std::optional<QueryLog::Log> getQueryLog(QueryId queryId) const;
     /// Summary structure for query.
-    [[nodiscard]] std::expected<QuerySummary, Exception> getQuerySummary(QueryId queryId) const noexcept;
+    [[nodiscard]] std::expected<LocalQueryStatus, Exception> getQueryStatus(QueryId queryId) const noexcept;
 };
 }

--- a/nes-single-node-worker/src/SingleNodeWorker.cpp
+++ b/nes-single-node-worker/src/SingleNodeWorker.cpp
@@ -26,12 +26,9 @@
 #include <Plans/LogicalPlan.hpp>
 #include <Runtime/NodeEngineBuilder.hpp>
 #include <Runtime/QueryTerminationType.hpp>
-#include <Util/Common.hpp>
-#include <Util/DumpMode.hpp>
 #include <Util/PlanRenderer.hpp>
 #include <Util/Pointers.hpp>
 #include <cpptrace/from_current.hpp>
-#include <fmt/format.h>
 #include <CompositeStatisticListener.hpp>
 #include <ErrorHandling.hpp>
 #include <GoogleEventTracePrinter.hpp>
@@ -57,7 +54,7 @@ SingleNodeWorker::SingleNodeWorker(const SingleNodeWorkerConfiguration& configur
         listener->addListener(googleTracePrinter);
     }
 
-    nodeEngine = NodeEngineBuilder(configuration.workerConfiguration, Util::copyPtr(listener)).build();
+    nodeEngine = NodeEngineBuilder(configuration.workerConfiguration, copyPtr(listener)).build();
 
     optimizer = std::make_unique<QueryOptimizer>(configuration.workerConfiguration.defaultQueryExecution);
     compiler = std::make_unique<QueryCompilation::QueryCompiler>();
@@ -141,16 +138,16 @@ std::expected<void, Exception> SingleNodeWorker::unregisterQuery(QueryId queryId
     std::unreachable();
 }
 
-std::expected<QuerySummary, Exception> SingleNodeWorker::getQuerySummary(QueryId queryId) const noexcept
+std::expected<LocalQueryStatus, Exception> SingleNodeWorker::getQueryStatus(QueryId queryId) const noexcept
 {
     CPPTRACE_TRY
     {
-        auto summary = nodeEngine->getQueryLog()->getQuerySummary(queryId);
-        if (not summary.has_value())
+        auto status = nodeEngine->getQueryLog()->getQueryStatus(queryId);
+        if (not status.has_value())
         {
             return std::unexpected{QueryNotFound("{}", queryId)};
         }
-        return summary.value();
+        return status.value();
     }
     CPPTRACE_CATCH(...)
     {

--- a/nes-systests/systest/include/QuerySubmitter.hpp
+++ b/nes-systests/systest/include/QuerySubmitter.hpp
@@ -41,10 +41,10 @@ public:
     void startQuery(QueryId query);
     void stopQuery(QueryId query);
     void unregisterQuery(QueryId query);
-    QuerySummary waitForQueryTermination(QueryId query);
+    LocalQueryStatus waitForQueryTermination(QueryId query);
 
     /// Blocks until atleast one query has finished (or potentially failed)
-    std::vector<QuerySummary> finishedQueries();
+    std::vector<LocalQueryStatus> finishedQueries();
 
 private:
     UniquePtr<QueryManager> queryManager;

--- a/nes-systests/systest/include/SystestState.hpp
+++ b/nes-systests/systest/include/SystestState.hpp
@@ -120,7 +120,7 @@ struct RunningQuery
 {
     SystestQuery systestQuery;
     QueryId queryId = INVALID_QUERY_ID;
-    QuerySummary querySummary;
+    LocalQueryStatus queryStatus;
     std::optional<uint64_t> bytesProcessed{0};
     std::optional<uint64_t> tuplesProcessed{0};
     bool passed = false;

--- a/nes-systests/systest/src/QuerySubmitter.cpp
+++ b/nes-systests/systest/src/QuerySubmitter.cpp
@@ -77,33 +77,33 @@ void QuerySubmitter::unregisterQuery(const QueryId query)
     }
 }
 
-QuerySummary QuerySubmitter::waitForQueryTermination(const QueryId query)
+LocalQueryStatus QuerySubmitter::waitForQueryTermination(const QueryId query)
 {
     while (true)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(25));
-        if (const auto summary = queryManager->status(query))
+        if (const auto queryStatus = queryManager->status(query))
         {
-            if (summary->currentStatus == QueryStatus::Stopped)
+            if (queryStatus->state == QueryState::Stopped)
             {
-                return *summary;
+                return *queryStatus;
             }
         }
     }
 }
 
-std::vector<QuerySummary> QuerySubmitter::finishedQueries()
+std::vector<LocalQueryStatus> QuerySubmitter::finishedQueries()
 {
     while (true)
     {
-        std::vector<QuerySummary> results;
+        std::vector<LocalQueryStatus> results;
         for (const auto id : ids)
         {
-            if (auto summary = queryManager->status(id))
+            if (auto queryStatus = queryManager->status(id))
             {
-                if (summary->currentStatus == QueryStatus::Failed || summary->currentStatus == QueryStatus::Stopped)
+                if (queryStatus->state == QueryState::Failed || queryStatus->state == QueryState::Stopped)
                 {
-                    results.emplace_back(std::move(*summary));
+                    results.emplace_back(std::move(*queryStatus));
                 }
             }
         }


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This pull request removes the query runs of the single node worker. 
These were unused and added unnecessary complexity. 
The change list is as follows:
- Remove `QueryRunSummary` and replace by `QueryMetrics` which include timestamps and errors as optionals for a single query
- Rename query status to `QueryState` to more accurately reflect its purpose
- Adapt grpc protocol to work with the new structure

## Verifying this change
This change is tested by
- New `QueryLogTest` in nes-runtime

## What components does this pull request potentially affect?
- Runtime

## Issue Closed by this pull request:

This PR closes #1078.
