### PR TITLE
chore(OriginId): remove `OriginId` from formatters, replace with `OperatorId` to detect source -> sink pipelines

### DIFF
--- a/nes-executable/include/CompiledQueryPlan.hpp
+++ b/nes-executable/include/CompiledQueryPlan.hpp
@@ -42,6 +42,7 @@ struct CompiledQueryPlan
         /// The Source representation in the `CompiledQueryPlan` is still an abstract source representation. During Query Instantiation
         /// the descriptor and originId are instantiated into concrete source implementation.
         OriginId originId;
+        OperatorId operatorId;
         SourceDescriptor descriptor;
 
         /// Sources do not have any predecessors
@@ -56,7 +57,7 @@ struct CompiledQueryPlan
         SinkDescriptor descriptor;
 
         /// Sinks do not have any successors
-        std::vector<std::variant<OriginId, std::weak_ptr<ExecutablePipeline>>> predecessor;
+        std::vector<std::variant<OperatorId, std::weak_ptr<ExecutablePipeline>>> predecessor;
     };
 
     static std::unique_ptr<CompiledQueryPlan> create(

--- a/nes-input-formatters/include/InputFormatters/InputFormatterProvider.hpp
+++ b/nes-input-formatters/include/InputFormatters/InputFormatterProvider.hpp
@@ -23,7 +23,7 @@
 
 namespace NES
 {
-std::unique_ptr<InputFormatterTaskPipeline> provideInputFormatterTask(OriginId originId, const Schema& schema, const ParserConfig& config);
+std::unique_ptr<InputFormatterTaskPipeline> provideInputFormatterTask(const Schema& schema, const ParserConfig& config);
 
 bool contains(const std::string& parserType);
 }

--- a/nes-input-formatters/private/InputFormatterTask.hpp
+++ b/nes-input-formatters/private/InputFormatterTask.hpp
@@ -30,7 +30,6 @@
 #include <DataTypes/DataType.hpp>
 #include <DataTypes/Schema.hpp>
 #include <Identifiers/Identifiers.hpp>
-#include <InputFormatters/InputFormatterTaskPipeline.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
 #include <Sources/SourceDescriptor.hpp>
@@ -169,10 +168,8 @@ class InputFormatterTask
 public:
     static constexpr bool hasSpanningTuple() { return FormatterType::HasSpanningTuple; }
 
-    explicit InputFormatterTask(
-        const OriginId originId, FormatterType inputFormatIndexer, const Schema& schema, const ParserConfig& parserConfig)
-        : originId(originId)
-        , inputFormatIndexer(std::move(inputFormatIndexer))
+    explicit InputFormatterTask(FormatterType inputFormatIndexer, const Schema& schema, const ParserConfig& parserConfig)
+        : inputFormatIndexer(std::move(inputFormatIndexer))
         , schemaInfo(schema)
         , indexerMetaData(typename FormatterType::IndexerMetaData{parserConfig, schema})
         /// Only if we need to resolve spanning tuples, we need the SequenceShredder
@@ -277,13 +274,12 @@ public:
     std::ostream& taskToString(std::ostream& os) const
     {
         /// Not using fmt::format, because it fails during build, trying to pass sequenceShredder as a const value
-        os << "InputFormatterTask(originId: " << originId << ", inputFormatIndexer: " << inputFormatIndexer
-           << ", sequenceShredder: " << *sequenceShredder << ")\n";
+        os << "InputFormatterTask(" << ", inputFormatIndexer: " << inputFormatIndexer << ", sequenceShredder: " << *sequenceShredder
+           << ")\n";
         return os;
     }
 
 private:
-    OriginId originId;
     FormatterType inputFormatIndexer;
     SchemaInfo schemaInfo;
     typename FormatterType::IndexerMetaData indexerMetaData;

--- a/nes-input-formatters/registry/include/InputFormatIndexerRegistry.hpp
+++ b/nes-input-formatters/registry/include/InputFormatIndexerRegistry.hpp
@@ -37,8 +37,8 @@ using InputFormatIndexerRegistryReturnType = std::unique_ptr<InputFormatterTaskP
 /// Calls constructor of specific InputFormatter and exposes public members to it.
 struct InputFormatIndexerRegistryArguments
 {
-    InputFormatIndexerRegistryArguments(ParserConfig config, const OriginId originId, const Schema& schema)
-        : inputFormatIndexerConfig(std::move(config)), originId(originId), schema(schema)
+    InputFormatIndexerRegistryArguments(ParserConfig config, const Schema& schema)
+        : inputFormatIndexerConfig(std::move(config)), schema(schema)
     {
     }
 
@@ -48,7 +48,7 @@ struct InputFormatIndexerRegistryArguments
     template <InputFormatIndexerType FormatterType>
     InputFormatIndexerRegistryReturnType createInputFormatterTaskPipeline(FormatterType inputFormatter)
     {
-        auto inputFormatterTask = InputFormatterTask<FormatterType>(originId, std::move(inputFormatter), schema, inputFormatIndexerConfig);
+        auto inputFormatterTask = InputFormatterTask<FormatterType>(std::move(inputFormatter), schema, inputFormatIndexerConfig);
         return std::make_unique<InputFormatterTaskPipeline>(std::move(inputFormatterTask));
     }
 
@@ -57,7 +57,6 @@ struct InputFormatIndexerRegistryArguments
     ParserConfig inputFormatIndexerConfig;
 
 private:
-    OriginId originId{OriginId(OriginId::INVALID)};
     Schema schema;
 };
 

--- a/nes-input-formatters/src/InputFormatterProvider.cpp
+++ b/nes-input-formatters/src/InputFormatterProvider.cpp
@@ -27,11 +27,10 @@
 namespace NES
 {
 
-std::unique_ptr<InputFormatterTaskPipeline>
-provideInputFormatterTask(const OriginId originId, const Schema& schema, const ParserConfig& config)
+std::unique_ptr<InputFormatterTaskPipeline> provideInputFormatterTask(const Schema& schema, const ParserConfig& config)
 {
     if (auto inputFormatter
-        = InputFormatIndexerRegistry::instance().create(config.parserType, InputFormatIndexerRegistryArguments(config, originId, schema)))
+        = InputFormatIndexerRegistry::instance().create(config.parserType, InputFormatIndexerRegistryArguments(config, schema)))
     {
         return std::move(inputFormatter.value());
     }

--- a/nes-input-formatters/tests/Util/InputFormatterTestUtil.cpp
+++ b/nes-input-formatters/tests/Util/InputFormatterTestUtil.cpp
@@ -40,11 +40,9 @@
 #include <Runtime/BufferManager.hpp>
 #include <Runtime/TupleBuffer.hpp>
 #include <Sources/SourceCatalog.hpp>
-#include <Sources/SourceDescriptor.hpp>
 #include <Sources/SourceHandle.hpp>
 #include <Sources/SourceProvider.hpp>
 #include <Sources/SourceReturnType.hpp>
-#include <Sources/SourceValidationProvider.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <Util/Overloaded.hpp>
 #include <fmt/format.h>
@@ -176,7 +174,7 @@ std::shared_ptr<InputFormatterTaskPipeline> createInputFormatterTask(const Schem
         {"type", std::move(formatterType)}, {"tuple_delimiter", "\n"}, {"field_delimiter", "|"}};
     const auto validatedParserConfiguration = validateAndFormatParserConfig(parserConfiguration);
 
-    return provideInputFormatterTask(OriginId(0), schema, validatedParserConfiguration);
+    return provideInputFormatterTask(schema, validatedParserConfiguration);
 }
 
 void waitForSource(const std::vector<TupleBuffer>& resultBuffers, const size_t numExpectedBuffers)

--- a/nes-input-formatters/tests/Util/InputFormatterTestUtil.hpp
+++ b/nes-input-formatters/tests/Util/InputFormatterTestUtil.hpp
@@ -355,7 +355,7 @@ template <typename TupleSchemaTemplate>
 std::vector<TestPipelineTask> createTasks(const TestHandle<TupleSchemaTemplate>& testHandle)
 {
     const std::shared_ptr<InputFormatterTaskPipeline> inputFormatterTask
-        = provideInputFormatterTask(OriginId(0), testHandle.schema, testHandle.testConfig.parserConfig);
+        = provideInputFormatterTask(testHandle.schema, testHandle.testConfig.parserConfig);
     std::vector<TestPipelineTask> tasks;
     tasks.reserve(testHandle.inputBuffers.size());
     for (const auto& inputBuffer : testHandle.inputBuffers)

--- a/nes-query-compiler/private/Phases/LowerToCompiledQueryPlanPhase.hpp
+++ b/nes-query-compiler/private/Phases/LowerToCompiledQueryPlanPhase.hpp
@@ -15,7 +15,10 @@
 #pragma once
 
 #include <memory>
+#include <unordered_map>
 #include <variant>
+#include <vector>
+
 #include <Identifiers/Identifiers.hpp>
 #include <Util/DumpMode.hpp>
 #include <CompiledQueryPlan.hpp>
@@ -34,7 +37,7 @@ public:
     std::unique_ptr<CompiledQueryPlan> apply(const std::shared_ptr<PipelinedQueryPlan>& pipelineQueryPlan);
 
 private:
-    using Predecessor = std::variant<OriginId, std::weak_ptr<ExecutablePipeline>>;
+    using Predecessor = std::variant<OperatorId, std::weak_ptr<ExecutablePipeline>>;
     using Successor = std::optional<std::shared_ptr<ExecutablePipeline>>;
 
     std::shared_ptr<ExecutablePipeline> processOperatorPipeline(const std::shared_ptr<Pipeline>& pipeline);

--- a/nes-query-compiler/src/Phases/LowerToCompiledQueryPlanPhase.cpp
+++ b/nes-query-compiler/src/Phases/LowerToCompiledQueryPlanPhase.cpp
@@ -63,9 +63,7 @@ void LowerToCompiledQueryPlanPhase::processSource(const std::shared_ptr<Pipeline
 
     const std::vector<std::shared_ptr<ExecutablePipeline>> executableSuccessorPipelines;
     auto inputFormatterTaskPipeline = provideInputFormatterTask(
-        sourceOperator.getOriginId(),
-        *sourceOperator.getDescriptor().getLogicalSource().getSchema(),
-        sourceOperator.getDescriptor().getParserConfig());
+        *sourceOperator.getDescriptor().getLogicalSource().getSchema(), sourceOperator.getDescriptor().getParserConfig());
 
     auto executableInputFormatterPipeline
         = ExecutablePipeline::create(pipeline->getPipelineId(), std::move(inputFormatterTaskPipeline), executableSuccessorPipelines);
@@ -86,7 +84,7 @@ void LowerToCompiledQueryPlanPhase::processSource(const std::shared_ptr<Pipeline
     pipelineToExecutableMap.emplace(getNextPipelineId(), executableInputFormatterPipeline);
     inputFormatterTasks.emplace_back(executableInputFormatterPipeline);
 
-    sources.emplace_back(sourceOperator.getOriginId(), sourceOperator.getDescriptor(), std::move(inputFormatterTasks));
+    sources.emplace_back(sourceOperator.getOriginId(), sourceOperator.id, sourceOperator.getDescriptor(), std::move(inputFormatterTasks));
 }
 
 void LowerToCompiledQueryPlanPhase::processSink(const Predecessor& predecessor, const std::shared_ptr<Pipeline>& pipeline)
@@ -170,9 +168,8 @@ std::unique_ptr<CompiledQueryPlan> LowerToCompiledQueryPlanPhase::apply(const st
 {
     this->pipelineQueryPlan = pipelineQueryPlan;
 
-    ///Process all pipelines recursively.
-    auto sourcePipelines = pipelineQueryPlan->getSourcePipelines();
-    for (const auto& pipeline : sourcePipelines)
+    /// Process all pipelines recursively.
+    for (auto sourcePipelines = pipelineQueryPlan->getSourcePipelines(); const auto& pipeline : sourcePipelines)
     {
         processSource(pipeline);
     }

--- a/nes-runtime/src/ExecutableQueryPlan.cpp
+++ b/nes-runtime/src/ExecutableQueryPlan.cpp
@@ -65,7 +65,7 @@ std::unique_ptr<ExecutableQueryPlan> ExecutableQueryPlan::instantiate(
 {
     std::vector<SourceWithSuccessor> instantiatedSources;
 
-    std::unordered_map<OriginId, std::vector<std::shared_ptr<ExecutablePipeline>>> instantiatedSinksWithSourcePredecessor;
+    std::unordered_map<OperatorId, std::vector<std::shared_ptr<ExecutablePipeline>>> instantiatedSinksWithSourcePredecessor;
 
     for (auto& [pipelineId, descriptor, predecessors] : compiledQueryPlan.sinks)
     {
@@ -75,18 +75,18 @@ std::unique_ptr<ExecutableQueryPlan> ExecutableQueryPlan::instantiate(
         {
             std::visit(
                 Overloaded{
-                    [&](const OriginId& source) { instantiatedSinksWithSourcePredecessor[source].push_back(sink); },
+                    [&](const OperatorId& source) { instantiatedSinksWithSourcePredecessor[source].push_back(sink); },
                     [&](const std::weak_ptr<ExecutablePipeline>& pipeline) { pipeline.lock()->successors.push_back(sink); },
                 },
                 predecessor);
         }
     }
 
-    for (auto [id, descriptor, successors] : compiledQueryPlan.sources)
+    for (auto [originId, operatorId, descriptor, successors] : compiledQueryPlan.sources)
     {
-        std::ranges::copy(instantiatedSinksWithSourcePredecessor[id], std::back_inserter(successors));
+        std::ranges::copy(instantiatedSinksWithSourcePredecessor[operatorId], std::back_inserter(successors));
         instantiatedSources.emplace_back(
-            SourceProvider::lower(id, descriptor, poolProvider, numberOfBuffersInSourceLocalPools), std::move(successors));
+            SourceProvider::lower(originId, descriptor, poolProvider, numberOfBuffersInSourceLocalPools), std::move(successors));
     }
 
 


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This pull request adds support for variable sized data to the nested loop join. The change list is as follows:
- Removed `originId` information from formatters completely. Input formatters set the origin ids of their output buffers entirely based on the input buffers they receive, therefore its not necessary to provide them with one during lowering.
- Exchanged the use of `originId` in the pipelining phase. They were used to detect source->sink type forwarding queries. For this, `OperatorId` serves the same purpose and it enables us to use multiple origin ids per source in the future. 

## Verifying this change
This change is tested by
- Existing test suite

## What components does this pull request potentially affect?
- Formatters: 

## Documentation
- No additional documentation required

## Issue Closed by this pull request:

This PR closes #1097.
