### PR TITLE
fix(benchmarks): missing snake case parameter

### DIFF
--- a/nes-systests/systest/CMakeLists.txt
+++ b/nes-systests/systest/CMakeLists.txt
@@ -93,7 +93,7 @@ if (ENABLE_LARGE_TESTS)
     ExternalData_Add_Test(test-data
             # currently, 4 worker threads perform the best on the large systests (avoids lock contention on NEXMARK Query 5)
             NAME systest_large_benchmark_${joinStrategy}
-            COMMAND systest -b --workingDir=${CMAKE_CURRENT_BINARY_DIR}/large_scale_benchmark_${joinStrategy} --data ${EXPANDED_TEST_DATA_PATH} --groups large -- --worker.defaultQueryExecution.executionMode=COMPILER --worker.queryEngine.numberOfWorkerThreads=4 --worker.numberOfBuffersInGlobalBufferManager=2000000 --worker.defaultQueryExecution.joinStrategy=${joinStrategy})
+            COMMAND systest -b --workingDir=${CMAKE_CURRENT_BINARY_DIR}/large_scale_benchmark_${joinStrategy} --data ${EXPANDED_TEST_DATA_PATH} --groups large -- --worker.default_query_execution.execution_mode=COMPILER --worker.query_engine.number_of_worker_threads=4 --worker.number_of_buffers_in_global_buffer_manager=2000000 --worker.default_query_execution.join_strategy=${joinStrategy})
 
 
     # Running here the Nexmark.test queries with NLJ to test it for larger data sets but the input data size


### PR DESCRIPTION
We missed one large scale benchmark when changing parameters to snake case, this fixes it.