### PR TITLE
Addresses TaskQueue Polling and improves repeated tasks

### DIFF
--- a/.github/.env/test-thread.env
+++ b/.github/.env/test-thread.env
@@ -1,1 +1,3 @@
+# This assumes the env file is evaluated from the repository root
+export TSAN_OPTIONS="suppressions=$PWD/.github/.env/tsan_suppressions.txt"
 export ADDITIONAL_CTEST_ARGS=""

--- a/.github/.env/tsan_suppressions.txt
+++ b/.github/.env/tsan_suppressions.txt
@@ -1,0 +1,5 @@
+# Suppress lock-order-inversion between RunningQueryPlan::start and QueryCatalog::start
+# Currently, it is impossible that these two operations (targeting the same query) run concurrently.
+
+deadlock:NES::RunningQueryPlan::start
+deadlock:NES::QueryCatalog::start

--- a/nes-common/include/ExceptionDefinitions.inc
+++ b/nes-common/include/ExceptionDefinitions.inc
@@ -95,6 +95,7 @@ EXCEPTION(CannotFormatMalformedStringValue, 3007, "cannot format malformed strin
 EXCEPTION(CannotAccessBuffer, 3008, "cannot access buffer")
 EXCEPTION(CannotAllocateBuffer, 3009, "cannot allocate buffer")
 EXCEPTION(TooMuchWork, 3010, "too much tasks for the internal task queue")
+EXCEPTION(SkippingDelayedTaskDuringShutdown, 3011, "skipping delayed task during shutdown")
 
 /// 4XXX Errors interpreting data stream, sources and sinks
 EXCEPTION(CannotFormatSourceData, 4000, "cannot format source data")

--- a/nes-executable/include/PipelineExecutionContext.hpp
+++ b/nes-executable/include/PipelineExecutionContext.hpp
@@ -13,6 +13,7 @@
 */
 
 #pragma once
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <unordered_map>
@@ -32,8 +33,7 @@ public:
     enum class ContinuationPolicy : uint8_t
     {
         POSSIBLE, /// It is possible for the emitted tuple buffer to be processed immediately. This is not a guarantee that that will happen
-        NEVER, /// The tuple buffer should never be processed immediately
-        REPEAT /// Put the same task back into the task queue
+        NEVER /// The tuple buffer should never be processed immediately
     };
 
     virtual ~PipelineExecutionContext() = default;
@@ -44,7 +44,13 @@ public:
     /// Please be aware of how you are setting the continuation policy, as this will/can lead to deadlocks and no progress in our system.
     /// We advise to use ContinuationPolicy::POSSIBLE, as this will ensure no deadlock arising.
     /// Returns success, if the buffer was emitted successfully.
+
     virtual bool emitBuffer(const TupleBuffer&, ContinuationPolicy) = 0;
+
+    /// This method can only be called once per pipeline execution! The Pipeline should immediately finish its execution as the exact same task could be executed
+    /// immediately.
+    virtual void repeatTask(const TupleBuffer&, std::chrono::milliseconds) = 0;
+
     virtual TupleBuffer allocateTupleBuffer() = 0;
     [[nodiscard]] virtual WorkerThreadId getId() const = 0;
     [[nodiscard]] virtual uint64_t getNumberOfWorkerThreads() const = 0;

--- a/nes-executable/tests/TestUtils/TestTaskQueue.cpp
+++ b/nes-executable/tests/TestUtils/TestTaskQueue.cpp
@@ -14,6 +14,7 @@
 
 #include <TestTaskQueue.hpp>
 
+#include <chrono>
 #include <cstddef>
 #include <memory>
 #include <ostream>
@@ -35,11 +36,6 @@ bool TestPipelineExecutionContext::emitBuffer(const TupleBuffer& resultBuffer, c
 {
     switch (continuationPolicy)
     {
-        case ContinuationPolicy::REPEAT: {
-            PRECONDITION(repeatTaskCallback != nullptr, "Cannot repeat a task without a valid repeatTaskCallback function");
-            repeatTaskCallback();
-            break;
-        }
         case ContinuationPolicy::NEVER: {
             resultBuffers->at(workerThreadId.getRawValue()).emplace_back(resultBuffer);
             break;
@@ -59,6 +55,12 @@ TupleBuffer TestPipelineExecutionContext::allocateTupleBuffer()
         return buffer.value();
     }
     throw BufferAllocationFailure("Required more buffers in TestTaskQueue than provided.");
+}
+
+void TestPipelineExecutionContext::repeatTask(const TupleBuffer&, std::chrono::milliseconds)
+{
+    PRECONDITION(repeatTaskCallback != nullptr, "Cannot repeat a task without a valid repeatTaskCallback function");
+    repeatTaskCallback();
 }
 
 void TestPipelineStage::execute(const TupleBuffer& tupleBuffer, PipelineExecutionContext& pec)

--- a/nes-executable/tests/TestUtils/TestTaskQueue.hpp
+++ b/nes-executable/tests/TestUtils/TestTaskQueue.hpp
@@ -107,6 +107,8 @@ public:
         this->operatorHandlers = operatorHandlers;
     }
 
+    void repeatTask(const TupleBuffer&, std::chrono::milliseconds) override;
+
     WorkerThreadId workerThreadId;
     PipelineId pipelineId;
 

--- a/nes-input-formatters/private/InputFormatterTask.hpp
+++ b/nes-input-formatters/private/InputFormatterTask.hpp
@@ -244,7 +244,7 @@ public:
         /// After enough out-of-range requests, the SequenceShredder increases the size of its ring buffer.
         if (not sequenceShredder->isInRange(rawBuffer.getSequenceNumber().getRawValue()))
         {
-            rawBuffer.emit(pec, PipelineExecutionContext::ContinuationPolicy::REPEAT);
+            rawBuffer.repeat(pec);
             return;
         }
 

--- a/nes-input-formatters/private/RawTupleBuffer.hpp
+++ b/nes-input-formatters/private/RawTupleBuffer.hpp
@@ -69,6 +69,8 @@ public:
         pec.emitBuffer(rawBuffer, continuationPolicy);
     }
 
+    void repeat(PipelineExecutionContext& pec) const { pec.repeatTask(rawBuffer, std::chrono::milliseconds{0}); }
+
     [[nodiscard]] const TupleBuffer& getRawBuffer() const noexcept { return rawBuffer; }
 
     void setSpanningTuple(const std::string_view spanningTuple) { this->bufferView = spanningTuple; }

--- a/nes-physical-operators/tests/EmitPhysicalOperatorTest.cpp
+++ b/nes-physical-operators/tests/EmitPhysicalOperatorTest.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <barrier>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -49,6 +50,7 @@
 #include <gtest/gtest.h>
 #include <BaseUnitTest.hpp>
 #include <EmitPhysicalOperator.hpp>
+#include <ErrorHandling.hpp>
 #include <ExecutionContext.hpp>
 #include <PipelineExecutionContext.hpp>
 
@@ -89,6 +91,8 @@ class EmitPhysicalOperatorTest : public Testing::BaseUnitTest
             : buffers(buffers), bufferManager(std::move(bufferManager))
         {
         }
+
+        void repeatTask(const TupleBuffer&, std::chrono::milliseconds) override { INVARIANT(false, "This function should not be called"); }
 
         ///NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members) lifetime is ensured by the `run` method.
         folly::Synchronized<std::vector<TupleBuffer>>& buffers;

--- a/nes-query-engine/DelayedTaskSubmitter.hpp
+++ b/nes-query-engine/DelayedTaskSubmitter.hpp
@@ -1,0 +1,164 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <queue>
+#include <stop_token>
+#include <thread>
+#include <utility>
+#include <vector>
+#include <absl/functional/any_invocable.h>
+#include <folly/Synchronized.h>
+#include <ErrorHandling.hpp>
+#include <Task.hpp>
+
+namespace NES
+{
+
+/// The DelayedTaskSubmitter enables the query engine to defer submission of Tasks to a future point in time.
+/// This is mostly used to implement retry/repeat logic without spamming the taskqueue.
+template <typename CT = std::chrono::steady_clock>
+class DelayedTaskSubmitter
+{
+public:
+    using SubmitFn = absl::AnyInvocable<void(Task) const noexcept>;
+    using ClockType = CT;
+
+private:
+    struct ScheduledTask
+    {
+        Task task;
+        typename ClockType::time_point deadline;
+    };
+
+    /// Comparator for priority queue - earlier deadlines have higher priority
+    struct TaskComparator
+    {
+        bool operator()(const ScheduledTask& left, const ScheduledTask& right) const { return left.deadline > right.deadline; }
+    };
+
+    SubmitFn submitFn;
+
+    std::condition_variable_any cv;
+    folly::Synchronized<std::priority_queue<ScheduledTask, std::vector<ScheduledTask>, TaskComparator>, std::mutex> taskQueueMtx;
+
+    /// The DelayedTaskSubmitter is implemented as its own dedicated thread. Most of the time is spent blocking on an empty task queue
+    /// or waiting until the deadline has passed to submit the next task.
+    std::jthread workerThread;
+
+    void workerLoop(const std::stop_token& stop);
+
+public:
+    explicit DelayedTaskSubmitter(SubmitFn submitFn);
+
+    /// Template function to accept any std::chrono::duration type
+    template <typename Rep, typename Period>
+    void submitTaskIn(Task task, std::chrono::duration<Rep, Period> delay)
+    {
+        auto deadline = ClockType::now() + delay;
+
+        auto taskQueue = taskQueueMtx.lock();
+        const bool isEarliest = taskQueue->empty() || deadline < taskQueue->top().deadline;
+        taskQueue->emplace(ScheduledTask{std::move(task), deadline});
+
+        /// Wake up the worker thread if this task has an earlier deadline or if the taskqueue was empty.
+        /// This is necessary, as we need to set the cv_wait_until to ensure no task being missed.
+        if (isEarliest)
+        {
+            taskQueue.unlock();
+            cv.notify_one();
+        }
+    }
+
+    /// Non-copyable and non-movable
+    DelayedTaskSubmitter(const DelayedTaskSubmitter&) = delete;
+    DelayedTaskSubmitter& operator=(const DelayedTaskSubmitter&) = delete;
+    DelayedTaskSubmitter(DelayedTaskSubmitter&&) = delete;
+    DelayedTaskSubmitter& operator=(DelayedTaskSubmitter&&) = delete;
+
+    ~DelayedTaskSubmitter();
+};
+
+template <typename CT>
+DelayedTaskSubmitter<CT>::DelayedTaskSubmitter(SubmitFn submitFn)
+    : submitFn(std::move(submitFn))
+    , workerThread([](const std::stop_token& stopToken, DelayedTaskSubmitter* self) { self->workerLoop(stopToken); }, this)
+{
+}
+
+template <typename CT>
+void DelayedTaskSubmitter<CT>::workerLoop(const std::stop_token& stop)
+{
+    auto taskQueue = taskQueueMtx.lock();
+    while (!stop.stop_requested())
+    {
+        if (taskQueue->empty())
+        {
+            /// Wait for tasks to be added or shutdown signal
+            cv.wait(taskQueue.as_lock(), stop, [&taskQueue] { return !taskQueue->empty(); });
+            continue;
+        }
+
+        auto now = ClockType::now();
+        const auto& nextTask = taskQueue->top();
+
+        if (nextTask.deadline <= now)
+        {
+            /// Task deadline has arrived - execute it
+
+            /// Priority queue's API design has a limitation where top only returns a const reference, however we have to move the task out of the queue.
+            /// Since we have exclusive access to the queue, and we are removing the task from the queue anyways and the underlying memory has to be mutable, stripping away the constness is ok (I think).
+            /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+            auto task = std::move(const_cast<ScheduledTask&>(nextTask).task);
+            taskQueue->pop();
+
+            /// Release lock while calling submit function to avoid blocking other operations
+            taskQueue.unlock();
+            submitFn(std::move(task));
+            taskQueue = taskQueueMtx.lock();
+        }
+        else
+        {
+            auto nextDeadline = nextTask.deadline;
+            /// Wait until the next task deadline or until notified of new more urgent task
+            cv.wait_until(
+                taskQueue.as_lock(),
+                stop,
+                nextDeadline,
+                [&taskQueue, nextDeadline] { return !taskQueue->empty() && taskQueue->top().deadline < nextDeadline; });
+        }
+    }
+}
+
+template <typename CT>
+DelayedTaskSubmitter<CT>::~DelayedTaskSubmitter()
+{
+    /// Signal shutdown and wake up worker threads.
+    workerThread = {};
+
+    /// Throw away all pending tasks, as the engine is about to shutdown and trying to actually execute these tasks is unlikely to
+    /// succeed, in addition to potentially creating infinite cycles.
+    auto taskQueue = taskQueueMtx.lock();
+    while (!taskQueue->empty())
+    {
+        auto task = std::move(const_cast<ScheduledTask&>(taskQueue->top()).task);
+        taskQueue->pop();
+        failTask(task, SkippingDelayedTaskDuringShutdown());
+    }
+}
+}

--- a/nes-query-engine/QueryEngine.cpp
+++ b/nes-query-engine/QueryEngine.cpp
@@ -399,7 +399,6 @@ public:
         std::shared_ptr<AbstractQueryStatusListener> listener,
         std::shared_ptr<QueryEngineStatisticListener> stats,
         std::shared_ptr<AbstractBufferProvider> bufferProvider,
-        const size_t,
         const size_t admissionQueueSize)
         : listener(std::move(listener))
         , statistic(std::move(std::move(stats)))
@@ -757,8 +756,7 @@ QueryEngine::QueryEngine(
     , statusListener(std::move(listener))
     , statisticListener(std::move(statListener))
     , queryCatalog(std::make_shared<QueryCatalog>())
-    , threadPool(std::make_unique<ThreadPool>(
-          statusListener, statisticListener, bufferManager, config.taskQueueSize.getValue(), config.admissionQueueSize.getValue()))
+    , threadPool(std::make_unique<ThreadPool>(statusListener, statisticListener, bufferManager, config.admissionQueueSize.getValue()))
 {
     for (size_t i = 0; i < config.numberOfWorkerThreads.getValue(); ++i)
     {

--- a/nes-query-engine/QueryEngine.cpp
+++ b/nes-query-engine/QueryEngine.cpp
@@ -661,7 +661,7 @@ bool ThreadPool::WorkerThread::operator()(FailSourceTask& failSource) const
     if (auto source = failSource.target.lock())
     {
         ENGINE_LOG_DEBUG("Fail Source Task for Query {} Source {}", failSource.queryId, source->getOriginId());
-        source->fail(failSource.exception);
+        source->fail(std::move(*failSource.exception));
         return true;
     }
     return false;

--- a/nes-query-engine/QueryEngine.cpp
+++ b/nes-query-engine/QueryEngine.cpp
@@ -41,6 +41,7 @@
 #include <Util/ThreadNaming.hpp>
 #include <fmt/format.h>
 #include <folly/MPMCQueue.h>
+#include <DelayedTaskSubmitter.hpp>
 #include <EngineLogger.hpp>
 #include <ErrorHandling.hpp>
 #include <ExecutablePipelineStage.hpp>
@@ -261,7 +262,7 @@ public:
             TaskCallback::OnFailure(injectQueryFailure(node, std::move(failure.callback))),
         };
 
-        auto task = WorkTask(qid, node->id, node, buffer, std::move(wrappedCallback));
+        auto task = WorkTask(qid, node->id, node, std::move(buffer), std::move(wrappedCallback));
         if (WorkerThread::id == INVALID<WorkerThreadId>)
         {
             /// Non-WorkerThread
@@ -354,6 +355,7 @@ public:
         , bufferProvider(std::move(bufferProvider))
         , admissionQueue(admissionQueueSize)
         , internalTaskQueue(internalTaskQueueSize)
+        , delayedTaskSubmitter([this](Task&& task) noexcept { internalTaskQueue.blockingWrite(std::move(task)); })
     {
     }
 
@@ -436,6 +438,7 @@ private:
 
     detail::Queue admissionQueue;
     detail::Queue internalTaskQueue;
+    DelayedTaskSubmitter<> delayedTaskSubmitter;
 
     /// Class Invariant: numberOfThreads == pool.size().
     /// We don't want to expose the vector directly to anyone, as this would introduce a race condition.
@@ -461,6 +464,7 @@ bool ThreadPool::WorkerThread::operator()(WorkTask& task) const
     if (auto pipeline = task.pipeline.lock())
     {
         ENGINE_LOG_DEBUG("Handle Task for {}-{}. Tuples: {}", task.queryId, pipeline->id, task.buf.getNumberOfTuples());
+        bool repeated = false;
         DefaultPEC pec(
             pool.numberOfThreads(),
             WorkerThread::id,
@@ -468,6 +472,7 @@ bool ThreadPool::WorkerThread::operator()(WorkTask& task) const
             pool.bufferProvider,
             [&](const TupleBuffer& tupleBuffer, PipelineExecutionContext::ContinuationPolicy continuationPolicy)
             {
+                INVARIANT(repeated == false, "A task cannot be repeated more than once");
                 ENGINE_LOG_DEBUG(
                     "Task emitted tuple buffer {}-{}. Tuples: {}", task.queryId, task.pipelineId, tupleBuffer.getNumberOfTuples());
                 /// If the current WorkTask is a 'repeat' task, re-emit the same tuple buffer and the same pipeline as a WorkTask.
@@ -475,7 +480,12 @@ bool ThreadPool::WorkerThread::operator()(WorkTask& task) const
                 {
                     pool.statistic->onEvent(
                         TaskEmit{id, task.queryId, pipeline->id, pipeline->id, taskId, tupleBuffer.getNumberOfTuples()});
-                    return pool.emitWork(task.queryId, pipeline, tupleBuffer, TaskCallback{}, continuationPolicy);
+
+                    pool.delayedTaskSubmitter.submitTaskIn(
+                        WorkTask(task.queryId, pipeline->id, pipeline, tupleBuffer, std::move(task.callback)),
+                        std::chrono::milliseconds(25));
+                    repeated = true;
+                    return true;
                 }
                 /// Otherwise, get the successor of the pipeline, and emit a work task for it.
                 return std::ranges::all_of(
@@ -589,6 +599,14 @@ bool ThreadPool::WorkerThread::operator()(StopPipelineTask& stopPipelineTask) co
                 return true;
             }
 
+            if (policy == PipelineExecutionContext::ContinuationPolicy::REPEAT)
+            {
+                pool.delayedTaskSubmitter.submitTaskIn(
+                    StopPipelineTask(stopPipelineTask.queryId, std::move(stopPipelineTask.pipeline), std::move(stopPipelineTask.callback)),
+                    std::chrono::milliseconds(25));
+                return true;
+            }
+
             for (const auto& successor : stopPipelineTask.pipeline->successors)
             {
                 /// The Termination Exceution Context appends a strong reference to the successer into the Task.
@@ -600,8 +618,10 @@ bool ThreadPool::WorkerThread::operator()(StopPipelineTask& stopPipelineTask) co
         });
 
     ENGINE_LOG_DEBUG("Stopping Pipeline {}-{}", stopPipelineTask.queryId, stopPipelineTask.pipeline->id);
+    auto pipelineId = stopPipelineTask.pipeline->id;
+    auto queryId = stopPipelineTask.queryId;
     stopPipelineTask.pipeline->stage->stop(pec);
-    pool.statistic->onEvent(PipelineStop{WorkerThread::id, stopPipelineTask.queryId, stopPipelineTask.pipeline->id});
+    pool.statistic->onEvent(PipelineStop{WorkerThread::id, queryId, pipelineId});
     return true;
 }
 

--- a/nes-query-engine/QueryEngine.cpp
+++ b/nes-query-engine/QueryEngine.cpp
@@ -181,7 +181,6 @@ public:
         const std::shared_ptr<QueryEngineStatisticListener>& statistic,
         QueryLifetimeController& controller,
         WorkEmitter& emitter);
-    QueryId registerQuery(std::unique_ptr<ExecutableQueryPlan>);
     void stopQuery(QueryId queryId);
 
     void clear()

--- a/nes-query-engine/QueryEngineConfiguration.cpp
+++ b/nes-query-engine/QueryEngineConfiguration.cpp
@@ -64,7 +64,7 @@ std::shared_ptr<ConfigurationValidation> QueryEngineConfiguration::numberOfThrea
     return std::make_shared<Validator>();
 }
 
-std::shared_ptr<ConfigurationValidation> QueryEngineConfiguration::taskQueueSizeValidator()
+std::shared_ptr<ConfigurationValidation> QueryEngineConfiguration::queueSizeValidator()
 {
     struct Validator : ConfigurationValidation
     {

--- a/nes-query-engine/Task.cpp
+++ b/nes-query-engine/Task.cpp
@@ -135,12 +135,12 @@ StopSourceTask::StopSourceTask(QueryId queryId, std::weak_ptr<RunningSource> tar
 {
 }
 
-FailSourceTask::FailSourceTask() : exception("", 0)
+FailSourceTask::FailSourceTask() : exception(nullptr)
 {
 }
 
 FailSourceTask::FailSourceTask(QueryId queryId, std::weak_ptr<RunningSource> target, Exception exception, TaskCallback callback)
-    : BaseTask(queryId, std::move(callback)), target(std::move(target)), exception(std::move(exception))
+    : BaseTask(queryId, std::move(callback)), target(std::move(target)), exception(std::make_unique<Exception>(std::move(exception)))
 {
 }
 

--- a/nes-query-engine/Task.cpp
+++ b/nes-query-engine/Task.cpp
@@ -130,8 +130,8 @@ StopPipelineTask::StopPipelineTask(QueryId queryId, std::unique_ptr<RunningQuery
 {
 }
 
-StopSourceTask::StopSourceTask(QueryId queryId, std::weak_ptr<RunningSource> target, TaskCallback callback)
-    : BaseTask(queryId, std::move(callback)), target(std::move(target))
+StopSourceTask::StopSourceTask(QueryId queryId, std::weak_ptr<RunningSource> target, size_t attempts, TaskCallback callback)
+    : BaseTask(queryId, std::move(callback)), attempts(attempts), target(std::move(target))
 {
 }
 

--- a/nes-query-engine/Task.hpp
+++ b/nes-query-engine/Task.hpp
@@ -152,8 +152,9 @@ struct StopSourceTask : BaseTask
 {
     StopSourceTask() = default;
 
-    StopSourceTask(QueryId queryId, std::weak_ptr<RunningSource> target, TaskCallback callback);
+    StopSourceTask(QueryId queryId, std::weak_ptr<RunningSource> target, size_t attempts, TaskCallback callback);
 
+    size_t attempts;
     std::weak_ptr<RunningSource> target;
 };
 

--- a/nes-query-engine/Task.hpp
+++ b/nes-query-engine/Task.hpp
@@ -165,7 +165,7 @@ struct FailSourceTask : BaseTask
     FailSourceTask(QueryId queryId, std::weak_ptr<RunningSource> target, Exception exception, TaskCallback callback);
 
     std::weak_ptr<RunningSource> target;
-    Exception exception;
+    std::unique_ptr<Exception> exception;
 };
 
 struct StopQueryTask : BaseTask

--- a/nes-query-engine/TaskQueue.hpp
+++ b/nes-query-engine/TaskQueue.hpp
@@ -1,0 +1,123 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <optional>
+#include <semaphore>
+#include <stop_token>
+#include <utility>
+#include <folly/MPMCQueue.h>
+#include <folly/concurrency/UnboundedQueue.h>
+
+namespace NES
+{
+
+/// The TaskQueue is a central component within the QueryEngine. External components like sources or users of the system can add new tasks
+/// to an admission queue which is bounded and will backpressure sources if necessary. Internally, WorkerThreads communicate via a shared
+/// internal queue, which is unbounded to deal with occasionally bursty loads like a large join. Access to the internal task queue is always
+/// non-blocking. The TaskQueue exposes a blocking `getNextTaskBlocking` method which reads from either queue without spinning and is
+/// supposed to be used by the worker threads.
+template <typename TaskType>
+class TaskQueue
+{
+    folly::UMPMCQueue<TaskType, true> internal;
+    folly::MPMCQueue<TaskType> admission;
+
+    /// INVARIANT: internal.size() + admission.size() >= tasksAvailable
+    std::counting_semaphore<> tasksAvailable{0};
+
+    /// To provide cancellation, we only block for StopTokenCheckInterval.
+    /// This parameter could be tuned to allow for more timely cancellation
+    static constexpr std::chrono::milliseconds StopTokenCheckInterval{100};
+
+    TaskType readElementAssumingItExists()
+    {
+        TaskType task;
+        /// The semaphore guarantees that there is at least one element in either one of the queues.
+        if (internal.try_dequeue(task))
+        {
+            return task;
+        }
+
+        /// However, the MPMC `read` can spuriously fail under high contention, the alternative `readIfNotEmpty` does not but is
+        /// significantly slower.
+        while (!admission.read(task)) [[unlikely]]
+        {
+        }
+
+        return task;
+    }
+
+public:
+    explicit TaskQueue(size_t admissionTaskQueueSize) : admission(admissionTaskQueueSize) { }
+
+    /// By design the admission queue is bounded, which could lead to writes being blocked.
+    /// The stop token allows cancellation. In case the writing was canceled, this method returns false.
+    template <typename T = TaskType>
+    bool addAdmissionTaskBlocking(const std::stop_token& stoken, T&& task)
+    {
+        while (!stoken.stop_requested())
+        {
+            /// The order of operation upholds the invariant
+            if (admission.tryWriteUntil(std::chrono::steady_clock::now() + StopTokenCheckInterval, std::forward<T>(task)))
+            {
+                /// tasksAvailable is only increased if write to admission queue was successful.
+                tasksAvailable.release();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// Write a Task to the internal task queue. The internal task queue is unbounded thus this operation will always succeed
+    template <typename T = TaskType>
+    void addInternalTaskNonBlocking(T&& task)
+    {
+        /// The order of operation upholds the invariant. internal is unbounded which makes this write always succeed (unless oom)
+        internal.enqueue(std::forward<T>(task));
+        tasksAvailable.release();
+    }
+
+    /// Blocking read to retrieve the next task from the internal queue, or the admission queue if the internal task queue is empty.
+    /// This operation can be canceled using a stop token. In case of a cancellation, this method returns an empty optional.
+    /// The method prioritizes reading over cancellation. This implies, if a read is non-blocking, it succeeds regardless of the state of
+    /// the stop token.
+    std::optional<TaskType> getNextTaskBlocking(const std::stop_token& stoken)
+    {
+        while (!tasksAvailable.try_acquire_for(StopTokenCheckInterval))
+        {
+            if (stoken.stop_requested())
+            {
+                return std::nullopt;
+            }
+        }
+
+        return readElementAssumingItExists();
+    }
+
+    /// Non-Blocking version of `getNextTaskBlocking` if the queue is empty, this method returns an empty optional.
+    std::optional<TaskType> getNextTaskNonBlocking()
+    {
+        if (!tasksAvailable.try_acquire())
+        {
+            return std::nullopt;
+        }
+
+        return readElementAssumingItExists();
+    }
+};
+}

--- a/nes-query-engine/include/QueryEngineConfiguration.hpp
+++ b/nes-query-engine/include/QueryEngineConfiguration.hpp
@@ -28,7 +28,7 @@ class QueryEngineConfiguration final : public BaseConfiguration
 {
     /// validators to prevent nonsensical values for the number of threads and task queue size
     static std::shared_ptr<ConfigurationValidation> numberOfThreadsValidator();
-    static std::shared_ptr<ConfigurationValidation> taskQueueSizeValidator();
+    static std::shared_ptr<ConfigurationValidation> queueSizeValidator();
 
 public:
     QueryEngineConfiguration() = default;
@@ -37,12 +37,10 @@ public:
 
     UIntOption numberOfWorkerThreads
         = {"number_of_worker_threads", "4", "Number of worker threads used within the QueryEngine", {numberOfThreadsValidator()}};
-    UIntOption taskQueueSize
-        = {"task_queue_size", "10000", "Size of the bounded task queue used within the QueryEngine", {taskQueueSizeValidator()}};
     UIntOption admissionQueueSize
-        = {"admission_queue_size", "1000", "Size of the bounded admission queue used within the QueryEngine", {taskQueueSizeValidator()}};
+        = {"admission_queue_size", "1000", "Size of the bounded admission queue used within the QueryEngine", {queueSizeValidator()}};
 
 protected:
-    std::vector<BaseOption*> getOptions() override { return {&numberOfWorkerThreads, &taskQueueSize, &admissionQueueSize}; }
+    std::vector<BaseOption*> getOptions() override { return {&numberOfWorkerThreads, &admissionQueueSize}; }
 };
 }

--- a/nes-query-engine/tests/CMakeLists.txt
+++ b/nes-query-engine/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ endmacro()
 
 add_query_engine_test(delayed-task-submitter-test DelayedTaskSubmitterTest.cpp)
 add_query_engine_test(query-engine-test QueryEngineTest.cpp)
+add_query_engine_test(query-engine-task-queue-test TaskQueueTest.cpp)
 add_query_engine_test(running-query-plan-test QueryPlanTest.cpp)
 add_query_engine_test(query-engine-configuration-test QueryEngineConfigurationTest.cpp)
 

--- a/nes-query-engine/tests/CMakeLists.txt
+++ b/nes-query-engine/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ macro(add_query_engine_test)
     target_include_directories(${TARGET_NAME} PRIVATE ..)
 endmacro()
 
+add_query_engine_test(delayed-task-submitter-test DelayedTaskSubmitterTest.cpp)
 add_query_engine_test(query-engine-test QueryEngineTest.cpp)
 add_query_engine_test(running-query-plan-test QueryPlanTest.cpp)
 add_query_engine_test(query-engine-configuration-test QueryEngineConfigurationTest.cpp)

--- a/nes-query-engine/tests/DelayedTaskSubmitterTest.cpp
+++ b/nes-query-engine/tests/DelayedTaskSubmitterTest.cpp
@@ -1,0 +1,326 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <DelayedTaskSubmitter.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <memory>
+#include <random>
+#include <thread>
+#include <utility>
+#include <variant>
+#include <vector>
+#include <Identifiers/Identifiers.hpp>
+#include <Util/Logger/LogLevel.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <Util/Logger/impl/NesLogger.hpp>
+#include <folly/Synchronized.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <BaseUnitTest.hpp>
+#include <ErrorHandling.hpp>
+#include <RunningQueryPlan.hpp>
+#include <Task.hpp>
+
+namespace NES::Testing
+{
+
+/// Testing the DelayedTaskSubmitter with an actual clock is impractical. The TestClock implements
+/// the std::chrono::Clock concept and is injected into the DelayedTaskSubmitter, that way the test
+/// can actually control how time is passing.
+struct TestClock
+{
+    using duration = std::chrono::nanoseconds;
+    using rep = duration::rep;
+    using period = duration::period;
+    using time_point = std::chrono::time_point<TestClock, duration>;
+    constexpr static bool is_steady = true;
+    static folly::Synchronized<time_point> now_;
+
+    static time_point now() noexcept { return *now_.rlock(); }
+
+    static void advance(duration advanceBy, bool doAnActualWait)
+    {
+        *now_.wlock() += advanceBy;
+        /// Note that only advancing the clock does not allow logic that relies on the time to run immediatly and take 0 time.
+        /// Thus we still have to rely on real time to give any actions caused by the advance of the Test clock to actually catch up.
+
+        if (doAnActualWait)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+    };
+
+    /// This should only be called during test setup as this breaks the is_steady assumption
+    static void reset() { *now_.wlock() = time_point(std::chrono::nanoseconds(0)); }
+};
+
+folly::Synchronized<TestClock::time_point> TestClock::now_{time_point(std::chrono::nanoseconds(0))};
+
+using DelayedTaskSubmitter = NES::DelayedTaskSubmitter<TestClock>;
+
+class DelayedTaskSubmitterTest : public BaseUnitTest
+{
+public:
+    static void SetUpTestSuite()
+    {
+        Logger::setupLogging("DelayedTaskSubmitterTest.log", NES::LogLevel::LOG_DEBUG);
+        NES_DEBUG("Setup DelayedTaskSubmitterTest test class.");
+    }
+
+    void SetUp() override
+    {
+        BaseUnitTest::SetUp();
+        TestClock::reset();
+    }
+
+protected:
+    folly::Synchronized<std::vector<Task>> submittedTasks;
+    std::atomic<int> taskCounter{0};
+
+    /// For tracking execution order in tests
+    folly::Synchronized<std::vector<int>> executionOrder;
+
+    void submitTask(Task task)
+    {
+        submittedTasks.wlock()->push_back(std::move(task));
+        ++taskCounter;
+    }
+
+    void clearSubmittedTasks()
+    {
+        submittedTasks.wlock()->clear();
+        taskCounter = 0;
+    }
+
+    size_t getSubmittedTaskCount() { return submittedTasks.rlock()->size(); }
+};
+
+/// NOLINTBEGIN(readability-magic-numbers): It's a test and these are just random values
+TEST_F(DelayedTaskSubmitterTest, testBasicTaskSubmission)
+{
+    auto submitter = DelayedTaskSubmitter([this](Task task) noexcept { submitTask(std::move(task)); });
+
+    /// Create a simple task
+    auto task = WorkTask(QueryId(1), PipelineId(1), std::weak_ptr<RunningQueryPlanNode>(), TupleBuffer(), {});
+
+    /// Submit task with immediate execution
+    submitter.submitTaskIn(std::move(task), std::chrono::milliseconds(10));
+
+    TestClock::advance(std::chrono::milliseconds(9), true);
+    ASSERT_EQ(getSubmittedTaskCount(), 0);
+
+    TestClock::advance(std::chrono::milliseconds(1), true);
+    ASSERT_EQ(getSubmittedTaskCount(), 1);
+}
+
+TEST_F(DelayedTaskSubmitterTest, testMultipleTasksOrderedExecution)
+{
+    /// Clear execution order for this test
+    executionOrder.wlock()->clear();
+
+    auto submitter = DelayedTaskSubmitter(
+        [this](Task task) noexcept
+        {
+            /// Track execution order through the submitFn callback before moving
+            if (std::holds_alternative<WorkTask>(task))
+            {
+                const auto& workTask = std::get<WorkTask>(task);
+                executionOrder.wlock()->push_back(workTask.queryId.getRawValue());
+            }
+            submitTask(std::move(task));
+        });
+
+    /// Submit tasks with different delays
+    auto task1 = WorkTask(QueryId(1), PipelineId(1), std::weak_ptr<RunningQueryPlanNode>(), TupleBuffer(), {});
+    auto task2 = WorkTask(QueryId(2), PipelineId(2), std::weak_ptr<RunningQueryPlanNode>(), TupleBuffer(), {});
+    auto task3 = WorkTask(QueryId(3), PipelineId(3), std::weak_ptr<RunningQueryPlanNode>(), TupleBuffer(), {});
+
+    /// Submit in reverse order with increasing delays
+    submitter.submitTaskIn(std::move(task3), std::chrono::milliseconds(30));
+    submitter.submitTaskIn(std::move(task2), std::chrono::milliseconds(20));
+    submitter.submitTaskIn(std::move(task1), std::chrono::milliseconds(10));
+
+    TestClock::advance(std::chrono::milliseconds(10), true);
+    ASSERT_EQ(getSubmittedTaskCount(), 1);
+    TestClock::advance(std::chrono::milliseconds(10), true);
+    ASSERT_EQ(getSubmittedTaskCount(), 2);
+    TestClock::advance(std::chrono::milliseconds(10), true);
+    ASSERT_EQ(getSubmittedTaskCount(), 3);
+
+    /// Check execution order
+    {
+        auto order = executionOrder.rlock();
+        ASSERT_EQ(order->size(), 3);
+        EXPECT_THAT(*order, ::testing::ElementsAre(1, 2, 3));
+    }
+}
+
+TEST_F(DelayedTaskSubmitterTest, testTaskWithZeroDelay)
+{
+    auto submitter = DelayedTaskSubmitter([this](Task task) noexcept { submitTask(std::move(task)); });
+
+    auto task = WorkTask(QueryId(1), PipelineId(1), std::weak_ptr<RunningQueryPlanNode>(), TupleBuffer(), {});
+
+    /// Submit task with zero delay
+    submitter.submitTaskIn(std::move(task), std::chrono::milliseconds(0));
+
+    /// Wait a bit for task to be executed
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    ASSERT_EQ(getSubmittedTaskCount(), 1);
+}
+
+TEST_F(DelayedTaskSubmitterTest, testDifferentDurationTypes)
+{
+    auto submitter = DelayedTaskSubmitter([this](Task task) noexcept { submitTask(std::move(task)); });
+
+    auto task1 = WorkTask(QueryId(1), PipelineId(1), std::weak_ptr<RunningQueryPlanNode>(), TupleBuffer(), {});
+    auto task2 = WorkTask(QueryId(2), PipelineId(2), std::weak_ptr<RunningQueryPlanNode>(), TupleBuffer(), {});
+    auto task3 = WorkTask(QueryId(3), PipelineId(3), std::weak_ptr<RunningQueryPlanNode>(), TupleBuffer(), {});
+
+    /// Test different duration types
+    submitter.submitTaskIn(std::move(task1), std::chrono::microseconds(10000)); /// 10ms
+    submitter.submitTaskIn(std::move(task2), std::chrono::milliseconds(10)); /// 10ms
+    submitter.submitTaskIn(std::move(task3), std::chrono::seconds(0)); /// 0s
+
+    /// Wait for all tasks to be executed
+    TestClock::advance(std::chrono::milliseconds(50), true);
+
+    ASSERT_EQ(getSubmittedTaskCount(), 3);
+}
+
+TEST_F(DelayedTaskSubmitterTest, testConcurrentTaskSubmission)
+{
+    auto submitter = DelayedTaskSubmitter([this](Task task) noexcept { submitTask(std::move(task)); });
+
+    std::vector<std::jthread> threads;
+    constexpr int numThreads = 10;
+    constexpr int tasksPerThread = 5;
+
+    /// Create multiple threads submitting tasks concurrently
+    threads.reserve(numThreads);
+    for (int i = 0; i < numThreads; ++i)
+    {
+        threads.emplace_back(
+            [&submitter, i]()
+            {
+                for (int j = 0; j < tasksPerThread; ++j)
+                {
+                    auto task = WorkTask(
+                        QueryId((i * tasksPerThread) + j),
+                        PipelineId((i * tasksPerThread) + j),
+                        std::weak_ptr<RunningQueryPlanNode>(),
+                        TupleBuffer(),
+                        {});
+                    if (j % 2 == 0)
+                    {
+                        TestClock::advance(std::chrono::milliseconds(1), false);
+                    }
+                    submitter.submitTaskIn(std::move(task), std::chrono::milliseconds(10));
+                }
+            });
+    }
+    threads.clear();
+
+    /// Wait for all tasks to be executed
+    for (size_t i = 0; i < 5; ++i)
+    {
+        TestClock::advance(std::chrono::milliseconds(2), true);
+    }
+
+    EXPECT_EQ(getSubmittedTaskCount(), numThreads * tasksPerThread);
+}
+
+TEST_F(DelayedTaskSubmitterTest, testDestructorCleanup)
+{
+    std::atomic submittedCount{0};
+    std::atomic failureCount{0};
+    std::atomic completeCount{0};
+
+    {
+        auto submitter = DelayedTaskSubmitter([&submittedCount](Task /*task*/) noexcept { ++submittedCount; });
+
+        /// Submit a task with long delay and custom onComplete and onFailure callbacks
+        auto task = WorkTask(
+            QueryId(1),
+            PipelineId(1),
+            std::weak_ptr<RunningQueryPlanNode>(),
+            TupleBuffer(),
+            TaskCallback(
+                TaskCallback::OnComplete([&completeCount] { ++completeCount; }),
+                TaskCallback::OnFailure([&failureCount](const Exception&) { ++failureCount; })));
+        submitter.submitTaskIn(std::move(task), std::chrono::milliseconds(1000));
+        TestClock::advance(std::chrono::milliseconds(100), true);
+        /// Destructor should be called here, cleaning up pending tasks
+    }
+
+    TestClock::advance(std::chrono::milliseconds(1000), true);
+    /// Task should not be executed since submitter was destroyed, but the failure callback should be called
+    EXPECT_EQ(submittedCount.load(), 0);
+    EXPECT_EQ(completeCount.load(), 0);
+    EXPECT_EQ(failureCount.load(), 1);
+}
+
+TEST_F(DelayedTaskSubmitterTest, testStressRandomTasks)
+{
+    constexpr int numThreads = 10;
+    constexpr int tasksPerThread = 20;
+    constexpr int totalTasks = numThreads * tasksPerThread;
+    constexpr int maxDelayMs = 50;
+
+    auto submitter = DelayedTaskSubmitter([this](Task task) noexcept { submitTask(std::move(task)); });
+    std::vector<std::jthread> threads;
+    threads.reserve(numThreads);
+    /// Create multiple threads submitting random tasks with random delays
+    for (int threadId = 0; threadId < numThreads; ++threadId)
+    {
+        threads.emplace_back(
+            [&submitter, threadId]()
+            {
+                /// Each thread gets its own random number generator
+                std::random_device randomDevice;
+                std::mt19937 gen(randomDevice());
+                std::uniform_int_distribution<> dis(0, maxDelayMs);
+
+                for (int i = 0; i < tasksPerThread; ++i)
+                {
+                    auto task = WorkTask(
+                        QueryId((threadId * tasksPerThread) + i),
+                        PipelineId((threadId * tasksPerThread) + i),
+                        std::weak_ptr<RunningQueryPlanNode>(),
+                        TupleBuffer(),
+                        {});
+
+                    /// Random delay between 0 and maxDelayMs milliseconds
+                    const int randomDelay = dis(gen);
+                    submitter.submitTaskIn(std::move(task), std::chrono::milliseconds(randomDelay));
+
+                    TestClock::advance(std::chrono::milliseconds(1), false);
+                }
+            });
+    }
+
+    threads.clear();
+
+    /// Now wait for the maximum delay to ensure all tasks have been processed
+    TestClock::advance(std::chrono::milliseconds(maxDelayMs), true);
+    /// Verify all tasks were submitted
+    ASSERT_EQ(getSubmittedTaskCount(), totalTasks);
+}
+
+/// NOLINTEND(readability-magic-numbers)
+}

--- a/nes-query-engine/tests/QueryEngineConfigurationTest.cpp
+++ b/nes-query-engine/tests/QueryEngineConfigurationTest.cpp
@@ -36,17 +36,15 @@ public:
 TEST_F(QueryEngineConfigurationTest, testConfigurationsDefault)
 {
     const QueryEngineConfiguration defaultConfig;
-    EXPECT_EQ(defaultConfig.taskQueueSize.getValue(), 10000);
+    EXPECT_EQ(defaultConfig.admissionQueueSize.getValue(), 1000);
     EXPECT_EQ(defaultConfig.numberOfWorkerThreads.getValue(), 4);
 }
 
 TEST_F(QueryEngineConfigurationTest, testConfigurationsValidInput)
 {
     QueryEngineConfiguration defaultConfig;
-    defaultConfig.overwriteConfigWithCommandLineInput(
-        {{"task_queue_size", "200"}, {"number_of_worker_threads", "2"}, {"admission_queue_size", "123"}});
+    defaultConfig.overwriteConfigWithCommandLineInput({{"number_of_worker_threads", "2"}, {"admission_queue_size", "123"}});
 
-    EXPECT_EQ(defaultConfig.taskQueueSize.getValue(), 200);
     EXPECT_EQ(defaultConfig.admissionQueueSize.getValue(), 123);
     EXPECT_EQ(defaultConfig.numberOfWorkerThreads.getValue(), 2);
 }
@@ -54,26 +52,31 @@ TEST_F(QueryEngineConfigurationTest, testConfigurationsValidInput)
 TEST_F(QueryEngineConfigurationTest, testConfigurationsBadInputNonString)
 {
     QueryEngineConfiguration defaultConfig;
-    EXPECT_ANY_THROW(defaultConfig.overwriteConfigWithCommandLineInput({{"task_queue_size", "XX"}, {"number_of_worker_threads", "2"}}));
+    EXPECT_ANY_THROW(
+        defaultConfig.overwriteConfigWithCommandLineInput({{"admission_queue_size", "XX"}, {"number_of_worker_threads", "2"}}));
 
     QueryEngineConfiguration defaultConfig1;
-    EXPECT_ANY_THROW(defaultConfig1.overwriteConfigWithCommandLineInput({{"task_queue_size", "200"}, {"number_of_worker_threads", "XX"}}));
+    EXPECT_ANY_THROW(
+        defaultConfig1.overwriteConfigWithCommandLineInput({{"admission_queue_size", "200"}, {"number_of_worker_threads", "XX"}}));
 
     QueryEngineConfiguration defaultConfig2;
-    EXPECT_ANY_THROW(defaultConfig2.overwriteConfigWithCommandLineInput({{"task_queue_size", "XX"}, {"number_of_worker_threads", "XX"}}));
+    EXPECT_ANY_THROW(
+        defaultConfig2.overwriteConfigWithCommandLineInput({{"admission_queue_size", "XX"}, {"number_of_worker_threads", "XX"}}));
 
     const QueryEngineConfiguration defaultConfig3;
-    EXPECT_ANY_THROW(defaultConfig2.overwriteConfigWithCommandLineInput({{"task_queue_size", "1.0"}, {"number_of_worker_threads", "1.5"}}));
+    EXPECT_ANY_THROW(
+        defaultConfig2.overwriteConfigWithCommandLineInput({{"admission_queue_size", "1.0"}, {"number_of_worker_threads", "1.5"}}));
 }
 
 TEST_F(QueryEngineConfigurationTest, testConfigurationsBadInputBadNumberOfThreads)
 {
     QueryEngineConfiguration defaultConfig;
-    EXPECT_ANY_THROW(defaultConfig.overwriteConfigWithCommandLineInput({{"task_queue_size", "200"}, {"number_of_worker_threads", "0"}}));
+    EXPECT_ANY_THROW(
+        defaultConfig.overwriteConfigWithCommandLineInput({{"admission_queue_size", "200"}, {"number_of_worker_threads", "0"}}));
 
     const QueryEngineConfiguration defaultConfig1;
     EXPECT_ANY_THROW(
-        defaultConfig.overwriteConfigWithCommandLineInput({{"task_queue_size", "200"}, {"number_of_worker_threads", "20000"}}));
+        defaultConfig.overwriteConfigWithCommandLineInput({{"admission_queue_size", "200"}, {"number_of_worker_threads", "20000"}}));
 }
 
 }

--- a/nes-query-engine/tests/QueryPlanTest.cpp
+++ b/nes-query-engine/tests/QueryPlanTest.cpp
@@ -12,6 +12,7 @@
     limitations under the License.
 */
 
+#include <chrono>
 #include <concepts>
 #include <condition_variable>
 #include <cstddef>
@@ -137,6 +138,7 @@ concept RangeOf = std::ranges::range<R> && std::same_as<std::ranges::range_value
 
 struct TestPipelineExecutionContext : PipelineExecutionContext
 {
+    MOCK_METHOD(void, repeatTask, (const TupleBuffer&, std::chrono::milliseconds), (override));
     MOCK_METHOD(WorkerThreadId, getId, (), (const, override));
     MOCK_METHOD(TupleBuffer, allocateTupleBuffer, (), (override));
     MOCK_METHOD(uint64_t, getNumberOfWorkerThreads, (), (const, override));

--- a/nes-query-engine/tests/TaskQueueTest.cpp
+++ b/nes-query-engine/tests/TaskQueueTest.cpp
@@ -1,0 +1,247 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <TaskQueue.hpp>
+
+#include <array>
+#include <atomic>
+#include <barrier>
+#include <chrono>
+#include <cstddef>
+#include <new>
+#include <optional>
+#include <random>
+#include <stop_token>
+#include <thread>
+#include <tuple>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+#include <gtest/gtest.h>
+
+namespace NES
+{
+
+class TaskQueueTest : public ::testing::Test
+{
+protected:
+    /// NOLINTNEXTLINE(readability-magic-numbers) 142 is roughly the current task size
+    using Task = std::tuple<int, int, std::array<std::byte, 142>>; /// {thread_id, sequence_number, payload}
+    TaskQueue<Task> queue{100};
+
+    template <size_t NumberOfConsumers>
+    struct ConsumedTasks
+    {
+        struct alignas(std::hardware_constructive_interference_size) LocalCounter
+        {
+            std::unordered_set<std::pair<int, int>> tasks;
+
+            void add(const Task& task)
+            {
+                ASSERT_TRUE(tasks.emplace(std::get<0>(task), std::get<1>(task)).second) << "Duplicate task found";
+            }
+        };
+
+        void verifyUnique()
+        {
+            std::unordered_set<std::pair<int, int>> merged;
+            for (auto& counter : localCounters)
+            {
+                const size_t oldSize = merged.size();
+                merged.insert(counter.tasks.begin(), counter.tasks.end());
+                ASSERT_EQ(oldSize + counter.tasks.size(), merged.size());
+            }
+        }
+
+        size_t size()
+        {
+            size_t size = 0;
+            for (auto& counter : localCounters)
+            {
+                size += counter.tasks.size();
+            }
+            return size;
+        }
+
+        std::array<LocalCounter, NumberOfConsumers> localCounters{};
+    };
+};
+
+/// Intentionally limited number of WorkerThreads should provoke backpressure on the Source Threads
+/// The Source Threads are instructed to create a fixed number of sources and are not listening to any cooperative stop_token,
+/// which means if for what ever reason the TaskQueue deadlocks this test will fail due to the global test timeout.
+/// The worker side consumes tasks using a mix of tryNextTask and nextTask.
+TEST_F(TaskQueueTest, BackpressureTest)
+{
+    constexpr int numberOfSources = 8;
+    constexpr int numberOfWorkers = 2;
+    constexpr int tasksPerSource = 10000;
+    constexpr int totalTasks = numberOfSources * tasksPerSource;
+    constexpr int totalThreads = numberOfSources + numberOfWorkers;
+
+    /// Track all consumed tasks to verify no duplicates/losses
+    ConsumedTasks<numberOfWorkers> consumedTasks;
+
+    /// Barrier to synchronize all threads to start at the same time
+    std::barrier syncBarrier{totalThreads};
+
+    /// Sources produce tasks added to the admission queue
+    std::vector<std::jthread> sources;
+    sources.reserve(numberOfSources);
+    for (int sourceId = 0; sourceId < numberOfSources; ++sourceId)
+    {
+        sources.emplace_back(
+            [&, sourceId]
+            {
+                /// Wait for all threads to be ready before starting
+                syncBarrier.arrive_and_wait();
+                for (int i = 0; i < tasksPerSource; ++i)
+                {
+                    queue.addAdmissionTaskBlocking({}, {sourceId, i, {}});
+                }
+            });
+    }
+
+    /// WorkerThreads (mix nextTask and tryNextTask)
+    std::vector<std::jthread> worker;
+    worker.reserve(numberOfWorkers);
+    for (int workerId = 0; workerId < numberOfWorkers; ++workerId)
+    {
+        worker.emplace_back(
+            [&, workerId](const std::stop_token& stoken)
+            {
+                std::mt19937 rng(workerId);
+                std::uniform_int_distribution dist(0, 1);
+
+                /// Wait for all threads to be ready before starting
+                syncBarrier.arrive_and_wait();
+                while (!stoken.stop_requested())
+                {
+                    if (auto task = dist(rng) == 0 ? queue.getNextTaskBlocking(stoken) : queue.getNextTaskNonBlocking())
+                    {
+                        consumedTasks.localCounters.at(workerId).add(*task);
+                    }
+                }
+            });
+    }
+
+    /// All threads will start simultaneously when the barrier is reached
+    /// Wait for all threads to complete their work
+    sources.clear();
+    worker.clear();
+
+    /// Drain remaining tasks
+    while (auto task = queue.getNextTaskNonBlocking())
+    {
+        consumedTasks.localCounters.back().add(*task);
+    }
+
+    /// Verify all tasks were consumed
+    EXPECT_EQ(consumedTasks.size(), totalTasks);
+    consumedTasks.verifyUnique();
+}
+
+/// This test is designed to stress the TaskQueue by injecting Tasks as fast as possible. Worker Threads can simulate occasional large(ish)
+/// join results. Stopping threads relies on cooperative multitasking, which is validated via the global test timeout.
+TEST_F(TaskQueueTest, StressTest)
+{
+    constexpr int numberOfSources = 4;
+    constexpr int numberOfWorkerThreads = 12;
+    constexpr std::chrono::milliseconds testDuration{1000};
+
+    std::atomic tasksAdded{0};
+    ConsumedTasks<numberOfWorkerThreads> consumedTasks;
+
+    /// Barrier to synchronize all threads to start at the same time
+    std::barrier syncBarrier{numberOfWorkerThreads + numberOfSources};
+
+    /// Source - rapid fire tasks into admission queue
+    std::vector<std::jthread> sources;
+    sources.reserve(numberOfSources);
+    for (int sourceId = 0; sourceId < numberOfSources; ++sourceId)
+    {
+        sources.emplace_back(
+            [&, sourceId](const std::stop_token& stoken)
+            {
+                /// Wait for all threads to be ready before starting
+                syncBarrier.arrive_and_wait();
+
+                int count = 0;
+                while (queue.addAdmissionTaskBlocking(stoken, Task{sourceId, count++, {}}))
+                {
+                }
+                tasksAdded.fetch_add(count - 1, std::memory_order::relaxed);
+            });
+    }
+
+    /// Workers: Simulate a very (arguably unrealistic) TaskQueue heavy workload, which stresses both: many concurrent reads aswell as
+    /// infrequent bursts of writes.
+    std::vector<std::jthread> worker;
+    worker.reserve(numberOfWorkerThreads);
+    for (int workerId = 0; workerId < numberOfWorkerThreads; ++workerId)
+    {
+        worker.emplace_back(
+            [&, workerId](const std::stop_token& stoken)
+            {
+                /// Simulate occasional large joins using a geometric distribution, (a.k.a frequent zeros) which is scaled by a scalar.
+                /// 0,0,0,0,6000,0,0,0,0,10000,0....
+                auto numberOfFollowUpTasks = [rng = std::mt19937(workerId), distribution = std::geometric_distribution<size_t>()]() mutable
+                {
+                    /// There are no good reasons for these numbers, we don't have any statistics of what real work loads look like so
+                    /// this is just a best effort guess.
+                    constexpr auto followUpTaskScaler = 1000;
+                    constexpr auto cutOff = 6;
+                    const auto value = distribution(rng);
+                    return value > cutOff ? value * followUpTaskScaler : 0;
+                };
+
+                /// Wait for all threads to be ready before starting
+                syncBarrier.arrive_and_wait();
+
+                int count = 0;
+                while (!stoken.stop_requested())
+                {
+                    if (auto task = queue.getNextTaskBlocking(stoken))
+                    {
+                        const size_t followUpTasks = numberOfFollowUpTasks();
+                        for (size_t i = 0; i < followUpTasks; ++i)
+                        {
+                            queue.addInternalTaskNonBlocking(Task{workerId + numberOfSources, count++, {}});
+                        }
+                        consumedTasks.localCounters.at(workerId).add(*task);
+                    }
+                }
+                tasksAdded.fetch_add(count, std::memory_order::relaxed);
+            });
+    }
+
+    /// Run for fixed duration
+    std::this_thread::sleep_for(testDuration);
+
+    /// Wait for all threads to complete their work
+    sources.clear();
+    worker.clear();
+
+    /// Drain remaining tasks
+    while (auto task = queue.getNextTaskNonBlocking())
+    {
+        consumedTasks.localCounters.back().add(*task);
+    }
+
+    /// Some tasks might still be in flight, but retrieved should never exceed added
+    EXPECT_EQ(consumedTasks.size(), tasksAdded.load());
+    consumedTasks.verifyUnique();
+}
+
+}

--- a/nes-systests/systest/CMakeLists.txt
+++ b/nes-systests/systest/CMakeLists.txt
@@ -60,8 +60,8 @@ target_include_directories(systest PUBLIC $<INSTALL_INTERFACE:/include/nebulastr
 
 # Add code coverage if enabled
 if (CODE_COVERAGE)
-    target_code_coverage(systest COVERAGE_TARGET_NAME systest_interpreter_coverage PUBLIC AUTO ALL ARGS -n 20 --exclude-groups large --workingDir=${CMAKE_CURRENT_BINARY_DIR}/interpreter_cc --data ${EXPANDED_TEST_DATA_PATH} -- --worker.default_query_execution.execution_mode=INTERPRETER --worker.query_engine.task_queue_size=100000 --worker.default_query_execution.join_strategy=NESTED_LOOP_JOIN --enable_google_eventTrace=true)
-    target_code_coverage(systest COVERAGE_TARGET_NAME systest_interpreter_coverage_Hash_Join PUBLIC AUTO ALL ARGS -n 20 --exclude-groups large --workingDir=${CMAKE_CURRENT_BINARY_DIR}/interpreter_cc --data ${EXPANDED_TEST_DATA_PATH} -- --worker.default_query_execution.execution_mode=INTERPRETER --worker.query_engine.task_queue_size=100000 --worker.default_query_execution.join_strategy=HASH_JOIN --enable_google_eventTrace=true)
+    target_code_coverage(systest COVERAGE_TARGET_NAME systest_interpreter_coverage PUBLIC AUTO ALL ARGS -n 20 --exclude-groups large --workingDir=${CMAKE_CURRENT_BINARY_DIR}/interpreter_cc --data ${EXPANDED_TEST_DATA_PATH} -- --worker.default_query_execution.execution_mode=INTERPRETER --worker.default_query_execution.join_strategy=NESTED_LOOP_JOIN --enable_google_eventTrace=true)
+    target_code_coverage(systest COVERAGE_TARGET_NAME systest_interpreter_coverage_Hash_Join PUBLIC AUTO ALL ARGS -n 20 --exclude-groups large --workingDir=${CMAKE_CURRENT_BINARY_DIR}/interpreter_cc --data ${EXPANDED_TEST_DATA_PATH} -- --worker.default_query_execution.execution_mode=INTERPRETER --worker.default_query_execution.join_strategy=HASH_JOIN --enable_google_eventTrace=true)
     # Make sure to fetch ExternalData before running the ccov targets
     add_dependencies(ccov-run-systest_interpreter_coverage test-data)
     add_dependencies(ccov-run-systest_interpreter_coverage_Hash_Join test-data)
@@ -72,12 +72,12 @@ set(joinStrategies NESTED_LOOP_JOIN HASH_JOIN)
 foreach (joinStrategy IN LISTS joinStrategies)
     ExternalData_Add_Test(test-data
             NAME systest_interpreter_${joinStrategy}
-            COMMAND systest -n 20 --workingDir=${CMAKE_CURRENT_BINARY_DIR}/interpreter_${joinStrategy} --exclude-groups large --data ${EXPANDED_TEST_DATA_PATH} -- --worker.default_query_execution.execution_mode=INTERPRETER --worker.query_engine.task_queue_size=100000 --worker.default_query_execution.join_strategy=${joinStrategy})
+            COMMAND systest -n 20 --workingDir=${CMAKE_CURRENT_BINARY_DIR}/interpreter_${joinStrategy} --exclude-groups large --data ${EXPANDED_TEST_DATA_PATH} -- --worker.default_query_execution.execution_mode=INTERPRETER --worker.default_query_execution.join_strategy=${joinStrategy})
 endforeach ()
 if (NOT CODE_COVERAGE)
     ExternalData_Add_Test(test-data
             NAME systest_compiler
-            COMMAND systest -n 20 --workingDir=${CMAKE_CURRENT_BINARY_DIR}/compiler --exclude-groups large --data ${EXPANDED_TEST_DATA_PATH} -- --worker.default_query_execution.execution_mode=COMPILER --worker.query_engine.task_queue_size=100000 --enable_google_eventTrace=true)
+            COMMAND systest -n 20 --workingDir=${CMAKE_CURRENT_BINARY_DIR}/compiler --exclude-groups large --data ${EXPANDED_TEST_DATA_PATH} -- --worker.default_query_execution.execution_mode=COMPILER --enable_google_eventTrace=true)
 endif (NOT CODE_COVERAGE)
 
 
@@ -106,18 +106,6 @@ endif ()
 
 
 if (NOT CODE_COVERAGE)
-    # We run all tests with some small and one large task queue size
-    # We set the number of worker threads to 8, to further stress the task queue
-    set(taskQueueSize 100 10000)
-    foreach (taskQueueSize IN LISTS taskQueueSize)
-        ExternalData_Add_Test(test-data
-                NAME systest_task_queue_size_${taskQueueSize}_interpreter
-                COMMAND systest -n 4 --exclude-groups large --workingDir=${CMAKE_CURRENT_BINARY_DIR}/${taskQueueSize}_interpreter --data ${EXPANDED_TEST_DATA_PATH} -- --worker.query_engine.number_of_worker_threads=4 --worker.default_query_execution.execution_mode=INTERPRETER --worker.number_of_buffers_in_global_buffer_manager=200000 --worker.query_engine.task_queue_size=${taskQueueSize})
-        ExternalData_Add_Test(test-data
-                NAME systest_task_queue_size_${taskQueueSize}_compiler
-                COMMAND systest -n 4 --exclude-groups large --workingDir=${CMAKE_CURRENT_BINARY_DIR}/${taskQueueSize}_compiler --data ${EXPANDED_TEST_DATA_PATH} -- --worker.query_engine.number_of_worker_threads=4 --worker.default_query_execution.execution_mode=COMPILER --worker.number_of_buffers_in_global_buffer_manager=200000 --worker.query_engine.task_queue_size=${taskQueueSize})
-    endforeach ()
-
     ## We run all join and aggregation tests with different no. worker threads and different join strategies
     set(workerThreads 1 2 4 8)
     set(joinStrategies NESTED_LOOP_JOIN HASH_JOIN)


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
**fix(engine): Suppresses a harmless lock inversion report**
The TSAN CI reports a lock inversion in the query engine. Unfortunately, there is no trivial change that could remove the lock inversion. The lock inversion will also never (I regret writing that) cause a deadlock, as currently, both code paths cannot run concurrently. One code path is called from the StartQueryTask, and the other one is called in a callback after all pipelines have been set up. The start task prevents the callback from triggering while it is holding the lock.

feat(engine): Adds DelayedTaskSubmitter
This commit introduces a new Active Component into the QueryEngine, which manages a queue of tasks that should be submitted at a later point. The component is mostly inactive, waiting for either a timer or new tasks to be added. The commit introduces unit tests and is also already used on the distributed branch to prevent busy polling during the network sink flush.

feat(engine): Improves TaskQueue implementation
This commit extracts the task queue logic out of the QueryEngine into its dedicated file. The complexity of the TaskQueue has grown beyond its initial design, necessitating this change. More importantly, the new version of the TaskQueue can synchronize access to both the `internal` and `admission` queue without introducing a mutex. It uses a semaphore, which on the happy path boils down to an additional atomic inc/dec, but allows a thread to block if the queue is empty. Initial performance measurements by me and @keyseven123 have not shown any performance regression (only a slight improvement, actually).
Additionally, this commit removes a lot of now unnecessary helper methods from the QueryEngine.

feat(engine): Improves Task size
The Task is currently implemented as a variant, which makes the size of the variant dependent on the size of the largest type. Previously, the largest type was the FailSourceTask, which is unjustified, as this task is infrequent. The culprit was an Exception within the Task, which is now allocated on the heap. The Task size is important as the entire task queue would waste memory and potential cache.

refactor(engine): Adds dedicated `repeatTask` method
Previously, the PipelineExecutionContext had a third ContinuationPolicy called REPEAT. However, the implementation and implications of REPEAT were vastly different than the other policies. This commit removes the REPEAT policy and instead adds a dedicated `repeatTask` method to the pipeline execution context. All code using the repeat functionality has been updated to the new function.

refactor(engine): removes minor copies
Small miscellaneous stuff

## Verifying this change
All changes are covered by tests

## What components does this pull request potentially affect?
- ExecutionEngine
- QueryEngine

## Documentation
- The change is reflected in the necessary documentation, e.g., design document, in-code documentation.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
