### PR TITLE
HashMap Optimizations for HashJoin and Aggregation

### DIFF
--- a/nes-common/tests/UnitTests/Util/RollingAverageTest.cpp
+++ b/nes-common/tests/UnitTests/Util/RollingAverageTest.cpp
@@ -25,7 +25,7 @@ class RollingAverageTest : public ::testing::Test
 {
 protected:
     template <typename T>
-    static void testRollingAverage(const std::vector<T>& inputs, const std::vector<double>& expectedAverages, size_t windowSize)
+    static void testRollingAverage(const std::vector<T>& inputs, const std::vector<T>& expectedAverages, size_t windowSize)
     {
         RollingAverage<T> rollingAvg(windowSize);
 
@@ -43,63 +43,63 @@ protected:
 TEST_F(RollingAverageTest, BasicTest)
 {
     const std::vector inputs = {1, 2, 3, 4, 5};
-    const std::vector expectedAverages = {1.0, 1.5, 2.0, 3.0, 4.0};
+    const std::vector expectedAverages = {1, 1, 2, 3, 4};
     testRollingAverage(inputs, expectedAverages, 3);
 }
 
 TEST_F(RollingAverageTest, AllIdenticalElements)
 {
     const std::vector inputs = {2, 2, 2, 2, 2};
-    const std::vector expectedAverages = {2.0, 2.0, 2.0, 2.0, 2.0};
+    const std::vector expectedAverages = {2, 2, 2, 2, 2};
     testRollingAverage(inputs, expectedAverages, 3);
 }
 
 TEST_F(RollingAverageTest, IncreasingSequence)
 {
     const std::vector inputs = {10, 20, 30, 40, 50};
-    const std::vector expectedAverages = {10.0, 15.0, 25.0, 35.0, 45.0};
+    const std::vector expectedAverages = {10, 15, 25, 35, 45};
     testRollingAverage(inputs, expectedAverages, 2);
 }
 
 TEST_F(RollingAverageTest, DecreasingSequence)
 {
     const std::vector inputs = {50, 40, 30, 20, 10};
-    const std::vector expectedAverages = {50.0, 45.0, 40.0, 35.0, 25.0};
+    const std::vector expectedAverages = {50, 45, 40, 35, 25};
     testRollingAverage(inputs, expectedAverages, 4);
 }
 
 TEST_F(RollingAverageTest, SingleElementWindow)
 {
     const std::vector inputs = {7, 8, 9, 10};
-    const std::vector expectedAverages = {7.0, 8.0, 9.0, 10.0};
+    const std::vector expectedAverages = {7, 8, 9, 10};
     testRollingAverage(inputs, expectedAverages, 1);
 }
 
 TEST_F(RollingAverageTest, WindowSizeLargerThanInput)
 {
     const std::vector inputs = {1, 2, 3};
-    const std::vector expectedAverages = {1.0, 1.5, 2.0};
+    const std::vector expectedAverages = {1, 1, 2};
     testRollingAverage(inputs, expectedAverages, 5);
 }
 
 TEST_F(RollingAverageTest, NegativeNumbers)
 {
     const std::vector inputs = {-1, -2, -3, -4, -5};
-    const std::vector expectedAverages = {-1.0, -1.5, -2.0, -3.0, -4.0};
+    const std::vector expectedAverages = {-1, -1, -2, -3, -4};
     testRollingAverage(inputs, expectedAverages, 3);
 }
 
 TEST_F(RollingAverageTest, MixedPositiveAndNegativeNumbers)
 {
-    const std::vector inputs = {-1, 2, -3, 4, -5};
+    const std::vector<double> inputs = {-1, 2, -3, 4, -5};
     const std::vector expectedAverages = {-1.0, 0.5, -0.5, 0.5, -0.5};
     testRollingAverage(inputs, expectedAverages, 2);
 }
 
 TEST_F(RollingAverageTest, EmptyInput)
 {
-    const std::vector<int> inputs = {};
-    const std::vector<double> expectedAverages = {};
+    constexpr std::vector<int> inputs = {};
+    constexpr std::vector<int> expectedAverages = {};
     testRollingAverage(inputs, expectedAverages, 3);
 }
 

--- a/nes-physical-operators/include/Aggregation/AggregationBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Aggregation/AggregationBuildPhysicalOperator.hpp
@@ -24,7 +24,7 @@
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Time/Timestamp.hpp>
 #include <Watermark/TimeFunction.hpp>
-#include <Engine.hpp>
+#include <CompilationContext.hpp>
 #include <HashMapOptions.hpp>
 #include <WindowBuildPhysicalOperator.hpp>
 
@@ -51,16 +51,13 @@ public:
         std::unique_ptr<TimeFunction> timeFunction,
         std::vector<std::shared_ptr<AggregationPhysicalFunction>> aggregationFunctions,
         HashMapOptions hashMapOptions);
+    void setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const override;
     void execute(ExecutionContext& ctx, Record& record) const override;
 
 private:
     /// The aggregation function is a shared_ptr, because it is used in the aggregation build and in the getSliceCleanupFunction()
     std::vector<std::shared_ptr<AggregationPhysicalFunction>> aggregationPhysicalFunctions;
     HashMapOptions hashMapOptions;
-
-    /// shared_ptr as multiple slices need access to it
-    using NautilusCleanupExec = nautilus::engine::CallableFunction<void, Nautilus::Interface::HashMap*>;
-    std::shared_ptr<NautilusCleanupExec> cleanupStateNautilusFunction;
 };
 
 }

--- a/nes-physical-operators/include/Aggregation/AggregationOperatorHandler.hpp
+++ b/nes-physical-operators/include/Aggregation/AggregationOperatorHandler.hpp
@@ -24,6 +24,7 @@
 #include <SliceStore/Slice.hpp>
 #include <SliceStore/WindowSlicesStoreInterface.hpp>
 #include <Util/RollingAverage.hpp>
+#include <HashMapSlice.hpp>
 #include <WindowBasedOperatorHandler.hpp>
 
 namespace NES
@@ -54,6 +55,8 @@ public:
     [[nodiscard]] std::function<std::vector<std::shared_ptr<Slice>>(SliceStart, SliceEnd)>
     getCreateNewSlicesFunction(const CreateNewSlicesArguments& newSlicesArguments) const override;
 
+    /// shared_ptr as multiple slices need access to it
+    std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec> cleanupStateNautilusFunction;
 
 protected:
     void triggerSlices(

--- a/nes-physical-operators/include/Aggregation/AggregationOperatorHandler.hpp
+++ b/nes-physical-operators/include/Aggregation/AggregationOperatorHandler.hpp
@@ -23,7 +23,7 @@
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <SliceStore/Slice.hpp>
 #include <SliceStore/WindowSlicesStoreInterface.hpp>
-#include <nautilus/Engine.hpp>
+#include <Util/RollingAverage.hpp>
 #include <WindowBasedOperatorHandler.hpp>
 
 namespace NES
@@ -35,6 +35,7 @@ namespace NES
 struct EmittedAggregationWindow
 {
     WindowInfo windowInfo;
+    Nautilus::Interface::HashMap* finalHashMapPtr;
     std::unique_ptr<Nautilus::Interface::HashMap>
         finalHashMap; /// Pointer to the final hash map that the probe should use to combine all hash maps
     uint64_t numberOfHashMaps;
@@ -47,7 +48,8 @@ public:
     AggregationOperatorHandler(
         const std::vector<OriginId>& inputOrigins,
         OriginId outputOriginId,
-        std::unique_ptr<WindowSlicesStoreInterface> sliceAndWindowStore);
+        std::unique_ptr<WindowSlicesStoreInterface> sliceAndWindowStore,
+        uint64_t maxNumberOfBuckets);
 
     [[nodiscard]] std::function<std::vector<std::shared_ptr<Slice>>(SliceStart, SliceEnd)>
     getCreateNewSlicesFunction(const CreateNewSlicesArguments& newSlicesArguments) const override;
@@ -57,6 +59,8 @@ protected:
     void triggerSlices(
         const std::map<WindowInfoAndSequenceNumber, std::vector<std::shared_ptr<Slice>>>& slicesAndWindowInfo,
         PipelineExecutionContext* pipelineCtx) override;
+    folly::Synchronized<RollingAverage<uint64_t>> rollingAverageNumberOfKeys;
+    uint64_t maxNumberOfBuckets;
 };
 
 }

--- a/nes-physical-operators/include/EmitPhysicalOperator.hpp
+++ b/nes-physical-operators/include/EmitPhysicalOperator.hpp
@@ -22,6 +22,8 @@
 #include <Nautilus/Interface/RecordBuffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <nautilus/val.hpp>
+#include <CompilationContext.hpp>
+#include <ExecutionContext.hpp>
 #include <PhysicalOperator.hpp>
 
 namespace NES
@@ -35,7 +37,7 @@ public:
     explicit EmitPhysicalOperator(
         OperatorHandlerId operatorHandlerId, std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> memoryProvider);
 
-    void setup(ExecutionContext&) const override { /*noop*/ }
+    void setup(ExecutionContext&, CompilationContext&) const override { /*noop*/ }
 
     void terminate(ExecutionContext&) const override { /*noop*/ }
 

--- a/nes-physical-operators/include/Join/HashJoin/HJBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJBuildPhysicalOperator.hpp
@@ -16,6 +16,7 @@
 #include <memory>
 #include <Identifiers/Identifiers.hpp>
 #include <Join/HashJoin/HJOperatorHandler.hpp>
+#include <Join/HashJoin/HJSlice.hpp>
 #include <Join/StreamJoinBuildPhysicalOperator.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Nautilus/Interface/HashMap/HashMap.hpp>
@@ -40,7 +41,7 @@ Interface::HashMap* getHashJoinHashMapProxy(
 /// This class is the first phase of the join. For both streams (left and right), the tuples are stored in a hash map of a
 /// corresponding slice one after the other. Afterward, the second phase (HJProbe) will start joining the tuples by comparing the join keys
 /// via a hash function.
-class HJBuildPhysicalOperator final : public StreamJoinBuildPhysicalOperator
+class HJBuildPhysicalOperator : public StreamJoinBuildPhysicalOperator
 {
 public:
     friend Interface::HashMap* getHashJoinHashMapProxy(
@@ -55,6 +56,7 @@ public:
         std::unique_ptr<TimeFunction> timeFunction,
         const std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider>& memoryProvider,
         HashMapOptions hashMapOptions);
+    ~HJBuildPhysicalOperator() override = default;
     void setup(ExecutionContext& executionCtx) const override;
     void execute(ExecutionContext& ctx, Record& record) const override;
 

--- a/nes-physical-operators/include/Join/HashJoin/HJBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJBuildPhysicalOperator.hpp
@@ -16,7 +16,6 @@
 #include <memory>
 #include <Identifiers/Identifiers.hpp>
 #include <Join/HashJoin/HJOperatorHandler.hpp>
-#include <Join/HashJoin/HJSlice.hpp>
 #include <Join/StreamJoinBuildPhysicalOperator.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Nautilus/Interface/HashMap/HashMap.hpp>
@@ -25,6 +24,7 @@
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Time/Timestamp.hpp>
 #include <Watermark/TimeFunction.hpp>
+#include <CompilationContext.hpp>
 #include <ExecutionContext.hpp>
 #include <HashMapOptions.hpp>
 
@@ -56,8 +56,7 @@ public:
         std::unique_ptr<TimeFunction> timeFunction,
         const std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider>& memoryProvider,
         HashMapOptions hashMapOptions);
-    ~HJBuildPhysicalOperator() override = default;
-    void setup(ExecutionContext& executionCtx) const override;
+    void setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const override;
     void execute(ExecutionContext& ctx, Record& record) const override;
 
 private:

--- a/nes-physical-operators/include/Join/HashJoin/HJOperatorHandler.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJOperatorHandler.hpp
@@ -26,6 +26,7 @@
 #include <Sequencing/SequenceData.hpp>
 #include <SliceStore/Slice.hpp>
 #include <SliceStore/WindowSlicesStoreInterface.hpp>
+#include <Util/RollingAverage.hpp>
 #include <HashMapSlice.hpp>
 
 namespace NES
@@ -48,11 +49,9 @@ class HJOperatorHandler final : public StreamJoinOperatorHandler
 public:
     HJOperatorHandler(
         const std::vector<OriginId>& inputOrigins,
-        const OriginId outputOriginId,
-        std::unique_ptr<WindowSlicesStoreInterface> sliceAndWindowStore)
-        : StreamJoinOperatorHandler(inputOrigins, outputOriginId, std::move(sliceAndWindowStore))
-    {
-    }
+        OriginId outputOriginId,
+        std::unique_ptr<WindowSlicesStoreInterface> sliceAndWindowStore,
+        uint64_t maxNumberOfBuckets);
 
     [[nodiscard]] std::function<std::vector<std::shared_ptr<Slice>>(SliceStart, SliceEnd)>
     getCreateNewSlicesFunction(const CreateNewSlicesArguments& newSlicesArguments) const override;
@@ -72,6 +71,9 @@ private:
         const WindowInfo& windowInfo,
         const SequenceData& sequenceData,
         PipelineExecutionContext* pipelineCtx) override;
+
+    folly::Synchronized<RollingAverage<uint64_t>> rollingAverageNumberOfKeys;
+    uint64_t maxNumberOfBuckets;
 };
 
 }

--- a/nes-physical-operators/include/Join/NestedLoopJoin/NLJBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/NestedLoopJoin/NLJBuildPhysicalOperator.hpp
@@ -37,9 +37,6 @@ public:
         JoinBuildSideType joinBuildSide,
         std::unique_ptr<TimeFunction> timeFunction,
         std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> memoryProvider);
-    ~NLJBuildPhysicalOperator() override = default;
-
-    NLJBuildPhysicalOperator(const NLJBuildPhysicalOperator& other) = default;
 
     void execute(ExecutionContext& executionCtx, Record& record) const override;
 };

--- a/nes-physical-operators/include/Join/NestedLoopJoin/NLJBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/NestedLoopJoin/NLJBuildPhysicalOperator.hpp
@@ -29,7 +29,7 @@ namespace NES
 /// This class is the first phase of the join. For both streams (left and right), the tuples are stored in the
 /// corresponding slice one after the other. Afterward, the second phase (NLJProbe) will start joining the tuples
 /// via two nested loops.
-class NLJBuildPhysicalOperator final : public StreamJoinBuildPhysicalOperator
+class NLJBuildPhysicalOperator : public StreamJoinBuildPhysicalOperator
 {
 public:
     NLJBuildPhysicalOperator(
@@ -37,6 +37,7 @@ public:
         JoinBuildSideType joinBuildSide,
         std::unique_ptr<TimeFunction> timeFunction,
         std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> memoryProvider);
+    ~NLJBuildPhysicalOperator() override = default;
 
     NLJBuildPhysicalOperator(const NLJBuildPhysicalOperator& other) = default;
 

--- a/nes-physical-operators/include/Join/StreamJoinBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/StreamJoinBuildPhysicalOperator.hpp
@@ -33,6 +33,7 @@ public:
         JoinBuildSideType joinBuildSide,
         std::unique_ptr<TimeFunction> timeFunction,
         std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> memoryProvider);
+    ~StreamJoinBuildPhysicalOperator() override = default;
 
     StreamJoinBuildPhysicalOperator(const StreamJoinBuildPhysicalOperator& other) = default;
 

--- a/nes-physical-operators/include/PhysicalOperator.hpp
+++ b/nes-physical-operators/include/PhysicalOperator.hpp
@@ -31,6 +31,7 @@
 #include <Util/Logger/Formatter.hpp>
 #include <Util/PlanRenderer.hpp>
 #include <boost/core/demangle.hpp>
+#include <CompilationContext.hpp>
 #include <ErrorHandling.hpp>
 
 namespace NES
@@ -59,7 +60,7 @@ struct PhysicalOperatorConcept
     virtual void setChild(struct PhysicalOperator child) = 0;
 
     /// This is called once before the operator starts processing records.
-    virtual void setup(ExecutionContext& executionCtx) const;
+    virtual void setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const;
 
     /// Opens the operator for processing records.
     /// This is called before each batch of records is processed.
@@ -81,7 +82,7 @@ struct PhysicalOperatorConcept
 
 protected:
     /// Helper classes to propagate to the child
-    void setupChild(ExecutionContext& executionCtx) const;
+    void setupChild(ExecutionContext& executionCtx, CompilationContext& compilationContext) const;
     void openChild(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
     void closeChild(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
     void executeChild(ExecutionContext& executionCtx, Record& record) const;
@@ -117,7 +118,7 @@ struct PhysicalOperator
     [[nodiscard]] std::optional<PhysicalOperator> getChild() const;
     [[nodiscard]] PhysicalOperator withChild(PhysicalOperator child) const;
 
-    void setup(ExecutionContext& executionCtx) const;
+    void setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const;
     void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
     void close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
     void terminate(ExecutionContext& executionCtx) const;
@@ -185,7 +186,10 @@ private:
 
         void setChild(PhysicalOperator child) override { data.setChild(child); }
 
-        void setup(ExecutionContext& executionCtx) const override { data.setup(executionCtx); }
+        void setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const override
+        {
+            data.setup(executionCtx, compilationContext);
+        }
 
         void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override { data.open(executionCtx, recordBuffer); }
 

--- a/nes-physical-operators/include/WindowBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/WindowBuildPhysicalOperator.hpp
@@ -19,6 +19,7 @@
 #include <optional>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Watermark/TimeFunction.hpp>
+#include <CompilationContext.hpp>
 #include <OperatorState.hpp>
 #include <PhysicalOperator.hpp>
 #include <val.hpp>
@@ -49,7 +50,7 @@ public:
     /// This setup function can be called in a multithreaded environment. Meaning that if
     /// multiple pipelines with the same operator (e.g. JoinBuild) have access to the same operator handler, this will lead to race conditions.
     /// Therefore, any setup to the operator handler should happen in the WindowProbePhysicalOperator.
-    void setup(ExecutionContext& executionCtx) const override;
+    void setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const override;
 
     /// Initializes the time function, e.g., method that extracts the timestamp from a record
     void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;

--- a/nes-physical-operators/include/WindowProbePhysicalOperator.hpp
+++ b/nes-physical-operators/include/WindowProbePhysicalOperator.hpp
@@ -18,6 +18,7 @@
 #include <Nautilus/Interface/RecordBuffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Windowing/WindowMetaData.hpp>
+#include <CompilationContext.hpp>
 #include <PhysicalOperator.hpp>
 
 namespace NES
@@ -33,7 +34,7 @@ public:
     /// The setup method is called for each pipeline during the query initialization procedure. Meaning that if
     /// multiple pipelines with the same operator (e.g. JoinBuild) have access to the same operator handler, this will lead to race conditions.
     /// Therefore, any setup to the operator handler should ONLY happen in the WindowProbePhysicalOperator.
-    void setup(ExecutionContext& executionCtx) const override;
+    void setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const override;
 
     /// Checks the current watermark and then deletes all slices and windows that are not valid anymore
     void close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;

--- a/nes-physical-operators/src/Aggregation/AggregationOperatorHandler.cpp
+++ b/nes-physical-operators/src/Aggregation/AggregationOperatorHandler.cpp
@@ -13,6 +13,9 @@
 */
 #include <Aggregation/AggregationOperatorHandler.hpp>
 
+#include <algorithm>
+#include <bit>
+#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <functional>

--- a/nes-physical-operators/src/Aggregation/AggregationProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/Aggregation/AggregationProbePhysicalOperator.cpp
@@ -19,11 +19,15 @@
 #include <vector>
 #include <Aggregation/AggregationOperatorHandler.hpp>
 #include <Aggregation/Function/AggregationPhysicalFunction.hpp>
+#include <Nautilus/DataTypes/DataTypesUtil.hpp>
 #include <Nautilus/Interface/HashMap/ChainedHashMap/ChainedHashMapRef.hpp>
 #include <Nautilus/Interface/HashMap/HashMap.hpp>
 #include <Nautilus/Interface/Record.hpp>
 #include <Nautilus/Interface/RecordBuffer.hpp>
+#include <Nautilus/Interface/TimestampRef.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
+#include <SliceStore/WindowSlicesStoreInterface.hpp>
+#include <Time/Timestamp.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <ErrorHandling.hpp>
 #include <ExecutionContext.hpp>

--- a/nes-physical-operators/src/Join/HashJoin/HJOperatorHandler.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJOperatorHandler.cpp
@@ -15,6 +15,8 @@
 
 #include <Join/HashJoin/HJOperatorHandler.hpp>
 
+#include <algorithm>
+#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <functional>
@@ -23,6 +25,7 @@
 #include <vector>
 #include <Identifiers/Identifiers.hpp>
 #include <Join/HashJoin/HJSlice.hpp>
+#include <Join/StreamJoinOperatorHandler.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Nautilus/Interface/HashMap/HashMap.hpp>
 #include <Sequencing/SequenceData.hpp>

--- a/nes-physical-operators/src/Join/HashJoin/HJProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJProbePhysicalOperator.cpp
@@ -20,12 +20,16 @@
 #include <Join/HashJoin/HJOperatorHandler.hpp>
 #include <Join/StreamJoinProbePhysicalOperator.hpp>
 #include <Join/StreamJoinUtil.hpp>
+#include <Nautilus/DataTypes/DataTypesUtil.hpp>
 #include <Nautilus/Interface/HashMap/ChainedHashMap/ChainedHashMapRef.hpp>
 #include <Nautilus/Interface/HashMap/HashMap.hpp>
 #include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
 #include <Nautilus/Interface/PagedVector/PagedVectorRef.hpp>
 #include <Nautilus/Interface/RecordBuffer.hpp>
+#include <Nautilus/Interface/TimestampRef.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
+#include <SliceStore/WindowSlicesStoreInterface.hpp>
+#include <Time/Timestamp.hpp>
 #include <Windowing/WindowMetaData.hpp>
 #include <ErrorHandling.hpp>
 #include <ExecutionContext.hpp>

--- a/nes-physical-operators/src/Join/NestedLoopJoin/NLJOperatorHandler.cpp
+++ b/nes-physical-operators/src/Join/NestedLoopJoin/NLJOperatorHandler.cpp
@@ -82,6 +82,8 @@ void NLJOperatorHandler::emitSlicesToProbe(
     tupleBuffer.setLastChunk(sequenceData.lastChunk);
     tupleBuffer.setWatermark(windowInfo.windowStart);
     tupleBuffer.setNumberOfTuples(totalNumberOfTuples);
+    tupleBuffer.setCreationTimestampInMS(Timestamp(
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count()));
 
     auto* bufferMemory = tupleBuffer.getBuffer<EmittedNLJWindowTrigger>();
     bufferMemory->leftSliceEnd = sliceLeft.getSliceEnd();

--- a/nes-physical-operators/src/Join/NestedLoopJoin/NLJOperatorHandler.cpp
+++ b/nes-physical-operators/src/Join/NestedLoopJoin/NLJOperatorHandler.cpp
@@ -15,6 +15,7 @@
 #include <Join/NestedLoopJoin/NLJOperatorHandler.hpp>
 
 #include <algorithm>
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <utility>

--- a/nes-physical-operators/src/Join/NestedLoopJoin/NLJProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/NestedLoopJoin/NLJProbePhysicalOperator.cpp
@@ -135,6 +135,7 @@ void NLJProbePhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer
 {
     /// As this operator functions as a scan, we have to set the execution context for this pipeline
     executionCtx.watermarkTs = recordBuffer.getWatermarkTs();
+    executionCtx.currentTs = recordBuffer.getCreatingTs();
     executionCtx.sequenceNumber = recordBuffer.getSequenceNumber();
     executionCtx.chunkNumber = recordBuffer.getChunkNumber();
     executionCtx.lastChunk = recordBuffer.isLastChunk();

--- a/nes-physical-operators/src/Join/StreamJoinProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/StreamJoinProbePhysicalOperator.cpp
@@ -66,12 +66,6 @@ Record StreamJoinProbePhysicalOperator::createJoinedRecord(
         joinedRecord.write(fieldName, innerRecord.read(fieldName));
     }
 
-    /// Writing the outerSchema fields, expect the join schema to have the fields in the same order then the outer schema
-    for (const auto& fieldName : nautilus::static_iterable(projectionsOuter))
-    {
-        joinedRecord.write(fieldName, outerRecord.read(fieldName));
-    }
-
     return joinedRecord;
 }
 }

--- a/nes-physical-operators/src/PhysicalOperator.cpp
+++ b/nes-physical-operators/src/PhysicalOperator.cpp
@@ -27,6 +27,7 @@
 #include <Util/PlanRenderer.hpp>
 #include <fmt/format.h>
 #include <magic_enum/magic_enum.hpp>
+#include <CompilationContext.hpp>
 #include <ErrorHandling.hpp>
 #include <ExecutionContext.hpp>
 
@@ -41,9 +42,9 @@ PhysicalOperatorConcept::PhysicalOperatorConcept(OperatorId existingId) : id(exi
 {
 }
 
-void PhysicalOperatorConcept::setup(ExecutionContext& executionCtx) const
+void PhysicalOperatorConcept::setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const
 {
-    setupChild(executionCtx);
+    setupChild(executionCtx, compilationContext);
 }
 
 void PhysicalOperatorConcept::open(ExecutionContext& executionCtx, RecordBuffer& rb) const
@@ -66,10 +67,10 @@ void PhysicalOperatorConcept::execute(ExecutionContext& executionCtx, Record& re
     executeChild(executionCtx, record);
 }
 
-void PhysicalOperatorConcept::setupChild(ExecutionContext& executionCtx) const
+void PhysicalOperatorConcept::setupChild(ExecutionContext& executionCtx, CompilationContext& compilationContext) const
 {
     INVARIANT(getChild().has_value(), "Child operator is not set");
-    getChild().value().setup(executionCtx);
+    getChild().value().setup(executionCtx, compilationContext);
 }
 
 void PhysicalOperatorConcept::openChild(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
@@ -123,9 +124,9 @@ PhysicalOperator PhysicalOperator::withChild(PhysicalOperator child) const
     return {copy};
 }
 
-void PhysicalOperator::setup(ExecutionContext& executionCtx) const
+void PhysicalOperator::setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const
 {
-    self->setup(executionCtx);
+    self->setup(executionCtx, compilationContext);
 }
 
 void PhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const

--- a/nes-physical-operators/src/WindowBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/WindowBuildPhysicalOperator.cpp
@@ -22,6 +22,7 @@
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Time/Timestamp.hpp>
 #include <Watermark/TimeFunction.hpp>
+#include <CompilationContext.hpp>
 #include <ErrorHandling.hpp>
 #include <ExecutionContext.hpp>
 #include <PhysicalOperator.hpp>
@@ -86,7 +87,7 @@ void WindowBuildPhysicalOperator::close(ExecutionContext& executionCtx, RecordBu
         executionCtx.originId);
 }
 
-void WindowBuildPhysicalOperator::setup(ExecutionContext& executionCtx) const
+void WindowBuildPhysicalOperator::setup(ExecutionContext& executionCtx, CompilationContext&) const
 {
     auto operatorHandlerMemRef = executionCtx.getGlobalOperatorHandler(operatorHandlerId);
     invoke(registerActivePipeline, operatorHandlerMemRef);

--- a/nes-physical-operators/src/WindowProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/WindowProbePhysicalOperator.cpp
@@ -11,6 +11,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
+#include <WindowProbePhysicalOperator.hpp>
 
 #include <optional>
 #include <utility>
@@ -21,11 +22,11 @@
 #include <Runtime/QueryTerminationType.hpp>
 #include <Time/Timestamp.hpp>
 #include <Windowing/WindowMetaData.hpp>
+#include <CompilationContext.hpp>
 #include <ErrorHandling.hpp>
 #include <ExecutionContext.hpp>
 #include <PhysicalOperator.hpp>
 #include <WindowBasedOperatorHandler.hpp>
-#include <WindowProbePhysicalOperator.hpp>
 #include <function.hpp>
 
 namespace NES
@@ -74,10 +75,10 @@ WindowProbePhysicalOperator::WindowProbePhysicalOperator(OperatorHandlerId opera
 {
 }
 
-void WindowProbePhysicalOperator::setup(ExecutionContext& executionCtx) const
+void WindowProbePhysicalOperator::setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const
 {
     /// Giving child operators the change to setup
-    setupChild(executionCtx);
+    setupChild(executionCtx, compilationContext);
     invoke(setupProxy, executionCtx.getGlobalOperatorHandler(operatorHandlerId), executionCtx.pipelineContext);
 }
 

--- a/nes-query-optimizer/include/QueryExecutionConfiguration.hpp
+++ b/nes-query-optimizer/include/QueryExecutionConfiguration.hpp
@@ -22,8 +22,8 @@
 #include <Configurations/BaseOption.hpp>
 #include <Configurations/Enums/EnumOption.hpp>
 #include <Configurations/ScalarOption.hpp>
-#include <Configurations/Validation/NumberValidation.hpp>
 #include <Configurations/Validation/FloatValidation.hpp>
+#include <Configurations/Validation/NumberValidation.hpp>
 #include <Util/ExecutionMode.hpp>
 
 namespace NES

--- a/nes-query-optimizer/include/QueryExecutionConfiguration.hpp
+++ b/nes-query-optimizer/include/QueryExecutionConfiguration.hpp
@@ -23,6 +23,7 @@
 #include <Configurations/Enums/EnumOption.hpp>
 #include <Configurations/ScalarOption.hpp>
 #include <Configurations/Validation/NumberValidation.hpp>
+#include <Configurations/Validation/FloatValidation.hpp>
 #include <Util/ExecutionMode.hpp>
 
 namespace NES
@@ -32,6 +33,7 @@ static constexpr auto DEFAULT_NUMBER_OF_PARTITIONS_DATASTRUCTURES = 100;
 static constexpr auto DEFAULT_PAGED_VECTOR_SIZE = 1024;
 static constexpr auto DEFAULT_OPERATOR_BUFFER_SIZE = 4096;
 static constexpr auto DEFAULT_NUMBER_OF_RECORDS_PER_KEY = 10;
+static constexpr auto DEFAULT_MAX_NUMBER_OF_BUCKETS = 10'000.0;
 
 enum class StreamJoinStrategy : uint8_t
 {
@@ -66,6 +68,11 @@ public:
            std::to_string(DEFAULT_NUMBER_OF_RECORDS_PER_KEY),
            "Expected number of records per key, for example in a hash join. If set too low or high affects the performance.",
            {std::make_shared<NumberValidation>()}};
+    UIntOption maxNumberOfBuckets = {
+        "max_number_of_buckets",
+        std::to_string(DEFAULT_MAX_NUMBER_OF_BUCKETS),
+        "Maximal number of buckets for a hash table. If set too low or high degrades either the performance or increases the memory usage.",
+        {std::make_shared<FloatValidation>()}};
     UIntOption operatorBufferSize
         = {"operator_buffer_size",
            std::to_string(DEFAULT_OPERATOR_BUFFER_SIZE),
@@ -80,7 +87,14 @@ public:
 private:
     std::vector<BaseOption*> getOptions() override
     {
-        return {&executionMode, &pageSize, &numberOfPartitions, &joinStrategy, &numberOfRecordsPerKey, &operatorBufferSize};
+        return {
+            &executionMode,
+            &pageSize,
+            &numberOfPartitions,
+            &joinStrategy,
+            &numberOfRecordsPerKey,
+            &maxNumberOfBuckets,
+            &operatorBufferSize};
     }
 };
 

--- a/nes-query-optimizer/src/RewriteRules/LowerToPhysical/LowerToPhysicalHashJoin.cpp
+++ b/nes-query-optimizer/src/RewriteRules/LowerToPhysical/LowerToPhysicalHashJoin.cpp
@@ -120,30 +120,34 @@ getJoinFieldExtensionsLeftRight(const Schema& leftInputSchema, const Schema& rig
                 {
                     const auto leftFieldNewName = leftField.getFieldName() + "_" + std::to_string(counter++);
                     const auto rightFieldNewName = rightField.getFieldName() + "_" + std::to_string(counter++);
-                    leftJoinNames.emplace_back(FieldNamesExtension{
-                        .oldName = leftField.getFieldName(),
-                        .newName = leftFieldNewName,
-                        .oldDataType = leftField.getDataType(),
-                        .newDataType = *joinedDataType});
-                    rightJoinNames.emplace_back(FieldNamesExtension{
-                        .oldName = rightField.getFieldName(),
-                        .newName = rightFieldNewName,
-                        .oldDataType = rightField.getDataType(),
-                        .newDataType = *joinedDataType});
+                    leftJoinNames.emplace_back(
+                        FieldNamesExtension{
+                            .oldName = leftField.getFieldName(),
+                            .newName = leftFieldNewName,
+                            .oldDataType = leftField.getDataType(),
+                            .newDataType = *joinedDataType});
+                    rightJoinNames.emplace_back(
+                        FieldNamesExtension{
+                            .oldName = rightField.getFieldName(),
+                            .newName = rightFieldNewName,
+                            .oldDataType = rightField.getDataType(),
+                            .newDataType = *joinedDataType});
                 }
             }
             else
             {
-                leftJoinNames.emplace_back(FieldNamesExtension{
-                    .oldName = leftField.getFieldName(),
-                    .newName = leftField.getFieldName(),
-                    .oldDataType = leftField.getDataType(),
-                    .newDataType = leftField.getDataType()});
-                rightJoinNames.emplace_back(FieldNamesExtension{
-                    .oldName = rightField.getFieldName(),
-                    .newName = rightField.getFieldName(),
-                    .oldDataType = rightField.getDataType(),
-                    .newDataType = rightField.getDataType()});
+                leftJoinNames.emplace_back(
+                    FieldNamesExtension{
+                        .oldName = leftField.getFieldName(),
+                        .newName = leftField.getFieldName(),
+                        .oldDataType = leftField.getDataType(),
+                        .newDataType = leftField.getDataType()});
+                rightJoinNames.emplace_back(
+                    FieldNamesExtension{
+                        .oldName = rightField.getFieldName(),
+                        .newName = rightField.getFieldName(),
+                        .oldDataType = rightField.getDataType(),
+                        .newDataType = rightField.getDataType()});
             }
         });
 
@@ -173,8 +177,9 @@ addMapOperators(const Schema& inputSchemaOfJoin, const std::vector<FieldNamesExt
         inputSchemaOfMap.addField(newName, newDataType);
 
         /// Create a new map operator with the cast as its function
-        mapPhysicalOperators.emplace_back(std::make_shared<PhysicalOperatorWrapper>(
-            MapPhysicalOperator(newName, castedPhysicalFunction), copyOfInputSchemaOfMap, inputSchemaOfMap));
+        mapPhysicalOperators.emplace_back(
+            std::make_shared<PhysicalOperatorWrapper>(
+                MapPhysicalOperator(newName, castedPhysicalFunction), copyOfInputSchemaOfMap, inputSchemaOfMap));
     }
 
     return {inputSchemaOfMap, mapPhysicalOperators};
@@ -279,7 +284,8 @@ RewriteRuleResultSubgraph LowerToPhysicalHashJoin::apply(LogicalOperator logical
     /// Creating the hash join operator handler
     auto sliceAndWindowStore
         = std::make_unique<DefaultTimeBasedSliceStore>(windowType->getSize().getTime(), windowType->getSlide().getTime());
-    auto handler = std::make_shared<HJOperatorHandler>(inputOriginIds, outputOriginId, std::move(sliceAndWindowStore));
+    auto handler
+        = std::make_shared<HJOperatorHandler>(inputOriginIds, outputOriginId, std::move(sliceAndWindowStore), conf.maxNumberOfBuckets);
 
 
     /// Building operator wrapper for the two builds and the probe.

--- a/nes-query-optimizer/src/RewriteRules/LowerToPhysical/LowerToPhysicalHashJoin.cpp
+++ b/nes-query-optimizer/src/RewriteRules/LowerToPhysical/LowerToPhysicalHashJoin.cpp
@@ -120,34 +120,30 @@ getJoinFieldExtensionsLeftRight(const Schema& leftInputSchema, const Schema& rig
                 {
                     const auto leftFieldNewName = leftField.getFieldName() + "_" + std::to_string(counter++);
                     const auto rightFieldNewName = rightField.getFieldName() + "_" + std::to_string(counter++);
-                    leftJoinNames.emplace_back(
-                        FieldNamesExtension{
-                            .oldName = leftField.getFieldName(),
-                            .newName = leftFieldNewName,
-                            .oldDataType = leftField.getDataType(),
-                            .newDataType = *joinedDataType});
-                    rightJoinNames.emplace_back(
-                        FieldNamesExtension{
-                            .oldName = rightField.getFieldName(),
-                            .newName = rightFieldNewName,
-                            .oldDataType = rightField.getDataType(),
-                            .newDataType = *joinedDataType});
+                    leftJoinNames.emplace_back(FieldNamesExtension{
+                        .oldName = leftField.getFieldName(),
+                        .newName = leftFieldNewName,
+                        .oldDataType = leftField.getDataType(),
+                        .newDataType = *joinedDataType});
+                    rightJoinNames.emplace_back(FieldNamesExtension{
+                        .oldName = rightField.getFieldName(),
+                        .newName = rightFieldNewName,
+                        .oldDataType = rightField.getDataType(),
+                        .newDataType = *joinedDataType});
                 }
             }
             else
             {
-                leftJoinNames.emplace_back(
-                    FieldNamesExtension{
-                        .oldName = leftField.getFieldName(),
-                        .newName = leftField.getFieldName(),
-                        .oldDataType = leftField.getDataType(),
-                        .newDataType = leftField.getDataType()});
-                rightJoinNames.emplace_back(
-                    FieldNamesExtension{
-                        .oldName = rightField.getFieldName(),
-                        .newName = rightField.getFieldName(),
-                        .oldDataType = rightField.getDataType(),
-                        .newDataType = rightField.getDataType()});
+                leftJoinNames.emplace_back(FieldNamesExtension{
+                    .oldName = leftField.getFieldName(),
+                    .newName = leftField.getFieldName(),
+                    .oldDataType = leftField.getDataType(),
+                    .newDataType = leftField.getDataType()});
+                rightJoinNames.emplace_back(FieldNamesExtension{
+                    .oldName = rightField.getFieldName(),
+                    .newName = rightField.getFieldName(),
+                    .oldDataType = rightField.getDataType(),
+                    .newDataType = rightField.getDataType()});
             }
         });
 
@@ -177,9 +173,8 @@ addMapOperators(const Schema& inputSchemaOfJoin, const std::vector<FieldNamesExt
         inputSchemaOfMap.addField(newName, newDataType);
 
         /// Create a new map operator with the cast as its function
-        mapPhysicalOperators.emplace_back(
-            std::make_shared<PhysicalOperatorWrapper>(
-                MapPhysicalOperator(newName, castedPhysicalFunction), copyOfInputSchemaOfMap, inputSchemaOfMap));
+        mapPhysicalOperators.emplace_back(std::make_shared<PhysicalOperatorWrapper>(
+            MapPhysicalOperator(newName, castedPhysicalFunction), copyOfInputSchemaOfMap, inputSchemaOfMap));
     }
 
     return {inputSchemaOfMap, mapPhysicalOperators};

--- a/nes-query-optimizer/src/RewriteRules/LowerToPhysical/LowerToPhysicalWindowedAggregation.cpp
+++ b/nes-query-optimizer/src/RewriteRules/LowerToPhysical/LowerToPhysicalWindowedAggregation.cpp
@@ -202,7 +202,8 @@ RewriteRuleResultSubgraph LowerToPhysicalWindowedAggregation::apply(LogicalOpera
 
     auto sliceAndWindowStore
         = std::make_unique<DefaultTimeBasedSliceStore>(windowType->getSize().getTime(), windowType->getSlide().getTime());
-    auto handler = std::make_shared<AggregationOperatorHandler>(inputOriginIds, outputOriginId, std::move(sliceAndWindowStore));
+    auto handler = std::make_shared<AggregationOperatorHandler>(
+        inputOriginIds, outputOriginId, std::move(sliceAndWindowStore), conf.maxNumberOfBuckets);
     auto build = AggregationBuildPhysicalOperator(handlerId, std::move(timeFunction), aggregationPhysicalFunctions, hashMapOptions);
     auto probe = AggregationProbePhysicalOperator(hashMapOptions, aggregationPhysicalFunctions, handlerId, windowMetaData);
 

--- a/nes-runtime/include/CompilationContext.hpp
+++ b/nes-runtime/include/CompilationContext.hpp
@@ -1,0 +1,44 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+#pragma once
+
+#include <functional>
+#include <Engine.hpp>
+#include <val_concepts.hpp>
+
+namespace NES
+{
+
+/// Similar to the execution context, this class provides access to functionality for compiling code in a pipeline.
+class CompilationContext
+{
+    /// We assume that a compilation context always outlives the engine
+    const nautilus::engine::NautilusEngine& engine; /// NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+
+public:
+    explicit CompilationContext(const nautilus::engine::NautilusEngine& engine) : engine(engine) { }
+
+    template <typename R, typename... FunctionArguments>
+    auto registerFunction(R (*fnptr)(nautilus::val<FunctionArguments>...)) const
+    {
+        return engine.registerFunction<R, FunctionArguments...>(fnptr);
+    }
+
+    template <typename R, typename... FunctionArguments>
+    auto registerFunction(std::function<R(nautilus::val<FunctionArguments>...)> func) const
+    {
+        return engine.registerFunction<R, FunctionArguments...>(func);
+    }
+};
+}

--- a/nes-runtime/include/Pipelines/CompiledExecutablePipelineStage.hpp
+++ b/nes-runtime/include/Pipelines/CompiledExecutablePipelineStage.hpp
@@ -46,7 +46,7 @@ protected:
 private:
     [[nodiscard]] nautilus::engine::CallableFunction<void, PipelineExecutionContext*, const TupleBuffer*, const Arena*>
     compilePipeline() const;
-    const nautilus::engine::Options options;
+    nautilus::engine::NautilusEngine engine;
     nautilus::engine::CallableFunction<void, PipelineExecutionContext*, const TupleBuffer*, const Arena*> compiledPipelineFunction;
     std::unordered_map<OperatorHandlerId, std::shared_ptr<OperatorHandler>> operatorHandlers;
     std::shared_ptr<Pipeline> pipeline;

--- a/nes-systests/systest/CMakeLists.txt
+++ b/nes-systests/systest/CMakeLists.txt
@@ -60,7 +60,7 @@ target_include_directories(systest PUBLIC $<INSTALL_INTERFACE:/include/nebulastr
 
 # Add code coverage if enabled
 if (CODE_COVERAGE)
-    target_code_coverage(systest COVERAGE_TARGET_NAME systest_interpreter_coverage PUBLIC AUTO ALL ARGS -n 20 --exclude-groups large --workingDir=${CMAKE_CURRENT_BINARY_DIR}/interpreter_cc --data ${EXPANDED_TEST_DATA_PATH} -- --worker.default_query_execution.execution_mode=INTERPRETER --worker.query_engine.task_queue_size=100000 --enable_google_eventTrace=true)
+    target_code_coverage(systest COVERAGE_TARGET_NAME systest_interpreter_coverage PUBLIC AUTO ALL ARGS -n 20 --exclude-groups large --workingDir=${CMAKE_CURRENT_BINARY_DIR}/interpreter_cc --data ${EXPANDED_TEST_DATA_PATH} -- --worker.default_query_execution.execution_mode=INTERPRETER --worker.query_engine.task_queue_size=100000 --worker.default_query_execution.join_strategy=NESTED_LOOP_JOIN --enable_google_eventTrace=true)
     target_code_coverage(systest COVERAGE_TARGET_NAME systest_interpreter_coverage_Hash_Join PUBLIC AUTO ALL ARGS -n 20 --exclude-groups large --workingDir=${CMAKE_CURRENT_BINARY_DIR}/interpreter_cc --data ${EXPANDED_TEST_DATA_PATH} -- --worker.default_query_execution.execution_mode=INTERPRETER --worker.query_engine.task_queue_size=100000 --worker.default_query_execution.join_strategy=HASH_JOIN --enable_google_eventTrace=true)
     # Make sure to fetch ExternalData before running the ccov targets
     add_dependencies(ccov-run-systest_interpreter_coverage test-data)

--- a/vcpkg/vcpkg-registry/ports/nautilus/0002_clang-tidy-fix-function.patch
+++ b/vcpkg/vcpkg-registry/ports/nautilus/0002_clang-tidy-fix-function.patch
@@ -1,0 +1,63 @@
+Index: nautilus/include/nautilus/Executable.hpp
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/nautilus/include/nautilus/Executable.hpp b/nautilus/include/nautilus/Executable.hpp
+--- a/nautilus/include/nautilus/Executable.hpp	(revision 598041b59644088ed431bb27a35e77f48c1e8bad)
++++ b/nautilus/include/nautilus/Executable.hpp	(date 1758642056172)
+@@ -4,6 +4,7 @@
+ #include <memory>
+ #include <string>
+ #include <variant>
++#include <type_traits>
+ #include <vector>
+
+ namespace nautilus::compiler {
+@@ -35,13 +36,14 @@
+ 	 */
+ 	template <typename R, typename... Args>
+ 	class Invocable {
+-	public:
+ 		using FunctionType = R(Args...);
++		std::variant<FunctionType*, std::unique_ptr<GenericInvocable>> func;
+
+-		explicit Invocable(void* fptr) : function(reinterpret_cast<FunctionType*>(fptr)) {
++	public:
++		explicit Invocable(void* fptr) : func(reinterpret_cast<FunctionType*>(fptr)) {
+ 		}
+
+-		explicit Invocable(std::unique_ptr<GenericInvocable> generic) : function(std::move(generic)) {
++		explicit Invocable(std::unique_ptr<GenericInvocable> generic) : func(std::move(generic)) {
+ 		}
+
+ 		template <typename T>
+@@ -67,15 +69,15 @@
+ 		 * @return returns the result of the function if any
+ 		 */
+ 		__attribute__((no_sanitize("function"))) R operator()(Args... arguments) {
+-			if (std::holds_alternative<FunctionType*>(function)) {
+-				auto fptr = std::get<FunctionType*>(function);
++			if (std::holds_alternative<FunctionType*>(func)) {
++				auto fptr = std::get<FunctionType*>(func);
+ 				if constexpr (!std::is_void_v<R>) {
+ 					return fptr(std::forward<Args>(arguments)...);
+ 				} else {
+ 					fptr(std::forward<Args>(arguments)...);
+ 				}
+ 			} else {
+-				auto& genericFunction = std::get<std::unique_ptr<GenericInvocable>>(function);
++				auto& genericFunction = std::get<std::unique_ptr<GenericInvocable>>(func);
+ 				if constexpr (!std::is_void_v<R>) {
+ 					std::vector<std::any> inputs_ = {getGenericArg(arguments)...};
+ 					auto res = genericFunction->invokeGeneric(inputs_);
+@@ -92,9 +94,6 @@
+ 				}
+ 			}
+ 		}
+-
+-	private:
+-		std::variant<FunctionType*, std::unique_ptr<GenericInvocable>> function;
+ 	};
+
+ 	/**

--- a/vcpkg/vcpkg-registry/ports/nautilus/portfile.cmake
+++ b/vcpkg/vcpkg-registry/ports/nautilus/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_from_github(
         SHA512 d458eb6d966d7d1885160f91fa0daae3c2bc9091ba3b8000d3166791d902b13b017e19489dcbc87705ac431946973b35aa5ca9ec7c6ad09f5ee259d68be6c572
 		PATCHES
 		0001-disable-ubsan-function-call-check.patch
+		0002_clang-tidy-fix-function.patch
 )
 
 set(ADDITIONAL_CMAKE_OPTIONS "")


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR adds optimizations to the build, probe, and operator handler of the aggregation and hash join. The optimizations are the same across both operators. 
We reduce the number of nautilus invoke calls in the probe and count the number of keys via a rolling average to reduce the amount of hash collisions.

## Verifying this change
This change is tested by running our unit and system-level tests.

## What components does this pull request potentially affect?
- ExecutionEngine