### PR TITLE
chore(Aggregations): Replace create method with std::make_shared

### DIFF
--- a/nes-logical-operators/include/Operators/Windows/Aggregations/AvgAggregationLogicalFunction.hpp
+++ b/nes-logical-operators/include/Operators/Windows/Aggregations/AvgAggregationLogicalFunction.hpp
@@ -28,9 +28,6 @@ namespace NES
 class AvgAggregationLogicalFunction final : public WindowAggregationLogicalFunction
 {
 public:
-    static std::shared_ptr<WindowAggregationLogicalFunction> create(const FieldAccessLogicalFunction& onField);
-    static std::shared_ptr<WindowAggregationLogicalFunction>
-    create(const FieldAccessLogicalFunction& onField, const FieldAccessLogicalFunction& asField);
     AvgAggregationLogicalFunction(const FieldAccessLogicalFunction& onField, const FieldAccessLogicalFunction& asField);
     explicit AvgAggregationLogicalFunction(const FieldAccessLogicalFunction& onField);
 

--- a/nes-logical-operators/include/Operators/Windows/Aggregations/CountAggregationLogicalFunction.hpp
+++ b/nes-logical-operators/include/Operators/Windows/Aggregations/CountAggregationLogicalFunction.hpp
@@ -29,9 +29,6 @@ namespace NES
 class CountAggregationLogicalFunction : public WindowAggregationLogicalFunction
 {
 public:
-    static std::shared_ptr<WindowAggregationLogicalFunction> create(const FieldAccessLogicalFunction& onField);
-    static std::shared_ptr<WindowAggregationLogicalFunction>
-    create(const FieldAccessLogicalFunction& onField, const FieldAccessLogicalFunction& asField);
     CountAggregationLogicalFunction(FieldAccessLogicalFunction onField, FieldAccessLogicalFunction asField);
     explicit CountAggregationLogicalFunction(const FieldAccessLogicalFunction& onField);
     ~CountAggregationLogicalFunction() override = default;

--- a/nes-logical-operators/include/Operators/Windows/Aggregations/MaxAggregationLogicalFunction.hpp
+++ b/nes-logical-operators/include/Operators/Windows/Aggregations/MaxAggregationLogicalFunction.hpp
@@ -27,9 +27,6 @@ namespace NES
 class MaxAggregationLogicalFunction : public WindowAggregationLogicalFunction
 {
 public:
-    static std::shared_ptr<WindowAggregationLogicalFunction> create(const FieldAccessLogicalFunction& onField);
-    static std::shared_ptr<WindowAggregationLogicalFunction>
-    create(const FieldAccessLogicalFunction& onField, const FieldAccessLogicalFunction& asField);
     MaxAggregationLogicalFunction(const FieldAccessLogicalFunction& onField, FieldAccessLogicalFunction asField);
     explicit MaxAggregationLogicalFunction(const FieldAccessLogicalFunction& onField);
 

--- a/nes-logical-operators/include/Operators/Windows/Aggregations/MedianAggregationLogicalFunction.hpp
+++ b/nes-logical-operators/include/Operators/Windows/Aggregations/MedianAggregationLogicalFunction.hpp
@@ -29,15 +29,11 @@ namespace NES
 class MedianAggregationLogicalFunction : public WindowAggregationLogicalFunction
 {
 public:
-    MedianAggregationLogicalFunction(const FieldAccessLogicalFunction& onField, FieldAccessLogicalFunction asField);
-    static std::shared_ptr<WindowAggregationLogicalFunction> create(const FieldAccessLogicalFunction& onField);
-    explicit MedianAggregationLogicalFunction(const FieldAccessLogicalFunction& onField);
-
     /// Creates a new MedianAggregationLogicalFunction
     /// @param onField field on which the aggregation should be performed
     /// @param asField function describing how the aggregated field should be called
-    static std::shared_ptr<WindowAggregationLogicalFunction>
-    create(const FieldAccessLogicalFunction& onField, const FieldAccessLogicalFunction& asField);
+    MedianAggregationLogicalFunction(const FieldAccessLogicalFunction& onField, FieldAccessLogicalFunction asField);
+    explicit MedianAggregationLogicalFunction(const FieldAccessLogicalFunction& onField);
 
     void inferStamp(const Schema& schema) override;
 

--- a/nes-logical-operators/include/Operators/Windows/Aggregations/MinAggregationLogicalFunction.hpp
+++ b/nes-logical-operators/include/Operators/Windows/Aggregations/MinAggregationLogicalFunction.hpp
@@ -27,10 +27,6 @@ namespace NES
 class MinAggregationLogicalFunction : public WindowAggregationLogicalFunction
 {
 public:
-    static std::shared_ptr<WindowAggregationLogicalFunction> create(const FieldAccessLogicalFunction& onField);
-    static std::shared_ptr<WindowAggregationLogicalFunction>
-    create(const FieldAccessLogicalFunction& onField, FieldAccessLogicalFunction asField);
-
     MinAggregationLogicalFunction(const FieldAccessLogicalFunction& onField, FieldAccessLogicalFunction asField);
     explicit MinAggregationLogicalFunction(const FieldAccessLogicalFunction& onField);
     ~MinAggregationLogicalFunction() override = default;

--- a/nes-logical-operators/include/Operators/Windows/Aggregations/SumAggregationLogicalFunction.hpp
+++ b/nes-logical-operators/include/Operators/Windows/Aggregations/SumAggregationLogicalFunction.hpp
@@ -32,10 +32,6 @@ public:
     explicit SumAggregationLogicalFunction(const FieldAccessLogicalFunction& onField);
     ~SumAggregationLogicalFunction() override = default;
 
-    static std::shared_ptr<WindowAggregationLogicalFunction> create(const LogicalFunction& onField);
-    static std::shared_ptr<WindowAggregationLogicalFunction>
-    create(const FieldAccessLogicalFunction& onField, const FieldAccessLogicalFunction& asField);
-
     void inferStamp(const Schema& schema) override;
     [[nodiscard]] SerializableAggregationFunction serialize() const override;
     [[nodiscard]] std::string_view getName() const noexcept override;

--- a/nes-logical-operators/src/Operators/Windows/Aggregations/AvgAggregationLogicalFunction.cpp
+++ b/nes-logical-operators/src/Operators/Windows/Aggregations/AvgAggregationLogicalFunction.cpp
@@ -48,17 +48,6 @@ AvgAggregationLogicalFunction::AvgAggregationLogicalFunction(
 {
 }
 
-std::shared_ptr<WindowAggregationLogicalFunction>
-AvgAggregationLogicalFunction::create(const FieldAccessLogicalFunction& onField, const FieldAccessLogicalFunction& asField)
-{
-    return std::make_shared<AvgAggregationLogicalFunction>(onField, asField);
-}
-
-std::shared_ptr<WindowAggregationLogicalFunction> AvgAggregationLogicalFunction::create(const FieldAccessLogicalFunction& onField)
-{
-    return std::make_shared<AvgAggregationLogicalFunction>(onField);
-}
-
 std::string_view AvgAggregationLogicalFunction::getName() const noexcept
 {
     return NAME;
@@ -136,6 +125,6 @@ AggregationLogicalFunctionGeneratedRegistrar::RegisterAvgAggregationLogicalFunct
     {
         throw CannotDeserialize("AvgAggregationLogicalFunction requires exactly two fields, but got {}", arguments.fields.size());
     }
-    return AvgAggregationLogicalFunction::create(arguments.fields[0], arguments.fields[1]);
+    return std::make_shared<AvgAggregationLogicalFunction>(arguments.fields[0], arguments.fields[1]);
 }
 }

--- a/nes-logical-operators/src/Operators/Windows/Aggregations/CountAggregationLogicalFunction.cpp
+++ b/nes-logical-operators/src/Operators/Windows/Aggregations/CountAggregationLogicalFunction.cpp
@@ -49,17 +49,6 @@ CountAggregationLogicalFunction::CountAggregationLogicalFunction(FieldAccessLogi
 {
 }
 
-std::shared_ptr<WindowAggregationLogicalFunction>
-CountAggregationLogicalFunction::create(const FieldAccessLogicalFunction& onField, const FieldAccessLogicalFunction& asField)
-{
-    return std::make_shared<CountAggregationLogicalFunction>(onField, asField);
-}
-
-std::shared_ptr<WindowAggregationLogicalFunction> CountAggregationLogicalFunction::create(const FieldAccessLogicalFunction& onField)
-{
-    return std::make_shared<CountAggregationLogicalFunction>(onField);
-}
-
 std::string_view CountAggregationLogicalFunction::getName() const noexcept
 {
     return NAME;
@@ -116,6 +105,6 @@ AggregationLogicalFunctionGeneratedRegistrar::RegisterCountAggregationLogicalFun
     {
         throw CannotDeserialize("CountAggregationLogicalFunction requires exactly two fields, but got {}", arguments.fields.size());
     }
-    return CountAggregationLogicalFunction::create(arguments.fields[0], arguments.fields[1]);
+    return std::make_shared<CountAggregationLogicalFunction>(arguments.fields[0], arguments.fields[1]);
 }
 }

--- a/nes-logical-operators/src/Operators/Windows/Aggregations/MaxAggregationLogicalFunction.cpp
+++ b/nes-logical-operators/src/Operators/Windows/Aggregations/MaxAggregationLogicalFunction.cpp
@@ -38,17 +38,6 @@ MaxAggregationLogicalFunction::MaxAggregationLogicalFunction(const FieldAccessLo
 {
 }
 
-std::shared_ptr<WindowAggregationLogicalFunction> MaxAggregationLogicalFunction::create(const FieldAccessLogicalFunction& onField)
-{
-    return std::make_shared<MaxAggregationLogicalFunction>(onField);
-}
-
-std::shared_ptr<WindowAggregationLogicalFunction>
-MaxAggregationLogicalFunction::create(const FieldAccessLogicalFunction& onField, const FieldAccessLogicalFunction& asField)
-{
-    return std::make_shared<MaxAggregationLogicalFunction>(onField, asField);
-}
-
 std::string_view MaxAggregationLogicalFunction::getName() const noexcept
 {
     return NAME;
@@ -106,6 +95,6 @@ AggregationLogicalFunctionGeneratedRegistrar::RegisterMaxAggregationLogicalFunct
     {
         throw CannotDeserialize("MaxAggregationLogicalFunction requires exactly two fields, but got {}", arguments.fields.size());
     }
-    return MaxAggregationLogicalFunction::create(arguments.fields[0], arguments.fields[1]);
+    return std::make_shared<MaxAggregationLogicalFunction>(arguments.fields[0], arguments.fields[1]);
 }
 }

--- a/nes-logical-operators/src/Operators/Windows/Aggregations/MedianAggregationLogicalFunction.cpp
+++ b/nes-logical-operators/src/Operators/Windows/Aggregations/MedianAggregationLogicalFunction.cpp
@@ -50,17 +50,6 @@ MedianAggregationLogicalFunction::MedianAggregationLogicalFunction(
 {
 }
 
-std::shared_ptr<WindowAggregationLogicalFunction>
-MedianAggregationLogicalFunction::create(const FieldAccessLogicalFunction& onField, const FieldAccessLogicalFunction& asField)
-{
-    return std::make_shared<MedianAggregationLogicalFunction>(onField, asField);
-}
-
-std::shared_ptr<WindowAggregationLogicalFunction> MedianAggregationLogicalFunction::create(const FieldAccessLogicalFunction& onField)
-{
-    return std::make_shared<MedianAggregationLogicalFunction>(onField);
-}
-
 std::string_view MedianAggregationLogicalFunction::getName() const noexcept
 {
     return NAME;
@@ -118,6 +107,6 @@ AggregationLogicalFunctionRegistryReturnType AggregationLogicalFunctionGenerated
     {
         throw CannotDeserialize("MedianAggregationLogicalFunction requires exactly two fields, but got {}", arguments.fields.size());
     }
-    return MedianAggregationLogicalFunction::create(arguments.fields[0], arguments.fields[1]);
+    return std::make_shared<MedianAggregationLogicalFunction>(arguments.fields[0], arguments.fields[1]);
 }
 }

--- a/nes-logical-operators/src/Operators/Windows/Aggregations/MinAggregationLogicalFunction.cpp
+++ b/nes-logical-operators/src/Operators/Windows/Aggregations/MinAggregationLogicalFunction.cpp
@@ -38,17 +38,6 @@ MinAggregationLogicalFunction::MinAggregationLogicalFunction(const FieldAccessLo
 {
 }
 
-std::shared_ptr<WindowAggregationLogicalFunction>
-MinAggregationLogicalFunction::create(const FieldAccessLogicalFunction& onField, FieldAccessLogicalFunction asField)
-{
-    return std::make_shared<MinAggregationLogicalFunction>(onField, std::move(asField));
-}
-
-std::shared_ptr<WindowAggregationLogicalFunction> MinAggregationLogicalFunction::create(const FieldAccessLogicalFunction& onField)
-{
-    return std::make_shared<MinAggregationLogicalFunction>(onField);
-}
-
 std::string_view MinAggregationLogicalFunction::getName() const noexcept
 {
     return NAME;
@@ -106,6 +95,6 @@ AggregationLogicalFunctionGeneratedRegistrar::RegisterMinAggregationLogicalFunct
     {
         throw CannotDeserialize("MinAggregationLogicalFunction requires exactly two fields, but got {}", arguments.fields.size());
     }
-    return MinAggregationLogicalFunction::create(arguments.fields[0], arguments.fields[1]);
+    return std::make_shared<MinAggregationLogicalFunction>(arguments.fields[0], arguments.fields[1]);
 }
 }

--- a/nes-logical-operators/src/Operators/Windows/Aggregations/SumAggregationLogicalFunction.cpp
+++ b/nes-logical-operators/src/Operators/Windows/Aggregations/SumAggregationLogicalFunction.cpp
@@ -43,17 +43,6 @@ std::string_view SumAggregationLogicalFunction::getName() const noexcept
     return NAME;
 }
 
-std::shared_ptr<WindowAggregationLogicalFunction>
-SumAggregationLogicalFunction::create(const FieldAccessLogicalFunction& onField, const FieldAccessLogicalFunction& asField)
-{
-    return std::make_shared<SumAggregationLogicalFunction>(onField, asField);
-}
-
-std::shared_ptr<WindowAggregationLogicalFunction> SumAggregationLogicalFunction::create(const LogicalFunction& onField)
-{
-    return std::make_shared<SumAggregationLogicalFunction>(onField.get<FieldAccessLogicalFunction>());
-}
-
 void SumAggregationLogicalFunction::inferStamp(const Schema& schema)
 {
     /// We first infer the dataType of the input field and set the output dataType as the same.
@@ -106,6 +95,6 @@ AggregationLogicalFunctionGeneratedRegistrar::RegisterSumAggregationLogicalFunct
     {
         throw CannotDeserialize("SumAggregationLogicalFunction requires exactly two fields, but got {}", arguments.fields.size());
     }
-    return SumAggregationLogicalFunction::create(arguments.fields[0], arguments.fields[1]);
+    return std::make_shared<SumAggregationLogicalFunction>(arguments.fields[0], arguments.fields[1]);
 }
 }

--- a/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
+++ b/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
@@ -803,7 +803,7 @@ void AntlrSQLQueryPlanCreator::exitFunctionCall(AntlrSQLParser::FunctionCallCont
                 throw InvalidQuerySyntax("Aggregation requires argument at {}", context->getText());
             }
             helpers.top().windowAggs.push_back(
-                CountAggregationLogicalFunction::create(helpers.top().functionBuilder.back().get<FieldAccessLogicalFunction>()));
+                std::make_shared<CountAggregationLogicalFunction>(helpers.top().functionBuilder.back().get<FieldAccessLogicalFunction>()));
             break;
         case AntlrSQLLexer::AVG:
             if (helpers.top().functionBuilder.empty())
@@ -811,7 +811,7 @@ void AntlrSQLQueryPlanCreator::exitFunctionCall(AntlrSQLParser::FunctionCallCont
                 throw InvalidQuerySyntax("Aggregation requires argument at {}", context->getText());
             }
             helpers.top().windowAggs.push_back(
-                AvgAggregationLogicalFunction::create(helpers.top().functionBuilder.back().get<FieldAccessLogicalFunction>()));
+                std::make_shared<AvgAggregationLogicalFunction>(helpers.top().functionBuilder.back().get<FieldAccessLogicalFunction>()));
             break;
         case AntlrSQLLexer::MAX:
             if (helpers.top().functionBuilder.empty())
@@ -819,7 +819,7 @@ void AntlrSQLQueryPlanCreator::exitFunctionCall(AntlrSQLParser::FunctionCallCont
                 throw InvalidQuerySyntax("Aggregation requires argument at {}", context->getText());
             }
             helpers.top().windowAggs.push_back(
-                MaxAggregationLogicalFunction::create(helpers.top().functionBuilder.back().get<FieldAccessLogicalFunction>()));
+                std::make_shared<MaxAggregationLogicalFunction>(helpers.top().functionBuilder.back().get<FieldAccessLogicalFunction>()));
             break;
         case AntlrSQLLexer::MIN:
             if (helpers.top().functionBuilder.empty())
@@ -827,7 +827,7 @@ void AntlrSQLQueryPlanCreator::exitFunctionCall(AntlrSQLParser::FunctionCallCont
                 throw InvalidQuerySyntax("Aggregation requires argument at {}", context->getText());
             }
             helpers.top().windowAggs.push_back(
-                MinAggregationLogicalFunction::create(helpers.top().functionBuilder.back().get<FieldAccessLogicalFunction>()));
+                std::make_shared<MinAggregationLogicalFunction>(helpers.top().functionBuilder.back().get<FieldAccessLogicalFunction>()));
             break;
         case AntlrSQLLexer::SUM:
             if (helpers.top().functionBuilder.empty())
@@ -835,7 +835,7 @@ void AntlrSQLQueryPlanCreator::exitFunctionCall(AntlrSQLParser::FunctionCallCont
                 throw InvalidQuerySyntax("Aggregation requires argument at {}", context->getText());
             }
             helpers.top().windowAggs.push_back(
-                SumAggregationLogicalFunction::create(helpers.top().functionBuilder.back().get<FieldAccessLogicalFunction>()));
+                std::make_shared<SumAggregationLogicalFunction>(helpers.top().functionBuilder.back().get<FieldAccessLogicalFunction>()));
             break;
         case AntlrSQLLexer::MEDIAN:
             if (helpers.top().functionBuilder.empty())
@@ -843,7 +843,7 @@ void AntlrSQLQueryPlanCreator::exitFunctionCall(AntlrSQLParser::FunctionCallCont
                 throw InvalidQuerySyntax("Aggregation requires argument at {}", context->getText());
             }
             helpers.top().windowAggs.push_back(
-                MedianAggregationLogicalFunction::create(helpers.top().functionBuilder.back().get<FieldAccessLogicalFunction>()));
+                std::make_shared<MedianAggregationLogicalFunction>(helpers.top().functionBuilder.back().get<FieldAccessLogicalFunction>()));
             break;
         default:
             /// Check if the function is a constructor for a datatype


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
The create method is a remnant of the old API and we instead use std::make_shared directly.

## Verifying this change
It compiles, so no usage of the create methods remains.

## What components does this pull request potentially affect?
Aggregations

## Documentation
n/a

## Issue Closed by this pull request:
