### PR TITLE
feat(Engine): Catch out of order timestamps

### DIFF
--- a/nes-common/include/Sequencing/NonBlockingMonotonicSeqQueue.hpp
+++ b/nes-common/include/Sequencing/NonBlockingMonotonicSeqQueue.hpp
@@ -85,6 +85,7 @@ public:
 
     void emplace(SequenceData sequenceData, T newValue)
     {
+        INVARIANT(getCurrentValue() <= newValue, "New value is smaller than current value: {} < {}", newValue, getCurrentValue());
         if (auto opt = chunks.collect(sequenceData, Timestamp(newValue)))
         {
             auto [sequenceNumber, value] = *opt;

--- a/nes-executable/include/PipelineExecutionContext.hpp
+++ b/nes-executable/include/PipelineExecutionContext.hpp
@@ -13,6 +13,7 @@
 */
 
 #pragma once
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <unordered_map>
@@ -32,8 +33,7 @@ public:
     enum class ContinuationPolicy : uint8_t
     {
         POSSIBLE, /// It is possible for the emitted tuple buffer to be processed immediately. This is not a guarantee that that will happen
-        NEVER, /// The tuple buffer should never be processed immediately
-        REPEAT /// Put the same task back into the task queue
+        NEVER /// The tuple buffer should never be processed immediately
     };
 
     virtual ~PipelineExecutionContext() = default;
@@ -44,7 +44,13 @@ public:
     /// Please be aware of how you are setting the continuation policy, as this will/can lead to deadlocks and no progress in our system.
     /// We advise to use ContinuationPolicy::POSSIBLE, as this will ensure no deadlock arising.
     /// Returns success, if the buffer was emitted successfully.
+
     virtual bool emitBuffer(const TupleBuffer&, ContinuationPolicy) = 0;
+
+    /// This method can only be called once per pipeline execution! The Pipeline should immediately finish its execution as the exact same task could be executed
+    /// immediately.
+    virtual void repeatTask(const TupleBuffer&, std::chrono::milliseconds) = 0;
+
     virtual TupleBuffer allocateTupleBuffer() = 0;
     [[nodiscard]] virtual WorkerThreadId getId() const = 0;
     [[nodiscard]] virtual uint64_t getNumberOfWorkerThreads() const = 0;

--- a/nes-executable/tests/TestUtils/TestTaskQueue.cpp
+++ b/nes-executable/tests/TestUtils/TestTaskQueue.cpp
@@ -14,6 +14,7 @@
 
 #include <TestTaskQueue.hpp>
 
+#include <chrono>
 #include <cstddef>
 #include <memory>
 #include <ostream>
@@ -35,11 +36,6 @@ bool TestPipelineExecutionContext::emitBuffer(const TupleBuffer& resultBuffer, c
 {
     switch (continuationPolicy)
     {
-        case ContinuationPolicy::REPEAT: {
-            PRECONDITION(repeatTaskCallback != nullptr, "Cannot repeat a task without a valid repeatTaskCallback function");
-            repeatTaskCallback();
-            break;
-        }
         case ContinuationPolicy::NEVER: {
             resultBuffers->at(workerThreadId.getRawValue()).emplace_back(resultBuffer);
             break;
@@ -59,6 +55,12 @@ TupleBuffer TestPipelineExecutionContext::allocateTupleBuffer()
         return buffer.value();
     }
     throw BufferAllocationFailure("Required more buffers in TestTaskQueue than provided.");
+}
+
+void TestPipelineExecutionContext::repeatTask(const TupleBuffer&, std::chrono::milliseconds)
+{
+    PRECONDITION(repeatTaskCallback != nullptr, "Cannot repeat a task without a valid repeatTaskCallback function");
+    repeatTaskCallback();
 }
 
 void TestPipelineStage::execute(const TupleBuffer& tupleBuffer, PipelineExecutionContext& pec)

--- a/nes-executable/tests/TestUtils/TestTaskQueue.hpp
+++ b/nes-executable/tests/TestUtils/TestTaskQueue.hpp
@@ -107,6 +107,8 @@ public:
         this->operatorHandlers = operatorHandlers;
     }
 
+    void repeatTask(const TupleBuffer&, std::chrono::milliseconds) override;
+
     WorkerThreadId workerThreadId;
     PipelineId pipelineId;
 

--- a/nes-input-formatters/private/InputFormatterTask.hpp
+++ b/nes-input-formatters/private/InputFormatterTask.hpp
@@ -244,7 +244,7 @@ public:
         /// After enough out-of-range requests, the SequenceShredder increases the size of its ring buffer.
         if (not sequenceShredder->isInRange(rawBuffer.getSequenceNumber().getRawValue()))
         {
-            rawBuffer.emit(pec, PipelineExecutionContext::ContinuationPolicy::REPEAT);
+            rawBuffer.repeat(pec);
             return;
         }
 

--- a/nes-input-formatters/private/RawTupleBuffer.hpp
+++ b/nes-input-formatters/private/RawTupleBuffer.hpp
@@ -69,6 +69,8 @@ public:
         pec.emitBuffer(rawBuffer, continuationPolicy);
     }
 
+    void repeat(PipelineExecutionContext& pec) const { pec.repeatTask(rawBuffer, std::chrono::milliseconds{0}); }
+
     [[nodiscard]] const TupleBuffer& getRawBuffer() const noexcept { return rawBuffer; }
 
     void setSpanningTuple(const std::string_view spanningTuple) { this->bufferView = spanningTuple; }

--- a/nes-physical-operators/tests/EmitPhysicalOperatorTest.cpp
+++ b/nes-physical-operators/tests/EmitPhysicalOperatorTest.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <barrier>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -49,6 +50,7 @@
 #include <gtest/gtest.h>
 #include <BaseUnitTest.hpp>
 #include <EmitPhysicalOperator.hpp>
+#include <ErrorHandling.hpp>
 #include <ExecutionContext.hpp>
 #include <PipelineExecutionContext.hpp>
 
@@ -89,6 +91,8 @@ class EmitPhysicalOperatorTest : public Testing::BaseUnitTest
             : buffers(buffers), bufferManager(std::move(bufferManager))
         {
         }
+
+        void repeatTask(const TupleBuffer&, std::chrono::milliseconds) override { INVARIANT(false, "This function should not be called"); }
 
         ///NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members) lifetime is ensured by the `run` method.
         folly::Synchronized<std::vector<TupleBuffer>>& buffers;

--- a/nes-query-engine/QueryEngine.cpp
+++ b/nes-query-engine/QueryEngine.cpp
@@ -399,7 +399,6 @@ public:
         std::shared_ptr<AbstractQueryStatusListener> listener,
         std::shared_ptr<QueryEngineStatisticListener> stats,
         std::shared_ptr<AbstractBufferProvider> bufferProvider,
-        const size_t,
         const size_t admissionQueueSize)
         : listener(std::move(listener))
         , statistic(std::move(std::move(stats)))
@@ -757,8 +756,7 @@ QueryEngine::QueryEngine(
     , statusListener(std::move(listener))
     , statisticListener(std::move(statListener))
     , queryCatalog(std::make_shared<QueryCatalog>())
-    , threadPool(std::make_unique<ThreadPool>(
-          statusListener, statisticListener, bufferManager, config.taskQueueSize.getValue(), config.admissionQueueSize.getValue()))
+    , threadPool(std::make_unique<ThreadPool>(statusListener, statisticListener, bufferManager, config.admissionQueueSize.getValue()))
 {
     for (size_t i = 0; i < config.numberOfWorkerThreads.getValue(); ++i)
     {

--- a/nes-query-engine/QueryEngine.cpp
+++ b/nes-query-engine/QueryEngine.cpp
@@ -181,7 +181,6 @@ public:
         const std::shared_ptr<QueryEngineStatisticListener>& statistic,
         QueryLifetimeController& controller,
         WorkEmitter& emitter);
-    QueryId registerQuery(std::unique_ptr<ExecutableQueryPlan>);
     void stopQuery(QueryId queryId);
 
     void clear()

--- a/nes-query-engine/QueryEngineConfiguration.cpp
+++ b/nes-query-engine/QueryEngineConfiguration.cpp
@@ -64,7 +64,7 @@ std::shared_ptr<ConfigurationValidation> QueryEngineConfiguration::numberOfThrea
     return std::make_shared<Validator>();
 }
 
-std::shared_ptr<ConfigurationValidation> QueryEngineConfiguration::taskQueueSizeValidator()
+std::shared_ptr<ConfigurationValidation> QueryEngineConfiguration::queueSizeValidator()
 {
     struct Validator : ConfigurationValidation
     {

--- a/nes-query-engine/include/QueryEngineConfiguration.hpp
+++ b/nes-query-engine/include/QueryEngineConfiguration.hpp
@@ -28,7 +28,7 @@ class QueryEngineConfiguration final : public BaseConfiguration
 {
     /// validators to prevent nonsensical values for the number of threads and task queue size
     static std::shared_ptr<ConfigurationValidation> numberOfThreadsValidator();
-    static std::shared_ptr<ConfigurationValidation> taskQueueSizeValidator();
+    static std::shared_ptr<ConfigurationValidation> queueSizeValidator();
 
 public:
     QueryEngineConfiguration() = default;
@@ -37,12 +37,10 @@ public:
 
     UIntOption numberOfWorkerThreads
         = {"number_of_worker_threads", "4", "Number of worker threads used within the QueryEngine", {numberOfThreadsValidator()}};
-    UIntOption taskQueueSize
-        = {"task_queue_size", "10000", "Size of the bounded task queue used within the QueryEngine", {taskQueueSizeValidator()}};
     UIntOption admissionQueueSize
-        = {"admission_queue_size", "1000", "Size of the bounded admission queue used within the QueryEngine", {taskQueueSizeValidator()}};
+        = {"admission_queue_size", "1000", "Size of the bounded admission queue used within the QueryEngine", {queueSizeValidator()}};
 
 protected:
-    std::vector<BaseOption*> getOptions() override { return {&numberOfWorkerThreads, &taskQueueSize, &admissionQueueSize}; }
+    std::vector<BaseOption*> getOptions() override { return {&numberOfWorkerThreads, &admissionQueueSize}; }
 };
 }

--- a/nes-query-engine/tests/QueryEngineConfigurationTest.cpp
+++ b/nes-query-engine/tests/QueryEngineConfigurationTest.cpp
@@ -36,17 +36,15 @@ public:
 TEST_F(QueryEngineConfigurationTest, testConfigurationsDefault)
 {
     const QueryEngineConfiguration defaultConfig;
-    EXPECT_EQ(defaultConfig.taskQueueSize.getValue(), 10000);
+    EXPECT_EQ(defaultConfig.admissionQueueSize.getValue(), 1000);
     EXPECT_EQ(defaultConfig.numberOfWorkerThreads.getValue(), 4);
 }
 
 TEST_F(QueryEngineConfigurationTest, testConfigurationsValidInput)
 {
     QueryEngineConfiguration defaultConfig;
-    defaultConfig.overwriteConfigWithCommandLineInput(
-        {{"task_queue_size", "200"}, {"number_of_worker_threads", "2"}, {"admission_queue_size", "123"}});
+    defaultConfig.overwriteConfigWithCommandLineInput({{"number_of_worker_threads", "2"}, {"admission_queue_size", "123"}});
 
-    EXPECT_EQ(defaultConfig.taskQueueSize.getValue(), 200);
     EXPECT_EQ(defaultConfig.admissionQueueSize.getValue(), 123);
     EXPECT_EQ(defaultConfig.numberOfWorkerThreads.getValue(), 2);
 }
@@ -54,26 +52,31 @@ TEST_F(QueryEngineConfigurationTest, testConfigurationsValidInput)
 TEST_F(QueryEngineConfigurationTest, testConfigurationsBadInputNonString)
 {
     QueryEngineConfiguration defaultConfig;
-    EXPECT_ANY_THROW(defaultConfig.overwriteConfigWithCommandLineInput({{"task_queue_size", "XX"}, {"number_of_worker_threads", "2"}}));
+    EXPECT_ANY_THROW(
+        defaultConfig.overwriteConfigWithCommandLineInput({{"admission_queue_size", "XX"}, {"number_of_worker_threads", "2"}}));
 
     QueryEngineConfiguration defaultConfig1;
-    EXPECT_ANY_THROW(defaultConfig1.overwriteConfigWithCommandLineInput({{"task_queue_size", "200"}, {"number_of_worker_threads", "XX"}}));
+    EXPECT_ANY_THROW(
+        defaultConfig1.overwriteConfigWithCommandLineInput({{"admission_queue_size", "200"}, {"number_of_worker_threads", "XX"}}));
 
     QueryEngineConfiguration defaultConfig2;
-    EXPECT_ANY_THROW(defaultConfig2.overwriteConfigWithCommandLineInput({{"task_queue_size", "XX"}, {"number_of_worker_threads", "XX"}}));
+    EXPECT_ANY_THROW(
+        defaultConfig2.overwriteConfigWithCommandLineInput({{"admission_queue_size", "XX"}, {"number_of_worker_threads", "XX"}}));
 
     const QueryEngineConfiguration defaultConfig3;
-    EXPECT_ANY_THROW(defaultConfig2.overwriteConfigWithCommandLineInput({{"task_queue_size", "1.0"}, {"number_of_worker_threads", "1.5"}}));
+    EXPECT_ANY_THROW(
+        defaultConfig2.overwriteConfigWithCommandLineInput({{"admission_queue_size", "1.0"}, {"number_of_worker_threads", "1.5"}}));
 }
 
 TEST_F(QueryEngineConfigurationTest, testConfigurationsBadInputBadNumberOfThreads)
 {
     QueryEngineConfiguration defaultConfig;
-    EXPECT_ANY_THROW(defaultConfig.overwriteConfigWithCommandLineInput({{"task_queue_size", "200"}, {"number_of_worker_threads", "0"}}));
+    EXPECT_ANY_THROW(
+        defaultConfig.overwriteConfigWithCommandLineInput({{"admission_queue_size", "200"}, {"number_of_worker_threads", "0"}}));
 
     const QueryEngineConfiguration defaultConfig1;
     EXPECT_ANY_THROW(
-        defaultConfig.overwriteConfigWithCommandLineInput({{"task_queue_size", "200"}, {"number_of_worker_threads", "20000"}}));
+        defaultConfig.overwriteConfigWithCommandLineInput({{"admission_queue_size", "200"}, {"number_of_worker_threads", "20000"}}));
 }
 
 }

--- a/nes-query-engine/tests/QueryPlanTest.cpp
+++ b/nes-query-engine/tests/QueryPlanTest.cpp
@@ -12,6 +12,7 @@
     limitations under the License.
 */
 
+#include <chrono>
 #include <concepts>
 #include <condition_variable>
 #include <cstddef>
@@ -137,6 +138,7 @@ concept RangeOf = std::ranges::range<R> && std::same_as<std::ranges::range_value
 
 struct TestPipelineExecutionContext : PipelineExecutionContext
 {
+    MOCK_METHOD(void, repeatTask, (const TupleBuffer&, std::chrono::milliseconds), (override));
     MOCK_METHOD(WorkerThreadId, getId, (), (const, override));
     MOCK_METHOD(TupleBuffer, allocateTupleBuffer, (), (override));
     MOCK_METHOD(uint64_t, getNumberOfWorkerThreads, (), (const, override));

--- a/nes-systests/systest/CMakeLists.txt
+++ b/nes-systests/systest/CMakeLists.txt
@@ -60,8 +60,8 @@ target_include_directories(systest PUBLIC $<INSTALL_INTERFACE:/include/nebulastr
 
 # Add code coverage if enabled
 if (CODE_COVERAGE)
-    target_code_coverage(systest COVERAGE_TARGET_NAME systest_interpreter_coverage PUBLIC AUTO ALL ARGS -n 20 --exclude-groups large --workingDir=${CMAKE_CURRENT_BINARY_DIR}/interpreter_cc --data ${EXPANDED_TEST_DATA_PATH} -- --worker.default_query_execution.execution_mode=INTERPRETER --worker.query_engine.task_queue_size=100000 --enable_google_eventTrace=true)
-    target_code_coverage(systest COVERAGE_TARGET_NAME systest_interpreter_coverage_Hash_Join PUBLIC AUTO ALL ARGS -n 20 --exclude-groups large --workingDir=${CMAKE_CURRENT_BINARY_DIR}/interpreter_cc --data ${EXPANDED_TEST_DATA_PATH} -- --worker.default_query_execution.execution_mode=INTERPRETER --worker.query_engine.task_queue_size=100000 --worker.default_query_execution.join_strategy=HASH_JOIN --enable_google_eventTrace=true)
+    target_code_coverage(systest COVERAGE_TARGET_NAME systest_interpreter_coverage PUBLIC AUTO ALL ARGS -n 20 --exclude-groups large --workingDir=${CMAKE_CURRENT_BINARY_DIR}/interpreter_cc --data ${EXPANDED_TEST_DATA_PATH} -- --worker.default_query_execution.execution_mode=INTERPRETER --enable_google_eventTrace=true)
+    target_code_coverage(systest COVERAGE_TARGET_NAME systest_interpreter_coverage_Hash_Join PUBLIC AUTO ALL ARGS -n 20 --exclude-groups large --workingDir=${CMAKE_CURRENT_BINARY_DIR}/interpreter_cc --data ${EXPANDED_TEST_DATA_PATH} -- --worker.default_query_execution.execution_mode=INTERPRETER --worker.default_query_execution.join_strategy=HASH_JOIN --enable_google_eventTrace=true)
     # Make sure to fetch ExternalData before running the ccov targets
     add_dependencies(ccov-run-systest_interpreter_coverage test-data)
     add_dependencies(ccov-run-systest_interpreter_coverage_Hash_Join test-data)
@@ -72,12 +72,12 @@ set(joinStrategies NESTED_LOOP_JOIN HASH_JOIN)
 foreach (joinStrategy IN LISTS joinStrategies)
     ExternalData_Add_Test(test-data
             NAME systest_interpreter_${joinStrategy}
-            COMMAND systest -n 20 --workingDir=${CMAKE_CURRENT_BINARY_DIR}/interpreter_${joinStrategy} --exclude-groups large --data ${EXPANDED_TEST_DATA_PATH} -- --worker.default_query_execution.execution_mode=INTERPRETER --worker.query_engine.task_queue_size=100000 --worker.default_query_execution.join_strategy=${joinStrategy})
+            COMMAND systest -n 20 --workingDir=${CMAKE_CURRENT_BINARY_DIR}/interpreter_${joinStrategy} --exclude-groups large --data ${EXPANDED_TEST_DATA_PATH} -- --worker.default_query_execution.execution_mode=INTERPRETER --worker.default_query_execution.join_strategy=${joinStrategy})
 endforeach ()
 if (NOT CODE_COVERAGE)
     ExternalData_Add_Test(test-data
             NAME systest_compiler
-            COMMAND systest -n 20 --workingDir=${CMAKE_CURRENT_BINARY_DIR}/compiler --exclude-groups large --data ${EXPANDED_TEST_DATA_PATH} -- --worker.default_query_execution.execution_mode=COMPILER --worker.query_engine.task_queue_size=100000 --enable_google_eventTrace=true)
+            COMMAND systest -n 20 --workingDir=${CMAKE_CURRENT_BINARY_DIR}/compiler --exclude-groups large --data ${EXPANDED_TEST_DATA_PATH} -- --worker.default_query_execution.execution_mode=COMPILER --enable_google_eventTrace=true)
 endif (NOT CODE_COVERAGE)
 
 
@@ -106,18 +106,6 @@ endif ()
 
 
 if (NOT CODE_COVERAGE)
-    # We run all tests with some small and one large task queue size
-    # We set the number of worker threads to 8, to further stress the task queue
-    set(taskQueueSize 100 10000)
-    foreach (taskQueueSize IN LISTS taskQueueSize)
-        ExternalData_Add_Test(test-data
-                NAME systest_task_queue_size_${taskQueueSize}_interpreter
-                COMMAND systest -n 4 --exclude-groups large --workingDir=${CMAKE_CURRENT_BINARY_DIR}/${taskQueueSize}_interpreter --data ${EXPANDED_TEST_DATA_PATH} -- --worker.query_engine.number_of_worker_threads=4 --worker.default_query_execution.execution_mode=INTERPRETER --worker.number_of_buffers_in_global_buffer_manager=200000 --worker.query_engine.task_queue_size=${taskQueueSize})
-        ExternalData_Add_Test(test-data
-                NAME systest_task_queue_size_${taskQueueSize}_compiler
-                COMMAND systest -n 4 --exclude-groups large --workingDir=${CMAKE_CURRENT_BINARY_DIR}/${taskQueueSize}_compiler --data ${EXPANDED_TEST_DATA_PATH} -- --worker.query_engine.number_of_worker_threads=4 --worker.default_query_execution.execution_mode=COMPILER --worker.number_of_buffers_in_global_buffer_manager=200000 --worker.query_engine.task_queue_size=${taskQueueSize})
-    endforeach ()
-
     ## We run all join and aggregation tests with different no. worker threads and different join strategies
     set(workerThreads 1 2 4 8)
     set(joinStrategies NESTED_LOOP_JOIN HASH_JOIN)


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Catches out of order tuples instead of crashing at a later point in time.

## Issue Closed by this pull request:

This is part of the distributed upstreaming


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"engine-task-queue-improvmentengine-task-queue-improvmentsrt-stop-fix","parentHead":"928c377f8ed34c04481ddbc39e8fbf085d9c9e46","parentPull":1121,"trunk":"main"}
```
-->
