### PR TITLE
chore(Dependencies): adds libuuid

### DIFF
--- a/nes-common/CMakeLists.txt
+++ b/nes-common/CMakeLists.txt
@@ -65,7 +65,11 @@ find_package(magic_enum CONFIG REQUIRED)
 find_package(spdlog     CONFIG REQUIRED)
 find_package(yaml-cpp   CONFIG REQUIRED)
 find_package(folly      CONFIG REQUIRED)
-target_link_libraries(nes-common PUBLIC nes-grpc cpptrace::cpptrace fmt::fmt libcuckoo::libcuckoo magic_enum::magic_enum spdlog::spdlog yaml-cpp::yaml-cpp folly::folly)
+
+find_package(PkgConfig)
+pkg_check_modules(uuid REQUIRED IMPORTED_TARGET GLOBAL uuid)
+
+target_link_libraries(nes-common PUBLIC nes-grpc cpptrace::cpptrace fmt::fmt libcuckoo::libcuckoo magic_enum::magic_enum spdlog::spdlog yaml-cpp::yaml-cpp folly::folly PkgConfig::uuid)
 
 target_include_directories(nes-common PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/nes-common/include/Util/UUID.hpp
+++ b/nes-common/include/Util/UUID.hpp
@@ -1,0 +1,23 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+#include <cstddef>
+#include <string>
+
+namespace NES
+{
+constexpr size_t UUID_STRING_LENGTH = 36;
+std::string generateUUID();
+}

--- a/nes-common/src/Util/CMakeLists.txt
+++ b/nes-common/src/Util/CMakeLists.txt
@@ -15,5 +15,6 @@ add_source_files(nes-common
         DumpHelper.cpp
         Strings.cpp
         ThreadNaming.cpp
+        UUID.cpp
 )
 add_subdirectory(Logger)

--- a/nes-common/src/Util/UUID.cpp
+++ b/nes-common/src/Util/UUID.cpp
@@ -1,0 +1,29 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Util/UUID.hpp>
+
+#include <string>
+#include <uuid/uuid.h>
+
+std::string NES::generateUUID()
+{
+    uuid_t bytes;
+    std::string uuidString;
+    uuidString.resize(UUID_STRING_LENGTH);
+
+    uuid_generate(bytes);
+    uuid_unparse(bytes, uuidString.data());
+    return uuidString;
+}

--- a/nes-common/tests/Util/src/BaseIntegrationTest.cpp
+++ b/nes-common/tests/Util/src/BaseIntegrationTest.cpp
@@ -14,8 +14,6 @@
 
 #include <BaseIntegrationTest.hpp>
 
-#include <uuid/uuid.h>
-
 #include <filesystem>
 #include <ios>
 #include <random>
@@ -23,7 +21,7 @@
 #include <string>
 
 #include <Util/Logger/Logger.hpp>
-#include <BaseIntegrationTest.hpp>
+#include <Util/UUID.hpp>
 #include <BaseUnitTest.hpp>
 #include <ErrorHandling.hpp>
 
@@ -31,20 +29,8 @@
 #endif
 namespace NES::Testing
 {
-namespace detail::uuid
-{
 
-std::string generateUUID()
-{
-    uuid_t bytes;
-    std::array<char, 36 + 1> parsed;
-    uuid_generate(bytes);
-    uuid_unparse(bytes, parsed.data());
-    return std::string(parsed.data(), 36);
-}
-}
-
-BaseIntegrationTest::BaseIntegrationTest() : testResourcePath(std::filesystem::current_path() / detail::uuid::generateUUID())
+BaseIntegrationTest::BaseIntegrationTest() : testResourcePath(std::filesystem::current_path() / generateUUID())
 {
 }
 

--- a/vcpkg/vcpkg.json
+++ b/vcpkg/vcpkg.json
@@ -3,16 +3,14 @@
   "version-string": "latest",
   "homepage": "https://nebula.stream",
   "description": "Data Management for the Internet of Things.",
-
   "builtin-baseline": "16e7a3eb109cde6115b1b5126449dfdf72341dfb",
   "$comment": [
     "BEWARE: changing the baseline might change the expected ANTLR_VERSION",
-    "        supplied to cmake by the antlr4 dependency." ,
+    "        supplied to cmake by the antlr4 dependency.",
     "        This in turn requires changing the version of the antlr jar that",
     "        is fetched by cmake or baked into the dev docker image.",
     "        (c.f. nes-sql-parser/CMakeLists.txt)"
   ],
-
   "features": {
     "mlir": {
       "description": "nautilus mlir backend",
@@ -36,6 +34,7 @@
     "grpc",
     "gtest",
     "libcuckoo",
+    "libuuid",
     "magic-enum",
     "nlohmann-json",
     "nautilus",


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Adds libuuid to generate uuids securely

## Issue Closed by this pull request:

This is part of the distributed upstreaming

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"flakey-ci-image-builds","parentHead":"e39c2ea7e40945a82d907767afbb1efcbc11d719","parentPull":1134,"trunk":"main"}
```
-->
