### PR TITLE
feat(grpc): enable health service

### DIFF
--- a/docker/nebuli/Nebuli.dockerfile
+++ b/docker/nebuli/Nebuli.dockerfile
@@ -13,13 +13,17 @@ RUN cd /home/ubuntu/src \
 # the binary is linked against libc++, thus we install it
 FROM ubuntu:24.04 AS app
 ENV LLVM_TOOLCHAIN_VERSION=19
-RUN apt update -y && apt install curl gpg -y
+RUN apt update -y && apt install wget curl gpg -y
 RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/keyrings/llvm-snapshot.gpg \
     && chmod a+r /etc/apt/keyrings/llvm-snapshot.gpg \
     && echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/"$(. /etc/os-release && echo "$VERSION_CODENAME")"/ llvm-toolchain-"$(. /etc/os-release && echo "$VERSION_CODENAME")"-${LLVM_TOOLCHAIN_VERSION} main" > /etc/apt/sources.list.d/llvm-snapshot.list \
     && echo "deb-src [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/"$(. /etc/os-release && echo "$VERSION_CODENAME")"/ llvm-toolchain-"$(. /etc/os-release && echo "$VERSION_CODENAME")"-${LLVM_TOOLCHAIN_VERSION} main" >> /etc/apt/sources.list.d/llvm-snapshot.list \
     && apt update -y \
     && apt install -y libc++1-${LLVM_TOOLCHAIN_VERSION} libc++abi1-${LLVM_TOOLCHAIN_VERSION}
+
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.40 && \
+    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+    chmod +x /bin/grpc_health_probe
 
 COPY --from=build /tmp/bin /usr/bin
 ENTRYPOINT ["nes-nebuli"]

--- a/docker/single-node-worker/SingleNodeWorker.dockerfile
+++ b/docker/single-node-worker/SingleNodeWorker.dockerfile
@@ -13,13 +13,17 @@ RUN cd /home/ubuntu/src \
 # the binary is linked against libc++, thus we install it
 FROM ubuntu:24.04 AS app
 ENV LLVM_TOOLCHAIN_VERSION=19
-RUN apt update -y && apt install curl gpg -y
+RUN apt update -y && apt install curl wget gpg -y
 RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/keyrings/llvm-snapshot.gpg \
     && chmod a+r /etc/apt/keyrings/llvm-snapshot.gpg \
     && echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/"$(. /etc/os-release && echo "$VERSION_CODENAME")"/ llvm-toolchain-"$(. /etc/os-release && echo "$VERSION_CODENAME")"-${LLVM_TOOLCHAIN_VERSION} main" > /etc/apt/sources.list.d/llvm-snapshot.list \
     && echo "deb-src [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/"$(. /etc/os-release && echo "$VERSION_CODENAME")"/ llvm-toolchain-"$(. /etc/os-release && echo "$VERSION_CODENAME")"-${LLVM_TOOLCHAIN_VERSION} main" >> /etc/apt/sources.list.d/llvm-snapshot.list \
     && apt update -y \
     && apt install -y libc++1-${LLVM_TOOLCHAIN_VERSION} libc++abi1-${LLVM_TOOLCHAIN_VERSION}
+
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.40 && \
+    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+    chmod +x /bin/grpc_health_probe
 
 COPY --from=build /tmp/bin /usr/bin
 ENTRYPOINT ["nes-single-node-worker"]

--- a/nes-single-node-worker/src/SingleNodeWorkerStarter.cpp
+++ b/nes-single-node-worker/src/SingleNodeWorkerStarter.cpp
@@ -77,6 +77,7 @@ int main(const int argc, const char* argv[])
             builder.SetMaxMessageSize(-1);
             builder.AddListeningPort(configuration->grpcAddressUri, grpc::InsecureServerCredentials());
             builder.RegisterService(&workerService);
+            grpc::EnableDefaultHealthCheckService(true);
 
             const auto server = builder.BuildAndStart();
             const auto hook = shutdownHook(*server);


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This commit enables the grpc health service, which is provided by grpc out of the box. The health service exposes a grpc endpoint that can be queried to detect if the worker is running. 
This commit installs the `grpc-health-probe` into the single-node-worker and nebuli docker images. The probe can be used to specify a running condition in docker-compose or kubernetes.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"adds-libuuid","parentHead":"98a72d2789342e6d2f12d07f52b4baec41e09cfc","parentPull":1126,"trunk":"main"}
```
-->
