### PR TITLE
refactor(Sources): Dedicated Type for FillTupleBufferResult

### DIFF
--- a/nes-plugins/Sources/GeneratorSource/GeneratorSource.cpp
+++ b/nes-plugins/Sources/GeneratorSource/GeneratorSource.cpp
@@ -26,6 +26,7 @@
 #include <unordered_map>
 #include <utility>
 #include <Configurations/Descriptor.hpp>
+#include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
 #include <Sources/Source.hpp>
 #include <Sources/SourceDescriptor.hpp>
@@ -67,7 +68,7 @@ GeneratorSource::GeneratorSource(const SourceDescriptor& sourceDescriptor)
     }
 }
 
-void GeneratorSource::open()
+void GeneratorSource::open(std::shared_ptr<AbstractBufferProvider>)
 {
     this->generatorStartTime = std::chrono::system_clock::now();
     this->startOfInterval = std::chrono::system_clock::now();

--- a/nes-plugins/Sources/GeneratorSource/GeneratorSource.hpp
+++ b/nes-plugins/Sources/GeneratorSource/GeneratorSource.hpp
@@ -61,7 +61,7 @@ public:
 
     [[nodiscard]] std::ostream& toString(std::ostream& str) const override;
 
-    void open() override;
+    void open(std::shared_ptr<AbstractBufferProvider> bufferProvider) override;
     void close() override;
 
     static DescriptorConfig::Config validateAndFormat(std::unordered_map<std::string, std::string> config);

--- a/nes-plugins/Sources/TCPSource/TCPSource.cpp
+++ b/nes-plugins/Sources/TCPSource/TCPSource.cpp
@@ -162,7 +162,7 @@ bool TCPSource::tryToConnect(const addrinfo* result, const int flags)
     return true;
 }
 
-void TCPSource::open()
+void TCPSource::open(std::shared_ptr<AbstractBufferProvider>)
 {
     NES_TRACE("TCPSource::open: Trying to create socket and connect.");
 

--- a/nes-plugins/Sources/TCPSource/TCPSource.hpp
+++ b/nes-plugins/Sources/TCPSource/TCPSource.hpp
@@ -182,7 +182,7 @@ public:
     FillTupleBufferResult fillTupleBuffer(TupleBuffer& tupleBuffer, const std::stop_token& stopToken) override;
 
     /// Open TCP connection.
-    void open() override;
+    void open(std::shared_ptr<AbstractBufferProvider> bufferProvider) override;
     /// Close TCP connection.
     void close() override;
 

--- a/nes-sources/include/Sources/Source.hpp
+++ b/nes-sources/include/Sources/Source.hpp
@@ -19,6 +19,7 @@
 #include <ostream>
 #include <stop_token>
 #include <variant>
+#include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
 #include <Util/Logger/Formatter.hpp>
 
@@ -65,7 +66,7 @@ public:
     virtual FillTupleBufferResult fillTupleBuffer(TupleBuffer& tupleBuffer, const std::stop_token& stopToken) = 0;
 
     /// If applicable, opens a connection, e.g., a socket connection to get ready for data consumption.
-    virtual void open() = 0;
+    virtual void open(std::shared_ptr<AbstractBufferProvider> bufferProvider) = 0;
     /// If applicable, closes a connection, e.g., a socket connection.
     virtual void close() = 0;
 

--- a/nes-sources/private/FileSource.hpp
+++ b/nes-sources/private/FileSource.hpp
@@ -49,7 +49,7 @@ public:
     FillTupleBufferResult fillTupleBuffer(TupleBuffer& tupleBuffer, const std::stop_token& stopToken) override;
 
     /// Open file socket.
-    void open() override;
+    void open(std::shared_ptr<AbstractBufferProvider> bufferProvider) override;
     /// Close file socket.
     void close() override;
 

--- a/nes-sources/src/FileSource.cpp
+++ b/nes-sources/src/FileSource.cpp
@@ -28,6 +28,7 @@
 #include <unordered_map>
 #include <utility>
 #include <Configurations/Descriptor.hpp>
+#include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
 #include <Sources/Source.hpp>
 #include <Sources/SourceDescriptor.hpp>
@@ -44,7 +45,7 @@ FileSource::FileSource(const SourceDescriptor& sourceDescriptor) : filePath(sour
 {
 }
 
-void FileSource::open()
+void FileSource::open(std::shared_ptr<AbstractBufferProvider>)
 {
     const auto realCSVPath = std::unique_ptr<char, decltype(std::free)*>{realpath(this->filePath.c_str(), nullptr), std::free};
     this->inputFile = std::ifstream(realCSVPath.get(), std::ios::binary);

--- a/nes-sources/src/SourceThread.cpp
+++ b/nes-sources/src/SourceThread.cpp
@@ -82,7 +82,10 @@ void threadSetup(OriginId originId)
 /// RAII-Wrapper around source open and close
 struct SourceHandle
 {
-    explicit SourceHandle(Source& source) : source(source) { source.open(); }
+    explicit SourceHandle(Source& source, std::shared_ptr<AbstractBufferProvider> bufferProvider) : source(source)
+    {
+        source.open(std::move(bufferProvider));
+    }
 
     SourceHandle(const SourceHandle& other) = delete;
     SourceHandle(SourceHandle&& other) noexcept = delete;
@@ -105,10 +108,10 @@ struct SourceHandle
     Source& source; ///NOLINT Source handle should never outlive the source
 };
 
-SourceImplementationTermination
-dataSourceThreadRoutine(const std::stop_token& stopToken, Source& source, AbstractBufferProvider& bufferProvider, const EmitFn& emit)
+SourceImplementationTermination dataSourceThreadRoutine(
+    const std::stop_token& stopToken, Source& source, std::shared_ptr<AbstractBufferProvider> bufferProvider, const EmitFn& emit)
 {
-    const SourceHandle sourceHandle(source);
+    const SourceHandle sourceHandle(source, bufferProvider);
     const bool requiresMetadata = !source.addsMetadata();
     while (!stopToken.stop_requested())
     {
@@ -120,7 +123,7 @@ dataSourceThreadRoutine(const std::stop_token& stopToken, Source& source, Abstra
         ///    The thread exits with `EndOfStream`
         /// 4. Failure. The fillTupleBuffer method will throw an exception, the exception is propagted to the SourceThread via the return promise.
         ///    The thread exists with an exception
-        auto emptyBuffer = bufferProvider.getBufferBlocking();
+        auto emptyBuffer = bufferProvider->getBufferBlocking();
         const auto fillTupleResult = source.fillTupleBuffer(emptyBuffer, stopToken);
 
         if (!fillTupleResult.isEoS())
@@ -166,7 +169,7 @@ void dataSourceThread(
 
     try
     {
-        result.set_value_at_thread_exit(dataSourceThreadRoutine(stopToken, *source, *bufferProvider, dataEmit));
+        result.set_value_at_thread_exit(dataSourceThreadRoutine(stopToken, *source, std::move(bufferProvider), dataEmit));
         if (!stopToken.stop_requested())
         {
             emit(originId, SourceReturnType::EoS{}, stopToken);

--- a/nes-sources/tests/Util/TestSource.cpp
+++ b/nes-sources/tests/Util/TestSource.cpp
@@ -194,7 +194,7 @@ NES::Source::FillTupleBufferResult NES::TestSource::fillTupleBuffer(NES::TupleBu
     return FillTupleBufferResult::withBytes(data->data.size());
 }
 
-void NES::TestSource::open()
+void NES::TestSource::open(std::shared_ptr<AbstractBufferProvider>)
 {
     control->open.set_value();
     if (control->fail_during_open)

--- a/nes-sources/tests/Util/TestSource.hpp
+++ b/nes-sources/tests/Util/TestSource.hpp
@@ -96,7 +96,7 @@ class TestSource : public Source
 {
 public:
     FillTupleBufferResult fillTupleBuffer(TupleBuffer& tupleBuffer, const std::stop_token& stopToken) override;
-    void open() override;
+    void open(std::shared_ptr<AbstractBufferProvider>) override;
     void close() override;
 
 protected:


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

This commit adds a switch that allows source implementation to
provide their own buffer metadata and prevents the source thread
from overwriting the metadata.

This is required for the network source as buffers received
from a different node will already have metadata

Currently, it is impossible for sources to allocate
child buffers. The distributed branches NetworkSource
need to allocate child buffers.

This PR closes #<issue number>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces raw size returns with `FillTupleBufferResult` and changes `open` to accept a buffer provider, updating `SourceThread`, Generator/TCP/File sources, and tests with EoS handling and metadata control.
> 
> - **Core API (`Sources/Source.hpp`)**:
>   - Add `FillTupleBufferResult` (with `eos()`/`withBytes()`), replacing `size_t` return from `fillTupleBuffer`.
>   - Change `open()` signature to `open(std::shared_ptr<AbstractBufferProvider>)`.
>   - Add `addsMetadata()` hook (default `false`).
> - **Runtime (`src/SourceThread.cpp`)**:
>   - Pass buffer provider to `source.open(...)`; manage via RAII `SourceHandle`.
>   - Handle `FillTupleBufferResult` and EoS; set bytes via `getNumberOfBytes()`.
>   - Respect `addsMetadata()` to avoid overwriting source-provided metadata.
>   - Minor logging/message cleanup and `EmitFn` now moves `TupleBuffer`.
> - **Sources**:
>   - `GeneratorSource`, `TCPSource`, `FileSource`:
>     - Update includes, `open(...)` signature, and `fillTupleBuffer` to return `FillTupleBufferResult` with EoS handling.
>     - Minor logging/flow adjustments (e.g., early EoS on stop/empty reads).
> - **Tests (`tests/Util/TestSource.*`)**:
>   - Adapt `TestSource` to new `open(...)` and `FillTupleBufferResult` API with EoS paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68ffdaee556c9ed347f18fc72e905f32f8bff40b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
