### PR TITLE
feat(Runtime): adds BackpressureChannel between sources and sinks

### DIFF
--- a/nes-executable/include/BackpressureChannel.hpp
+++ b/nes-executable/include/BackpressureChannel.hpp
@@ -1,0 +1,69 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <memory>
+#include <stop_token>
+#include <utility>
+
+struct Channel;
+class Ingestion;
+class Valve;
+
+/// This is the entrypoint to a backpressure channel. It creates a pair of connected Valve and Ingestion.
+/// A Valve controls the Backpressure and an Ingestion only allows further progress if there is no backpressure.
+/// In NebulaStream a Valve is owned by exactly one sink, which controls all the Ingestion of all sources within the same query plan.
+/// Currently, the Backpressure channel enforces the invariant that sinks always outlive sources. Thus, if a Valve is destroyed, all
+/// connected Ingestions that are still alive and in use will report an assertion failure.
+std::pair<Valve, Ingestion> Backpressure();
+
+/// A Valve is the exclusive controller of a backpressure channel. It allows the user to apply and release backpressure, which blocks
+/// or unblocks all connected Ingestions.
+class Valve
+{
+    explicit Valve(std::shared_ptr<Channel> channel);
+
+    std::shared_ptr<Channel> channel;
+    friend std::pair<Valve, Ingestion> Backpressure();
+
+public:
+    ~Valve();
+
+    /// Currently, a valve represents unique ownership over the backpressure channel, thus copying is not enabled.
+    Valve(const Valve& other) = delete;
+    Valve& operator=(const Valve& other) = delete;
+
+    /// Default moves leaves channel in an empty state which prevents unintended destruction of the underlying channel
+    Valve(Valve&& other) noexcept = default;
+    Valve& operator=(Valve&& other) noexcept = default;
+
+    bool applyPressure();
+    bool releasePressure();
+};
+
+/// Listener of the backpressure channel is the Ingestion type that is used by sources.
+/// Before initiating a read of a new buffer, the source can if backpressure has been requested by a sink with a call to `wait`.
+/// This will cause the thread to block on the call if backpressure has been applied, until pressure is released by a sink, in which case
+/// the thread will be notified via the condition_variable in the channel.
+class Ingestion
+{
+    explicit Ingestion(std::shared_ptr<Channel> channel) : channel(std::move(channel)) { }
+
+    friend std::pair<Valve, Ingestion> Backpressure();
+    std::shared_ptr<Channel> channel;
+
+public:
+    void wait(const std::stop_token& stopToken) const;
+};

--- a/nes-executable/src/BackpressureChannel.cpp
+++ b/nes-executable/src/BackpressureChannel.cpp
@@ -1,0 +1,104 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <BackpressureChannel.hpp>
+
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <stop_token>
+#include <utility>
+
+#include <folly/Synchronized.h>
+
+#include <ErrorHandling.hpp>
+
+/// Represents the state of the backpressure channel guarded by a mutex and communicated to the listener via the condition variable.
+/// The channel is initially open.
+struct Channel
+{
+    enum State : uint8_t
+    {
+        OPEN,
+        CLOSED,
+        DESTROYED,
+    };
+
+    folly::Synchronized<State, std::mutex> stateMtx{OPEN};
+    std::condition_variable_any change;
+};
+
+Valve::Valve(std::shared_ptr<Channel> channel) : channel{std::move(channel)}
+{
+}
+
+Valve::~Valve()
+{
+    if (channel)
+    {
+        *channel->stateMtx.lock() = Channel::DESTROYED;
+        channel->change.notify_all();
+    }
+}
+
+bool Valve::applyPressure()
+{
+    const auto old = std::exchange(*channel->stateMtx.lock(), Channel::CLOSED);
+    INVARIANT(old != Channel::DESTROYED, "The valve is still alive thus the channel should not have been destroyed");
+    return old == Channel::OPEN;
+}
+
+bool Valve::releasePressure()
+{
+    const auto old = std::exchange(*channel->stateMtx.lock(), Channel::OPEN);
+    INVARIANT(old != Channel::DESTROYED, "The valve is still alive thus the channel should not have been destroyed");
+    if (old == Channel::CLOSED)
+    {
+        /// The Valve was opened, wake up all waiting Ingestions
+        channel->change.notify_all();
+        return true;
+    }
+    return false;
+}
+
+void Ingestion::wait(const std::stop_token& stopToken) const
+{
+    auto state = channel->stateMtx.lock();
+    /// If the channel is open, ingestion can proceed
+    if (*state == Channel::State::OPEN)
+    {
+        return;
+    }
+
+    bool destroyed = false;
+    /// Wait for the channel state to change
+    channel->change.wait(
+        state.as_lock(),
+        stopToken,
+        [&destroyed, &state] -> bool
+        {
+            destroyed = *state == Channel::DESTROYED;
+            return destroyed || *state == Channel::OPEN;
+        });
+
+    INVARIANT(!destroyed, "Valve was destroyed before the Ingestion");
+}
+
+std::pair<Valve, Ingestion> Backpressure()
+{
+    const auto channel = std::make_shared<Channel>();
+    return {Valve{channel}, Ingestion{channel}};
+}

--- a/nes-executable/src/CMakeLists.txt
+++ b/nes-executable/src/CMakeLists.txt
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 add_source_files(nes-executable
+        BackpressureChannel.cpp
         CompiledQueryPlan.cpp
         Pipeline.cpp
 )

--- a/nes-executable/tests/BackpressureChannelTest.cpp
+++ b/nes-executable/tests/BackpressureChannelTest.cpp
@@ -1,0 +1,336 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <BackpressureChannel.hpp>
+
+#include <atomic>
+#include <barrier>
+#include <chrono>
+#include <memory>
+#include <random>
+#include <stop_token>
+#include <thread>
+#include <utility>
+#include <vector>
+#include <Util/Logger/LogLevel.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <gtest/gtest.h>
+#include <BaseUnitTest.hpp>
+
+namespace NES
+{
+
+class BackpressureChannelTest : public ::testing::Test
+{
+protected:
+    void SetUp() override { Logger::setupLogging("BackpressureChannelTest.log", NES::LogLevel::LOG_DEBUG); }
+};
+
+/// Test basic construction and destruction of Valve and Ingestion
+TEST_F(BackpressureChannelTest, BasicConstruction)
+{
+    /// Test that we can create a backpressure channel
+    auto [valve, ingestion] = Backpressure();
+
+    /// Test that the objects are functional by using their public methods
+    /// Initially, the channel should be open (no backpressure)
+    EXPECT_TRUE(valve.applyPressure()); /// Should return true (was open)
+    EXPECT_TRUE(valve.releasePressure()); /// Should return true (was closed)
+}
+
+/// Test basic functionality with 1 valve and 1 ingestion
+TEST_F(BackpressureChannelTest, BasicFunctionality)
+{
+    auto [valve, ingestion] = Backpressure();
+
+    /// Initially, the channel should be open (no backpressure)
+    /// We can't directly test the internal state, but we can test the behavior
+
+    /// Apply pressure - should return true (was open)
+    EXPECT_TRUE(valve.applyPressure());
+
+    /// Apply pressure again - should return false (was already closed)
+    EXPECT_FALSE(valve.applyPressure());
+
+    /// Release pressure - should return true (was closed)
+    EXPECT_TRUE(valve.releasePressure());
+
+    /// Release pressure again - should return false (was already open)
+    EXPECT_FALSE(valve.releasePressure());
+}
+
+/// Test that ingestion proceeds immediately when no pressure is applied
+TEST_F(BackpressureChannelTest, IngestionProceedsWhenNoPressure)
+{
+    std::barrier syncBarrier{2};
+    std::atomic ingestionCounter{0};
+
+    auto [valve, ingestion] = Backpressure();
+
+    /// Start ingestion without applying pressure
+    std::jthread ingestionThread(
+        [&](const std::stop_token& stopToken)
+        {
+            syncBarrier.arrive_and_wait();
+            while (!stopToken.stop_requested())
+            {
+                ingestion.wait(stopToken);
+                ingestionCounter.fetch_add(1, std::memory_order::relaxed);
+            }
+        });
+
+    syncBarrier.arrive_and_wait();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    ingestionThread = {};
+
+    /// This is a guess, however 100 sounds very doable on any real hardware
+    EXPECT_GT(ingestionCounter.load(), 100);
+}
+
+/// Test that ingestion is blocked when pressure is applied
+TEST_F(BackpressureChannelTest, IngestionProceedsWithPressure)
+{
+    std::barrier syncBarrier{2};
+    std::atomic ingestionCounter{0};
+
+    auto [valve, ingestion] = Backpressure();
+
+    /// Start ingestion without applying pressure
+    std::jthread ingestionThread(
+        [&](const std::stop_token& stopToken)
+        {
+            syncBarrier.arrive_and_wait();
+            while (!stopToken.stop_requested())
+            {
+                ingestion.wait(stopToken);
+                ingestionCounter.fetch_add(1, std::memory_order::relaxed);
+            }
+        });
+
+    syncBarrier.arrive_and_wait();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    /// This is a guess, however 100 sounds very doable on any real hardware
+    EXPECT_GT(ingestionCounter.load(), 100);
+    EXPECT_TRUE(valve.applyPressure());
+
+    /// Expect that the ingestion does not increase any further after pressure has been applied
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    const auto current = ingestionCounter.load();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    EXPECT_EQ(current, ingestionCounter.load());
+}
+
+/// Test that ingestion waits when pressure is applied
+TEST_F(BackpressureChannelTest, IngestionWaitsWhenPressureApplied)
+{
+    constexpr size_t numberOfSources = 5;
+    /// Read on main thread only happens after the ingestionThreads have been stopped.
+    std::vector<std::chrono::milliseconds> durations(numberOfSources);
+
+    std::barrier syncBeforeWait{numberOfSources + 1};
+    std::barrier syncAfterWait{numberOfSources + 1};
+
+    auto [valve, ingestion] = Backpressure();
+
+    /// Apply pressure before starting ingestion
+    valve.applyPressure();
+
+    std::vector<std::jthread> ingestionThreads;
+    ingestionThreads.reserve(numberOfSources);
+    for (size_t i = 0; i < numberOfSources; ++i)
+    {
+        /// Start a thread that will try to ingest
+        ingestionThreads.emplace_back(
+            [&, i](const std::stop_token& stopToken)
+            {
+                syncBeforeWait.arrive_and_wait();
+                auto start = std::chrono::steady_clock::now();
+
+                /// This should block until pressure is released
+                ingestion.wait(stopToken);
+
+                auto end = std::chrono::steady_clock::now();
+
+                syncAfterWait.arrive_and_wait();
+
+                /// Report time spend waiting
+                durations[i] = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+            });
+    }
+    syncBeforeWait.arrive_and_wait();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    /// Release pressure
+    EXPECT_TRUE(valve.releasePressure());
+    syncAfterWait.arrive_and_wait();
+
+    /// Stop thread to ensure that there is no data race on duration
+    ingestionThreads.clear();
+
+    /// Expect time to have passed while waiting for backpressure release. This is a guess, we cannot predict an actual duration
+    for (auto duration : durations)
+    {
+        EXPECT_GT(duration, std::chrono::milliseconds(50));
+    }
+}
+
+/// Stress test with multiple valves and ingestions in a multithreaded environment
+TEST_F(BackpressureChannelTest, MultithreadedStressTest)
+{
+    constexpr int numChannels = 10;
+    constexpr int numIngestionsPerChannel = 5;
+    constexpr int testDurationMs = 1000;
+
+    std::vector<std::pair<Valve, Ingestion>> channels;
+    channels.reserve(numChannels);
+
+    /// Create multiple backpressure channels
+    for (int i = 0; i < numChannels; ++i)
+    {
+        channels.emplace_back(Backpressure());
+    }
+
+    std::atomic totalOperations{0};
+    std::atomic successfulWaits{0};
+
+    /// Barrier to synchronize all threads
+    std::barrier syncBarrier{1 + (numChannels * numIngestionsPerChannel) + numChannels};
+
+    /// Start ingestion threads
+    std::vector<std::jthread> ingestionThreads;
+    for (int channelId = 0; channelId < numChannels; ++channelId)
+    {
+        for (int ingestionId = 0; ingestionId < numIngestionsPerChannel; ++ingestionId)
+        {
+            ingestionThreads.emplace_back(
+                [&, channelId](const std::stop_token& stopToken)
+                {
+                    syncBarrier.arrive_and_wait();
+
+                    while (!stopToken.stop_requested())
+                    {
+                        channels[channelId].second.wait(stopToken);
+                        successfulWaits.fetch_add(1);
+                    }
+                });
+        }
+    }
+
+    /// Start valve operation threads
+    std::vector<std::jthread> valveThreads;
+    valveThreads.reserve(numChannels);
+    for (int channelId = 0; channelId < numChannels; ++channelId)
+    {
+        valveThreads.emplace_back(
+            [&, channelId](const std::stop_token& stopToken)
+            {
+                syncBarrier.arrive_and_wait();
+
+                std::mt19937 rng(channelId);
+                std::uniform_int_distribution<> dist(0, 1);
+
+                while (!stopToken.stop_requested())
+                {
+                    if (dist(rng) == 0)
+                    {
+                        channels[channelId].first.applyPressure();
+                    }
+                    else
+                    {
+                        channels[channelId].first.releasePressure();
+                    }
+
+                    totalOperations.fetch_add(1);
+                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                }
+            });
+    }
+
+
+    /// Run the test for the specified duration
+    syncBarrier.arrive_and_wait();
+    std::this_thread::sleep_for(std::chrono::milliseconds(testDurationMs));
+    ingestionThreads.clear();
+    valveThreads.clear();
+
+    /// Verify we had some activity
+    EXPECT_GT(totalOperations.load(), 0);
+    EXPECT_GT(successfulWaits.load(), 0);
+
+    /// All channels should still be functional
+    for (int i = 0; i < numChannels; ++i)
+    {
+        channels[i].first.applyPressure();
+        EXPECT_TRUE(channels[i].first.releasePressure());
+    }
+}
+
+/// Test valve destruction behavior
+TEST_F(BackpressureChannelTest, ValveDestruction)
+{
+    SKIP_IF_TSAN();
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+
+    auto [valve, ingestion] = Backpressure();
+
+    /// Apply pressure
+    EXPECT_TRUE(valve.applyPressure());
+
+    std::barrier syncBarrier{2};
+
+    /// Valve Thread keeps valve alive until barrier is reached
+    const std::jthread ingestionThread(
+        [&, valve = std::move(valve)]
+        {
+            syncBarrier.arrive_and_wait();
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        });
+
+    syncBarrier.arrive_and_wait();
+    EXPECT_DEATH_DEBUG(ingestion.wait({}), "");
+}
+
+/// Test stop token functionality
+TEST_F(BackpressureChannelTest, StopTokenFunctionality)
+{
+    auto [valve, ingestion] = Backpressure();
+
+    /// Apply pressure
+    EXPECT_TRUE(valve.applyPressure());
+
+    std::atomic ingestionStarted{false};
+    std::atomic ingestionStopped{false};
+
+    /// Start ingestion thread
+    std::jthread ingestionThread(
+        [&](const std::stop_token& stopToken)
+        {
+            ingestionStarted = true;
+            ingestion.wait(stopToken);
+            ingestionStopped = true;
+        });
+
+    /// Wait for ingestion to start
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    EXPECT_TRUE(ingestionStarted);
+    EXPECT_FALSE(ingestionStopped);
+
+    /// Stop thread, should trigger stop token
+    ingestionThread = {};
+    EXPECT_TRUE(ingestionStopped);
+    EXPECT_TRUE(valve.releasePressure());
+}
+
+}

--- a/nes-executable/tests/CMakeLists.txt
+++ b/nes-executable/tests/CMakeLists.txt
@@ -14,3 +14,7 @@ add_library(nes-executable-test-utils TestUtils/TestTaskQueue.cpp)
 target_include_directories(nes-executable-test-utils PUBLIC TestUtils)
 target_link_libraries(nes-executable-test-utils PUBLIC nes-executable nes-memory nes-runtime nes-configurations)
 
+add_executable(backpressure-channel-test BackpressureChannelTest.cpp)
+target_include_directories(backpressure-channel-test PRIVATE ${CMAKE_SOURCE_DIR}/nes-common/tests/Util/include)
+target_link_libraries(backpressure-channel-test PRIVATE nes-executable nes-common GTest::gtest GTest::gtest_main)
+

--- a/nes-input-formatters/tests/UnitTests/SmallFilesTest.cpp
+++ b/nes-input-formatters/tests/UnitTests/SmallFilesTest.cpp
@@ -207,7 +207,7 @@ public:
         std::shared_ptr<BufferManager> sourceBufferPool = BufferManager::create(testConfig.sizeOfRawBuffers, numberOfRequiredSourceBuffers);
 
         /// TODO #774: Sources sometimes need an extra buffer (reason currently unknown)
-        const auto fileSource = InputFormatterTestUtil::createFileSource(
+        const auto [value, fileSource] = InputFormatterTestUtil::createFileSource(
             sourceCatalog, testFilePath, schema, std::move(sourceBufferPool), numberOfRequiredSourceBuffers);
         fileSource->start(InputFormatterTestUtil::getEmitFunction(rawBuffers));
         rawBuffers.waitForSize(numberOfExpectedRawBuffers);

--- a/nes-input-formatters/tests/Util/InputFormatterTestUtil.cpp
+++ b/nes-input-formatters/tests/Util/InputFormatterTestUtil.cpp
@@ -47,6 +47,7 @@
 #include <Util/Logger/Logger.hpp>
 #include <Util/Overloaded.hpp>
 #include <fmt/format.h>
+#include <BackpressureChannel.hpp>
 #include <ErrorHandling.hpp>
 #include <TestTaskQueue.hpp>
 
@@ -162,7 +163,7 @@ ParserConfig validateAndFormatParserConfig(const std::unordered_map<std::string,
     return validParserConfig;
 }
 
-std::unique_ptr<SourceHandle> createFileSource(
+std::pair<Valve, std::unique_ptr<SourceHandle>> createFileSource(
     SourceCatalog& sourceCatalog,
     const std::string& filePath,
     const Schema& schema,
@@ -176,9 +177,9 @@ std::unique_ptr<SourceHandle> createFileSource(
     const auto sourceDescriptor
         = sourceCatalog.addPhysicalSource(logicalSource.value(), "File", std::move(fileSourceConfiguration), ParserConfig{});
     INVARIANT(sourceDescriptor.has_value(), "Test File Source couldn't be created");
-
+    auto [valve, ingestion] = Backpressure();
     const SourceProvider sourceProvider(numberOfRequiredSourceBuffers, std::move(sourceBufferPool));
-    return sourceProvider.lower(NES::OriginId(1), sourceDescriptor.value());
+    return {std::move(valve), sourceProvider.lower(NES::OriginId(1), ingestion, sourceDescriptor.value())};
 }
 
 std::shared_ptr<InputFormatterTaskPipeline> createInputFormatterTask(const Schema& schema, std::string formatterType)

--- a/nes-input-formatters/tests/Util/InputFormatterTestUtil.hpp
+++ b/nes-input-formatters/tests/Util/InputFormatterTestUtil.hpp
@@ -147,7 +147,7 @@ SourceReturnType::EmitFunction getEmitFunction(ThreadSafeVector<TupleBuffer>& re
 
 ParserConfig validateAndFormatParserConfig(const std::unordered_map<std::string, std::string>& parserConfig);
 
-std::unique_ptr<SourceHandle> createFileSource(
+std::pair<Valve, std::unique_ptr<SourceHandle>> createFileSource(
     SourceCatalog& sourceCatalog,
     const std::string& filePath,
     const Schema& schema,

--- a/nes-plugins/Sinks/ChecksumSink/ChecksumSink.cpp
+++ b/nes-plugins/Sinks/ChecksumSink/ChecksumSink.cpp
@@ -36,8 +36,9 @@
 namespace NES
 {
 
-ChecksumSink::ChecksumSink(const SinkDescriptor& sinkDescriptor)
-    : isOpen(false)
+ChecksumSink::ChecksumSink(Valve valve, const SinkDescriptor& sinkDescriptor)
+    : Sink(std::move(valve))
+    , isOpen(false)
     , outputFilePath(sinkDescriptor.getFromConfig(SinkDescriptor::FILE_PATH))
     , formatter(std::make_unique<CSVFormat>(*sinkDescriptor.getSchema(), true))
 {
@@ -100,7 +101,7 @@ SinkValidationRegistryReturnType RegisterChecksumSinkValidation(SinkValidationRe
 
 SinkRegistryReturnType RegisterChecksumSink(SinkRegistryArguments sinkRegistryArguments)
 {
-    return std::make_unique<ChecksumSink>(sinkRegistryArguments.sinkDescriptor);
+    return std::make_unique<ChecksumSink>(std::move(sinkRegistryArguments.valve), sinkRegistryArguments.sinkDescriptor);
 }
 
 }

--- a/nes-plugins/Sinks/ChecksumSink/ChecksumSink.hpp
+++ b/nes-plugins/Sinks/ChecksumSink/ChecksumSink.hpp
@@ -42,7 +42,7 @@ class ChecksumSink : public Sink
 {
 public:
     static constexpr std::string_view NAME = "Checksum";
-    explicit ChecksumSink(const SinkDescriptor& sinkDescriptor);
+    explicit ChecksumSink(Valve valve, const SinkDescriptor& sinkDescriptor);
 
     /// Opens file and writes schema to file, if the file is empty.
     void start(PipelineExecutionContext&) override;

--- a/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.cpp
+++ b/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.cpp
@@ -129,9 +129,9 @@ std::ostream& TestSink::toString(std::ostream& os) const
 }
 
 std::tuple<std::shared_ptr<ExecutablePipeline>, std::shared_ptr<TestSinkController>>
-createSinkPipeline(PipelineId id, std::shared_ptr<AbstractBufferProvider> bm)
+createSinkPipeline(PipelineId id, Valve valve, std::shared_ptr<AbstractBufferProvider> bm)
 {
-    auto sinkController = std::make_shared<TestSinkController>();
+    auto sinkController = std::make_shared<TestSinkController>(std::move(valve));
     auto stage = std::make_unique<TestSink>(std::move(bm), sinkController);
     auto pipeline = ExecutablePipeline::create(id, std::move(stage), {});
     return {pipeline, sinkController};
@@ -197,6 +197,8 @@ QueryPlanBuilder::TestPlanCtrl QueryPlanBuilder::build(QueryId queryId, std::sha
     std::unordered_map<identifier_t, std::shared_ptr<TestSinkController>> sinkCtrls;
     std::unordered_map<identifier_t, std::shared_ptr<TestPipelineController>> pipelineCtrls;
     std::unordered_map<identifier_t, std::shared_ptr<ExecutablePipeline>> cache{};
+
+    auto [valve, ingestion] = Backpressure();
     std::function<std::shared_ptr<ExecutablePipeline>(identifier_t)> getOrCreatePipeline = [&](identifier_t identifier)
     {
         if (auto it = cache.find(identifier); it != cache.end())
@@ -213,7 +215,7 @@ QueryPlanBuilder::TestPlanCtrl QueryPlanBuilder::build(QueryId queryId, std::sha
                 },
                 [&](SinkDescriptor descriptor) -> std::shared_ptr<ExecutablePipeline>
                 {
-                    auto [sink, ctrl] = createSinkPipeline(descriptor.pipelineId, bm);
+                    auto [sink, ctrl] = createSinkPipeline(descriptor.pipelineId, std::move(valve), bm);
                     pipelines.push_back(sink);
                     stages[identifier] = sink->stage.get();
                     sinkCtrls[identifier] = ctrl;
@@ -241,7 +243,7 @@ QueryPlanBuilder::TestPlanCtrl QueryPlanBuilder::build(QueryId queryId, std::sha
     {
         std::vector<std::weak_ptr<ExecutablePipeline>> successors;
         std::ranges::transform(forwardRelations.at(source.first), std::back_inserter(successors), getOrCreatePipeline);
-        auto [s, ctrl] = getTestSource(std::get<SourceDescriptor>(source.second).sourceId, bm);
+        auto [s, ctrl] = getTestSource(ingestion, std::get<SourceDescriptor>(source.second).sourceId, bm);
         sourceIds.emplace(source.first, s->getSourceId());
         sources.emplace_back(std::move(s), std::move(successors));
         sourceCtrls[source.first] = ctrl;

--- a/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.hpp
+++ b/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.hpp
@@ -323,6 +323,8 @@ protected:
 
 struct TestSinkController
 {
+    explicit TestSinkController(Valve valve) : valve(std::move(valve)) { }
+
     /// Waits for *at least* `numberOfExpectedBuffers`
     testing::AssertionResult waitForNumberOfReceivedBuffersOrMore(size_t numberOfExpectedBuffers);
 
@@ -350,6 +352,8 @@ struct TestSinkController
     std::atomic<size_t> invocations = 0;
     std::atomic<size_t> repeatCount = 0;
     std::atomic<size_t> repeatCountDuringStop = 0;
+
+    Valve valve;
 
 private:
     folly::Synchronized<std::vector<TupleBuffer>, std::mutex> receivedBuffers;
@@ -428,7 +432,7 @@ private:
 };
 
 std::tuple<std::shared_ptr<ExecutablePipeline>, std::shared_ptr<TestSinkController>>
-createSinkPipeline(PipelineId id, std::shared_ptr<AbstractBufferProvider> bm);
+createSinkPipeline(PipelineId id, Valve valve, std::shared_ptr<AbstractBufferProvider> bm);
 
 std::tuple<std::shared_ptr<ExecutablePipeline>, std::shared_ptr<TestPipelineController>>
 createPipeline(PipelineId id, const std::vector<std::shared_ptr<ExecutablePipeline>>& successors);

--- a/nes-runtime/src/ExecutableQueryPlan.cpp
+++ b/nes-runtime/src/ExecutableQueryPlan.cpp
@@ -30,7 +30,9 @@
 #include <Sources/SourceHandle.hpp>
 #include <Sources/SourceProvider.hpp>
 #include <Util/Overloaded.hpp>
+#include <BackpressureChannel.hpp>
 #include <CompiledQueryPlan.hpp>
+#include <ErrorHandling.hpp>
 #include <ExecutablePipelineStage.hpp>
 
 namespace NES
@@ -67,25 +69,32 @@ ExecutableQueryPlan::instantiate(CompiledQueryPlan& compiledQueryPlan, const Sou
 
     std::unordered_map<OperatorId, std::vector<std::shared_ptr<ExecutablePipeline>>> instantiatedSinksWithSourcePredecessor;
 
-    for (auto& [pipelineId, descriptor, predecessors] : compiledQueryPlan.sinks)
+    auto [valve, ingestion] = Backpressure();
+
+    if (compiledQueryPlan.sinks.size() != 1)
     {
-        auto sink = ExecutablePipeline::create(pipelineId, lower(descriptor), {});
-        compiledQueryPlan.pipelines.push_back(sink);
-        for (const auto& predecessor : predecessors)
-        {
-            std::visit(
-                Overloaded{
-                    [&](const OperatorId& source) { instantiatedSinksWithSourcePredecessor[source].push_back(sink); },
-                    [&](const std::weak_ptr<ExecutablePipeline>& pipeline) { pipeline.lock()->successors.push_back(sink); },
-                },
-                predecessor);
-        }
+        throw NotImplemented("Currently our execution model expects exactly one sink per query plan");
     }
+
+    auto& [pipelineId, descriptor, predecessors] = compiledQueryPlan.sinks.front();
+
+    auto sink = ExecutablePipeline::create(pipelineId, lower(std::move(valve), descriptor), {});
+    compiledQueryPlan.pipelines.push_back(sink);
+    for (const auto& predecessor : predecessors)
+    {
+        std::visit(
+            Overloaded{
+                [&](const OperatorId& source) { instantiatedSinksWithSourcePredecessor[source].push_back(sink); },
+                [&](const std::weak_ptr<ExecutablePipeline>& pipeline) { pipeline.lock()->successors.push_back(sink); },
+            },
+            predecessor);
+    }
+
 
     for (auto [originId, operatorId, descriptor, successors] : compiledQueryPlan.sources)
     {
         std::ranges::copy(instantiatedSinksWithSourcePredecessor[operatorId], std::back_inserter(successors));
-        instantiatedSources.emplace_back(sourceProvider.lower(originId, descriptor), std::move(successors));
+        instantiatedSources.emplace_back(sourceProvider.lower(originId, ingestion, descriptor), std::move(successors));
     }
 
 

--- a/nes-sinks/include/Sinks/FileSink.hpp
+++ b/nes-sinks/include/Sinks/FileSink.hpp
@@ -14,22 +14,22 @@
 
 #pragma once
 
-#include <cstdint>
 #include <fstream>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <string>
 #include <string_view>
 #include <unordered_map>
 
+#include <folly/Synchronized.h>
+
 #include <Configurations/Descriptor.hpp>
-#include <Identifiers/Identifiers.hpp>
 #include <Runtime/TupleBuffer.hpp>
 #include <Sinks/Sink.hpp>
 #include <Sinks/SinkDescriptor.hpp>
 #include <SinksParsing/CSVFormat.hpp>
 #include <SinksParsing/Format.hpp>
-#include <folly/Synchronized.h>
 #include <PipelineExecutionContext.hpp>
 
 namespace NES
@@ -39,7 +39,7 @@ class FileSink final : public Sink
 {
 public:
     static constexpr std::string_view NAME = "File";
-    explicit FileSink(const SinkDescriptor& sinkDescriptor);
+    explicit FileSink(Valve valve, const SinkDescriptor& sinkDescriptor);
     ~FileSink() override = default;
 
     FileSink(const FileSink&) = delete;

--- a/nes-sinks/include/Sinks/PrintSink.hpp
+++ b/nes-sinks/include/Sinks/PrintSink.hpp
@@ -60,18 +60,25 @@ protected:
 private:
     folly::Synchronized<std::ostream*> outputStream;
     std::unique_ptr<Format> outputParser;
+
+    uint32_t ingestion = 0;
 };
 
 /// Todo #355 : combine configuration with source configuration (get rid of duplicated code)
 struct ConfigParametersPrint
 {
+    static inline const DescriptorConfig::ConfigParameter<uint32_t> INGESTION{
+        "ingestion",
+        0,
+        [](const std::unordered_map<std::string, std::string>& config) { return DescriptorConfig::tryGet(INGESTION, config); }};
+
     static inline const DescriptorConfig::ConfigParameter<EnumWrapper, InputFormat> INPUT_FORMAT{
         "input_format",
         std::nullopt,
         [](const std::unordered_map<std::string, std::string>& config) { return DescriptorConfig::tryGet(INPUT_FORMAT, config); }};
 
     static inline std::unordered_map<std::string, DescriptorConfig::ConfigParameterContainer> parameterMap
-        = DescriptorConfig::createConfigParameterContainerMap(INPUT_FORMAT);
+        = DescriptorConfig::createConfigParameterContainerMap(INGESTION, INPUT_FORMAT);
 };
 
 }

--- a/nes-sinks/include/Sinks/PrintSink.hpp
+++ b/nes-sinks/include/Sinks/PrintSink.hpp
@@ -21,6 +21,8 @@
 #include <string_view>
 #include <unordered_map>
 
+#include <folly/Synchronized.h>
+
 #include <Configurations/Descriptor.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Runtime/TupleBuffer.hpp>
@@ -28,7 +30,7 @@
 #include <Sinks/SinkDescriptor.hpp>
 #include <SinksParsing/CSVFormat.hpp>
 #include <SinksParsing/Format.hpp>
-#include <folly/Synchronized.h>
+#include <BackpressureChannel.hpp>
 #include <PipelineExecutionContext.hpp>
 
 namespace NES
@@ -39,7 +41,7 @@ class PrintSink final : public Sink
 public:
     static constexpr std::string_view NAME = "Print";
 
-    explicit PrintSink(const SinkDescriptor& sinkDescriptor);
+    explicit PrintSink(Valve valve, const SinkDescriptor& sinkDescriptor);
     ~PrintSink() override = default;
 
     PrintSink(const PrintSink&) = delete;

--- a/nes-sinks/include/Sinks/Sink.hpp
+++ b/nes-sinks/include/Sinks/Sink.hpp
@@ -16,6 +16,7 @@
 
 #include <ostream>
 #include <fmt/ostream.h>
+#include <BackpressureChannel.hpp>
 #include <ExecutablePipelineStage.hpp>
 
 namespace NES
@@ -24,8 +25,12 @@ namespace NES
 class Sink : public ExecutablePipelineStage
 {
 public:
+    Sink(Valve valve) : valve(std::move(valve)) { }
+
     ~Sink() override = default;
     friend std::ostream& operator<<(std::ostream& out, const Sink& sink);
+
+    Valve valve;
 };
 
 }

--- a/nes-sinks/include/Sinks/SinkProvider.hpp
+++ b/nes-sinks/include/Sinks/SinkProvider.hpp
@@ -16,11 +16,12 @@
 #include <memory>
 #include <Sinks/Sink.hpp>
 #include <Sinks/SinkDescriptor.hpp>
+#include <BackpressureChannel.hpp>
 
 namespace NES
 {
 
 /// Takes a SinkDescriptor and in exchange returns a SinkPipeline, which Tasks can process (together with a TupleBuffer).
-std::unique_ptr<Sink> lower(const SinkDescriptor& sinkDescriptor);
+std::unique_ptr<Sink> lower(Valve valve, const SinkDescriptor& sinkDescriptor);
 
 }

--- a/nes-sinks/registry/include/SinkRegistry.hpp
+++ b/nes-sinks/registry/include/SinkRegistry.hpp
@@ -18,6 +18,7 @@
 #include <Sinks/Sink.hpp>
 #include <Sinks/SinkDescriptor.hpp>
 #include <Util/Registry.hpp>
+#include <BackpressureChannel.hpp>
 
 namespace NES
 {
@@ -26,6 +27,7 @@ using SinkRegistryReturnType = std::unique_ptr<Sink>;
 
 struct SinkRegistryArguments
 {
+    Valve valve;
     SinkDescriptor sinkDescriptor;
 };
 

--- a/nes-sinks/src/FileSink.cpp
+++ b/nes-sinks/src/FileSink.cpp
@@ -24,6 +24,9 @@
 #include <unordered_map>
 #include <utility>
 
+#include <fmt/format.h>
+#include <magic_enum/magic_enum.hpp>
+
 #include <Configurations/Descriptor.hpp>
 #include <Runtime/TupleBuffer.hpp>
 #include <Sinks/Sink.hpp>
@@ -31,8 +34,7 @@
 #include <SinksParsing/CSVFormat.hpp>
 #include <SinksParsing/JSONFormat.hpp>
 #include <Util/Logger/Logger.hpp>
-#include <fmt/format.h>
-#include <magic_enum/magic_enum.hpp>
+#include <BackpressureChannel.hpp>
 #include <ErrorHandling.hpp>
 #include <PipelineExecutionContext.hpp>
 #include <SinkRegistry.hpp>
@@ -41,8 +43,8 @@
 namespace NES
 {
 
-FileSink::FileSink(const SinkDescriptor& sinkDescriptor)
-    : Sink()
+FileSink::FileSink(Valve valve, const SinkDescriptor& sinkDescriptor)
+    : Sink(std::move(valve))
     , outputFilePath(sinkDescriptor.getFromConfig(SinkDescriptor::FILE_PATH))
     , isAppend(sinkDescriptor.getFromConfig(ConfigParametersFile::APPEND))
     , isOpen(false)
@@ -69,14 +71,13 @@ std::ostream& FileSink::toString(std::ostream& str) const
 void FileSink::start(PipelineExecutionContext&)
 {
     NES_DEBUG("Setting up file sink: {}", *this);
-    auto stream = outputFileStream.wlock();
+    const auto stream = outputFileStream.wlock();
     /// Remove an existing file unless the isAppend mode is isAppend.
     if (!isAppend)
     {
         if (std::filesystem::exists(outputFilePath.c_str()))
         {
-            std::error_code ec;
-            if (!std::filesystem::remove(outputFilePath.c_str(), ec))
+            if (std::error_code ec; !std::filesystem::remove(outputFilePath.c_str(), ec))
             {
                 isOpen = false;
                 throw CannotOpenSink("Could not remove existing output file: filePath={} ", outputFilePath);
@@ -113,7 +114,7 @@ void FileSink::execute(const TupleBuffer& inputTupleBuffer, PipelineExecutionCon
         auto fBuffer = formatter->getFormattedBuffer(inputTupleBuffer);
         NES_TRACE("Writing tuples to file sink; filePathOutput={}, fBuffer={}", outputFilePath, fBuffer);
         {
-            auto wlocked = outputFileStream.wlock();
+            const auto wlocked = outputFileStream.wlock();
             wlocked->write(fBuffer.c_str(), static_cast<long>(fBuffer.size()));
             wlocked->flush();
         }
@@ -123,7 +124,7 @@ void FileSink::execute(const TupleBuffer& inputTupleBuffer, PipelineExecutionCon
 void FileSink::stop(PipelineExecutionContext&)
 {
     NES_DEBUG("Closing file sink, filePathOutput={}", outputFilePath);
-    auto stream = outputFileStream.wlock();
+    const auto stream = outputFileStream.wlock();
     stream->flush();
     stream->close();
 }
@@ -140,7 +141,7 @@ SinkValidationRegistryReturnType RegisterFileSinkValidation(SinkValidationRegist
 
 SinkRegistryReturnType RegisterFileSink(SinkRegistryArguments sinkRegistryArguments)
 {
-    return std::make_unique<FileSink>(sinkRegistryArguments.sinkDescriptor);
+    return std::make_unique<FileSink>(std::move(sinkRegistryArguments.valve), sinkRegistryArguments.sinkDescriptor);
 }
 
 }

--- a/nes-sinks/src/PrintSink.cpp
+++ b/nes-sinks/src/PrintSink.cpp
@@ -38,7 +38,9 @@
 namespace NES
 {
 
-PrintSink::PrintSink(Valve valve, const SinkDescriptor& sinkDescriptor) : Sink(std::move(valve)), outputStream(&std::cout)
+
+PrintSink::PrintSink(Valve valve, const SinkDescriptor& sinkDescriptor)
+    : Sink(std::move(valve)), outputStream(&std::cout), ingestion(sinkDescriptor.getFromConfig(ConfigParametersPrint::INGESTION))
 {
     switch (const auto inputFormat = sinkDescriptor.getFromConfig(ConfigParametersPrint::INPUT_FORMAT))
     {
@@ -67,6 +69,7 @@ void PrintSink::execute(const TupleBuffer& inputBuffer, PipelineExecutionContext
 
     const auto bufferAsString = outputParser->getFormattedBuffer(inputBuffer);
     *(*outputStream.wlock()) << bufferAsString << '\n';
+    std::this_thread::sleep_for(std::chrono::milliseconds{ingestion});
 }
 
 std::ostream& PrintSink::toString(std::ostream& str) const

--- a/nes-sinks/src/PrintSink.cpp
+++ b/nes-sinks/src/PrintSink.cpp
@@ -68,7 +68,7 @@ void PrintSink::execute(const TupleBuffer& inputBuffer, PipelineExecutionContext
     PRECONDITION(inputBuffer, "Invalid input buffer in PrintSink.");
 
     const auto bufferAsString = outputParser->getFormattedBuffer(inputBuffer);
-    *(*outputStream.wlock()) << bufferAsString << '\n';
+    *(*outputStream.wlock()) << bufferAsString;
     std::this_thread::sleep_for(std::chrono::milliseconds{ingestion});
 }
 

--- a/nes-sinks/src/PrintSink.cpp
+++ b/nes-sinks/src/PrintSink.cpp
@@ -29,6 +29,7 @@
 #include <SinksParsing/JSONFormat.hpp>
 #include <fmt/format.h>
 #include <magic_enum/magic_enum.hpp>
+#include <BackpressureChannel.hpp>
 #include <ErrorHandling.hpp>
 #include <PipelineExecutionContext.hpp>
 #include <SinkRegistry.hpp>
@@ -37,7 +38,7 @@
 namespace NES
 {
 
-PrintSink::PrintSink(const SinkDescriptor& sinkDescriptor) : outputStream(&std::cout)
+PrintSink::PrintSink(Valve valve, const SinkDescriptor& sinkDescriptor) : Sink(std::move(valve)), outputStream(&std::cout)
 {
     switch (const auto inputFormat = sinkDescriptor.getFromConfig(ConfigParametersPrint::INPUT_FORMAT))
     {
@@ -86,7 +87,7 @@ SinkValidationRegistryReturnType RegisterPrintSinkValidation(SinkValidationRegis
 
 SinkRegistryReturnType RegisterPrintSink(SinkRegistryArguments sinkRegistryArguments)
 {
-    return std::make_unique<PrintSink>(sinkRegistryArguments.sinkDescriptor);
+    return std::make_unique<PrintSink>(std::move(sinkRegistryArguments.valve), sinkRegistryArguments.sinkDescriptor);
 }
 
 }

--- a/nes-sinks/src/SinkProvider.cpp
+++ b/nes-sinks/src/SinkProvider.cpp
@@ -25,11 +25,11 @@
 namespace NES
 {
 
-std::unique_ptr<Sink> lower(const SinkDescriptor& sinkDescriptor)
+std::unique_ptr<Sink> lower(Valve valve, const SinkDescriptor& sinkDescriptor)
 {
     NES_DEBUG("The sinkDescriptor is: {}", sinkDescriptor);
-    auto sinkArguments = SinkRegistryArguments(sinkDescriptor);
-    if (auto sink = SinkRegistry::instance().create(sinkDescriptor.getSinkType(), sinkArguments); sink.has_value())
+    auto sinkArguments = SinkRegistryArguments(std::move(valve), sinkDescriptor);
+    if (auto sink = SinkRegistry::instance().create(sinkDescriptor.getSinkType(), std::move(sinkArguments)); sink.has_value())
     {
         return std::move(sink.value());
     }

--- a/nes-sources/CMakeLists.txt
+++ b/nes-sources/CMakeLists.txt
@@ -14,7 +14,7 @@ add_subdirectory(src)
 get_source(nes-sources NES_SOURCES_SOURCE_FILES)
 
 add_library(nes-sources ${NES_SOURCES_SOURCE_FILES})
-target_link_libraries(nes-sources PUBLIC nes-common nes-configurations nes-memory nes-systest-sources)
+target_link_libraries(nes-sources PUBLIC nes-common nes-configurations nes-memory nes-systest-sources nes-executable)
 
 target_include_directories(nes-sources PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/nes-sources/include/Sources/SourceHandle.hpp
+++ b/nes-sources/include/Sources/SourceHandle.hpp
@@ -23,6 +23,7 @@
 #include <Util/Logger/Formatter.hpp>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#include <BackpressureChannel.hpp>
 
 namespace NES
 {
@@ -44,6 +45,7 @@ class SourceHandle
 {
 public:
     explicit SourceHandle(
+        Ingestion ingestion,
         OriginId originId, /// Todo #241: Rethink use of originId for sources, use new identifier for unique identification.
         SourceRuntimeConfiguration configuration,
         std::shared_ptr<AbstractBufferProvider> bufferPool,

--- a/nes-sources/include/Sources/SourceProvider.hpp
+++ b/nes-sources/include/Sources/SourceProvider.hpp
@@ -20,6 +20,7 @@
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Sources/SourceHandle.hpp>
+#include <BackpressureChannel.hpp>
 
 namespace NES
 {
@@ -37,7 +38,8 @@ public:
     SourceProvider(size_t defaultMaxInflightBuffers, std::shared_ptr<AbstractBufferProvider> bufferPool);
 
     /// Returning a shared pointer, because sources may be shared by multiple executable query plans (qeps).
-    [[nodiscard]] std::unique_ptr<SourceHandle> lower(OriginId originId, const SourceDescriptor& sourceDescriptor) const;
+    [[nodiscard]] std::unique_ptr<SourceHandle>
+    lower(OriginId originId, Ingestion ingestion, const SourceDescriptor& sourceDescriptor) const;
 
     [[nodiscard]] bool contains(const std::string& sourceType) const;
 };

--- a/nes-sources/private/SourceThread.hpp
+++ b/nes-sources/private/SourceThread.hpp
@@ -29,6 +29,7 @@
 #include <Sources/SourceReturnType.hpp>
 #include <Util/Logger/Formatter.hpp>
 #include <magic_enum/magic_enum.hpp>
+#include <BackpressureChannel.hpp>
 #include <NESThread.hpp>
 
 namespace NES
@@ -58,6 +59,7 @@ class SourceThread
 
 public:
     explicit SourceThread(
+        Ingestion ingestion,
         OriginId originId, /// Todo #241: Rethink use of originId for sources, use new identifier for unique identification.
         std::shared_ptr<AbstractBufferProvider> bufferManager,
         std::unique_ptr<Source> sourceImplementation);
@@ -91,6 +93,7 @@ protected:
     std::shared_ptr<AbstractBufferProvider> localBufferManager;
     std::unique_ptr<Source> sourceImplementation;
     std::atomic_bool started;
+    Ingestion ingestion;
 
     Thread thread;
     std::future<SourceImplementationTermination> terminationFuture;

--- a/nes-sources/src/SourceHandle.cpp
+++ b/nes-sources/src/SourceHandle.cpp
@@ -23,18 +23,21 @@
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Sources/Source.hpp>
 #include <Sources/SourceReturnType.hpp>
+#include <BackpressureChannel.hpp>
 #include <SourceThread.hpp>
 
 namespace NES
 {
 SourceHandle::SourceHandle(
+    Ingestion ingestion,
     OriginId originId,
     SourceRuntimeConfiguration configuration,
     std::shared_ptr<AbstractBufferProvider> bufferPool,
     std::unique_ptr<Source> sourceImplementation)
     : configuration(std::move(configuration))
 {
-    this->sourceThread = std::make_unique<SourceThread>(std::move(originId), std::move(bufferPool), std::move(sourceImplementation));
+    this->sourceThread
+        = std::make_unique<SourceThread>(std::move(ingestion), std::move(originId), std::move(bufferPool), std::move(sourceImplementation));
 }
 
 SourceHandle::~SourceHandle() = default;

--- a/nes-sources/src/SourceProvider.cpp
+++ b/nes-sources/src/SourceProvider.cpp
@@ -21,6 +21,7 @@
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Sources/SourceHandle.hpp>
+#include <BackpressureChannel.hpp>
 #include <ErrorHandling.hpp>
 #include <SourceRegistry.hpp>
 
@@ -32,7 +33,7 @@ SourceProvider::SourceProvider(size_t defaultMaxInflightBuffers, std::shared_ptr
 {
 }
 
-std::unique_ptr<SourceHandle> SourceProvider::lower(OriginId originId, const SourceDescriptor& sourceDescriptor) const
+std::unique_ptr<SourceHandle> SourceProvider::lower(OriginId originId, Ingestion ingestion, const SourceDescriptor& sourceDescriptor) const
 {
     /// Todo #241: Get the new source identfier from the source descriptor and pass it to SourceHandle.
     auto sourceArguments = SourceRegistryArguments(sourceDescriptor);
@@ -45,7 +46,8 @@ std::unique_ptr<SourceHandle> SourceProvider::lower(OriginId originId, const Sou
             : defaultMaxInflightBuffers;
         SourceRuntimeConfiguration runtimeConfig{maxInflightBuffers};
 
-        return std::make_unique<SourceHandle>(std::move(originId), std::move(runtimeConfig), bufferPool, std::move(source.value()));
+        return std::make_unique<SourceHandle>(
+            std::move(ingestion), std::move(originId), std::move(runtimeConfig), bufferPool, std::move(source.value()));
     }
     throw UnknownSourceType("unknown source descriptor type: {}", sourceDescriptor.getSourceType());
 }

--- a/nes-sources/src/SourceThread.cpp
+++ b/nes-sources/src/SourceThread.cpp
@@ -39,8 +39,14 @@ namespace NES
 {
 
 SourceThread::SourceThread(
-    OriginId originId, std::shared_ptr<AbstractBufferProvider> poolProvider, std::unique_ptr<Source> sourceImplementation)
-    : originId(originId), localBufferManager(std::move(poolProvider)), sourceImplementation(std::move(sourceImplementation))
+    Ingestion ingestion,
+    OriginId originId,
+    std::shared_ptr<AbstractBufferProvider> poolProvider,
+    std::unique_ptr<Source> sourceImplementation)
+    : originId(originId)
+    , localBufferManager(std::move(poolProvider))
+    , sourceImplementation(std::move(sourceImplementation))
+    , ingestion(std::move(ingestion))
 {
     PRECONDITION(this->localBufferManager, "Invalid buffer manager");
 }
@@ -100,11 +106,15 @@ struct SourceHandle
 };
 
 SourceImplementationTermination dataSourceThreadRoutine(
-    const std::stop_token& stopToken, Source& source, std::shared_ptr<AbstractBufferProvider> bufferProvider, const EmitFn& emit)
+    const std::stop_token& stopToken,
+    Ingestion ingestion,
+    Source& source,
+    std::shared_ptr<AbstractBufferProvider> bufferProvider,
+    const EmitFn& emit)
 {
     const SourceHandle sourceHandle(source, bufferProvider);
     const bool requiresMetadata = !source.addsMetadata();
-    while (!stopToken.stop_requested())
+    while (ingestion.wait(stopToken), !stopToken.stop_requested())
     {
         /// 4 Things that could happen:
         /// 1. Happy Path: Source produces a tuple buffer and emit is called. The loop continues.
@@ -114,15 +124,25 @@ SourceImplementationTermination dataSourceThreadRoutine(
         ///    The thread exits with `EndOfStream`
         /// 4. Failure. The fillTupleBuffer method will throw an exception, the exception is propagted to the SourceThread via the return promise.
         ///    The thread exists with an exception
-        auto emptyBuffer = bufferProvider->getBufferBlocking();
-        const auto fillTupleResult = source.fillTupleBuffer(emptyBuffer, stopToken);
+
+        std::optional<TupleBuffer> emptyBuffer;
+        while (!emptyBuffer && !stopToken.stop_requested())
+        {
+            emptyBuffer = bufferProvider->getBufferWithTimeout(std::chrono::milliseconds(25));
+        }
+        if (stopToken.stop_requested())
+        {
+            return {SourceImplementationTermination::StopRequested};
+        }
+
+        const auto fillTupleResult = source.fillTupleBuffer(*emptyBuffer, stopToken);
 
         if (const auto* numberOfTuples = std::get_if<Source::FillTupleBufferResult::Tuples>(&fillTupleResult.result))
         {
             /// The source read in raw bytes, thus we don't know the number of tuples yet.
             /// The InputFormatterTask expects that the source set the number of bytes this way and uses it to determine the number of tuples.
-            emptyBuffer.setNumberOfTuples(numberOfTuples->numTuples);
-            emit(std::move(emptyBuffer), requiresMetadata);
+            emptyBuffer->setNumberOfTuples(numberOfTuples->numTuples);
+            emit(std::move(*emptyBuffer), requiresMetadata);
         }
         else
         {
@@ -139,6 +159,7 @@ SourceImplementationTermination dataSourceThreadRoutine(
 
 void dataSourceThread(
     const std::stop_token& stopToken,
+    Ingestion ingestion,
     std::promise<SourceImplementationTermination> result,
     Source* source,
     SourceReturnType::EmitFunction emit,
@@ -158,7 +179,8 @@ void dataSourceThread(
 
     try
     {
-        result.set_value_at_thread_exit(dataSourceThreadRoutine(stopToken, *source, std::move(bufferProvider), dataEmit));
+        result.set_value_at_thread_exit(
+            dataSourceThreadRoutine(stopToken, std::move(ingestion), *source, std::move(bufferProvider), dataEmit));
         if (!stopToken.stop_requested())
         {
             emit(originId, SourceReturnType::EoS{}, stopToken);
@@ -188,6 +210,7 @@ bool SourceThread::start(SourceReturnType::EmitFunction&& emitFunction)
     Thread sourceThread(
         fmt::format("DataSrc-{}", originId),
         detail::dataSourceThread,
+        ingestion,
         std::move(terminationPromise),
         sourceImplementation.get(),
         std::move(emitFunction),

--- a/nes-sources/tests/SourceThreadTest.cpp
+++ b/nes-sources/tests/SourceThreadTest.cpp
@@ -172,10 +172,16 @@ void verify_number_of_emits(
 TEST_F(SourceThreadTest, DestructionOfStartedSourceThread)
 {
     auto bm = BufferManager::create();
+    auto [valve, ingestion] = Backpressure();
     RecordingEmitFunction recorder(*bm);
     auto control = std::make_shared<TestSourceControl>();
     {
-        SourceThread sourceThread(INITIAL<OriginId>, bm, std::make_unique<TestSource>(INITIAL<OriginId>, control));
+        SourceThread sourceThread(
+            std::move(ingestion),
+            INITIAL<OriginId>,
+            bm,
+
+            std::make_unique<TestSource>(INITIAL<OriginId>, control));
         verify_non_blocking_start(
             sourceThread,
             [&](const OriginId originId, SourceReturnType::SourceReturnType ret, const std::stop_token&)
@@ -194,10 +200,11 @@ TEST_F(SourceThreadTest, DestructionOfStartedSourceThread)
 TEST_F(SourceThreadTest, NoOpDestruction)
 {
     auto bm = BufferManager::create();
+    auto [valve, ingestion] = Backpressure();
     RecordingEmitFunction recorder(*bm);
     auto control = std::make_shared<TestSourceControl>();
     {
-        const SourceThread sourceThread(INITIAL<OriginId>, bm, std::make_unique<TestSource>(INITIAL<OriginId>, control));
+        const SourceThread sourceThread(ingestion, INITIAL<OriginId>, bm, std::make_unique<TestSource>(INITIAL<OriginId>, control));
     }
 
     verify_no_events(recorder);
@@ -209,13 +216,14 @@ TEST_F(SourceThreadTest, NoOpDestruction)
 TEST_F(SourceThreadTest, FailureDuringRunning)
 {
     auto bm = BufferManager::create();
+    auto [valve, ingestion] = Backpressure();
     RecordingEmitFunction recorder(*bm);
     auto control = std::make_shared<TestSourceControl>();
     control->injectData(std::vector{DEFAULT_BUFFER_SIZE, std::byte(0)}, DEFAULT_NUMBER_OF_TUPLES_IN_BUFFER);
     control->injectData(std::vector{DEFAULT_BUFFER_SIZE, std::byte(0)}, DEFAULT_NUMBER_OF_TUPLES_IN_BUFFER);
     control->injectError("I should fail");
     {
-        SourceThread sourceThread(INITIAL<OriginId>, bm, std::make_unique<TestSource>(INITIAL<OriginId>, control));
+        SourceThread sourceThread(ingestion, INITIAL<OriginId>, bm, std::make_unique<TestSource>(INITIAL<OriginId>, control));
         verify_non_blocking_start(
             sourceThread,
             [&](const OriginId originId, SourceReturnType::SourceReturnType ret, const std::stop_token&)
@@ -237,11 +245,12 @@ TEST_F(SourceThreadTest, FailureDuringRunning)
 TEST_F(SourceThreadTest, FailureDuringOpen)
 {
     auto bm = BufferManager::create();
+    auto [valve, ingestion] = Backpressure();
     RecordingEmitFunction recorder(*bm);
     auto control = std::make_shared<TestSourceControl>();
     control->failDuringOpen(std::chrono::milliseconds(0));
     {
-        SourceThread sourceThread(INITIAL<OriginId>, bm, std::make_unique<TestSource>(INITIAL<OriginId>, control));
+        SourceThread sourceThread(ingestion, INITIAL<OriginId>, bm, std::make_unique<TestSource>(INITIAL<OriginId>, control));
         verify_non_blocking_start(
             sourceThread,
             [&](const OriginId originId, SourceReturnType::SourceReturnType ret, const std::stop_token&)
@@ -263,13 +272,14 @@ TEST_F(SourceThreadTest, FailureDuringOpen)
 TEST_F(SourceThreadTest, SimpleCaseWithInternalStop)
 {
     auto bm = BufferManager::create();
+    auto [valve, ingestion] = Backpressure();
     RecordingEmitFunction recorder(*bm);
     auto control = std::make_shared<TestSourceControl>();
     control->injectData(std::vector{DEFAULT_BUFFER_SIZE, std::byte(0)}, DEFAULT_NUMBER_OF_TUPLES_IN_BUFFER);
     control->injectData(std::vector{DEFAULT_BUFFER_SIZE, std::byte(0)}, DEFAULT_NUMBER_OF_TUPLES_IN_BUFFER);
     control->injectData(std::vector{DEFAULT_BUFFER_SIZE, std::byte(0)}, DEFAULT_NUMBER_OF_TUPLES_IN_BUFFER);
     {
-        SourceThread sourceThread(INITIAL<OriginId>, bm, std::make_unique<TestSource>(INITIAL<OriginId>, control));
+        SourceThread sourceThread(ingestion, INITIAL<OriginId>, bm, std::make_unique<TestSource>(INITIAL<OriginId>, control));
         verify_non_blocking_start(
             sourceThread,
             [&](const OriginId originId, SourceReturnType::SourceReturnType ret, const std::stop_token&)
@@ -292,13 +302,13 @@ TEST_F(SourceThreadTest, EoSFromSourceWithStop)
 {
     auto bm = BufferManager::create();
     RecordingEmitFunction recorder(*bm);
+    auto [valve, ingestion] = Backpressure();
     auto control = std::make_shared<TestSourceControl>();
     control->injectData(std::vector{DEFAULT_BUFFER_SIZE, std::byte(0)}, DEFAULT_NUMBER_OF_TUPLES_IN_BUFFER);
     control->injectData(std::vector{DEFAULT_BUFFER_SIZE, std::byte(0)}, DEFAULT_NUMBER_OF_TUPLES_IN_BUFFER);
     control->injectData(std::vector{DEFAULT_BUFFER_SIZE, std::byte(0)}, DEFAULT_NUMBER_OF_TUPLES_IN_BUFFER);
-    control->injectEoS();
     {
-        SourceThread sourceThread(INITIAL<OriginId>, bm, std::make_unique<TestSource>(INITIAL<OriginId>, control));
+        SourceThread sourceThread(ingestion, INITIAL<OriginId>, bm, std::make_unique<TestSource>(INITIAL<OriginId>, control));
         verify_non_blocking_start(
             sourceThread,
             [&](const OriginId originId, SourceReturnType::SourceReturnType ret, const std::stop_token&)
@@ -318,5 +328,75 @@ TEST_F(SourceThreadTest, EoSFromSourceWithStop)
     EXPECT_TRUE(control->wasClosed());
     EXPECT_TRUE(control->wasDestroyed());
 }
+
+TEST_F(SourceThreadTest, ApplyBackbressure)
+{
+    auto bm = BufferManager::create();
+    RecordingEmitFunction recorder(*bm);
+    auto [valve, ingestion] = Backpressure();
+    valve.applyPressure();
+    auto control = std::make_shared<TestSourceControl>();
+    control->injectData(std::vector{DEFAULT_BUFFER_SIZE, std::byte(0)}, DEFAULT_NUMBER_OF_TUPLES_IN_BUFFER);
+    control->injectData(std::vector{DEFAULT_BUFFER_SIZE, std::byte(0)}, DEFAULT_NUMBER_OF_TUPLES_IN_BUFFER);
+    control->injectData(std::vector{DEFAULT_BUFFER_SIZE, std::byte(0)}, DEFAULT_NUMBER_OF_TUPLES_IN_BUFFER);
+    control->injectEoS();
+    {
+        SourceThread sourceThread(ingestion, INITIAL<OriginId>, bm, std::make_unique<TestSource>(INITIAL<OriginId>, control));
+        verify_non_blocking_start(
+            sourceThread,
+            [&](const OriginId originId, SourceReturnType::SourceReturnType ret, const auto&)
+            {
+                recorder(originId, std::move(ret));
+                return SourceReturnType::EmitResult::SUCCESS;
+            });
+        wait_for_emits(recorder, 0);
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        EXPECT_FALSE(control->wasClosed());
+        wait_for_emits(recorder, 0);
+        valve.releasePressure();
+        wait_for_emits(recorder, 4);
+        verify_non_blocking_stop(sourceThread);
+    }
+
+    verify_number_of_emits(recorder, 4);
+    verify_last_event<SourceReturnType::EoS>(recorder);
+    EXPECT_TRUE(control->wasOpened());
+    EXPECT_TRUE(control->wasClosed());
+    EXPECT_TRUE(control->wasDestroyed());
+}
+
+TEST_F(SourceThreadTest, StopDuringBackpressure)
+{
+    auto bm = BufferManager::create();
+    RecordingEmitFunction recorder(*bm);
+    auto [valve, ingestion] = Backpressure();
+    valve.applyPressure();
+    auto control = std::make_shared<TestSourceControl>();
+    control->injectData(std::vector{DEFAULT_BUFFER_SIZE, std::byte(0)}, DEFAULT_NUMBER_OF_TUPLES_IN_BUFFER);
+    control->injectData(std::vector{DEFAULT_BUFFER_SIZE, std::byte(0)}, DEFAULT_NUMBER_OF_TUPLES_IN_BUFFER);
+    control->injectData(std::vector{DEFAULT_BUFFER_SIZE, std::byte(0)}, DEFAULT_NUMBER_OF_TUPLES_IN_BUFFER);
+    control->injectEoS();
+    {
+        SourceThread sourceThread(ingestion, INITIAL<OriginId>, bm, std::make_unique<TestSource>(INITIAL<OriginId>, control));
+        verify_non_blocking_start(
+            sourceThread,
+            [&](const OriginId originId, SourceReturnType::SourceReturnType ret, const auto&)
+            {
+                recorder(originId, std::move(ret));
+                return SourceReturnType::EmitResult::SUCCESS;
+            });
+        wait_for_emits(recorder, 0);
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        EXPECT_FALSE(control->wasClosed());
+        wait_for_emits(recorder, 0);
+        verify_non_blocking_stop(sourceThread);
+    }
+
+    verify_number_of_emits(recorder, 0);
+    EXPECT_TRUE(control->wasOpened());
+    EXPECT_TRUE(control->wasClosed());
+    EXPECT_TRUE(control->wasDestroyed());
+}
+
 
 }

--- a/nes-sources/tests/Util/TestSource.cpp
+++ b/nes-sources/tests/Util/TestSource.cpp
@@ -228,13 +228,13 @@ NES::TestSource::~TestSource()
 }
 
 std::pair<std::unique_ptr<NES::SourceHandle>, std::shared_ptr<NES::TestSourceControl>>
-NES::getTestSource(OriginId originId, std::shared_ptr<AbstractBufferProvider> bufferPool)
+NES::getTestSource(Ingestion ingestion, OriginId originId, std::shared_ptr<AbstractBufferProvider> bufferPool)
 {
     auto ctrl = std::make_shared<TestSourceControl>();
     auto testSource = std::make_unique<TestSource>(originId, ctrl);
     SourceRuntimeConfiguration runtimeConfig{DEFAULT_NUMBER_OF_LOCAL_BUFFERS};
 
-    auto sourceHandle
-        = std::make_unique<SourceHandle>(std::move(originId), std::move(runtimeConfig), std::move(bufferPool), std::move(testSource));
+    auto sourceHandle = std::make_unique<SourceHandle>(
+        std::move(ingestion), std::move(originId), std::move(runtimeConfig), std::move(bufferPool), std::move(testSource));
     return {std::move(sourceHandle), ctrl};
 }

--- a/nes-sources/tests/Util/TestSource.hpp
+++ b/nes-sources/tests/Util/TestSource.hpp
@@ -112,6 +112,6 @@ private:
 };
 
 std::pair<std::unique_ptr<SourceHandle>, std::shared_ptr<TestSourceControl>>
-getTestSource(OriginId originId, std::shared_ptr<AbstractBufferProvider> bufferPool);
+getTestSource(Ingestion ingestion, OriginId originId, std::shared_ptr<AbstractBufferProvider> bufferPool);
 
 }


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

This PR implements the backpressure mechanism which is used by the network sink and source in the distributed PR. In theory this could be used by any sink. The logic for quering the current state of backpressre is implemented within the source thread which means all sources apply backpressure by default.
Conceptionally this PR introduces a Backpressure channel which can be controlled via a Valve. The valve controls one or more Ingestions (ingestions can be copied), which can block if the valve applies backpressure.

As an example the PR adds an `ingestion` configuration to the print sink which allows a query to limit the number of tuples it can produce per second.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"thread-and-context-based-logging","parentHead":"1bc2e7b020c500b93ecbcde4ab60a423cd3ee3bd","parentPull":1130,"trunk":"main"}
```
-->
