### PR TITLE
fix(Lowering): sanity check for pipeline insertion

### DIFF
--- a/nes-query-compiler/src/Phases/PipeliningPhase.cpp
+++ b/nes-query-compiler/src/Phases/PipeliningPhase.cpp
@@ -162,7 +162,7 @@ void buildPipelineRecursively(
     /// it should close the pipeline without adding a default emit
     if (opWrapper->getPipelineLocation() == PhysicalOperatorWrapper::PipelineLocation::EMIT)
     {
-        if (prevOpWrapper->getPipelineLocation() == PhysicalOperatorWrapper::PipelineLocation::EMIT)
+        if (not prevOpWrapper || prevOpWrapper->getPipelineLocation() == PhysicalOperatorWrapper::PipelineLocation::EMIT)
         {
             /// If the current operator is an emit operator and the prev operator was also an emit operator, we need to add a scan before the
             /// current operator to create a new pipeline


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

This PR addresses a bug in the pipeline phase which does not properly handle if the first operator in queryplan is an EMIT. While in the current state of nebulastream this cannot happen, the query decomposition in the upcomming distributed PR can cause those scenarios. 
The proper behaivor of the PipelinePhase is to add a scan before the emit.
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handle EMIT as the first operator by inserting a scan and creating a new pipeline when no previous operator exists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0aa2cf4e1d5de23ad2bb82acf0be645e41b9c842. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
