### PR TITLE
fix(CI): fixes flakey docker image builds

### DIFF
--- a/.github/workflows/get_dev_images.yml
+++ b/.github/workflows/get_dev_images.yml
@@ -167,62 +167,72 @@ jobs:
         with:
           version: v0.10.0
       - name: Build Base Image
-        uses: docker/build-push-action@v6
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          push: true
-          tags: nebulastream/nes-development-base:${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}
-          cache-to: type=registry,ref=nebulastream/nes-development-base-cache:${{inputs.branch-name}}-${{matrix.arch}},mode=max
-          cache-from: |
-            type=registry,ref=nebulastream/nes-development-base-cache:${{inputs.branch-name}}-${{matrix.arch}}
-            type=registry,ref=nebulastream/nes-development-base-cache:latest-${{matrix.arch}}
-          context: .
-          file: docker/dependency/Base.dockerfile
+          action: docker/build-push-action@v6
+          with: |
+            push: true
+            tags: nebulastream/nes-development-base:${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}
+            cache-to: type=registry,ref=nebulastream/nes-development-base-cache:${{inputs.branch-name}}-${{matrix.arch}},mode=max
+            cache-from: |
+              type=registry,ref=nebulastream/nes-development-base-cache:${{inputs.branch-name}}-${{matrix.arch}}
+              type=registry,ref=nebulastream/nes-development-base-cache:latest-${{matrix.arch}}
+            context: .
+            file: docker/dependency/Base.dockerfile
       - name: Build Dependency Image
-        uses: docker/build-push-action@v6
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          push: true
-          tags: nebulastream/nes-development-dependency:${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}-${{matrix.stdlib}}-${{matrix.sanitizer}}
-          cache-to: type=registry,ref=nebulastream/nes-development-dependency-cache:${{inputs.branch-name}}-${{matrix.arch}}-${{matrix.stdlib}}-${{matrix.sanitizer}},mode=max
-          cache-from: |
-            type=registry,ref=nebulastream/nes-development-dependency-cache:${{inputs.branch-name}}-${{matrix.arch}}-${{matrix.stdlib}}-${{matrix.sanitizer}}
-            type=registry,ref=nebulastream/nes-development-dependency-cache:latest-${{matrix.arch}}-${{matrix.stdlib}}-${{matrix.sanitizer}}
-          build-args: |
-            TAG=${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}
-            ARCH=${{matrix.arch}}
-            STDLIB=${{matrix.stdlib}}
-            SANITIZER=${{matrix.sanitizer}}
-            VCPKG_DEPENDENCY_HASH=${{ needs.detect-dependency-changes.outputs.hash }}
-          context: .
-          file: docker/dependency/Dependency.dockerfile
+          action: docker/build-push-action@v6
+          with: |
+            push: true
+            tags: nebulastream/nes-development-dependency:${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}-${{matrix.stdlib}}-${{matrix.sanitizer}}
+            cache-to: type=registry,ref=nebulastream/nes-development-dependency-cache:${{inputs.branch-name}}-${{matrix.arch}}-${{matrix.stdlib}}-${{matrix.sanitizer}},mode=max
+            cache-from: |
+              type=registry,ref=nebulastream/nes-development-dependency-cache:${{inputs.branch-name}}-${{matrix.arch}}-${{matrix.stdlib}}-${{matrix.sanitizer}}
+              type=registry,ref=nebulastream/nes-development-dependency-cache:latest-${{matrix.arch}}-${{matrix.stdlib}}-${{matrix.sanitizer}}
+            build-args: |
+              TAG=${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}
+              ARCH=${{matrix.arch}}
+              STDLIB=${{matrix.stdlib}}
+              SANITIZER=${{matrix.sanitizer}}
+              VCPKG_DEPENDENCY_HASH=${{ needs.detect-dependency-changes.outputs.hash }}
+            context: .
+            file: docker/dependency/Dependency.dockerfile
       - name: Build Development Image
-        uses: docker/build-push-action@v6
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          push: true
-          tags: nebulastream/nes-development:${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}-${{matrix.stdlib}}-${{matrix.sanitizer}}
-          cache-to: type=registry,ref=nebulastream/nes-development-cache:${{inputs.branch-name}}-${{matrix.arch}}-${{matrix.stdlib}}-${{matrix.sanitizer}},mode=max
-          cache-from: |
-            type=registry,ref=nebulastream/nes-development-cache:${{inputs.branch-name}}-${{matrix.arch}}-${{matrix.stdlib}}-${{matrix.sanitizer}}
-            type=registry,ref=nebulastream/nes-development-dependency-cache:latest-${{matrix.arch}}-${{matrix.stdlib}}-${{matrix.sanitizer}}
-          build-args: TAG=${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}-${{matrix.stdlib}}-${{matrix.sanitizer}}
-          context: .
-          file: docker/dependency/Development.dockerfile
+          action: docker/build-push-action@v6
+          with: |
+            push: true
+            tags: nebulastream/nes-development:${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}-${{matrix.stdlib}}-${{matrix.sanitizer}}
+            cache-to: type=registry,ref=nebulastream/nes-development-cache:${{inputs.branch-name}}-${{matrix.arch}}-${{matrix.stdlib}}-${{matrix.sanitizer}},mode=max
+            cache-from: |
+              type=registry,ref=nebulastream/nes-development-cache:${{inputs.branch-name}}-${{matrix.arch}}-${{matrix.stdlib}}-${{matrix.sanitizer}}
+              type=registry,ref=nebulastream/nes-development-dependency-cache:latest-${{matrix.arch}}-${{matrix.stdlib}}-${{matrix.sanitizer}}
+            build-args: TAG=${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}-${{matrix.stdlib}}-${{matrix.sanitizer}}
+            context: .
+            file: docker/dependency/Development.dockerfile
       - name: Build CI Image
-        uses: docker/build-push-action@v6
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          push: true
-          tags: nebulastream/nes-ci:${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}-${{matrix.stdlib}}-${{matrix.sanitizer}}
-          build-args: TAG=${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}-${{matrix.stdlib}}-${{matrix.sanitizer}}
-          context: .
-          file: docker/dependency/DevelopmentCI.dockerfile
+          action: docker/build-push-action@v6
+          with: |
+            push: true
+            tags: nebulastream/nes-ci:${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}-${{matrix.stdlib}}-${{matrix.sanitizer}}
+            build-args: TAG=${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}-${{matrix.stdlib}}-${{matrix.sanitizer}}
+            context: .
+            file: docker/dependency/DevelopmentCI.dockerfile
       - name: Build benchmark image
-        uses: docker/build-push-action@v6
+        uses: Wandalen/wretry.action/main@v3.8.0
         if: ${{matrix.sanitizer == 'none'}}
         with:
-          push: true
-          tags: nebulastream/nes-benchmark:${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}-${{matrix.stdlib}}
-          build-args: TAG=${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}-${{matrix.stdlib}}-none
-          context: .
-          file: docker/dependency/Benchmark.dockerfile
+          action: docker/build-push-action@v6
+          with: |
+            push: true
+            tags: nebulastream/nes-benchmark:${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}-${{matrix.stdlib}}
+            build-args: TAG=${{ needs.detect-dependency-changes.outputs.tag }}-${{matrix.arch}}-${{matrix.stdlib}}-none
+            context: .
+            file: docker/dependency/Benchmark.dockerfile
   merge-dev-images:
     # This Job merges platform specific images into a single multi-platform image
     name: "Merge Dev Images"


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Building a new development image fails frequently (although not deterministically), due to unknown reasons. The push into the registry gets rejected due to a Bad Request. Some internet search provided a solution which requires additional flags when pushing the image to the docker cache.

After countless of retries I switched to simply retrying the action on failure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wraps all Docker image build steps in `get_dev_images.yml` with `Wandalen/wretry.action` to retry `docker/build-push-action` executions.
> 
> - **CI Workflow** (`.github/workflows/get_dev_images.yml`):
>   - Wrap Docker build steps with `Wandalen/wretry.action`:
>     - Base, Dependency, Development, CI, and Benchmark image builds now call `docker/build-push-action@v6` via the retry wrapper.
>   - Preserves existing build args, tags, cache settings, contexts, and Dockerfiles; only execution is routed through the retry action.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43eb331e8ad0b7417f7387a74b21a1e79b6846fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
