### PR TITLE
Fix(Schema) Fixed function getFieldByName(fieldName) to not return any field with fieldName as suffix

### DIFF
--- a/nes-data-types/src/DataTypes/Schema.cpp
+++ b/nes-data-types/src/DataTypes/Schema.cpp
@@ -80,24 +80,21 @@ std::optional<Schema::Field> Schema::getFieldByName(const std::string& fieldName
     }
 
     ///Iterate over all fields and look for field which fully qualified name
-    std::vector<Field> matchedFields;
     for (const auto& field : fields)
     {
         if (auto fullyQualifiedFieldName = field.name; fieldName.length() <= fullyQualifiedFieldName.length())
         {
-            ///Check if the field name ends with the input field name
-            const auto startingPos = fullyQualifiedFieldName.length() - fieldName.length();
-            const auto fieldWithoutQualifier = fullyQualifiedFieldName.substr(startingPos, fieldName.length());
-            if (fieldWithoutQualifier == fieldName)
+            const std::string::size_type separatorPos = fullyQualifiedFieldName.find("$");
+            if (separatorPos == std::string::npos)
             {
-                matchedFields.emplace_back(field);
+                continue;
+            }
+
+            if (const auto fieldWithoutQualifier = fullyQualifiedFieldName.substr(separatorPos + 1); fieldWithoutQualifier == fieldName)
+            {
+                return field;
             }
         }
-    }
-    ///Check how many matching fields were found log an ERROR
-    if (not matchedFields.empty())
-    {
-        return matchedFields.front();
     }
     NES_WARNING("Schema: field with name {} does not exist", fieldName);
     return std::nullopt;

--- a/nes-data-types/tests/UnitTests/API/SchemaTest.cpp
+++ b/nes-data-types/tests/UnitTests/API/SchemaTest.cpp
@@ -165,6 +165,28 @@ TEST_F(SchemaTest, getFieldByNameWithSimilarFieldNames)
                                             << " are not equal"; ///NOLINT(bugprone-unchecked-optional-access)
 }
 
+TEST_F(SchemaTest, getFieldByNameWithSameSuffix)
+{
+    const auto field1 = Schema::Field{"stream$PREFIXabc", DataTypeProvider::provideDataType(DataType::Type::UINT64)};
+    const auto field2 = Schema::Field{"stream$abc", DataTypeProvider::provideDataType(DataType::Type::UINT64)};
+
+    const auto schemaUnderTest = Schema{}
+                                     .addField("stream$PREFIXabc", DataTypeProvider::provideDataType(DataType::Type::UINT64))
+                                     .addField("stream$abc", DataTypeProvider::provideDataType(DataType::Type::UINT64));
+
+    const auto fieldByName1 = schemaUnderTest.getFieldByName("PREFIXabc");
+    const auto fieldByName2 = schemaUnderTest.getFieldByName("abc");
+    const auto fieldByName3NotExistent = schemaUnderTest.getFieldByName("bc");
+
+
+    EXPECT_EQ(field1, fieldByName1.value()) << "Field 1 " << field1 << " and field by name 1 " << fieldByName1.value()
+                                            << " are not equal"; ///NOLINT(bugprone-unchecked-optional-access)
+    EXPECT_EQ(field2, fieldByName2.value()) << "Field 2 " << field2 << " and field by name 2 " << fieldByName2.value()
+                                            << " are not equal"; ///NOLINT(bugprone-unchecked-optional-access)
+    EXPECT_FALSE(fieldByName3NotExistent.has_value())
+        << "Searched for nonexistent field with name \"bc\" but found " << fieldByName3NotExistent.value();
+}
+
 TEST_F(SchemaTest, replaceFieldTest)
 {
     {


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
The function `Schema::getFieldByName(const std::string& fieldName)` returned any field with `fieldName` as suffix.

E.g. if a schema contains the fields (STREAM$somethingABC, STREAM$ABC) and the function is called for the fieldName `ABC`, it returned the field `STREAM$somethingABC`. 

## Verifying this change
Added a new unit test that corrects this behavior by ensuring only truly equal names, either by full name, or by being equal after the stream identifier "$". 

## What components does this pull request potentially affect?
Any component that access a Field of a schema by string name, such as:
* nes-logical-operators
* nes-memory
* nes-nautilus
* nes-physical-operators
* nes-query-optimizer
* nes-systest
