### PR TITLE
add .mailmap file to canonize git author names and mail addresses

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,78 @@
+Adrian Michalke <adrian.michalke@yahoo.de> <adrianmichalke@users.noreply.github.com>
+Adrian Michalke <adrian.michalke@yahoo.de> <adrian.michalke@yahoo.de>
+Adrian Michalke <adrian.michalke@yahoo.de> <michalke@campus.tu-berlin.de>
+Aljoscha Lepping <aljoschalepping@gmail.com>
+Aljoscha Lepping <aljoschalepping@gmail.com> <alepping@users.noreply.github.com>
+Anastasiia Kozar <kozar.anastasiia@gmail.com> <akozar@client-141-23-131-161.wlan.tu-berlin.de>
+Anastasiia Kozar <kozar.anastasiia@gmail.com> <akozar@Lutzs-MBP.fritz.box>
+Anastasiia Kozar <kozar.anastasiia@gmail.com> <anastasiia.kozar@uni-bamberg.de>
+Anastasiia Kozar <kozar.anastasiia@gmail.com> <kisa7@users.noreply.github.com>
+Anastasiia Kozar <kozar.anastasiia@gmail.com> <kozar.anastasiia@gmail.com>
+Ankit Chaudhary <ankit.chaudhary@tu-berlin.de>
+Ankit Chaudhary <ankit.chaudhary@tu-berlin.de> <ankitgit@users.noreply.github.com>
+Ankit Chaudhary <ankit.chaudhary@tu-berlin.de> <my007id@gmail.com>
+Ariane Ziehn <ariane.ziehn@tu-berlin.de> <ariane.ziehn@campus.tu-berlin.de>
+Ariane Ziehn <ariane.ziehn@tu-berlin.de> <arianeziehn@googlemail.com>
+Ariane Ziehn <ariane.ziehn@tu-berlin.de> <arianeziehn@users.noreply.github.com>
+Benedikt Maria Beckermann <beckermann@tu-berlin.de>
+Dimitrios Giouroukis <dimitrios.giouroukis@tu-berlin.de>
+Dimitrios Giouroukis <dimitrios.giouroukis@tu-berlin.de> <digiou@users.noreply.github.com>
+Dimitrios Giouroukis <dimitrios.giouroukis@tu-berlin.de> <digitalbckp@gmail.com>
+Dwi Nugroho <d.nugroho@tu-berlin.de>
+Dwi Nugroho <d.nugroho@tu-berlin.de> <dwiprasetyo.an@gmail.com>
+Dwi Nugroho <d.nugroho@tu-berlin.de> <dpanugroho@users.noreply.github.com>
+Eric Benschneider <eric.benschneider@tu-berlin.de>
+Eric Benschneider <eric.benschneider@tu-berlin.de> <84377096+HerrTumorius@users.noreply.github.com>
+Felix Lang <felix.s.lang@campus.tu-berlin.de>
+Hoang Mi Pham <ph.hoangmi@gmail.com>
+Ipek Turkan <ipekturkan@yahoo.com>
+Johannes Maess <maess.johannes@gmail.com>
+Johannes Russ <johannes.russ@dfki.de>
+Johannes Russ <johannes.russ@dfki.de> <47149263+JohannesRuss@users.noreply.github.com>
+Kyle Krüger <kyle-steven.krueger@charite.de>
+Kyle Krüger <kyle-steven.krueger@charite.de> <7158199+kykrueger@users.noreply.github.com>
+Kyle Krüger <kyle-steven.krueger@charite.de> <kykrueger@users.noreply.github.com>
+Laura Kutter <laurakutter@yahoo.de>
+Laura Kutter <laurakutter@yahoo.de> <95348732+laurakutter@users.noreply.github.com>
+Laura Mons <laura.mons@web.de>
+Lukas Schwerdtfeger <lukas.schwerdtfeger@gmail.com>
+Lukas Schwerdtfeger <lukas.schwerdtfeger@gmail.com> <ls-1801@users.noreply.github.com>
+M Stendler <stendler@campus.tu-berlin.de>
+M Stendler <stendler@campus.tu-berlin.de> <m.stendler@fu-berlin.de>
+Niklas Tantow <n.tantow@campus.tu-berlin.de>
+Niklas Tantow <n.tantow@campus.tu-berlin.de> <119663627+nikla44@users.noreply.github.com>
+Niklas Tantow <n.tantow@campus.tu-berlin.de> <n.tantow@tu-berlin.de>
+Nils Schubert <nilslpschubert@gmail.com> <45949765+keyseven123@users.noreply.github.com>
+Nils Schubert <nilslpschubert@gmail.com> <keyseven123@users.noreply.github.com>
+Nils Schubert <nilslpschubert@gmail.com> <nilslpschubert@gmail.com>
+Nils Schubert <nilslpschubert@gmail.com> <n.schubert.1@tu-berlin.de>
+Nils Schubert <nilslpschubert@gmail.com> <n.schubert@campus.tu-berlin.de>
+Philipp Grulich <philippgrulich@hotmail.de>
+Philipp Grulich <PhilippGrulich@users.noreply.github.com>
+Philipp Timm <philipptimm25@gmail.com>
+Philipp Timm <philipptimm25@gmail.com> <158486148+Philipp-Timm@users.noreply.github.com>
+Phillip Grote <phigro161@gmail.com>
+Quirin  Schlegel <34195172+QSchlegel@users.noreply.github.com>
+Quirin  Schlegel <quirin.schlegel@icloud.com>
+Steffen Zeuch <steffen.zeuch@tu-berlin.de> <steffen.zeuch@dfki.de>
+Steffen Zeuch <steffen.zeuch@tu-berlin.de> <zeuchste@informatik.hu-berlin.de>
+Steffen Zeuch <steffen.zeuch@tu-berlin.de> <zeuchste@users.noreply.github.com>
+Taha Tekdogan <tekdogan@tu-berlin.de> <tahatekdogan97@hotmail.com>
+Taha Tekdogan <tekdogan@tu-berlin.de> <tekdogan@users.noreply.github.com>
+Tilman Dietzel <dietzel@tu-berlin.de>
+Tilman Dietzel <dietzel@tu-berlin.de> <12828175+nmlt@users.noreply.github.com>
+Tilman Dietzel <dietzel@tu-berlin.de> <kgithub@nmlt.de>
+Tilman Dietzel <dietzel@tu-berlin.de> <nmlt@users.noreply.github.com>
+Tim Nacken <t.nacken@campus.tu-berlin.de>
+Tobias Engelbrecht <tobias.engelbrecht98@gmail.com>
+Varun Pandey <varun.pandey@tu-berlin.de>
+Varun Pandey <varun.pandey@tu-berlin.de> <varpande@users.noreply.github.com>
+Varun Pandey <varun.pandey@tu-berlin.de> <Varun Pandey>
+Ventura Del Monte <venturadelmonte@gmail.com> <VenturaDelMonte@users.noreply.github.com>
+Viktor Rosenfeld <viktor.rosenfeld@tu-berlin.de> <24hesk@gmail.com>
+Viktor Rosenfeld <viktor.rosenfeld@tu-berlin.de> <he-sk@users.noreply.github.com>
+Xenofon Chatziliadis <x.chatziliadis@tu-berlin.de>
+Xenofon Chatziliadis <x.chatziliadis@tu-berlin.de> <xchatzil@users.noreply.github.com>
+Yannik Schröder <schroeder_yannik@web.de>
+Yannik Schröder <schroeder_yannik@web.de> <65348331+yschroeder97@users.noreply.github.com>
+Zongxiong Chen <czxczf@gmail.com>

--- a/scripts/check_preamble.py
+++ b/scripts/check_preamble.py
@@ -59,6 +59,7 @@ INGORED_ENDINGS = {
     "dummy",
     "env",
     "gitignore",
+    "mailmap",
     "json",
     "kts",
     "md",


### PR DESCRIPTION
[git docs for mailmap](https://git-scm.com/docs/gitmailmap)

## before

```
$ git shortlog --after=2025-01-01 | grep "^[^ ]"
Adrian Michalke (240):
Benjamin Greb (6):
Eric Benschneider (15):
Klaas tom Dieck (16):
Kyle Krueger (4):
Kyle Krüger (1):
Leo Raasch (15):
Leonhard Rose (24):
Lukas Schwerdtfeger (33):
Matthis Gördel (221):
Niklas Tantow (7):
Nils L. Schubert (52):
Nils Schubert (120):
Philipp-Timm (8):
Sara Lhamo Schnaterbeck (1):
Tilman (2):
Tim Nacken (16):
Yanikovic (9):
Yannik Schröder (1):
alepping (120):
aljoscha lepping (1):
fkuzun (1):
greenBene (1):
lukas schwerdtfeger (153):
nikla44 (1):
nmlt (5):
tdietzel@beaver (1):
tekdogan (5):
```

## after

```sh
$ git shortlog --after=2025-01-01 | grep "^[^ ]"
Adrian Michalke (240):
Aljoscha Lepping (121):
Benedikt Beckermann (1):
Benjamin Greb (6):
Eric Benschneider (15):
Felix Lang (1):
Klaas tom Dieck (16):
Kyle Krüger (5):
Leo Raasch (15):
Leonhard Rose (24):
Lukas Schwerdtfeger (186):
Matthis Gördel (222):
Niklas Tantow (8):
Nils Schubert (172):
Philipp Timm (8):
Sara Lhamo Schnaterbeck (1):
Taha Tekdogan (5):
Tilman Dietzel (8):
Tim Nacken (16):
Yannik Schröder (10):
```