### PR TITLE
1059 rename tuple buffer memory provider to tuple buffer ref

### DIFF
--- a/nes-input-formatters/private/InputFormatterTask.hpp
+++ b/nes-input-formatters/private/InputFormatterTask.hpp
@@ -91,7 +91,7 @@ void processTuple(
 
     /// Currently, we still allow only row-wise writing to the formatted buffer
     /// This will will change with #496, which implements the InputFormatterTask in Nautilus
-    /// The InputFormatterTask then becomes part of a pipeline with a scan/emit phase and has access to the MemoryProvider
+    /// The InputFormatterTask then becomes part of a pipeline with a scan/emit phase and has access to the BufferRef
     for (size_t fieldIndex = 0; fieldIndex < schemaInfo.getFieldSizesInBytes().size(); ++fieldIndex)
     {
         /// Get the current field, parse it, and write it to the correct position in the formatted buffer

--- a/nes-nautilus/include/Nautilus/Interface/BufferRef/ColumnTupleBufferMemoryProvider.hpp
+++ b/nes-nautilus/include/Nautilus/Interface/BufferRef/ColumnTupleBufferMemoryProvider.hpp
@@ -17,13 +17,13 @@
 #include <memory>
 #include <MemoryLayout/ColumnLayout.hpp>
 #include <MemoryLayout/MemoryLayout.hpp>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
 
-namespace NES::Nautilus::Interface::MemoryProvider
+namespace NES::Nautilus::Interface::BufferRef
 {
 
-/// Implements MemoryProvider. Provides columnar memory access.
-class ColumnTupleBufferMemoryProvider final : public TupleBufferMemoryProvider
+/// Implements BufferRef. Provides columnar memory access.
+class ColumnTupleBufferMemoryProvider final : public TupleBufferRef
 {
 public:
     /// Creates a column memory provider based on a valid column memory layout pointer.

--- a/nes-nautilus/include/Nautilus/Interface/BufferRef/ColumnTupleBufferRef.hpp
+++ b/nes-nautilus/include/Nautilus/Interface/BufferRef/ColumnTupleBufferRef.hpp
@@ -23,12 +23,12 @@ namespace NES::Nautilus::Interface::BufferRef
 {
 
 /// Implements BufferRef. Provides columnar memory access.
-class ColumnTupleBufferMemoryProvider final : public TupleBufferRef
+class ColumnTupleBufferRef final : public TupleBufferRef
 {
 public:
     /// Creates a column memory provider based on a valid column memory layout pointer.
-    ColumnTupleBufferMemoryProvider(std::shared_ptr<ColumnLayout> columnMemoryLayoutPtr);
-    ~ColumnTupleBufferMemoryProvider() override = default;
+    explicit ColumnTupleBufferRef(std::shared_ptr<ColumnLayout> columnMemoryLayoutPtr);
+    ~ColumnTupleBufferRef() override = default;
 
     [[nodiscard]] std::shared_ptr<MemoryLayout> getMemoryLayout() const override;
 

--- a/nes-nautilus/include/Nautilus/Interface/BufferRef/RowTupleBufferMemoryProvider.hpp
+++ b/nes-nautilus/include/Nautilus/Interface/BufferRef/RowTupleBufferMemoryProvider.hpp
@@ -17,13 +17,13 @@
 #include <memory>
 #include <MemoryLayout/MemoryLayout.hpp>
 #include <MemoryLayout/RowLayout.hpp>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
 
-namespace NES::Nautilus::Interface::MemoryProvider
+namespace NES::Nautilus::Interface::BufferRef
 {
 
-/// Implements MemoryProvider. Provides row-wise memory access.
-class RowTupleBufferMemoryProvider final : public TupleBufferMemoryProvider
+/// Implements BufferRef. Provides row-wise memory access.
+class RowTupleBufferMemoryProvider final : public TupleBufferRef
 {
 public:
     /// Creates a row memory provider based on a valid row memory layout pointer.

--- a/nes-nautilus/include/Nautilus/Interface/BufferRef/RowTupleBufferRef.hpp
+++ b/nes-nautilus/include/Nautilus/Interface/BufferRef/RowTupleBufferRef.hpp
@@ -23,12 +23,12 @@ namespace NES::Nautilus::Interface::BufferRef
 {
 
 /// Implements BufferRef. Provides row-wise memory access.
-class RowTupleBufferMemoryProvider final : public TupleBufferRef
+class RowTupleBufferRef final : public TupleBufferRef
 {
 public:
     /// Creates a row memory provider based on a valid row memory layout pointer.
-    RowTupleBufferMemoryProvider(std::shared_ptr<RowLayout> rowMemoryLayoutPtr);
-    ~RowTupleBufferMemoryProvider() override = default;
+    explicit RowTupleBufferRef(std::shared_ptr<RowLayout> rowMemoryLayoutPtr);
+    ~RowTupleBufferRef() override = default;
 
     [[nodiscard]] std::shared_ptr<MemoryLayout> getMemoryLayout() const override;
 

--- a/nes-nautilus/include/Nautilus/Interface/BufferRef/TupleBufferRef.hpp
+++ b/nes-nautilus/include/Nautilus/Interface/BufferRef/TupleBufferRef.hpp
@@ -24,19 +24,19 @@
 #include <Nautilus/Interface/RecordBuffer.hpp>
 #include <val_ptr.hpp>
 
-namespace NES::Nautilus::Interface::MemoryProvider
+namespace NES::Nautilus::Interface::BufferRef
 {
 
 /// This class takes care of reading and writing data from/to a TupleBuffer.
-/// A TupleBufferMemoryProvider is closely coupled with a memory layout, and we support row and column layouts, currently.
+/// A TupleBufferRef is closely coupled with a memory layout, and we support row and column layouts, currently.
 /// We store multiple variable sized datas in one pooled buffer. If the pooled buffer is not large enough or there are no pooled buffer
 /// available, we fall back to an unpooled buffer.
-class TupleBufferMemoryProvider
+class TupleBufferRef
 {
 public:
-    virtual ~TupleBufferMemoryProvider();
+    virtual ~TupleBufferRef();
 
-    static std::shared_ptr<TupleBufferMemoryProvider> create(uint64_t bufferSize, const Schema& schema);
+    static std::shared_ptr<TupleBufferRef> create(uint64_t bufferSize, const Schema& schema);
 
     [[nodiscard]] virtual std::shared_ptr<MemoryLayout> getMemoryLayout() const = 0;
 

--- a/nes-nautilus/include/Nautilus/Interface/HashMap/ChainedHashMap/ChainedEntryMemoryProvider.hpp
+++ b/nes-nautilus/include/Nautilus/Interface/HashMap/ChainedHashMap/ChainedEntryMemoryProvider.hpp
@@ -25,7 +25,7 @@
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <val_concepts.hpp>
 
-namespace NES::Nautilus::Interface::MemoryProvider
+namespace NES::Nautilus::Interface::BufferRef
 {
 
 /// ChainedEntryMemoryProvider uses it to store the offsets for the keys and values of the ChainedHashMapEntry
@@ -44,7 +44,7 @@ public:
 
     /// We need to create the fields for the keys and values here, as we know here how the fields and the values are stored in the ChainedHashMapEntry.
     /// We can use here "normal" C++ values, as only the C++ runtime MUST call this method
-    static std::pair<std::vector<MemoryProvider::FieldOffsets>, std::vector<MemoryProvider::FieldOffsets>> createFieldOffsets(
+    static std::pair<std::vector<BufferRef::FieldOffsets>, std::vector<BufferRef::FieldOffsets>> createFieldOffsets(
         const Schema& schema,
         const std::vector<Record::RecordFieldIdentifier>& fieldNameKeys,
         const std::vector<Record::RecordFieldIdentifier>& fieldNameValues);

--- a/nes-nautilus/include/Nautilus/Interface/HashMap/ChainedHashMap/ChainedHashMapRef.hpp
+++ b/nes-nautilus/include/Nautilus/Interface/HashMap/ChainedHashMap/ChainedHashMapRef.hpp
@@ -55,14 +55,14 @@ public:
         ChainedEntryRef(
             const nautilus::val<ChainedHashMapEntry*>& entryRef,
             const nautilus::val<ChainedHashMap*>& hashMapRef,
-            std::vector<MemoryProvider::FieldOffsets> fieldsKey,
-            std::vector<MemoryProvider::FieldOffsets> fieldsValue);
+            std::vector<BufferRef::FieldOffsets> fieldsKey,
+            std::vector<BufferRef::FieldOffsets> fieldsValue);
 
         ChainedEntryRef(
             const nautilus::val<ChainedHashMapEntry*>& entryRef,
             const nautilus::val<ChainedHashMap*>& hashMapRef,
-            MemoryProvider::ChainedEntryMemoryProvider memoryProviderKeys,
-            MemoryProvider::ChainedEntryMemoryProvider memoryProviderValues);
+            BufferRef::ChainedEntryMemoryProvider memoryProviderKeys,
+            BufferRef::ChainedEntryMemoryProvider memoryProviderValues);
 
         ChainedEntryRef(const ChainedEntryRef& other);
         ChainedEntryRef& operator=(const ChainedEntryRef& other);
@@ -72,8 +72,8 @@ public:
 
         nautilus::val<ChainedHashMapEntry*> entryRef;
         nautilus::val<ChainedHashMap*> hashMapRef;
-        MemoryProvider::ChainedEntryMemoryProvider memoryProviderKeys;
-        MemoryProvider::ChainedEntryMemoryProvider memoryProviderValues;
+        BufferRef::ChainedEntryMemoryProvider memoryProviderKeys;
+        BufferRef::ChainedEntryMemoryProvider memoryProviderValues;
     };
 
     /// Iterator for iterating over all entries in the hash map.
@@ -110,8 +110,8 @@ public:
 
     ChainedHashMapRef(
         const nautilus::val<HashMap*>& hashMapRef,
-        std::vector<MemoryProvider::FieldOffsets> fieldsKey,
-        std::vector<MemoryProvider::FieldOffsets> fieldsValue,
+        std::vector<BufferRef::FieldOffsets> fieldsKey,
+        std::vector<BufferRef::FieldOffsets> fieldsValue,
         const nautilus::val<uint64_t>& entriesPerPage,
         const nautilus::val<uint64_t>& entrySize);
     ChainedHashMapRef(const ChainedHashMapRef& other);
@@ -142,8 +142,8 @@ private:
     [[nodiscard]] nautilus::val<ChainedHashMapEntry*> findKey(const Record& recordKey, const HashFunction::HashValue& hash) const;
     [[nodiscard]] nautilus::val<ChainedHashMapEntry*> findEntry(const ChainedEntryRef& otherEntryRef) const;
 
-    std::vector<MemoryProvider::FieldOffsets> fieldKeys;
-    std::vector<MemoryProvider::FieldOffsets> fieldValues;
+    std::vector<BufferRef::FieldOffsets> fieldKeys;
+    std::vector<BufferRef::FieldOffsets> fieldValues;
     nautilus::val<uint64_t> entriesPerPage;
     nautilus::val<uint64_t> entrySize;
 };

--- a/nes-nautilus/include/Nautilus/Interface/PagedVector/PagedVectorRef.hpp
+++ b/nes-nautilus/include/Nautilus/Interface/PagedVector/PagedVectorRef.hpp
@@ -18,7 +18,7 @@
 #include <memory>
 #include <vector>
 #include <MemoryLayout/MemoryLayout.hpp>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
 #include <Nautilus/Interface/PagedVector/PagedVector.hpp>
 #include <Nautilus/Interface/Record.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
@@ -37,9 +37,7 @@ class PagedVectorRef
 public:
     /// Declaring PagedVectorRefIter a friend class such that we can access the private members
     friend class PagedVectorRefIter;
-    PagedVectorRef(
-        const nautilus::val<PagedVector*>& pagedVectorRef,
-        const std::shared_ptr<MemoryProvider::TupleBufferMemoryProvider>& memoryProvider);
+    PagedVectorRef(const nautilus::val<PagedVector*>& pagedVectorRef, const std::shared_ptr<BufferRef::TupleBufferRef>& bufferRef);
 
     /// Writes a new record to the pagedVectorRef
     /// @param record the new record to be written
@@ -59,7 +57,7 @@ public:
 
 private:
     nautilus::val<PagedVector*> pagedVectorRef;
-    std::shared_ptr<MemoryProvider::TupleBufferMemoryProvider> memoryProvider;
+    std::shared_ptr<BufferRef::TupleBufferRef> bufferRef;
     nautilus::val<MemoryLayout*> memoryLayout;
 };
 
@@ -68,7 +66,7 @@ class PagedVectorRefIter
 public:
     explicit PagedVectorRefIter(
         PagedVectorRef pagedVector,
-        const std::shared_ptr<MemoryProvider::TupleBufferMemoryProvider>& memoryProvider,
+        const std::shared_ptr<BufferRef::TupleBufferRef>& bufferRef,
         const std::vector<Record::RecordFieldIdentifier>& projections,
         const nautilus::val<TupleBuffer*>& curPage,
         const nautilus::val<uint64_t>& posOnPage,
@@ -89,7 +87,7 @@ private:
     /// TODO #1152 create a custom class for these indices
     nautilus::val<uint64_t> posOnPage;
     nautilus::val<TupleBuffer*> curPage;
-    std::shared_ptr<MemoryProvider::TupleBufferMemoryProvider> memoryProvider;
+    std::shared_ptr<BufferRef::TupleBufferRef> bufferRef;
 };
 
 }

--- a/nes-nautilus/src/Nautilus/Interface/BufferRef/CMakeLists.txt
+++ b/nes-nautilus/src/Nautilus/Interface/BufferRef/CMakeLists.txt
@@ -12,6 +12,6 @@
 
 add_source_files(nes-nautilus
         TupleBufferRef.cpp
-        ColumnTupleBufferMemoryProvider.cpp
+        ColumnTupleBufferRef.cpp
         RowTupleBufferRef.cpp
         )

--- a/nes-nautilus/src/Nautilus/Interface/BufferRef/CMakeLists.txt
+++ b/nes-nautilus/src/Nautilus/Interface/BufferRef/CMakeLists.txt
@@ -11,7 +11,7 @@
 # limitations under the License.
 
 add_source_files(nes-nautilus
-        TupleBufferMemoryProvider.cpp
+        TupleBufferRef.cpp
         ColumnTupleBufferMemoryProvider.cpp
         RowTupleBufferMemoryProvider.cpp
         )

--- a/nes-nautilus/src/Nautilus/Interface/BufferRef/CMakeLists.txt
+++ b/nes-nautilus/src/Nautilus/Interface/BufferRef/CMakeLists.txt
@@ -13,5 +13,5 @@
 add_source_files(nes-nautilus
         TupleBufferRef.cpp
         ColumnTupleBufferMemoryProvider.cpp
-        RowTupleBufferMemoryProvider.cpp
+        RowTupleBufferRef.cpp
         )

--- a/nes-nautilus/src/Nautilus/Interface/BufferRef/ColumnTupleBufferMemoryProvider.cpp
+++ b/nes-nautilus/src/Nautilus/Interface/BufferRef/ColumnTupleBufferMemoryProvider.cpp
@@ -11,7 +11,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-#include <Nautilus/Interface/MemoryProvider/ColumnTupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/ColumnTupleBufferMemoryProvider.hpp>
 
 #include <memory>
 #include <utility>
@@ -26,7 +26,7 @@
 #include <nautilus/val_ptr.hpp>
 #include <val.hpp>
 
-namespace NES::Nautilus::Interface::MemoryProvider
+namespace NES::Nautilus::Interface::BufferRef
 {
 
 ColumnTupleBufferMemoryProvider::ColumnTupleBufferMemoryProvider(std::shared_ptr<ColumnLayout> columnMemoryLayoutPtr)

--- a/nes-nautilus/src/Nautilus/Interface/BufferRef/ColumnTupleBufferRef.cpp
+++ b/nes-nautilus/src/Nautilus/Interface/BufferRef/ColumnTupleBufferRef.cpp
@@ -11,7 +11,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-#include <Nautilus/Interface/BufferRef/ColumnTupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/ColumnTupleBufferRef.hpp>
 
 #include <memory>
 #include <utility>
@@ -29,15 +29,15 @@
 namespace NES::Nautilus::Interface::BufferRef
 {
 
-ColumnTupleBufferMemoryProvider::ColumnTupleBufferMemoryProvider(std::shared_ptr<ColumnLayout> columnMemoryLayoutPtr)
+ColumnTupleBufferRef::ColumnTupleBufferRef(std::shared_ptr<ColumnLayout> columnMemoryLayoutPtr)
     : columnMemoryLayout(std::move(std::move(columnMemoryLayoutPtr))) { };
 
-std::shared_ptr<MemoryLayout> ColumnTupleBufferMemoryProvider::getMemoryLayout() const
+std::shared_ptr<MemoryLayout> ColumnTupleBufferRef::getMemoryLayout() const
 {
     return columnMemoryLayout;
 }
 
-nautilus::val<int8_t*> ColumnTupleBufferMemoryProvider::calculateFieldAddress(
+nautilus::val<int8_t*> ColumnTupleBufferRef::calculateFieldAddress(
     const nautilus::val<int8_t*>& bufferAddress, nautilus::val<uint64_t>& recordIndex, const uint64_t fieldIndex) const
 {
     auto fieldSize = columnMemoryLayout->getFieldSize(fieldIndex);
@@ -47,7 +47,7 @@ nautilus::val<int8_t*> ColumnTupleBufferMemoryProvider::calculateFieldAddress(
     return fieldAddress;
 }
 
-Record ColumnTupleBufferMemoryProvider::readRecord(
+Record ColumnTupleBufferRef::readRecord(
     const std::vector<Record::RecordFieldIdentifier>& projections,
     const RecordBuffer& recordBuffer,
     nautilus::val<uint64_t>& recordIndex) const
@@ -70,7 +70,7 @@ Record ColumnTupleBufferMemoryProvider::readRecord(
     return record;
 }
 
-void ColumnTupleBufferMemoryProvider::writeRecord(
+void ColumnTupleBufferRef::writeRecord(
     nautilus::val<uint64_t>& recordIndex,
     const RecordBuffer& recordBuffer,
     const Record& rec,

--- a/nes-nautilus/src/Nautilus/Interface/BufferRef/RowTupleBufferMemoryProvider.cpp
+++ b/nes-nautilus/src/Nautilus/Interface/BufferRef/RowTupleBufferMemoryProvider.cpp
@@ -11,7 +11,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-#include <Nautilus/Interface/MemoryProvider/RowTupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/RowTupleBufferMemoryProvider.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -28,7 +28,7 @@
 #include <static.hpp>
 #include <val.hpp>
 
-namespace NES::Nautilus::Interface::MemoryProvider
+namespace NES::Nautilus::Interface::BufferRef
 {
 
 RowTupleBufferMemoryProvider::RowTupleBufferMemoryProvider(std::shared_ptr<RowLayout> rowMemoryLayout)

--- a/nes-nautilus/src/Nautilus/Interface/BufferRef/RowTupleBufferRef.cpp
+++ b/nes-nautilus/src/Nautilus/Interface/BufferRef/RowTupleBufferRef.cpp
@@ -11,7 +11,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-#include <Nautilus/Interface/BufferRef/RowTupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/RowTupleBufferRef.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -31,23 +31,21 @@
 namespace NES::Nautilus::Interface::BufferRef
 {
 
-RowTupleBufferMemoryProvider::RowTupleBufferMemoryProvider(std::shared_ptr<RowLayout> rowMemoryLayout)
-    : rowMemoryLayout(std::move(rowMemoryLayout)) { };
+RowTupleBufferRef::RowTupleBufferRef(std::shared_ptr<RowLayout> rowMemoryLayout) : rowMemoryLayout(std::move(rowMemoryLayout)) { };
 
-std::shared_ptr<MemoryLayout> RowTupleBufferMemoryProvider::getMemoryLayout() const
+std::shared_ptr<MemoryLayout> RowTupleBufferRef::getMemoryLayout() const
 {
     return rowMemoryLayout;
 }
 
-nautilus::val<int8_t*>
-RowTupleBufferMemoryProvider::calculateFieldAddress(const nautilus::val<int8_t*>& recordOffset, const uint64_t fieldIndex) const
+nautilus::val<int8_t*> RowTupleBufferRef::calculateFieldAddress(const nautilus::val<int8_t*>& recordOffset, const uint64_t fieldIndex) const
 {
     auto fieldOffset = rowMemoryLayout->getFieldOffset(fieldIndex);
     auto fieldAddress = recordOffset + nautilus::val<uint64_t>(fieldOffset);
     return fieldAddress;
 }
 
-Record RowTupleBufferMemoryProvider::readRecord(
+Record RowTupleBufferRef::readRecord(
     const std::vector<Record::RecordFieldIdentifier>& projections,
     const RecordBuffer& recordBuffer,
     nautilus::val<uint64_t>& recordIndex) const
@@ -72,7 +70,7 @@ Record RowTupleBufferMemoryProvider::readRecord(
     return record;
 }
 
-void RowTupleBufferMemoryProvider::writeRecord(
+void RowTupleBufferRef::writeRecord(
     nautilus::val<uint64_t>& recordIndex,
     const RecordBuffer& recordBuffer,
     const Record& rec,

--- a/nes-nautilus/src/Nautilus/Interface/BufferRef/TupleBufferRef.cpp
+++ b/nes-nautilus/src/Nautilus/Interface/BufferRef/TupleBufferRef.cpp
@@ -12,7 +12,7 @@
     limitations under the License.
 */
 
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
 
 #include <algorithm>
 #include <cstdint>
@@ -30,8 +30,8 @@
 #include <Nautilus/DataTypes/DataTypesUtil.hpp>
 #include <Nautilus/DataTypes/VarVal.hpp>
 #include <Nautilus/DataTypes/VariableSizedData.hpp>
-#include <Nautilus/Interface/MemoryProvider/ColumnTupleBufferMemoryProvider.hpp>
-#include <Nautilus/Interface/MemoryProvider/RowTupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/ColumnTupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/RowTupleBufferMemoryProvider.hpp>
 #include <Nautilus/Interface/Record.hpp>
 #include <Nautilus/Interface/RecordBuffer.hpp>
 #include <Nautilus/Interface/VariableSizedAccessRef.hpp>
@@ -42,11 +42,11 @@
 #include <val.hpp>
 #include <val_ptr.hpp>
 
-namespace NES::Nautilus::Interface::MemoryProvider
+namespace NES::Nautilus::Interface::BufferRef
 {
 
-VarVal TupleBufferMemoryProvider::loadValue(
-    const DataType& physicalType, const RecordBuffer& recordBuffer, const nautilus::val<int8_t*>& fieldReference)
+VarVal
+TupleBufferRef::loadValue(const DataType& physicalType, const RecordBuffer& recordBuffer, const nautilus::val<int8_t*>& fieldReference)
 {
     if (physicalType.type != DataType::Type::VARSIZED)
     {
@@ -65,7 +65,7 @@ VarVal TupleBufferMemoryProvider::loadValue(
     return VariableSizedData(varSizedPtr);
 }
 
-VarVal TupleBufferMemoryProvider::storeValue(
+VarVal TupleBufferRef::storeValue(
     const DataType& physicalType,
     const RecordBuffer& recordBuffer,
     const nautilus::val<int8_t*>& fieldReference,
@@ -101,15 +101,15 @@ VarVal TupleBufferMemoryProvider::storeValue(
     return value;
 }
 
-bool TupleBufferMemoryProvider::includesField(
+bool TupleBufferRef::includesField(
     const std::vector<Record::RecordFieldIdentifier>& projections, const Record::RecordFieldIdentifier& fieldIndex)
 {
     return std::ranges::find(projections, fieldIndex) != projections.end();
 }
 
-TupleBufferMemoryProvider::~TupleBufferMemoryProvider() = default;
+TupleBufferRef::~TupleBufferRef() = default;
 
-std::shared_ptr<TupleBufferMemoryProvider> TupleBufferMemoryProvider::create(const uint64_t bufferSize, const Schema& schema)
+std::shared_ptr<TupleBufferRef> TupleBufferRef::create(const uint64_t bufferSize, const Schema& schema)
 {
     if (schema.memoryLayoutType == Schema::MemoryLayoutType::ROW_LAYOUT)
     {

--- a/nes-nautilus/src/Nautilus/Interface/BufferRef/TupleBufferRef.cpp
+++ b/nes-nautilus/src/Nautilus/Interface/BufferRef/TupleBufferRef.cpp
@@ -30,7 +30,7 @@
 #include <Nautilus/DataTypes/DataTypesUtil.hpp>
 #include <Nautilus/DataTypes/VarVal.hpp>
 #include <Nautilus/DataTypes/VariableSizedData.hpp>
-#include <Nautilus/Interface/BufferRef/ColumnTupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/ColumnTupleBufferRef.hpp>
 #include <Nautilus/Interface/BufferRef/RowTupleBufferRef.hpp>
 #include <Nautilus/Interface/Record.hpp>
 #include <Nautilus/Interface/RecordBuffer.hpp>
@@ -119,7 +119,7 @@ std::shared_ptr<TupleBufferRef> TupleBufferRef::create(const uint64_t bufferSize
     if (schema.memoryLayoutType == Schema::MemoryLayoutType::COLUMNAR_LAYOUT)
     {
         auto columnMemoryLayout = std::make_shared<ColumnLayout>(bufferSize, schema);
-        return std::make_shared<ColumnTupleBufferMemoryProvider>(std::move(columnMemoryLayout));
+        return std::make_shared<ColumnTupleBufferRef>(std::move(columnMemoryLayout));
     }
     throw NotImplemented("Currently only row and column layout are supported");
 }

--- a/nes-nautilus/src/Nautilus/Interface/BufferRef/TupleBufferRef.cpp
+++ b/nes-nautilus/src/Nautilus/Interface/BufferRef/TupleBufferRef.cpp
@@ -31,7 +31,7 @@
 #include <Nautilus/DataTypes/VarVal.hpp>
 #include <Nautilus/DataTypes/VariableSizedData.hpp>
 #include <Nautilus/Interface/BufferRef/ColumnTupleBufferMemoryProvider.hpp>
-#include <Nautilus/Interface/BufferRef/RowTupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/RowTupleBufferRef.hpp>
 #include <Nautilus/Interface/Record.hpp>
 #include <Nautilus/Interface/RecordBuffer.hpp>
 #include <Nautilus/Interface/VariableSizedAccessRef.hpp>
@@ -114,7 +114,7 @@ std::shared_ptr<TupleBufferRef> TupleBufferRef::create(const uint64_t bufferSize
     if (schema.memoryLayoutType == Schema::MemoryLayoutType::ROW_LAYOUT)
     {
         auto rowMemoryLayout = std::make_shared<RowLayout>(bufferSize, schema);
-        return std::make_shared<RowTupleBufferMemoryProvider>(std::move(rowMemoryLayout));
+        return std::make_shared<RowTupleBufferRef>(std::move(rowMemoryLayout));
     }
     if (schema.memoryLayoutType == Schema::MemoryLayoutType::COLUMNAR_LAYOUT)
     {

--- a/nes-nautilus/src/Nautilus/Interface/CMakeLists.txt
+++ b/nes-nautilus/src/Nautilus/Interface/CMakeLists.txt
@@ -12,7 +12,7 @@
 
 add_subdirectory(Hash)
 add_subdirectory(HashMap)
-add_subdirectory(MemoryProvider)
+add_subdirectory(BufferRef)
 add_subdirectory(PagedVector)
 
 add_source_files(nes-nautilus

--- a/nes-nautilus/src/Nautilus/Interface/HashMap/ChainedHashMap/ChainedEntryMemoryProvider.cpp
+++ b/nes-nautilus/src/Nautilus/Interface/HashMap/ChainedHashMap/ChainedEntryMemoryProvider.cpp
@@ -29,11 +29,10 @@
 #include <static.hpp>
 #include <val.hpp>
 
-namespace NES::Nautilus::Interface::MemoryProvider
+namespace NES::Nautilus::Interface::BufferRef
 {
 
-std::pair<std::vector<MemoryProvider::FieldOffsets>, std::vector<MemoryProvider::FieldOffsets>>
-ChainedEntryMemoryProvider::createFieldOffsets(
+std::pair<std::vector<BufferRef::FieldOffsets>, std::vector<BufferRef::FieldOffsets>> ChainedEntryMemoryProvider::createFieldOffsets(
     const Schema& schema,
     const std::vector<Record::RecordFieldIdentifier>& fieldNameKeys,
     const std::vector<Record::RecordFieldIdentifier>& fieldNameValues)
@@ -41,8 +40,8 @@ ChainedEntryMemoryProvider::createFieldOffsets(
     /// For now, we assume that we the fields lie consecutively in the memory like in a row layout.
     /// First, the key fields and then the value fields.
     /// The key and values start after the ChainedHashMapEntry and its hash, see @ref ChainedHashMapEntry
-    std::vector<MemoryProvider::FieldOffsets> fieldsKey;
-    std::vector<MemoryProvider::FieldOffsets> fieldsValue;
+    std::vector<BufferRef::FieldOffsets> fieldsKey;
+    std::vector<BufferRef::FieldOffsets> fieldsValue;
     uint64_t offset = sizeof(ChainedHashMapEntry);
     for (const auto& fieldName : fieldNameKeys)
     {
@@ -50,7 +49,7 @@ ChainedEntryMemoryProvider::createFieldOffsets(
         INVARIANT(field.has_value(), "Field {} not found in schema", fieldName);
         const auto& fieldValue = field.value();
         fieldsKey.emplace_back(
-            MemoryProvider::FieldOffsets{.fieldIdentifier = fieldValue.name, .type = fieldValue.dataType, .fieldOffset = offset});
+            BufferRef::FieldOffsets{.fieldIdentifier = fieldValue.name, .type = fieldValue.dataType, .fieldOffset = offset});
         offset += fieldValue.dataType.getSizeInBytes();
     }
 
@@ -60,7 +59,7 @@ ChainedEntryMemoryProvider::createFieldOffsets(
         INVARIANT(field.has_value(), "Field {} not found in schema", fieldName);
         const auto& fieldValue = field.value();
         fieldsValue.emplace_back(
-            MemoryProvider::FieldOffsets{.fieldIdentifier = fieldValue.name, .type = fieldValue.dataType, .fieldOffset = offset});
+            BufferRef::FieldOffsets{.fieldIdentifier = fieldValue.name, .type = fieldValue.dataType, .fieldOffset = offset});
         offset += fieldValue.dataType.getSizeInBytes();
     }
     return {fieldsKey, fieldsValue};

--- a/nes-nautilus/src/Nautilus/Interface/HashMap/ChainedHashMap/ChainedHashMapRef.cpp
+++ b/nes-nautilus/src/Nautilus/Interface/HashMap/ChainedHashMap/ChainedHashMapRef.cpp
@@ -141,8 +141,8 @@ nautilus::val<ChainedHashMapEntry*> ChainedHashMapRef::ChainedEntryRef::getNext(
 ChainedHashMapRef::ChainedEntryRef::ChainedEntryRef(
     const nautilus::val<ChainedHashMapEntry*>& entryRef,
     const nautilus::val<ChainedHashMap*>& hashMapRef,
-    std::vector<MemoryProvider::FieldOffsets> fieldsKey,
-    std::vector<MemoryProvider::FieldOffsets> fieldsValue)
+    std::vector<BufferRef::FieldOffsets> fieldsKey,
+    std::vector<BufferRef::FieldOffsets> fieldsValue)
     : entryRef(entryRef), hashMapRef(hashMapRef), memoryProviderKeys(std::move(fieldsKey)), memoryProviderValues(std::move(fieldsValue))
 {
 }
@@ -150,8 +150,8 @@ ChainedHashMapRef::ChainedEntryRef::ChainedEntryRef(
 ChainedHashMapRef::ChainedEntryRef::ChainedEntryRef(
     const nautilus::val<ChainedHashMapEntry*>& entryRef,
     const nautilus::val<ChainedHashMap*>& hashMapRef,
-    MemoryProvider::ChainedEntryMemoryProvider memoryProviderKeys,
-    MemoryProvider::ChainedEntryMemoryProvider memoryProviderValues)
+    BufferRef::ChainedEntryMemoryProvider memoryProviderKeys,
+    BufferRef::ChainedEntryMemoryProvider memoryProviderValues)
     : entryRef(entryRef)
     , hashMapRef(hashMapRef)
     , memoryProviderKeys(std::move(memoryProviderKeys))
@@ -343,8 +343,8 @@ nautilus::val<bool> ChainedHashMapRef::compareKeys(const ChainedEntryRef& entryR
 
 ChainedHashMapRef::ChainedHashMapRef(
     const nautilus::val<HashMap*>& hashMapRef,
-    std::vector<MemoryProvider::FieldOffsets> fieldsKey,
-    std::vector<MemoryProvider::FieldOffsets> fieldsValue,
+    std::vector<BufferRef::FieldOffsets> fieldsKey,
+    std::vector<BufferRef::FieldOffsets> fieldsValue,
     const nautilus::val<uint64_t>& entriesPerPage,
     const nautilus::val<uint64_t>& entrySize)
     : HashMapRef(hashMapRef)

--- a/nes-nautilus/tests/TestUtils/include/ChainedHashMapTestUtils.hpp
+++ b/nes-nautilus/tests/TestUtils/include/ChainedHashMapTestUtils.hpp
@@ -21,10 +21,10 @@
 #include <vector>
 #include <DataTypes/DataType.hpp>
 #include <DataTypes/Schema.hpp>
+#include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
 #include <Nautilus/Interface/HashMap/ChainedHashMap/ChainedEntryMemoryProvider.hpp>
 #include <Nautilus/Interface/HashMap/ChainedHashMap/ChainedHashMap.hpp>
 #include <Nautilus/Interface/HashMap/HashMap.hpp>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
 #include <Nautilus/Interface/Record.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/BufferManager.hpp>
@@ -64,10 +64,10 @@ public:
     std::shared_ptr<BufferManager> bufferManager;
     std::unique_ptr<nautilus::engine::NautilusEngine> nautilusEngine;
     Schema inputSchema;
-    std::vector<Interface::MemoryProvider::FieldOffsets> fieldKeys, fieldValues;
+    std::vector<Interface::BufferRef::FieldOffsets> fieldKeys, fieldValues;
     std::vector<Record::RecordFieldIdentifier> projectionKeys, projectionValues;
     std::vector<TupleBuffer> inputBuffers;
-    std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> memoryProviderInputBuffer;
+    std::shared_ptr<Interface::BufferRef::TupleBufferRef> inputBufferRef;
     uint64_t keySize, valueSize, entriesPerPage, entrySize;
     TestParams params;
 
@@ -85,7 +85,7 @@ public:
 
     std::string compareExpectedWithActual(
         const TupleBuffer& bufferActual,
-        const Interface::MemoryProvider::TupleBufferMemoryProvider& memoryProviderInputBuffer,
+        const Interface::BufferRef::TupleBufferRef& memoryProviderInputBuffer,
         const std::map<RecordWithFields, Record>& exactMap);
 
     /// Compiles the query that writes the values for all keys in keyBufferRef to outputBufferForKeys.

--- a/nes-nautilus/tests/TestUtils/include/NautilusTestUtils.hpp
+++ b/nes-nautilus/tests/TestUtils/include/NautilusTestUtils.hpp
@@ -25,8 +25,8 @@
 #include <vector>
 #include <DataTypes/DataType.hpp>
 #include <DataTypes/Schema.hpp>
+#include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
 #include <Nautilus/Interface/Hash/HashFunction.hpp>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
 #include <Nautilus/Interface/Record.hpp>
 #include <Runtime/TupleBuffer.hpp>
 #include <Util/ExecutionMode.hpp>
@@ -158,7 +158,7 @@ public:
         ExecutionMode backend,
         nautilus::engine::Options& options,
         const Schema& schema,
-        const std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider>& memoryProviderInputBuffer);
+        const std::shared_ptr<Interface::BufferRef::TupleBufferRef>& memoryProviderInputBuffer);
 
     /// Compares two records and if they are not equal returning a string. If the records are equal, return nullopt
     static std::string
@@ -178,8 +178,8 @@ public:
     static std::string compareRecordBuffers(
         const std::vector<TupleBuffer>& actualRecords,
         const std::vector<TupleBuffer>& expectedRecords,
-        const Nautilus::Interface::MemoryProvider::TupleBufferMemoryProvider& memoryProviderActualBuffer,
-        const Nautilus::Interface::MemoryProvider::TupleBufferMemoryProvider& memoryProviderInputBuffer);
+        const Nautilus::Interface::BufferRef::TupleBufferRef& memoryProviderActualBuffer,
+        const Nautilus::Interface::BufferRef::TupleBufferRef& memoryProviderInputBuffer);
 
 
 protected:

--- a/nes-nautilus/tests/TestUtils/src/ChainedHashMapCustomValueTestUtils.cpp
+++ b/nes-nautilus/tests/TestUtils/src/ChainedHashMapCustomValueTestUtils.cpp
@@ -50,7 +50,7 @@ ChainedHashMapCustomValueTestUtils::compileFindAndInsertIntoPagedVector(
         {
             Interface::ChainedHashMapRef hashMapRef(hashMapVal, fieldKeys, fieldValues, entriesPerPage, entrySize);
             const RecordBuffer recordBufferKey(bufferKey);
-            auto recordKey = memoryProviderInputBuffer->readRecord(projectionKeys, recordBufferKey, keyPositionVal);
+            auto recordKey = inputBufferRef->readRecord(projectionKeys, recordBufferKey, keyPositionVal);
 
             auto foundEntry = hashMapRef.findOrCreateEntry(
                 recordKey,
@@ -70,11 +70,11 @@ ChainedHashMapCustomValueTestUtils::compileFindAndInsertIntoPagedVector(
                 bufferManagerVal);
 
             const Interface::ChainedHashMapRef::ChainedEntryRef ref(foundEntry, hashMapVal, fieldKeys, fieldValues);
-            const Interface::PagedVectorRef pagedVectorRef(ref.getValueMemArea(), memoryProviderInputBuffer);
+            const Interface::PagedVectorRef pagedVectorRef(ref.getValueMemArea(), inputBufferRef);
             const RecordBuffer recordBufferValue(bufferValue);
             for (nautilus::val<uint64_t> idxValues = 0; idxValues < recordBufferValue.getNumRecords(); idxValues = idxValues + 1)
             {
-                auto recordValue = memoryProviderInputBuffer->readRecord(projectionAllFields, recordBufferValue, idxValues);
+                auto recordValue = inputBufferRef->readRecord(projectionAllFields, recordBufferValue, idxValues);
                 pagedVectorRef.writeRecord(recordValue, bufferManagerVal);
             }
         }));
@@ -98,17 +98,17 @@ ChainedHashMapCustomValueTestUtils::compileWriteAllRecordsIntoOutputBuffer(
             Interface::ChainedHashMapRef hashMapRef(hashMapVal, fieldKeys, {}, entriesPerPage, entrySize);
             const RecordBuffer recordBufferKey(keyBufferRef);
             RecordBuffer recordBufferOutput(outputBufferRef);
-            const auto recordKey = memoryProviderInputBuffer->readRecord(projectionKeys, recordBufferKey, keyPositionVal);
+            const auto recordKey = inputBufferRef->readRecord(projectionKeys, recordBufferKey, keyPositionVal);
             const auto foundEntry
                 = hashMapRef.findOrCreateEntry(recordKey, *getMurMurHashFunction(), ASSERT_VIOLATION_FOR_ON_INSERT, bufferManagerVal);
 
             const Interface::ChainedHashMapRef::ChainedEntryRef ref(foundEntry, hashMapVal, fieldKeys, fieldValues);
-            const Interface::PagedVectorRef pagedVectorRef(ref.getValueMemArea(), memoryProviderInputBuffer);
+            const Interface::PagedVectorRef pagedVectorRef(ref.getValueMemArea(), inputBufferRef);
             nautilus::val<uint64_t> recordBufferIndex = 0;
             for (auto it = pagedVectorRef.begin(projectionAllFields); it != pagedVectorRef.end(projectionAllFields); ++it)
             {
                 const auto record = *it;
-                memoryProviderInputBuffer->writeRecord(recordBufferIndex, recordBufferOutput, record, bufferManagerVal);
+                inputBufferRef->writeRecord(recordBufferIndex, recordBufferOutput, record, bufferManagerVal);
                 recordBufferIndex = recordBufferIndex + 1;
                 recordBufferOutput.setNumRecords(recordBufferIndex);
             }

--- a/nes-nautilus/tests/TestUtils/src/NautilusTestUtils.cpp
+++ b/nes-nautilus/tests/TestUtils/src/NautilusTestUtils.cpp
@@ -30,9 +30,9 @@
 #include <MemoryLayout/MemoryLayout.hpp>
 #include <Nautilus/DataTypes/VarVal.hpp>
 #include <Nautilus/DataTypes/VariableSizedData.hpp>
+#include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
 #include <Nautilus/Interface/Hash/HashFunction.hpp>
 #include <Nautilus/Interface/Hash/MurMur3HashFunction.hpp>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
 #include <Nautilus/Interface/Record.hpp>
 #include <Nautilus/Interface/RecordBuffer.hpp>
 #include <Nautilus/Util.hpp>
@@ -85,8 +85,7 @@ std::vector<TupleBuffer> NautilusTestUtils::createMonotonicallyIncreasingValues(
     const uint64_t maxSizeVarSizedData)
 {
     /// Creating here the memory provider for the tuple buffers that store the data
-    const auto memoryProviderInputBuffer
-        = Interface::MemoryProvider::TupleBufferMemoryProvider::create(bufferManager.getBufferSize(), schema);
+    const auto memoryProviderInputBuffer = Interface::BufferRef::TupleBufferRef::create(bufferManager.getBufferSize(), schema);
 
 
     /// If we have large number of tuples, we should compile the query otherwise, it is faster to run it in the interpreter.
@@ -166,7 +165,7 @@ void NautilusTestUtils::compileFillBufferFunction(
     ExecutionMode backend,
     nautilus::engine::Options& options,
     const Schema& schema,
-    const std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider>& memoryProviderInputBuffer)
+    const std::shared_ptr<Interface::BufferRef::TupleBufferRef>& memoryProviderInputBuffer)
 {
     /// We are not allowed to use const or const references for the lambda function params, as nautilus does not support this in the registerFunction method.
     /// NOLINTBEGIN(performance-unnecessary-value-param)

--- a/nes-nautilus/tests/UnitTests/PagedVectorTest.cpp
+++ b/nes-nautilus/tests/UnitTests/PagedVectorTest.cpp
@@ -22,7 +22,7 @@
 #include <DataTypes/DataType.hpp>
 #include <DataTypes/DataTypeProvider.hpp>
 #include <DataTypes/Schema.hpp>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
 #include <Nautilus/Interface/PagedVector/PagedVector.hpp>
 #include <Runtime/BufferManager.hpp>
 #include <Runtime/TupleBuffer.hpp>
@@ -92,7 +92,7 @@ TEST_P(PagedVectorTest, storeAndRetrieveFixedSizeValues)
     const auto projections = testSchema.getFieldNames();
     const auto allRecords = createMonotonicallyIncreasingValues(testSchema, numberOfItems, *bufferManager);
 
-    const auto memoryProvider = MemoryProvider::TupleBufferMemoryProvider::create(pageSize, testSchema);
+    const auto memoryProvider = BufferRef::TupleBufferRef::create(pageSize, testSchema);
     PagedVector pagedVector;
     TestUtils::runStoreTest(pagedVector, testSchema, pageSize, projections, allRecords, *nautilusEngine, *bufferManager);
     TestUtils::runRetrieveTest(pagedVector, testSchema, pageSize, projections, allRecords, *nautilusEngine, *bufferManager);
@@ -109,7 +109,7 @@ TEST_P(PagedVectorTest, storeAndRetrieveVarSizeValues)
     const auto projections = testSchema.getFieldNames();
     const auto allRecords = createMonotonicallyIncreasingValues(testSchema, numberOfItems, *bufferManager);
 
-    const auto memoryProvider = MemoryProvider::TupleBufferMemoryProvider::create(pageSize, testSchema);
+    const auto memoryProvider = BufferRef::TupleBufferRef::create(pageSize, testSchema);
     PagedVector pagedVector;
     TestUtils::runStoreTest(pagedVector, testSchema, pageSize, projections, allRecords, *nautilusEngine, *bufferManager);
     TestUtils::runRetrieveTest(pagedVector, testSchema, pageSize, projections, allRecords, *nautilusEngine, *bufferManager);
@@ -128,7 +128,7 @@ TEST_P(PagedVectorTest, storeAndRetrieveLargeValues)
     const auto projections = testSchema.getFieldNames();
     const auto allRecords = createMonotonicallyIncreasingValues(testSchema, numberOfItems, *bufferManager, sizeVarSizedData);
 
-    const auto memoryProvider = MemoryProvider::TupleBufferMemoryProvider::create(pageSize, testSchema);
+    const auto memoryProvider = BufferRef::TupleBufferRef::create(pageSize, testSchema);
     PagedVector pagedVector;
     TestUtils::runStoreTest(pagedVector, testSchema, pageSize, projections, allRecords, *nautilusEngine, *bufferManager);
     TestUtils::runRetrieveTest(pagedVector, testSchema, pageSize, projections, allRecords, *nautilusEngine, *bufferManager);
@@ -145,7 +145,7 @@ TEST_P(PagedVectorTest, storeAndRetrieveMixedValueTypes)
     const auto projections = testSchema.getFieldNames();
     const auto allRecords = createMonotonicallyIncreasingValues(testSchema, numberOfItems, *bufferManager);
 
-    const auto memoryProvider = MemoryProvider::TupleBufferMemoryProvider::create(pageSize, testSchema);
+    const auto memoryProvider = BufferRef::TupleBufferRef::create(pageSize, testSchema);
     PagedVector pagedVector;
     TestUtils::runStoreTest(pagedVector, testSchema, pageSize, projections, allRecords, *nautilusEngine, *bufferManager);
     TestUtils::runRetrieveTest(pagedVector, testSchema, pageSize, projections, allRecords, *nautilusEngine, *bufferManager);
@@ -161,7 +161,7 @@ TEST_P(PagedVectorTest, storeAndRetrieveFixedValuesNonDefaultPageSize)
     const auto projections = testSchema.getFieldNames();
     const auto allRecords = createMonotonicallyIncreasingValues(testSchema, numberOfItems, *bufferManager);
 
-    const auto memoryProvider = MemoryProvider::TupleBufferMemoryProvider::create(pageSize, testSchema);
+    const auto memoryProvider = BufferRef::TupleBufferRef::create(pageSize, testSchema);
     PagedVector pagedVector;
     TestUtils::runStoreTest(pagedVector, testSchema, pageSize, projections, allRecords, *nautilusEngine, *bufferManager);
     TestUtils::runRetrieveTest(pagedVector, testSchema, pageSize, projections, allRecords, *nautilusEngine, *bufferManager);

--- a/nes-physical-operators/include/Aggregation/Function/MedianAggregationPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Aggregation/Function/MedianAggregationPhysicalFunction.hpp
@@ -19,7 +19,7 @@
 #include <Aggregation/Function/AggregationPhysicalFunction.hpp>
 #include <DataTypes/DataType.hpp>
 #include <Functions/PhysicalFunction.hpp>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
 #include <Nautilus/Interface/Record.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <val_concepts.hpp>
@@ -35,7 +35,7 @@ public:
         DataType resultType,
         PhysicalFunction inputFunction,
         Nautilus::Record::RecordFieldIdentifier resultFieldIdentifier,
-        std::shared_ptr<Nautilus::Interface::MemoryProvider::TupleBufferMemoryProvider> memProviderPagedVector);
+        std::shared_ptr<Nautilus::Interface::BufferRef::TupleBufferRef> bufferRefPagedVector);
     void lift(
         const nautilus::val<AggregationState*>& aggregationState,
         PipelineMemoryProvider& pipelineMemoryProvider,
@@ -51,7 +51,7 @@ public:
     ~MedianAggregationPhysicalFunction() override = default;
 
 private:
-    std::shared_ptr<Nautilus::Interface::MemoryProvider::TupleBufferMemoryProvider> memProviderPagedVector;
+    std::shared_ptr<Nautilus::Interface::BufferRef::TupleBufferRef> bufferRefPagedVector;
 };
 
 }

--- a/nes-physical-operators/include/EmitPhysicalOperator.hpp
+++ b/nes-physical-operators/include/EmitPhysicalOperator.hpp
@@ -17,7 +17,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
 #include <Nautilus/Interface/Record.hpp>
 #include <Nautilus/Interface/RecordBuffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
@@ -34,8 +34,7 @@ namespace NES
 class EmitPhysicalOperator final : public PhysicalOperatorConcept
 {
 public:
-    explicit EmitPhysicalOperator(
-        OperatorHandlerId operatorHandlerId, std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> memoryProvider);
+    explicit EmitPhysicalOperator(OperatorHandlerId operatorHandlerId, std::shared_ptr<Interface::BufferRef::TupleBufferRef> bufferRef);
 
     void setup(ExecutionContext&, CompilationContext&) const override { /*noop*/ }
 
@@ -57,7 +56,7 @@ private:
     [[nodiscard]] uint64_t getMaxRecordsPerBuffer() const;
 
     std::optional<PhysicalOperator> child;
-    std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> memoryProvider;
+    std::shared_ptr<Interface::BufferRef::TupleBufferRef> bufferRef;
     OperatorHandlerId operatorHandlerId;
 };
 

--- a/nes-physical-operators/include/HashMapOptions.hpp
+++ b/nes-physical-operators/include/HashMapOptions.hpp
@@ -35,8 +35,8 @@ struct HashMapOptions
     HashMapOptions(
         std::unique_ptr<Nautilus::Interface::HashFunction> hashFunction,
         std::vector<PhysicalFunction> keyFunctions,
-        std::vector<Nautilus::Interface::MemoryProvider::FieldOffsets> fieldKeys,
-        std::vector<Nautilus::Interface::MemoryProvider::FieldOffsets> fieldValues,
+        std::vector<Nautilus::Interface::BufferRef::FieldOffsets> fieldKeys,
+        std::vector<Nautilus::Interface::BufferRef::FieldOffsets> fieldValues,
         const uint64_t entriesPerPage,
         const uint64_t entrySize,
         const uint64_t keySize,
@@ -147,8 +147,8 @@ struct HashMapOptions
     /// It is fine that these are not nautilus types, because they are only used in the tracing and not in the actual execution
     std::unique_ptr<Nautilus::Interface::HashFunction> hashFunction;
     std::vector<PhysicalFunction> keyFunctions;
-    std::vector<Nautilus::Interface::MemoryProvider::FieldOffsets> fieldKeys;
-    std::vector<Nautilus::Interface::MemoryProvider::FieldOffsets> fieldValues;
+    std::vector<Nautilus::Interface::BufferRef::FieldOffsets> fieldKeys;
+    std::vector<Nautilus::Interface::BufferRef::FieldOffsets> fieldValues;
     uint64_t entriesPerPage;
     uint64_t entrySize;
     uint64_t keySize;

--- a/nes-physical-operators/include/Join/HashJoin/HJBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJBuildPhysicalOperator.hpp
@@ -18,8 +18,8 @@
 #include <Join/HashJoin/HJOperatorHandler.hpp>
 #include <Join/StreamJoinBuildPhysicalOperator.hpp>
 #include <Join/StreamJoinUtil.hpp>
+#include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
 #include <Nautilus/Interface/HashMap/HashMap.hpp>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
 #include <Nautilus/Interface/Record.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Time/Timestamp.hpp>
@@ -54,7 +54,7 @@ public:
         OperatorHandlerId operatorHandlerId,
         JoinBuildSideType joinBuildSide,
         std::unique_ptr<TimeFunction> timeFunction,
-        const std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider>& memoryProvider,
+        const std::shared_ptr<Interface::BufferRef::TupleBufferRef>& bufferRef,
         HashMapOptions hashMapOptions);
     void setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const override;
     void execute(ExecutionContext& ctx, Record& record) const override;

--- a/nes-physical-operators/include/Join/HashJoin/HJProbePhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJProbePhysicalOperator.hpp
@@ -18,7 +18,7 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Join/StreamJoinProbePhysicalOperator.hpp>
 #include <Join/StreamJoinUtil.hpp>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
 #include <Nautilus/Interface/RecordBuffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Windowing/WindowMetaData.hpp>
@@ -37,8 +37,8 @@ public:
         PhysicalFunction joinFunction,
         WindowMetaData windowMetaData,
         JoinSchema joinSchema,
-        std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> leftMemoryProvider,
-        std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> rightMemoryProvider,
+        std::shared_ptr<Interface::BufferRef::TupleBufferRef> leftBufferRef,
+        std::shared_ptr<Interface::BufferRef::TupleBufferRef> rightBufferRef,
         HashMapOptions leftHashMapBasedOptions,
         HashMapOptions rightHashMapBasedOptions);
 
@@ -47,7 +47,7 @@ public:
     void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
 
 private:
-    std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> leftMemoryProvider, rightMemoryProvider;
+    std::shared_ptr<Interface::BufferRef::TupleBufferRef> leftBufferRef, rightBufferRef;
     HashMapOptions leftHashMapOptions, rightHashMapOptions;
 };
 

--- a/nes-physical-operators/include/Join/NestedLoopJoin/NLJBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/NestedLoopJoin/NLJBuildPhysicalOperator.hpp
@@ -18,7 +18,7 @@
 #include <memory>
 #include <Join/StreamJoinBuildPhysicalOperator.hpp>
 #include <Join/StreamJoinUtil.hpp>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
 #include <Nautilus/Interface/Record.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Watermark/TimeFunction.hpp>
@@ -36,7 +36,7 @@ public:
         OperatorHandlerId operatorHandlerId,
         JoinBuildSideType joinBuildSide,
         std::unique_ptr<TimeFunction> timeFunction,
-        std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> memoryProvider);
+        std::shared_ptr<Interface::BufferRef::TupleBufferRef> bufferRef);
 
     void execute(ExecutionContext& executionCtx, Record& record) const override;
 };

--- a/nes-physical-operators/include/Join/NestedLoopJoin/NLJProbePhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/NestedLoopJoin/NLJProbePhysicalOperator.hpp
@@ -19,7 +19,7 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Join/StreamJoinProbePhysicalOperator.hpp>
 #include <Join/StreamJoinUtil.hpp>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
 #include <Nautilus/Interface/PagedVector/PagedVectorRef.hpp>
 #include <Nautilus/Interface/RecordBuffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
@@ -27,7 +27,7 @@
 
 namespace NES
 {
-using namespace Interface::MemoryProvider;
+using namespace Interface::BufferRef;
 
 /// Performs the second phase of the join. The tuples are joined via two nested loops.
 class NLJProbePhysicalOperator final : public StreamJoinProbePhysicalOperator
@@ -38,8 +38,8 @@ public:
         PhysicalFunction joinFunction,
         WindowMetaData windowMetaData,
         const JoinSchema& joinSchema,
-        std::shared_ptr<TupleBufferMemoryProvider> leftMemoryProvider,
-        std::shared_ptr<TupleBufferMemoryProvider> rightMemoryProvider);
+        std::shared_ptr<TupleBufferRef> leftMemoryProvider,
+        std::shared_ptr<TupleBufferRef> rightMemoryProvider);
 
     void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
 
@@ -47,12 +47,12 @@ protected:
     void performNLJ(
         const Interface::PagedVectorRef& outerPagedVector,
         const Interface::PagedVectorRef& innerPagedVector,
-        Interface::MemoryProvider::TupleBufferMemoryProvider& outerMemoryProvider,
-        Interface::MemoryProvider::TupleBufferMemoryProvider& innerMemoryProvider,
+        Interface::BufferRef::TupleBufferRef& outerMemoryProvider,
+        Interface::BufferRef::TupleBufferRef& innerMemoryProvider,
         ExecutionContext& executionCtx,
         const nautilus::val<Timestamp>& windowStart,
         const nautilus::val<Timestamp>& windowEnd) const;
-    std::shared_ptr<TupleBufferMemoryProvider> leftMemoryProvider;
-    std::shared_ptr<TupleBufferMemoryProvider> rightMemoryProvider;
+    std::shared_ptr<TupleBufferRef> leftMemoryProvider;
+    std::shared_ptr<TupleBufferRef> rightMemoryProvider;
 };
 }

--- a/nes-physical-operators/include/Join/StreamJoinBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/StreamJoinBuildPhysicalOperator.hpp
@@ -17,7 +17,7 @@
 #include <cstdint>
 #include <memory>
 #include <Join/StreamJoinUtil.hpp>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Watermark/TimeFunction.hpp>
 #include <WindowBuildPhysicalOperator.hpp>
@@ -32,14 +32,14 @@ public:
         OperatorHandlerId operatorHandlerId,
         JoinBuildSideType joinBuildSide,
         std::unique_ptr<TimeFunction> timeFunction,
-        std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> memoryProvider);
+        std::shared_ptr<Interface::BufferRef::TupleBufferRef> memoryProvider);
     ~StreamJoinBuildPhysicalOperator() override = default;
 
     StreamJoinBuildPhysicalOperator(const StreamJoinBuildPhysicalOperator& other) = default;
 
 protected:
     const JoinBuildSideType joinBuildSide;
-    const std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> memoryProvider;
+    const std::shared_ptr<Interface::BufferRef::TupleBufferRef> bufferRef;
 };
 
 }

--- a/nes-physical-operators/include/Join/StreamJoinOperatorHandler.hpp
+++ b/nes-physical-operators/include/Join/StreamJoinOperatorHandler.hpp
@@ -18,7 +18,6 @@
 #include <memory>
 #include <vector>
 #include <Identifiers/Identifiers.hpp>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <SliceStore/Slice.hpp>
 #include <SliceStore/WindowSlicesStoreInterface.hpp>

--- a/nes-physical-operators/include/ScanPhysicalOperator.hpp
+++ b/nes-physical-operators/include/ScanPhysicalOperator.hpp
@@ -17,7 +17,7 @@
 #include <memory>
 #include <optional>
 #include <vector>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
 #include <Nautilus/Interface/Record.hpp>
 #include <Nautilus/Interface/RecordBuffer.hpp>
 #include <PhysicalOperator.hpp>
@@ -34,15 +34,14 @@ public:
     /// @param memoryLayout memory layout that describes the tuple buffer.
     /// @param projections projection vector
     ScanPhysicalOperator(
-        std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> memoryProvider,
-        std::vector<Record::RecordFieldIdentifier> projections);
+        std::shared_ptr<Interface::BufferRef::TupleBufferRef> bufferRef, std::vector<Record::RecordFieldIdentifier> projections);
 
     void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
     [[nodiscard]] std::optional<PhysicalOperator> getChild() const override;
     void setChild(PhysicalOperator child) override;
 
 private:
-    std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> memoryProvider;
+    std::shared_ptr<Interface::BufferRef::TupleBufferRef> bufferRef;
     std::vector<Record::RecordFieldIdentifier> projections;
     std::optional<PhysicalOperator> child;
 };

--- a/nes-physical-operators/registry/include/AggregationPhysicalFunctionRegistry.hpp
+++ b/nes-physical-operators/registry/include/AggregationPhysicalFunctionRegistry.hpp
@@ -20,7 +20,7 @@
 #include <Aggregation/Function/AggregationPhysicalFunction.hpp>
 #include <DataTypes/DataType.hpp>
 #include <Functions/PhysicalFunction.hpp>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
 #include <Nautilus/Interface/Record.hpp>
 #include <Util/Registry.hpp>
 
@@ -35,7 +35,7 @@ struct AggregationPhysicalFunctionRegistryArguments
     DataType resultType;
     PhysicalFunction inputFunction;
     Record::RecordFieldIdentifier resultFieldIdentifier;
-    std::optional<std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider>> memProviderPagedVector;
+    std::optional<std::shared_ptr<Interface::BufferRef::TupleBufferRef>> bufferRefPagedVector;
 };
 
 class AggregationPhysicalFunctionRegistry : public BaseRegistry<

--- a/nes-physical-operators/src/EmitPhysicalOperator.cpp
+++ b/nes-physical-operators/src/EmitPhysicalOperator.cpp
@@ -20,7 +20,7 @@
 #include <optional>
 #include <utility>
 #include <Identifiers/Identifiers.hpp>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
 #include <Nautilus/Interface/NESStrongTypeRef.hpp>
 #include <Nautilus/Interface/Record.hpp>
 #include <Nautilus/Interface/RecordBuffer.hpp>
@@ -123,7 +123,7 @@ void EmitPhysicalOperator::execute(ExecutionContext& ctx, Record& record) const
     /// We need to first check if the buffer has to be emitted and then write to it. Otherwise, it can happen that we will
     /// emit a tuple twice. Once in the execute() and then again in close(). This happens only for buffers that are filled
     /// to the brim, i.e., have no more space left.
-    memoryProvider->writeRecord(emitState->outputIndex, emitState->resultBuffer, record, ctx.pipelineMemoryProvider.bufferProvider);
+    bufferRef->writeRecord(emitState->outputIndex, emitState->resultBuffer, record, ctx.pipelineMemoryProvider.bufferProvider);
     emitState->outputIndex = emitState->outputIndex + 1;
 }
 
@@ -165,14 +165,14 @@ void EmitPhysicalOperator::emitRecordBuffer(
 }
 
 EmitPhysicalOperator::EmitPhysicalOperator(
-    OperatorHandlerId operatorHandlerId, std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> memoryProvider)
-    : memoryProvider(std::move(memoryProvider)), operatorHandlerId(operatorHandlerId)
+    OperatorHandlerId operatorHandlerId, std::shared_ptr<Interface::BufferRef::TupleBufferRef> memoryProvider)
+    : bufferRef(std::move(memoryProvider)), operatorHandlerId(operatorHandlerId)
 {
 }
 
 [[nodiscard]] uint64_t EmitPhysicalOperator::getMaxRecordsPerBuffer() const
 {
-    return memoryProvider->getMemoryLayout()->getCapacity();
+    return bufferRef->getMemoryLayout()->getCapacity();
 }
 
 std::optional<PhysicalOperator> EmitPhysicalOperator::getChild() const

--- a/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
@@ -23,9 +23,9 @@
 #include <Join/HashJoin/HJSlice.hpp>
 #include <Join/StreamJoinBuildPhysicalOperator.hpp>
 #include <Join/StreamJoinUtil.hpp>
+#include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
 #include <Nautilus/Interface/HashMap/ChainedHashMap/ChainedHashMapRef.hpp>
 #include <Nautilus/Interface/HashMap/HashMap.hpp>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
 #include <Nautilus/Interface/PagedVector/PagedVector.hpp>
 #include <Nautilus/Interface/PagedVector/PagedVectorRef.hpp>
 #include <Nautilus/Interface/Record.hpp>
@@ -171,7 +171,7 @@ void HJBuildPhysicalOperator::execute(ExecutionContext& ctx, Record& record) con
     const Interface::ChainedHashMapRef::ChainedEntryRef entryRef{
         hashMapEntry, hashMapPtr, hashMapOptions.fieldKeys, hashMapOptions.fieldValues};
     auto entryMemArea = entryRef.getValueMemArea();
-    const Nautilus::Interface::PagedVectorRef pagedVectorRef(entryMemArea, memoryProvider);
+    const Nautilus::Interface::PagedVectorRef pagedVectorRef(entryMemArea, bufferRef);
     pagedVectorRef.writeRecord(record, ctx.pipelineMemoryProvider.bufferProvider);
 }
 
@@ -179,9 +179,9 @@ HJBuildPhysicalOperator::HJBuildPhysicalOperator(
     const OperatorHandlerId operatorHandlerId,
     const JoinBuildSideType joinBuildSide,
     std::unique_ptr<TimeFunction> timeFunction,
-    const std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider>& memoryProvider,
+    const std::shared_ptr<Interface::BufferRef::TupleBufferRef>& bufferRef,
     HashMapOptions hashMapOptions)
-    : StreamJoinBuildPhysicalOperator(operatorHandlerId, joinBuildSide, std::move(timeFunction), memoryProvider)
+    : StreamJoinBuildPhysicalOperator(operatorHandlerId, joinBuildSide, std::move(timeFunction), bufferRef)
     , hashMapOptions(std::move(hashMapOptions))
 {
 }

--- a/nes-physical-operators/src/Join/NestedLoopJoin/NLJBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/NestedLoopJoin/NLJBuildPhysicalOperator.cpp
@@ -19,7 +19,7 @@
 #include <Join/NestedLoopJoin/NLJSlice.hpp>
 #include <Join/StreamJoinBuildPhysicalOperator.hpp>
 #include <Join/StreamJoinUtil.hpp>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
 #include <Nautilus/Interface/PagedVector/PagedVectorRef.hpp>
 #include <Nautilus/Interface/Record.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
@@ -50,8 +50,8 @@ NLJBuildPhysicalOperator::NLJBuildPhysicalOperator(
     const OperatorHandlerId operatorHandlerId,
     const JoinBuildSideType joinBuildSide,
     std::unique_ptr<TimeFunction> timeFunction,
-    std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> memoryProvider)
-    : StreamJoinBuildPhysicalOperator(operatorHandlerId, joinBuildSide, std::move(timeFunction), std::move(memoryProvider))
+    std::shared_ptr<Interface::BufferRef::TupleBufferRef> bufferRef)
+    : StreamJoinBuildPhysicalOperator(operatorHandlerId, joinBuildSide, std::move(timeFunction), std::move(bufferRef))
 {
 }
 
@@ -85,7 +85,7 @@ void NLJBuildPhysicalOperator::execute(ExecutionContext& executionCtx, Record& r
 
 
     /// Write record to the pagedVector
-    const Interface::PagedVectorRef pagedVectorRef(nljPagedVectorMemRef, memoryProvider);
+    const Interface::PagedVectorRef pagedVectorRef(nljPagedVectorMemRef, bufferRef);
     pagedVectorRef.writeRecord(record, executionCtx.pipelineMemoryProvider.bufferProvider);
 }
 }

--- a/nes-physical-operators/src/Join/NestedLoopJoin/NLJOperatorHandler.cpp
+++ b/nes-physical-operators/src/Join/NestedLoopJoin/NLJOperatorHandler.cpp
@@ -24,7 +24,6 @@
 #include <Join/NestedLoopJoin/NLJSlice.hpp>
 #include <Join/StreamJoinOperatorHandler.hpp>
 #include <Join/StreamJoinUtil.hpp>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
 #include <Nautilus/Interface/PagedVector/PagedVector.hpp>
 #include <Sequencing/SequenceData.hpp>
 #include <SliceStore/Slice.hpp>

--- a/nes-physical-operators/src/Join/NestedLoopJoin/NLJProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/NestedLoopJoin/NLJProbePhysicalOperator.cpp
@@ -23,7 +23,7 @@
 #include <Join/NestedLoopJoin/NLJSlice.hpp>
 #include <Join/StreamJoinProbePhysicalOperator.hpp>
 #include <Join/StreamJoinUtil.hpp>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
 #include <Nautilus/Interface/NESStrongTypeRef.hpp>
 #include <Nautilus/Interface/PagedVector/PagedVectorRef.hpp>
 #include <Nautilus/Interface/RecordBuffer.hpp>
@@ -88,8 +88,8 @@ NLJProbePhysicalOperator::NLJProbePhysicalOperator(
     PhysicalFunction joinFunction,
     WindowMetaData windowMetaData,
     const JoinSchema& joinSchema,
-    std::shared_ptr<TupleBufferMemoryProvider> leftMemoryProvider,
-    std::shared_ptr<TupleBufferMemoryProvider> rightMemoryProvider)
+    std::shared_ptr<TupleBufferRef> leftMemoryProvider,
+    std::shared_ptr<TupleBufferRef> rightMemoryProvider)
     : StreamJoinProbePhysicalOperator(operatorHandlerId, std::move(joinFunction), WindowMetaData(std::move(windowMetaData)), joinSchema)
     , leftMemoryProvider(std::move(leftMemoryProvider))
     , rightMemoryProvider(std::move(rightMemoryProvider))
@@ -99,8 +99,8 @@ NLJProbePhysicalOperator::NLJProbePhysicalOperator(
 void NLJProbePhysicalOperator::performNLJ(
     const Interface::PagedVectorRef& outerPagedVector,
     const Interface::PagedVectorRef& innerPagedVector,
-    Interface::MemoryProvider::TupleBufferMemoryProvider& outerMemoryProvider,
-    Interface::MemoryProvider::TupleBufferMemoryProvider& innerMemoryProvider,
+    Interface::BufferRef::TupleBufferRef& outerMemoryProvider,
+    Interface::BufferRef::TupleBufferRef& innerMemoryProvider,
     ExecutionContext& executionCtx,
     const nautilus::val<Timestamp>& windowStart,
     const nautilus::val<Timestamp>& windowEnd) const

--- a/nes-physical-operators/src/Join/StreamJoinBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/StreamJoinBuildPhysicalOperator.cpp
@@ -11,12 +11,12 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
+#include <Join/StreamJoinBuildPhysicalOperator.hpp>
 
 #include <memory>
 #include <utility>
-#include <Join/StreamJoinBuildPhysicalOperator.hpp>
 #include <Join/StreamJoinUtil.hpp>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Watermark/TimeFunction.hpp>
 #include <WindowBuildPhysicalOperator.hpp>
@@ -28,10 +28,10 @@ StreamJoinBuildPhysicalOperator::StreamJoinBuildPhysicalOperator(
     const OperatorHandlerId operatorHandlerId,
     const JoinBuildSideType joinBuildSide,
     std::unique_ptr<TimeFunction> timeFunction,
-    std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> memoryProvider)
+    std::shared_ptr<Interface::BufferRef::TupleBufferRef> bufferRef)
     : WindowBuildPhysicalOperator(operatorHandlerId, std::move(timeFunction))
     , joinBuildSide(joinBuildSide)
-    , memoryProvider(std::move(std::move(memoryProvider)))
+    , bufferRef(std::move(std::move(bufferRef)))
 {
 }
 }

--- a/nes-physical-operators/src/Join/StreamJoinOperatorHandler.cpp
+++ b/nes-physical-operators/src/Join/StreamJoinOperatorHandler.cpp
@@ -20,7 +20,6 @@
 #include <utility>
 #include <vector>
 #include <Identifiers/Identifiers.hpp>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
 #include <Sequencing/SequenceData.hpp>
 #include <SliceStore/Slice.hpp>
 #include <SliceStore/WindowSlicesStoreInterface.hpp>

--- a/nes-physical-operators/src/ScanPhysicalOperator.cpp
+++ b/nes-physical-operators/src/ScanPhysicalOperator.cpp
@@ -20,7 +20,7 @@
 #include <optional>
 #include <utility>
 #include <vector>
-#include <Nautilus/Interface/MemoryProvider/TupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
 #include <Nautilus/Interface/Record.hpp>
 #include <Nautilus/Interface/RecordBuffer.hpp>
 #include <Util/StdInt.hpp>
@@ -31,9 +31,8 @@ namespace NES
 {
 
 ScanPhysicalOperator::ScanPhysicalOperator(
-    std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> memoryProvider,
-    std::vector<Record::RecordFieldIdentifier> projections)
-    : memoryProvider(std::move(memoryProvider)), projections(std::move(projections))
+    std::shared_ptr<Interface::BufferRef::TupleBufferRef> bufferRef, std::vector<Record::RecordFieldIdentifier> projections)
+    : bufferRef(std::move(bufferRef)), projections(std::move(projections))
 {
 }
 
@@ -52,7 +51,7 @@ void ScanPhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& re
     auto numberOfRecords = recordBuffer.getNumRecords();
     for (nautilus::val<uint64_t> i = 0_u64; i < numberOfRecords; i = i + 1_u64)
     {
-        auto record = memoryProvider->readRecord(projections, recordBuffer, i);
+        auto record = bufferRef->readRecord(projections, recordBuffer, i);
         executeChild(executionCtx, record);
     }
 }

--- a/nes-physical-operators/tests/EmitPhysicalOperatorTest.cpp
+++ b/nes-physical-operators/tests/EmitPhysicalOperatorTest.cpp
@@ -34,7 +34,7 @@
 #include <Identifiers/Identifiers.hpp>
 #include <Identifiers/NESStrongType.hpp>
 #include <MemoryLayout/RowLayout.hpp>
-#include <Nautilus/Interface/BufferRef/RowTupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/RowTupleBufferRef.hpp>
 #include <Nautilus/Interface/RecordBuffer.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/BufferManager.hpp>
@@ -113,7 +113,7 @@ public:
     {
         auto schema = Schema{}.addField("A_FIELD", DataType::Type::UINT32);
         auto layout = std::make_shared<RowLayout>(512, schema);
-        EmitPhysicalOperator emit{OperatorHandlerId(0), std::make_shared<Interface::BufferRef::RowTupleBufferMemoryProvider>(layout)};
+        EmitPhysicalOperator emit{OperatorHandlerId(0), std::make_shared<Interface::BufferRef::RowTupleBufferRef>(layout)};
         handlers.emplace(OperatorHandlerId(0), std::make_shared<EmitOperatorHandler>());
         return emit;
     }

--- a/nes-physical-operators/tests/EmitPhysicalOperatorTest.cpp
+++ b/nes-physical-operators/tests/EmitPhysicalOperatorTest.cpp
@@ -34,7 +34,7 @@
 #include <Identifiers/Identifiers.hpp>
 #include <Identifiers/NESStrongType.hpp>
 #include <MemoryLayout/RowLayout.hpp>
-#include <Nautilus/Interface/MemoryProvider/RowTupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/RowTupleBufferMemoryProvider.hpp>
 #include <Nautilus/Interface/RecordBuffer.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/BufferManager.hpp>
@@ -113,7 +113,7 @@ public:
     {
         auto schema = Schema{}.addField("A_FIELD", DataType::Type::UINT32);
         auto layout = std::make_shared<RowLayout>(512, schema);
-        EmitPhysicalOperator emit{OperatorHandlerId(0), std::make_shared<Interface::MemoryProvider::RowTupleBufferMemoryProvider>(layout)};
+        EmitPhysicalOperator emit{OperatorHandlerId(0), std::make_shared<Interface::BufferRef::RowTupleBufferMemoryProvider>(layout)};
         handlers.emplace(OperatorHandlerId(0), std::make_shared<EmitOperatorHandler>());
         return emit;
     }

--- a/nes-query-compiler/src/Phases/PipeliningPhase.cpp
+++ b/nes-query-compiler/src/Phases/PipeliningPhase.cpp
@@ -20,7 +20,7 @@
 #include <utility>
 #include <Identifiers/Identifiers.hpp>
 #include <MemoryLayout/RowLayout.hpp>
-#include <Nautilus/Interface/MemoryProvider/RowTupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/RowTupleBufferMemoryProvider.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <EmitOperatorHandler.hpp>
@@ -52,7 +52,7 @@ void addDefaultScan(const std::shared_ptr<Pipeline>& pipeline, const PhysicalOpe
     INVARIANT(schema.has_value(), "Wrapped operator has no input schema");
 
     auto layout = std::make_shared<RowLayout>(configuredBufferSize, schema.value());
-    const auto memoryProvider = std::make_shared<Interface::MemoryProvider::RowTupleBufferMemoryProvider>(layout);
+    const auto memoryProvider = std::make_shared<Interface::BufferRef::RowTupleBufferMemoryProvider>(layout);
     /// Prepend the default scan operator.
     pipeline->prependOperator(ScanPhysicalOperator(memoryProvider, schema->getFieldNames()));
 }
@@ -68,7 +68,7 @@ std::shared_ptr<Pipeline> createNewPiplineWithScan(
     INVARIANT(schema.has_value(), "Wrapped operator has no input schema");
 
     auto layout = std::make_shared<RowLayout>(configuredBufferSize, schema.value());
-    const auto memoryProvider = std::make_shared<Interface::MemoryProvider::RowTupleBufferMemoryProvider>(layout);
+    const auto memoryProvider = std::make_shared<Interface::BufferRef::RowTupleBufferMemoryProvider>(layout);
 
     const auto newPipeline = std::make_shared<Pipeline>(ScanPhysicalOperator(memoryProvider, schema->getFieldNames()));
     prevPipeline->addSuccessor(newPipeline, prevPipeline);
@@ -88,7 +88,7 @@ void addDefaultEmit(const std::shared_ptr<Pipeline>& pipeline, const PhysicalOpe
     INVARIANT(schema.has_value(), "Wrapped operator has no output schema");
 
     auto layout = std::make_shared<RowLayout>(configuredBufferSize, schema.value());
-    const auto memoryProvider = std::make_shared<Interface::MemoryProvider::RowTupleBufferMemoryProvider>(layout);
+    const auto memoryProvider = std::make_shared<Interface::BufferRef::RowTupleBufferMemoryProvider>(layout);
     /// Create an operator handler for the emit
     const OperatorHandlerId operatorHandlerIndex = getNextOperatorHandlerId();
     pipeline->getOperatorHandlers().emplace(operatorHandlerIndex, std::make_shared<EmitOperatorHandler>());

--- a/nes-query-optimizer/src/RewriteRules/LowerToPhysical/LowerToPhysicalProjection.cpp
+++ b/nes-query-optimizer/src/RewriteRules/LowerToPhysical/LowerToPhysicalProjection.cpp
@@ -20,7 +20,7 @@
 #include <vector>
 #include <Functions/FunctionProvider.hpp>
 #include <MemoryLayout/RowLayout.hpp>
-#include <Nautilus/Interface/BufferRef/RowTupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/RowTupleBufferRef.hpp>
 #include <Operators/LogicalOperator.hpp>
 #include <Operators/ProjectionLogicalOperator.hpp>
 #include <RewriteRules/AbstractRewriteRule.hpp>
@@ -41,9 +41,9 @@ RewriteRuleResultSubgraph LowerToPhysicalProjection::apply(LogicalOperator proje
     auto bufferSize = conf.pageSize.getValue();
 
     auto scanLayout = std::make_shared<RowLayout>(bufferSize, inputSchema);
-    auto scanMemoryProvider = std::make_shared<Interface::BufferRef::RowTupleBufferMemoryProvider>(scanLayout);
+    auto scanBufferRef = std::make_shared<Interface::BufferRef::RowTupleBufferRef>(scanLayout);
     auto accessedFields = projection.getAccessedFields();
-    auto scan = ScanPhysicalOperator(scanMemoryProvider, accessedFields);
+    auto scan = ScanPhysicalOperator(scanBufferRef, accessedFields);
     auto scanWrapper = std::make_shared<PhysicalOperatorWrapper>(
         scan, outputSchema, outputSchema, std::nullopt, std::nullopt, PhysicalOperatorWrapper::PipelineLocation::SCAN);
 

--- a/nes-query-optimizer/src/RewriteRules/LowerToPhysical/LowerToPhysicalProjection.cpp
+++ b/nes-query-optimizer/src/RewriteRules/LowerToPhysical/LowerToPhysicalProjection.cpp
@@ -20,7 +20,7 @@
 #include <vector>
 #include <Functions/FunctionProvider.hpp>
 #include <MemoryLayout/RowLayout.hpp>
-#include <Nautilus/Interface/MemoryProvider/RowTupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/RowTupleBufferMemoryProvider.hpp>
 #include <Operators/LogicalOperator.hpp>
 #include <Operators/ProjectionLogicalOperator.hpp>
 #include <RewriteRules/AbstractRewriteRule.hpp>
@@ -41,7 +41,7 @@ RewriteRuleResultSubgraph LowerToPhysicalProjection::apply(LogicalOperator proje
     auto bufferSize = conf.pageSize.getValue();
 
     auto scanLayout = std::make_shared<RowLayout>(bufferSize, inputSchema);
-    auto scanMemoryProvider = std::make_shared<Interface::MemoryProvider::RowTupleBufferMemoryProvider>(scanLayout);
+    auto scanMemoryProvider = std::make_shared<Interface::BufferRef::RowTupleBufferMemoryProvider>(scanLayout);
     auto accessedFields = projection.getAccessedFields();
     auto scan = ScanPhysicalOperator(scanMemoryProvider, accessedFields);
     auto scanWrapper = std::make_shared<PhysicalOperatorWrapper>(

--- a/nes-query-optimizer/src/RewriteRules/LowerToPhysical/LowerToPhysicalWindowedAggregation.cpp
+++ b/nes-query-optimizer/src/RewriteRules/LowerToPhysical/LowerToPhysicalWindowedAggregation.cpp
@@ -28,10 +28,10 @@
 #include <Functions/FunctionProvider.hpp>
 #include <Functions/PhysicalFunction.hpp>
 #include <MemoryLayout/ColumnLayout.hpp>
+#include <Nautilus/Interface/BufferRef/ColumnTupleBufferRef.hpp>
 #include <Nautilus/Interface/Hash/MurMur3HashFunction.hpp>
 #include <Nautilus/Interface/HashMap/ChainedHashMap/ChainedEntryMemoryProvider.hpp>
 #include <Nautilus/Interface/HashMap/ChainedHashMap/ChainedHashMap.hpp>
-#include <Nautilus/Interface/BufferRef/ColumnTupleBufferMemoryProvider.hpp>
 #include <Nautilus/Interface/Record.hpp>
 #include <Operators/LogicalOperator.hpp>
 #include <Operators/Windows/WindowedAggregationLogicalOperator.hpp>
@@ -116,7 +116,7 @@ getAggregationPhysicalFunctions(const WindowedAggregationLogicalOperator& logica
         auto aggregationInputFunction = QueryCompilation::FunctionProvider::lowerFunction(descriptor->onField);
         const auto resultFieldIdentifier = descriptor->asField.getFieldName();
         auto layout = std::make_shared<ColumnLayout>(configuration.pageSize.getValue(), logicalOperator.getInputSchemas()[0]);
-        auto memoryProvider = std::make_shared<Interface::BufferRef::ColumnTupleBufferMemoryProvider>(layout);
+        auto bufferRef = std::make_shared<Interface::BufferRef::ColumnTupleBufferRef>(layout);
 
         auto name = descriptor->getName();
         auto aggregationArguments = AggregationPhysicalFunctionRegistryArguments(
@@ -124,7 +124,7 @@ getAggregationPhysicalFunctions(const WindowedAggregationLogicalOperator& logica
             std::move(physicalFinalType),
             std::move(aggregationInputFunction),
             resultFieldIdentifier,
-            memoryProvider);
+            bufferRef);
         if (auto aggregationPhysicalFunction
             = AggregationPhysicalFunctionRegistry::instance().create(std::string(name), std::move(aggregationArguments)))
         {

--- a/nes-query-optimizer/src/RewriteRules/LowerToPhysical/LowerToPhysicalWindowedAggregation.cpp
+++ b/nes-query-optimizer/src/RewriteRules/LowerToPhysical/LowerToPhysicalWindowedAggregation.cpp
@@ -31,7 +31,7 @@
 #include <Nautilus/Interface/Hash/MurMur3HashFunction.hpp>
 #include <Nautilus/Interface/HashMap/ChainedHashMap/ChainedEntryMemoryProvider.hpp>
 #include <Nautilus/Interface/HashMap/ChainedHashMap/ChainedHashMap.hpp>
-#include <Nautilus/Interface/MemoryProvider/ColumnTupleBufferMemoryProvider.hpp>
+#include <Nautilus/Interface/BufferRef/ColumnTupleBufferMemoryProvider.hpp>
 #include <Nautilus/Interface/Record.hpp>
 #include <Operators/LogicalOperator.hpp>
 #include <Operators/Windows/WindowedAggregationLogicalOperator.hpp>
@@ -116,7 +116,7 @@ getAggregationPhysicalFunctions(const WindowedAggregationLogicalOperator& logica
         auto aggregationInputFunction = QueryCompilation::FunctionProvider::lowerFunction(descriptor->onField);
         const auto resultFieldIdentifier = descriptor->asField.getFieldName();
         auto layout = std::make_shared<ColumnLayout>(configuration.pageSize.getValue(), logicalOperator.getInputSchemas()[0]);
-        auto memoryProvider = std::make_shared<Interface::MemoryProvider::ColumnTupleBufferMemoryProvider>(layout);
+        auto memoryProvider = std::make_shared<Interface::BufferRef::ColumnTupleBufferMemoryProvider>(layout);
 
         auto name = descriptor->getName();
         auto aggregationArguments = AggregationPhysicalFunctionRegistryArguments(
@@ -184,7 +184,7 @@ RewriteRuleResultSubgraph LowerToPhysicalWindowedAggregation::apply(LogicalOpera
 
     const auto& [fieldKeyNames, fieldValueNames] = getKeyAndValueFields(aggregation);
     const auto& [fieldKeys, fieldValues]
-        = Interface::MemoryProvider::ChainedEntryMemoryProvider::createFieldOffsets(newInputSchema, fieldKeyNames, fieldValueNames);
+        = Interface::BufferRef::ChainedEntryMemoryProvider::createFieldOffsets(newInputSchema, fieldKeyNames, fieldValueNames);
 
     const auto windowMetaData = WindowMetaData{aggregation.getWindowStartFieldName(), aggregation.getWindowEndFieldName()};
 


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR renames 

- `TupleBufferMemoryProvider` -> `TupleBufferRef`
- `RowTupleBufferMemoryProvider` -> `RowTupleBufferRef`
- `ColumnTupleBufferMemoryProvider` -> `ColumnTupleBufferRef`

Additionally I went through where these types where used changed the variable names from `*MemoryProvider*` to `*BufferRef*`

## Issue Closed by this pull request:

This PR closes #1059 
