### PR TITLE
hotfix(CI): Adds missing emit rate configuration

### DIFF
--- a/.github/workflows/execute_query.yml
+++ b/.github/workflows/execute_query.yml
@@ -49,7 +49,7 @@ on:
 
 jobs:
   execute-query:
-    name: "Execute Query with runtime of ${{ inputs.runtime_seconds }} seconds"
+    name: "E2E Test"
     container:
       image: nebulastream/nes-development:${{ inputs.dev_image_tag }}
       volumes:

--- a/.github/workflows/execute_query.yml
+++ b/.github/workflows/execute_query.yml
@@ -42,6 +42,8 @@ on:
                 fieldDelimiter: ","
               type: Generator
               source_config:
+                generator_rate_type: FIXED
+                generator_rate_config: emit_rate 1000
                 stop_generator_when_sequence_finishes: NONE
                 seed: 1
                 generator_schema: |

--- a/.github/workflows/execute_query.yml
+++ b/.github/workflows/execute_query.yml
@@ -115,3 +115,9 @@ jobs:
           kill $WORKER_PID
           wait $WORKER_PID || true
           tail -n 50 worker.log
+
+      - name: Output Logs on failure
+        if: failure()
+        run: |
+          cat nebuli.log
+          cat worker.log

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -75,8 +75,8 @@ jobs:
       ref: ${{ github.event.pull_request.head.ref }}
 
   test-nebuli-and-single-node-worker:
-    needs: [ get-dev-images ]
-    name: "Run a query using Nebuli and the single node worker"
+    needs: [ get-dev-images, smoke-tests ]
+    name: "E2E Test using Nebuli and SingleNodeWorker"
     uses: ./.github/workflows/execute_query.yml
     with:
       ref: ${{ github.event.pull_request.head.sha }}

--- a/nes-plugins/Sources/GeneratorSource/GeneratorFields.cpp
+++ b/nes-plugins/Sources/GeneratorSource/GeneratorFields.cpp
@@ -321,6 +321,7 @@ NormalDistributionField::NormalDistributionField(const std::string_view rawSchem
             break;
         case DataType::Type::FLOAT64:
             distribution = createDistribution<double, double>(mean, stddev);
+            break;
 
         /// We require an integer for binomial_distribution
         case DataType::Type::BOOLEAN:


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

The execute query ci job was not updated according to the new emit_rate generator source configuration.

## Verifying this change

CI Passes again


## What components does this pull request potentially affect?

- CI

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
