### PR TITLE
Fix clang tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -54,6 +54,7 @@ Checks: [
   "-misc-no-recursion", # we allow recursion
   "-modernize-use-trailing-return-type", # purely cosmetic
   "-readability-named-parameter", # does not work with our error of unused variable
+  "-cert-err60-cpp", # conflicts with using cpptrace::lazy_exception
 
   # The following are aliases to other checks, thus we disable them
   "-bugprone-narrowing-conversions",

--- a/nes-plugins/Sources/GeneratorSource/GeneratorFields.hpp
+++ b/nes-plugins/Sources/GeneratorSource/GeneratorFields.hpp
@@ -24,8 +24,6 @@
 #include <variant>
 #include <DataTypes/DataType.hpp>
 
-#include <DataTypes/DataType.hpp>
-
 namespace NES::GeneratorFields
 {
 


### PR DESCRIPTION
- disables [cert-err60-cpp](https://clang.llvm.org/extra/clang-tidy/checks/cert/err60-cpp.html) which afaics conflicts with using `cpptrace::lazy_exception`.
- removes duplicate include