### PR TITLE
feat(PhysicalOperator): adds return state to open() function

### DIFF
--- a/nes-physical-operators/include/Aggregation/AggregationProbePhysicalOperator.hpp
+++ b/nes-physical-operators/include/Aggregation/AggregationProbePhysicalOperator.hpp
@@ -34,7 +34,7 @@ public:
         std::vector<std::shared_ptr<AggregationPhysicalFunction>> aggregationPhysicalFunctions,
         OperatorHandlerId operatorHandlerId,
         WindowMetaData windowMetaData);
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    OpenReturnState open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
 
 private:
     std::vector<std::shared_ptr<AggregationPhysicalFunction>> aggregationPhysicalFunctions;

--- a/nes-physical-operators/include/EmitPhysicalOperator.hpp
+++ b/nes-physical-operators/include/EmitPhysicalOperator.hpp
@@ -41,7 +41,7 @@ public:
 
     void terminate(ExecutionContext&) const override { /*noop*/ }
 
-    void open(ExecutionContext& ctx, RecordBuffer& recordBuffer) const override;
+    OpenReturnState open(ExecutionContext& ctx, RecordBuffer& recordBuffer) const override;
     void execute(ExecutionContext& ctx, Record& record) const override;
     void close(ExecutionContext& ctx, RecordBuffer& recordBuffer) const override;
     void emitRecordBuffer(

--- a/nes-physical-operators/include/Join/HashJoin/HJProbePhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJProbePhysicalOperator.hpp
@@ -44,7 +44,7 @@ public:
 
     /// As the second phase gets triggered by the first phase, we receive a tuple buffer containing all information for performing the probe.
     /// Thus, we start a new pipeline and therefore, we create new Records from the built-up state.
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    OpenReturnState open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
 
 private:
     std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> leftMemoryProvider, rightMemoryProvider;

--- a/nes-physical-operators/include/Join/NestedLoopJoin/NLJProbePhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/NestedLoopJoin/NLJProbePhysicalOperator.hpp
@@ -41,7 +41,7 @@ public:
         std::shared_ptr<TupleBufferMemoryProvider> leftMemoryProvider,
         std::shared_ptr<TupleBufferMemoryProvider> rightMemoryProvider);
 
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    OpenReturnState open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
 
 protected:
     void performNLJ(

--- a/nes-physical-operators/include/PhysicalOperator.hpp
+++ b/nes-physical-operators/include/PhysicalOperator.hpp
@@ -36,6 +36,13 @@
 
 namespace NES
 {
+
+enum class OpenReturnState : uint8_t
+{
+    NOT_FINISHED = 0,
+    FINISHED = 1,
+};
+
 using namespace Nautilus;
 struct ExecutionContext;
 
@@ -64,7 +71,7 @@ struct PhysicalOperatorConcept
 
     /// Opens the operator for processing records.
     /// This is called before each batch of records is processed.
-    virtual void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
+    virtual OpenReturnState open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
 
     /// Closes the operator after processing records.
     /// This is called after each batch of records is processed.
@@ -83,7 +90,7 @@ struct PhysicalOperatorConcept
 protected:
     /// Helper classes to propagate to the child
     void setupChild(ExecutionContext& executionCtx, CompilationContext& compilationContext) const;
-    void openChild(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
+    OpenReturnState openChild(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
     void closeChild(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
     void executeChild(ExecutionContext& executionCtx, Record& record) const;
     void terminateChild(ExecutionContext& executionCtx) const;
@@ -119,7 +126,7 @@ struct PhysicalOperator
     [[nodiscard]] PhysicalOperator withChild(PhysicalOperator child) const;
 
     void setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const;
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
+    OpenReturnState open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
     void close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
     void terminate(ExecutionContext& executionCtx) const;
     void execute(ExecutionContext& executionCtx, Record& record) const;
@@ -191,7 +198,10 @@ private:
             data.setup(executionCtx, compilationContext);
         }
 
-        void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override { data.open(executionCtx, recordBuffer); }
+        OpenReturnState open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override
+        {
+            return data.open(executionCtx, recordBuffer);
+        }
 
         void close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override { data.close(executionCtx, recordBuffer); }
 

--- a/nes-physical-operators/include/ScanPhysicalOperator.hpp
+++ b/nes-physical-operators/include/ScanPhysicalOperator.hpp
@@ -37,7 +37,7 @@ public:
         std::shared_ptr<Interface::MemoryProvider::TupleBufferMemoryProvider> memoryProvider,
         std::vector<Record::RecordFieldIdentifier> projections);
 
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    OpenReturnState open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
     [[nodiscard]] std::optional<PhysicalOperator> getChild() const override;
     void setChild(PhysicalOperator child) override;
 

--- a/nes-physical-operators/include/Watermark/EventTimeWatermarkAssignerPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Watermark/EventTimeWatermarkAssignerPhysicalOperator.hpp
@@ -27,7 +27,7 @@ class EventTimeWatermarkAssignerPhysicalOperator : public PhysicalOperatorConcep
 {
 public:
     explicit EventTimeWatermarkAssignerPhysicalOperator(EventTimeFunction timeFunction);
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    OpenReturnState open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
     void execute(ExecutionContext& ctx, Record& record) const override;
     void close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
     [[nodiscard]] std::optional<PhysicalOperator> getChild() const override;

--- a/nes-physical-operators/include/Watermark/IngestionTimeWatermarkAssignerPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Watermark/IngestionTimeWatermarkAssignerPhysicalOperator.hpp
@@ -24,7 +24,7 @@ class IngestionTimeWatermarkAssignerPhysicalOperator : public PhysicalOperatorCo
 {
 public:
     explicit IngestionTimeWatermarkAssignerPhysicalOperator(IngestionTimeFunction timeFunction);
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    OpenReturnState open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
     void execute(ExecutionContext& ctx, Record& record) const override;
     [[nodiscard]] std::optional<PhysicalOperator> getChild() const override;
     void setChild(PhysicalOperator child) override;

--- a/nes-physical-operators/include/WindowBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/WindowBuildPhysicalOperator.hpp
@@ -53,7 +53,7 @@ public:
     void setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const override;
 
     /// Initializes the time function, e.g., method that extracts the timestamp from a record
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    OpenReturnState open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
 
     /// Passes emits slices that are ready to the second phase (probe) for further processing
     void close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;

--- a/nes-physical-operators/src/Aggregation/AggregationProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/Aggregation/AggregationProbePhysicalOperator.cpp
@@ -48,7 +48,7 @@ Interface::HashMap* getHashMapPtrProxy(const EmittedAggregationWindow* emittedAg
     return emittedAggregationWindow->hashMaps[currentHashMapVal];
 }
 
-void AggregationProbePhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+OpenReturnState AggregationProbePhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
 {
     /// As this operator functions as a scan, we have to set the execution context for this pipeline
     executionCtx.watermarkTs = recordBuffer.getWatermarkTs();
@@ -173,6 +173,7 @@ void AggregationProbePhysicalOperator::open(ExecutionContext& executionCtx, Reco
             emittedAggregationWindow->finalHashMap.reset();
         },
         aggregationWindowRef);
+    return OpenReturnState::FINISHED;
 }
 
 AggregationProbePhysicalOperator::AggregationProbePhysicalOperator(

--- a/nes-physical-operators/src/EmitPhysicalOperator.cpp
+++ b/nes-physical-operators/src/EmitPhysicalOperator.cpp
@@ -98,13 +98,14 @@ public:
     nautilus::val<int8_t*> bufferMemoryArea;
 };
 
-void EmitPhysicalOperator::open(ExecutionContext& ctx, RecordBuffer&) const
+OpenReturnState EmitPhysicalOperator::open(ExecutionContext& ctx, RecordBuffer&) const
 {
     /// initialize state variable and create new buffer
     const auto resultBufferRef = ctx.allocateBuffer();
     const auto resultBuffer = RecordBuffer(resultBufferRef);
     auto emitState = std::make_unique<EmitState>(resultBuffer);
     ctx.setLocalOperatorState(id, std::move(emitState));
+    return OpenReturnState::FINISHED;
 }
 
 void EmitPhysicalOperator::execute(ExecutionContext& ctx, Record& record) const

--- a/nes-physical-operators/src/Join/HashJoin/HJProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJProbePhysicalOperator.cpp
@@ -58,7 +58,7 @@ HJProbePhysicalOperator::HJProbePhysicalOperator(
 {
 }
 
-void HJProbePhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+OpenReturnState HJProbePhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
 {
     /// As this operator functions as a scan, we have to set the execution context for this pipeline
     executionCtx.watermarkTs = recordBuffer.getWatermarkTs();
@@ -77,7 +77,7 @@ void HJProbePhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer&
         Nautilus::Util::getMemberRef(hashJoinWindowRef, &EmittedHJWindowTrigger::rightNumberOfHashMaps));
     if (leftNumberOfHashMaps == 0 and rightNumberOfHashMaps == 0)
     {
-        return;
+        return OpenReturnState::FINISHED;
     }
 
     /// Getting necessary values from the record buffer
@@ -146,5 +146,6 @@ void HJProbePhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer&
             }
         }
     }
+    return OpenReturnState::FINISHED;
 }
 }

--- a/nes-physical-operators/src/Join/NestedLoopJoin/NLJProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/NestedLoopJoin/NLJProbePhysicalOperator.cpp
@@ -131,7 +131,7 @@ void NLJProbePhysicalOperator::performNLJ(
     }
 }
 
-void NLJProbePhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+OpenReturnState NLJProbePhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
 {
     /// As this operator functions as a scan, we have to set the execution context for this pipeline
     executionCtx.watermarkTs = recordBuffer.getWatermarkTs();
@@ -192,6 +192,7 @@ void NLJProbePhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer
     {
         performNLJ(rightPagedVector, leftPagedVector, *rightMemoryProvider, *leftMemoryProvider, executionCtx, windowStart, windowEnd);
     }
+    return OpenReturnState::FINISHED;
 }
 
 }

--- a/nes-physical-operators/src/PhysicalOperator.cpp
+++ b/nes-physical-operators/src/PhysicalOperator.cpp
@@ -47,9 +47,9 @@ void PhysicalOperatorConcept::setup(ExecutionContext& executionCtx, CompilationC
     setupChild(executionCtx, compilationContext);
 }
 
-void PhysicalOperatorConcept::open(ExecutionContext& executionCtx, RecordBuffer& rb) const
+OpenReturnState PhysicalOperatorConcept::open(ExecutionContext& executionCtx, RecordBuffer& rb) const
 {
-    openChild(executionCtx, rb);
+    return openChild(executionCtx, rb);
 }
 
 void PhysicalOperatorConcept::close(ExecutionContext& executionCtx, RecordBuffer& rb) const
@@ -73,10 +73,10 @@ void PhysicalOperatorConcept::setupChild(ExecutionContext& executionCtx, Compila
     getChild().value().setup(executionCtx, compilationContext);
 }
 
-void PhysicalOperatorConcept::openChild(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+OpenReturnState PhysicalOperatorConcept::openChild(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
 {
     INVARIANT(getChild().has_value(), "Child operator is not set");
-    getChild().value().open(executionCtx, recordBuffer);
+    return getChild().value().open(executionCtx, recordBuffer);
 }
 
 void PhysicalOperatorConcept::closeChild(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
@@ -129,9 +129,9 @@ void PhysicalOperator::setup(ExecutionContext& executionCtx, CompilationContext&
     self->setup(executionCtx, compilationContext);
 }
 
-void PhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+OpenReturnState PhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
 {
-    self->open(executionCtx, recordBuffer);
+    return self->open(executionCtx, recordBuffer);
 }
 
 void PhysicalOperator::close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const

--- a/nes-physical-operators/src/ScanPhysicalOperator.cpp
+++ b/nes-physical-operators/src/ScanPhysicalOperator.cpp
@@ -37,7 +37,7 @@ ScanPhysicalOperator::ScanPhysicalOperator(
 {
 }
 
-void ScanPhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+OpenReturnState ScanPhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
 {
     /// initialize global state variables to keep track of the watermark ts and the origin id
     executionCtx.watermarkTs = recordBuffer.getWatermarkTs();
@@ -55,6 +55,7 @@ void ScanPhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& re
         auto record = memoryProvider->readRecord(projections, recordBuffer, i);
         executeChild(executionCtx, record);
     }
+    return OpenReturnState::FINISHED;
 }
 
 std::optional<PhysicalOperator> ScanPhysicalOperator::getChild() const

--- a/nes-physical-operators/src/Watermark/EventTimeWatermarkAssignerPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Watermark/EventTimeWatermarkAssignerPhysicalOperator.cpp
@@ -39,11 +39,12 @@ struct WatermarkState final : OperatorState
 EventTimeWatermarkAssignerPhysicalOperator::EventTimeWatermarkAssignerPhysicalOperator(EventTimeFunction timeFunction)
     : timeFunction(std::move(std::move(timeFunction))) { };
 
-void EventTimeWatermarkAssignerPhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+OpenReturnState EventTimeWatermarkAssignerPhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
 {
     openChild(executionCtx, recordBuffer);
     executionCtx.setLocalOperatorState(id, std::make_unique<WatermarkState>());
     timeFunction.open(executionCtx, recordBuffer);
+    return OpenReturnState::FINISHED;
 }
 
 void EventTimeWatermarkAssignerPhysicalOperator::execute(ExecutionContext& ctx, Record& record) const

--- a/nes-physical-operators/src/Watermark/IngestionTimeWatermarkAssignerPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Watermark/IngestionTimeWatermarkAssignerPhysicalOperator.cpp
@@ -12,11 +12,12 @@
     limitations under the License.
 */
 
+#include <Watermark/IngestionTimeWatermarkAssignerPhysicalOperator.hpp>
+
 #include <optional>
 #include <utility>
 #include <Nautilus/Interface/Record.hpp>
 #include <Nautilus/Interface/RecordBuffer.hpp>
-#include <Watermark/IngestionTimeWatermarkAssignerPhysicalOperator.hpp>
 #include <Watermark/TimeFunction.hpp>
 #include <ExecutionContext.hpp>
 #include <PhysicalOperator.hpp>
@@ -27,7 +28,7 @@ namespace NES
 IngestionTimeWatermarkAssignerPhysicalOperator::IngestionTimeWatermarkAssignerPhysicalOperator(IngestionTimeFunction timeFunction)
     : timeFunction(std::move(timeFunction)) { };
 
-void IngestionTimeWatermarkAssignerPhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+OpenReturnState IngestionTimeWatermarkAssignerPhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
 {
     openChild(executionCtx, recordBuffer);
     timeFunction.open(executionCtx, recordBuffer);
@@ -41,6 +42,7 @@ void IngestionTimeWatermarkAssignerPhysicalOperator::open(ExecutionContext& exec
     {
         executionCtx.watermarkTs = tsField;
     }
+    return OpenReturnState::FINISHED;
 }
 
 void IngestionTimeWatermarkAssignerPhysicalOperator::execute(ExecutionContext& executionCtx, Record& record) const

--- a/nes-physical-operators/src/WindowBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/WindowBuildPhysicalOperator.cpp
@@ -93,7 +93,7 @@ void WindowBuildPhysicalOperator::setup(ExecutionContext& executionCtx, Compilat
     invoke(registerActivePipeline, operatorHandlerMemRef);
 };
 
-void WindowBuildPhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+OpenReturnState WindowBuildPhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
 {
     /// Initializing the time function
     timeFunction->open(executionCtx, recordBuffer);
@@ -101,6 +101,7 @@ void WindowBuildPhysicalOperator::open(ExecutionContext& executionCtx, RecordBuf
     /// Creating the local state for the window operator build.
     const auto operatorHandler = executionCtx.getGlobalOperatorHandler(operatorHandlerId);
     executionCtx.setLocalOperatorState(id, std::make_unique<WindowOperatorBuildLocalState>(operatorHandler));
+    return OpenReturnState::FINISHED;
 }
 
 void WindowBuildPhysicalOperator::terminate(ExecutionContext& executionCtx) const


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
The open function can now return an OpenFunctionReturnState that allows the compiledFunction to not necessarily call the close function (or other stuff in the future).
This becomes important, e.g., if an operator wants to repeatedly call open without closing.
For example, the compiled raw scan (see PR #1153) wants to repeat a task, if its SequenceShredder detects a buffer as out of range of its ring structure. Currently, there is no simple way to avoid the `close()` call, which calls emit, which then emits the TupleBuffer and marks the SequenceNumber as seen and its chunk as 'seenLastChunk'. Later, when the task is repeated, the buffer with the same SequenceNumber is emitted again, causing a crash.

With this change, an operator can return from an open() call, stating that it is not finished yet.
The return value is an enum, which we can easily adapt/customize later on.
