### PR TITLE
fix(QueryCompiler): Disable mlir multithreading for nautilus

### DIFF
--- a/nes-nautilus/tests/TestUtils/include/NautilusTestUtils.hpp
+++ b/nes-nautilus/tests/TestUtils/include/NautilusTestUtils.hpp
@@ -188,7 +188,7 @@ protected:
     /// This map can and will be filled in this class but also in the tests themselves.
     std::map<NameAndNautilusBackend, std::unique_ptr<FunctionWrapperBase>> compiledFunctions;
 
-    /// We disable multithreading in MLIR by default to not interfer with NebulaStream's thread model
+    /// We disable multithreading in MLIR by default to not interfere with NebulaStream's thread model
     bool mlirEnableMultithreading = false;
 };
 

--- a/nes-query-compiler/src/Phases/LowerToCompiledQueryPlanPhase.cpp
+++ b/nes-query-compiler/src/Phases/LowerToCompiledQueryPlanPhase.cpp
@@ -102,6 +102,8 @@ void LowerToCompiledQueryPlanPhase::processSink(const Predecessor& predecessor, 
 std::unique_ptr<ExecutablePipelineStage> LowerToCompiledQueryPlanPhase::getStage(const std::shared_ptr<Pipeline>& pipeline)
 {
     nautilus::engine::Options options;
+    /// We disable multithreading in MLIR by default to not interfere with NebulaStream's thread model
+    options.setOption("mlir.enableMultithreading", false);
     switch (pipelineQueryPlan->getExecutionMode())
     {
         case ExecutionMode::COMPILER: {


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This is a fix that disables mlir multithreading in the query compiler. We disable multithreading in MLIR by default to not interfere with NebulaStream's thread model

## Verifying this change
This change is tested by running our test suite.
