### PR TITLE
fix(docker install script): Added latest stable syntax flag

### DIFF
--- a/scripts/install-local-docker-environment.sh
+++ b/scripts/install-local-docker-environment.sh
@@ -164,6 +164,7 @@ if [ $BUILD_LOCAL -eq 1 ]; then
 
   docker build -f docker/dependency/Development.dockerfile \
             --build-arg TAG=local \
+            --build-arg BUILDKIT_SYNTAX=docker/dockerfile:1 \
             -t nebulastream/nes-development:default .
 
   docker build -f docker/dependency/DevelopmentLocal.dockerfile \


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
- The checksum flag used in the add command to download the antlr jar in Development.dockerfile is not supported by default in all dockerfile syntax versions
- Added `BUILDKIT_SYNTAX` flag to the docker build command for the associated dockerfile in the script
- used `docker/dockerfile:1` value which uses the latest syntax version according to the [documentation](https://docs.docker.com/build/buildkit/frontend/)

## Verifying this change
This change is tested by
- building using the docker script

## What components does this pull request potentially affect?
- docker installation script
