### PR TITLE
chore: suppress std::cerr prints of Antlr parser and throw message instead

### DIFF
--- a/nes-sql-parser/include/SQLQueryParser/AntlrSQLQueryParser.hpp
+++ b/nes-sql-parser/include/SQLQueryParser/AntlrSQLQueryParser.hpp
@@ -70,6 +70,7 @@ private:
     antlr4::CommonTokenStream tokens;
     AntlrSQLParser parser;
     std::string originalQuery;
+    std::shared_ptr<antlr4::ANTLRErrorListener> errorListener;
 };
 
 }


### PR DESCRIPTION
Suppresses warning print such as:
```
line 4:0 no viable alternative at input 'id\nWHERE'
line 5:0 no viable alternative at input 'id\nINTO'
```