### PR TITLE
fix(Aggregations): Remove unused config parameter

### DIFF
--- a/nes-logical-operators/include/Operators/Windows/WindowedAggregationLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Windows/WindowedAggregationLogicalOperator.hpp
@@ -94,26 +94,13 @@ public:
             std::nullopt,
             [](const std::unordered_map<std::string, std::string>& config) { return DescriptorConfig::tryGet(WINDOW_KEYS, config); }};
 
-        static inline const DescriptorConfig::ConfigParameter<std::string> WINDOW_START_FIELD_NAME{
-            "windowStartFieldName",
-            std::nullopt,
-            [](const std::unordered_map<std::string, std::string>& config)
-            { return DescriptorConfig::tryGet(WINDOW_START_FIELD_NAME, config); }};
-
-        static inline const DescriptorConfig::ConfigParameter<std::string> WINDOW_END_FIELD_NAME{
-            "windowEndFieldName",
-            std::nullopt,
-            [](const std::unordered_map<std::string, std::string>& config)
-            { return DescriptorConfig::tryGet(WINDOW_END_FIELD_NAME, config); }};
-
         static inline const DescriptorConfig::ConfigParameter<std::string> WINDOW_INFOS{
             "windowInfos",
             std::nullopt,
             [](const std::unordered_map<std::string, std::string>& config) { return DescriptorConfig::tryGet(WINDOW_INFOS, config); }};
 
         static inline std::unordered_map<std::string, DescriptorConfig::ConfigParameterContainer> parameterMap
-            = DescriptorConfig::createConfigParameterContainerMap(
-                WINDOW_AGGREGATIONS, WINDOW_INFOS, WINDOW_KEYS, WINDOW_START_FIELD_NAME, WINDOW_END_FIELD_NAME);
+            = DescriptorConfig::createConfigParameterContainerMap(WINDOW_AGGREGATIONS, WINDOW_INFOS, WINDOW_KEYS);
     };
 
 private:

--- a/nes-logical-operators/src/Operators/Windows/WindowedAggregationLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Windows/WindowedAggregationLogicalOperator.cpp
@@ -321,11 +321,6 @@ void WindowedAggregationLogicalOperator::serialize(SerializableOperator& seriali
     }
     (*serializableOperator.mutable_config())[ConfigParameters::WINDOW_INFOS] = descriptorConfigTypeToProto(windowInfo);
 
-    (*serializableOperator.mutable_config())[ConfigParameters::WINDOW_START_FIELD_NAME]
-        = descriptorConfigTypeToProto(windowMetaData.windowStartFieldName);
-    (*serializableOperator.mutable_config())[ConfigParameters::WINDOW_END_FIELD_NAME]
-        = descriptorConfigTypeToProto(windowMetaData.windowEndFieldName);
-
     serializableOperator.mutable_operator_()->CopyFrom(proto);
 }
 
@@ -335,8 +330,6 @@ LogicalOperatorGeneratedRegistrar::RegisterWindowedAggregationLogicalOperator(Lo
     auto aggregationsVariant = arguments.config[WindowedAggregationLogicalOperator::ConfigParameters::WINDOW_AGGREGATIONS];
     auto keysVariant = arguments.config[WindowedAggregationLogicalOperator::ConfigParameters::WINDOW_KEYS];
     auto windowInfoVariant = arguments.config[WindowedAggregationLogicalOperator::ConfigParameters::WINDOW_INFOS];
-    auto windowStartVariant = arguments.config[WindowedAggregationLogicalOperator::ConfigParameters::WINDOW_START_FIELD_NAME];
-    auto windowEndVariant = arguments.config[WindowedAggregationLogicalOperator::ConfigParameters::WINDOW_END_FIELD_NAME];
 
     if (!std::holds_alternative<AggregationFunctionList>(aggregationsVariant))
     {


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
There was a config parameter (in the (de)serialization) of WindowedAggregationLogicalOperator that was not used. The time of the window is stored in WINDOW_INFOS instead, so it is also not needed.
The second commit removes the storing of start and end field names because the inferrence function overwrites those anyway with default values. If that's also a bug, the second commit should not be merged.

## Verifying this change
Compiles and tests run.

## What components does this pull request potentially affect?
(de)serialization

## Documentation
I don't think there's documentation for this.

## Issue Closed by this pull request:

