### PR TITLE
Improves Projection Explain

### DIFF
--- a/nes-logical-operators/src/Operators/ProjectionLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/ProjectionLogicalOperator.cpp
@@ -52,7 +52,7 @@ std::string explainProjection(const ProjectionLogicalOperator::Projection& proje
 {
     std::stringstream builder;
     builder << projection.second.explain(verbosity);
-    if (projection.first)
+    if (projection.first && projection.first->getFieldName() != projection.second.explain(verbosity))
     {
         builder << " as " << projection.first->getFieldName();
     }
@@ -110,10 +110,10 @@ std::string ProjectionLogicalOperator::explain(ExplainVerbosity verbosity, Opera
     if (verbosity == ExplainVerbosity::Debug)
     {
         builder << "opId: " << id << ", ";
-    }
-    if (!outputSchema.getFieldNames().empty())
-    {
-        builder << "schema: " << outputSchema << ", ";
+        if (!outputSchema.getFieldNames().empty())
+        {
+            builder << "schema: " << outputSchema << ", ";
+        }
     }
 
     builder << "fields: [";
@@ -126,8 +126,13 @@ std::string ProjectionLogicalOperator::explain(ExplainVerbosity verbosity, Opera
         }
     }
     builder << fmt::format("{}", fmt::join(explainedProjections, ", "));
-    builder << fmt::format(", traitSet: {}", traitSet.explain(verbosity));
-    builder << "])";
+    builder << "]";
+
+    if (verbosity == ExplainVerbosity::Debug)
+    {
+        builder << fmt::format(", traitSet: {}", traitSet.explain(verbosity));
+    }
+    builder << ")";
     return builder.str();
 }
 


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
The currention explain for the LogicalProjectionOperator is incredibly noisy.
This PR changes the explain to produce explain like this: 
```
                                                                                                            SINK(Q8VARIANTCHECKSUM5)                                                                                                            
                                                                                                                        │                                                                                                                       
PROJECTION(fields: [BIDAUCTION$START, BIDAUCTION$END, BID_TIMESTAMP, BID$AUCTIONID, BID$BIDDER, BID$DATETIME, BID$PRICE, AUCTION_TIMESTAMP, AUCTION$ID, AUCTION$INITIALBID, AUCTION$RESERVE, AUCTION$EXPIRES, AUCTION$SELLER, AUCTION$CATEGORY])
                                                                                                                        │                                                                                                                       
                                                                                                        Join(BID$AUCTIONID = AUCTION$ID)                                                                                                        
                                                           ┌────────────────────────────────────────────────────────────┴──────────────────────────────────────────────────────────┐                                                            
                                            WATERMARK_ASSIGNER(Event time)                                                                                          WATERMARK_ASSIGNER(Event time)                                             
                                                         ┌─┘                                                                                                                     ┌─┘                                                            
                              PROJECTION(fields: [*, BID$TIMESTAMP as BID_TIMESTAMP])                                                             PROJECTION(fields: [*, AUCTION$TIMESTAMP as AUCTION_TIMESTAMP])                              
                                                         └┐                                                                                                                      └┐                                                             
                                                     SOURCE(BID)                                                                                                           SOURCE(AUCTION)                                                     
```
, where previously it was like this:

```
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            SINK(Q8VARIANTCHECKSUM5)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        │                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
PROJECTION(schema: Schema(fields(Field(name: BIDAUCTION$START, DataType: DataType(type: UINT64)),Field(name: BIDAUCTION$END, DataType: DataType(type: UINT64)),Field(name: BID_TIMESTAMP, DataType: DataType(type: UINT64)),Field(name: BID$AUCTIONID, DataType: DataType(type: INT32)),Field(name: BID$BIDDER, DataType: DataType(type: INT32)),Field(name: BID$DATETIME, DataType: DataType(type: INT64)),Field(name: BID$PRICE, DataType: DataType(type: FLOAT64)),Field(name: AUCTION_TIMESTAMP, DataType: DataType(type: UINT64)),Field(name: AUCTION$ID, DataType: DataType(type: INT32)),Field(name: AUCTION$INITIALBID, DataType: DataType(type: INT32)),Field(name: AUCTION$RESERVE, DataType: DataType(type: INT32)),Field(name: AUCTION$EXPIRES, DataType: DataType(type: INT64)),Field(name: AUCTION$SELLER, DataType: DataType(type: INT32)),Field(name: AUCTION$CATEGORY, DataType: DataType(type: INT32))), size in bytes: 84, layout type: ROW_LAYOUT), fields: [BIDAUCTION$START as BIDAUCTION$START, BIDAUCTION$END as BIDAUCTION$END, BID_TIMESTAMP as BID_TIMESTAMP, BID$AUCTIONID as BID$AUCTIONID, BID$BIDDER as BID$BIDDER, BID$DATETIME as BID$DATETIME, BID$PRICE as BID$PRICE, AUCTION_TIMESTAMP as AUCTION_TIMESTAMP, AUCTION$ID as AUCTION$ID, AUCTION$INITIALBID as AUCTION$INITIALBID, AUCTION$RESERVE as AUCTION$RESERVE, AUCTION$EXPIRES as AUCTION$EXPIRES, AUCTION$SELLER as AUCTION$SELLER, AUCTION$CATEGORY as AUCTION$CATEGORY, traitSet: ])
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        │                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        Join(BID$AUCTIONID = AUCTION$ID)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                    ┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐                                                                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                     WATERMARK_ASSIGNER(Event time)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           WATERMARK_ASSIGNER(Event time)                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                              ┌─────────────────────────────────────┘                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  ┌─────────────────────────────────────┘                                                                                                                                                                                                                                                                                                                                                                   
                                                                        PROJECTION(schema: Schema(fields(Field(name: BID$TIMESTAMP, DataType: DataType(type: UINT64)),Field(name: BID$AUCTIONID, DataType: DataType(type: INT32)),Field(name: BID$BIDDER, DataType: DataType(type: INT32)),Field(name: BID$DATETIME, DataType: DataType(type: INT64)),Field(name: BID$PRICE, DataType: DataType(type: FLOAT64)),Field(name: BID_TIMESTAMP, DataType: DataType(type: UINT64))), size in bytes: 40, layout type: ROW_LAYOUT), fields: [*, BID$TIMESTAMP as BID_TIMESTAMP, traitSet: ])                                                                                                                                                 PROJECTION(schema: Schema(fields(Field(name: AUCTION$TIMESTAMP, DataType: DataType(type: UINT64)),Field(name: AUCTION$ID, DataType: DataType(type: INT32)),Field(name: AUCTION$INITIALBID, DataType: DataType(type: INT32)),Field(name: AUCTION$RESERVE, DataType: DataType(type: INT32)),Field(name: AUCTION$EXPIRES, DataType: DataType(type: INT64)),Field(name: AUCTION$SELLER, DataType: DataType(type: INT32)),Field(name: AUCTION$CATEGORY, DataType: DataType(type: INT32)),Field(name: AUCTION_TIMESTAMP, DataType: DataType(type: UINT64))), size in bytes: 44, layout type: ROW_LAYOUT), fields: [*, AUCTION$TIMESTAMP as AUCTION_TIMESTAMP, traitSet: ])                                                                        
                                                                                                                                                                                                                                                                                                                              └────────────────────────────────────┐                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   └────────────────────────────────────┐                                                                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                             SOURCE(BID)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            SOURCE(AUCTION)                                                                                                                                                                                                                                                                                                                                                              
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies Projection explain by omitting redundant aliases and showing schema/traitSet only in Debug.
> 
> - **Explain output improvements (`nes-logical-operators/src/Operators/ProjectionLogicalOperator.cpp`)**:
>   - Suppress redundant aliases in projections: only append `as <name>` when it differs from the expression.
>   - Restrict verbose details to Debug: include `schema` and `traitSet` only when `verbosity == Debug`.
>   - Clean up formatting of `fields: [...]` and closing parentheses, preserving `*` handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7adb49729bd7cf2b78a4899a44fdbdca4aaf0cb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"fix-worker-config-case","parentHead":"29c7ab0c5fb1dcee6f0e5f1e210f19bc07a0e6c0","parentPull":1202,"trunk":"main"}
```
-->
