### PR TITLE
chore(Tidy): Allow `fuchsia-trailing-return`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -44,6 +44,7 @@ Checks: [
 
   "-boost-use-ranges", # we don't use boost
   "-bugprone-easily-swappable-parameters", # annoying-ish
+  "-fuchsia-trailing-return", # we do not have a problem with that
   "-fuchsia-default-arguments-calls", # we do not forbid default args
   "-fuchsia-overloaded-operator", # we can not overload the operator() anywhere
   "-fuchsia-statically-constructed-objects", # we allow statically constructed objects; constexpr is not always possible


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR removes the `fuchsia-trailing-return` rule from our clang-tidy check. 
The Rule is fuchsia specific, there is not really a reason to ban it in any other codebase. 
Infact it is very useful the help the compiler to deduce a type in a lambda function.
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables the `fuchsia-trailing-return` clang-tidy check by adding it to the disabled `Checks` in `.clang-tidy`.
> 
> - **Tooling / clang-tidy**:
>   - Update `.clang-tidy` to disable `fuchsia-trailing-return` via `Checks` exclusions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 198453414222fdefca77b98538588c6f142ab00f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
