### PR TITLE
fix(Logical): Remove unused `addAdditionalTraits`

### DIFF
--- a/nes-logical-operators/include/Operators/LogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/LogicalOperator.hpp
@@ -427,16 +427,6 @@ inline std::ostream& operator<<(std::ostream& os, const LogicalOperator& op)
     return os << op.explain(ExplainVerbosity::Short);
 }
 
-/// Adds additional traits to the given operator, returning a new operator
-/// If the same trait (with the same data) is already present, the new trait will not be added.
-template <IsTrait... TraitType>
-LogicalOperator addAdditionalTraits(const LogicalOperator& op, const TraitType&... traits)
-{
-    auto result = op.getTraitSet();
-    (result.tryInsert(traits), ...);
-    return op.withTraitSet(std::move(result));
-}
-
 }
 
 /// Hash is based solely on unique identifier (needed for e.g. unordered_set)


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

~~This PR removes the `nodiscard` attribute from `tryInsert`.
There are reasons why you wouldn't bother to check if tryInserts has actually succeeded. 
The codebase already uses patterns like `(result.tryInsert(traits), ...);` which don't actually compile.~~

This PR removes the unused addAdditionalTraits method, which would fail to compile anyway due to [[nodiscard]].
@Artraxon pointed out that it is unlikely to add multiple traits at once
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the unused `addAdditionalTraits` helper from `nes-logical-operators/include/Operators/LogicalOperator.hpp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41c3aab66dcecbecbcbfa6e1a033328c3aed1086. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
