### PR TITLE
feat(operators): remove default constructor for LogicalOperator

### DIFF
--- a/nes-logical-operators/include/Operators/LogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/LogicalOperator.hpp
@@ -232,7 +232,7 @@ struct TypedLogicalOperator
         }
     }
 
-    TypedLogicalOperator() = default;
+    TypedLogicalOperator() = delete;
 
     /// Attempts to get the underlying operator as type T.
     /// @tparam T The type to try to get the operator as.

--- a/nes-logical-operators/include/Plans/LogicalPlan.hpp
+++ b/nes-logical-operators/include/Plans/LogicalPlan.hpp
@@ -35,7 +35,7 @@ namespace NES
 class LogicalPlan
 {
 public:
-    LogicalPlan() = default;
+    LogicalPlan() = delete;
     explicit LogicalPlan(LogicalOperator rootOperator);
     explicit LogicalPlan(QueryId queryId, std::vector<LogicalOperator> rootOperators);
     explicit LogicalPlan(QueryId queryId, std::vector<LogicalOperator> rootOperators, std::string originalSql);

--- a/nes-nebuli/src/NebuLIStarter.cpp
+++ b/nes-nebuli/src/NebuLIStarter.cpp
@@ -255,20 +255,20 @@ int main(int argc, char** argv)
 
         const std::string command = program.is_subcommand_used("register") ? "register" : "dump";
         auto input = program.at<argparse::ArgumentParser>(command).get("-i");
-        NES::LogicalPlan boundPlan;
-        if (input == "-")
+        const NES::LogicalPlan boundPlan = [&]
         {
-            boundPlan = yamlBinder.parseAndBind(std::cin);
-        }
-        else
-        {
+            if (input == "-")
+            {
+                return yamlBinder.parseAndBind(std::cin);
+            }
             std::ifstream file{input};
             if (!file)
             {
                 throw NES::QueryDescriptionNotReadable(std::strerror(errno)); /// NOLINT(concurrency-mt-unsafe)
             }
-            boundPlan = yamlBinder.parseAndBind(file);
-        }
+            return yamlBinder.parseAndBind(file);
+        }();
+
 
         const NES::LogicalPlan optimizedQueryPlan = optimizer->optimize(boundPlan);
 

--- a/nes-systests/systest/include/SystestState.hpp
+++ b/nes-systests/systest/include/SystestState.hpp
@@ -158,7 +158,7 @@ struct SystestQuery
         std::unordered_map<SourceDescriptor, std::pair<SourceInputFile, uint64_t>> sourcesToFilePathsAndCounts;
         Schema sinkOutputSchema;
 
-        PlanInfo() = default;
+        PlanInfo() = delete;
 
         PlanInfo(LogicalPlan plan, std::unordered_map<SourceDescriptor, std::pair<SourceInputFile, uint64_t>> sources, Schema sinkSchema)
             : queryPlan(std::move(plan)), sourcesToFilePathsAndCounts(std::move(sources)), sinkOutputSchema(std::move(sinkSchema))


### PR DESCRIPTION
This commit removes the default constructor for LogicalOperator, refractoring the code to use the pattern mentioned in #1198 where possible, otherwise optionals.

## Purpose of the Change and Brief Change Log
- remove `LogicalOperator` default constructor


## Issue Closed by this pull request:

This PR closes #1198
