### PR TITLE
fix(logical-operators): Use qualified detail namespace

### DIFF
--- a/nes-logical-operators/include/Operators/LogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/LogicalOperator.hpp
@@ -49,7 +49,7 @@ namespace detail
 struct ErasedLogicalOperator;
 }
 
-template <typename Checked = detail::ErasedLogicalOperator>
+template <typename Checked = NES::detail::ErasedLogicalOperator>
 struct TypedLogicalOperator;
 using LogicalOperator = TypedLogicalOperator<>;
 
@@ -115,7 +115,7 @@ struct DynamicBase
 /// This class is only there to add a commonly accessible VTable so that we can cast the pointer to the operator.
 /// @tparam T the type to be able to cast to from LogicalOperator
 template <typename T>
-struct Castable : detail::DynamicBase
+struct Castable : NES::detail::DynamicBase
 {
     const T& get() const { return *dynamic_cast<const T*>(this); }
 
@@ -173,7 +173,7 @@ template <typename Checked>
 struct TypedLogicalOperator
 {
     template <LogicalOperatorConcept T>
-    requires std::same_as<Checked, detail::ErasedLogicalOperator>
+    requires std::same_as<Checked, NES::detail::ErasedLogicalOperator>
     TypedLogicalOperator(TypedLogicalOperator<T> other) : self(other.self) /// NOLINT(google-explicit-constructor)
     {
     }
@@ -182,52 +182,52 @@ struct TypedLogicalOperator
     /// @tparam T The type of the operator. Must satisfy IsLogicalOperator concept.
     /// @param op The operator to wrap.
     template <LogicalOperatorConcept T>
-    TypedLogicalOperator(const T& op) : self(std::make_shared<detail::OperatorModel<T>>(op)) /// NOLINT(google-explicit-constructor)
+    TypedLogicalOperator(const T& op) : self(std::make_shared<NES::detail::OperatorModel<T>>(op)) /// NOLINT(google-explicit-constructor)
     {
     }
 
     template <LogicalOperatorConcept T>
-    TypedLogicalOperator(const detail::OperatorModel<T>& op) /// NOLINT(google-explicit-constructor)
-        : self(std::make_shared<detail::OperatorModel<T>>(op.impl, op.id))
+    TypedLogicalOperator(const NES::detail::OperatorModel<T>& op) /// NOLINT(google-explicit-constructor)
+        : self(std::make_shared<NES::detail::OperatorModel<T>>(op.impl, op.id))
     {
     }
 
-    explicit TypedLogicalOperator(std::shared_ptr<const detail::ErasedLogicalOperator> op) : self(std::move(op)) { }
+    explicit TypedLogicalOperator(std::shared_ptr<const NES::detail::ErasedLogicalOperator> op) : self(std::move(op)) { }
 
     ///@brief Alternative to operator*
     [[nodiscard]] const Checked& get() const
     {
-        if constexpr (std::is_same_v<detail::ErasedLogicalOperator, Checked>)
+        if constexpr (std::is_same_v<NES::detail::ErasedLogicalOperator, Checked>)
         {
-            return *std::dynamic_pointer_cast<const detail::ErasedLogicalOperator>(self);
+            return *std::dynamic_pointer_cast<const NES::detail::ErasedLogicalOperator>(self);
         }
         else
         {
-            return std::dynamic_pointer_cast<const detail::OperatorModel<Checked>>(self)->impl;
+            return std::dynamic_pointer_cast<const NES::detail::OperatorModel<Checked>>(self)->impl;
         }
     }
 
     const Checked& operator*() const
     {
-        if constexpr (std::is_same_v<detail::ErasedLogicalOperator, Checked>)
+        if constexpr (std::is_same_v<NES::detail::ErasedLogicalOperator, Checked>)
         {
-            return *std::dynamic_pointer_cast<const detail::ErasedLogicalOperator>(self);
+            return *std::dynamic_pointer_cast<const NES::detail::ErasedLogicalOperator>(self);
         }
         else
         {
-            return std::dynamic_pointer_cast<const detail::OperatorModel<Checked>>(self)->impl;
+            return std::dynamic_pointer_cast<const NES::detail::OperatorModel<Checked>>(self)->impl;
         }
     }
 
     const Checked* operator->() const
     {
-        if constexpr (std::is_same_v<detail::ErasedLogicalOperator, Checked>)
+        if constexpr (std::is_same_v<NES::detail::ErasedLogicalOperator, Checked>)
         {
-            return std::dynamic_pointer_cast<const detail::ErasedLogicalOperator>(self).get();
+            return std::dynamic_pointer_cast<const NES::detail::ErasedLogicalOperator>(self).get();
         }
         else
         {
-            auto casted = std::dynamic_pointer_cast<const detail::OperatorModel<Checked>>(self);
+            auto casted = std::dynamic_pointer_cast<const NES::detail::OperatorModel<Checked>>(self);
             return &casted->impl;
         }
     }
@@ -240,9 +240,9 @@ struct TypedLogicalOperator
     template <LogicalOperatorConcept T>
     std::optional<TypedLogicalOperator<T>> tryGetAs() const
     {
-        if (auto model = std::dynamic_pointer_cast<const detail::OperatorModel<T>>(self))
+        if (auto model = std::dynamic_pointer_cast<const NES::detail::OperatorModel<T>>(self))
         {
-            return TypedLogicalOperator<T>{std::static_pointer_cast<const detail::ErasedLogicalOperator>(model)};
+            return TypedLogicalOperator<T>{std::static_pointer_cast<const NES::detail::ErasedLogicalOperator>(model)};
         }
         return std::nullopt;
     }
@@ -271,9 +271,9 @@ struct TypedLogicalOperator
     template <LogicalOperatorConcept T>
     TypedLogicalOperator<T> getAs() const
     {
-        if (auto model = std::dynamic_pointer_cast<const detail::OperatorModel<T>>(self))
+        if (auto model = std::dynamic_pointer_cast<const NES::detail::OperatorModel<T>>(self))
         {
-            return TypedLogicalOperator<T>{std::static_pointer_cast<const detail::ErasedLogicalOperator>(model)};
+            return TypedLogicalOperator<T>{std::static_pointer_cast<const NES::detail::ErasedLogicalOperator>(model)};
         }
         PRECONDITION(false, "requested type {} , but stored type is {}", typeid(T).name(), typeid(self).name());
         std::unreachable();
@@ -338,7 +338,7 @@ private:
 
     [[nodiscard]] TypedLogicalOperator withOperatorId(const OperatorId id) const { return self->withOperatorId(id); };
 
-    std::shared_ptr<const detail::ErasedLogicalOperator> self;
+    std::shared_ptr<const NES::detail::ErasedLogicalOperator> self;
 };
 
 namespace detail


### PR DESCRIPTION
We are using the `NES::detail` namespace unqualified in LogicalOperator.hpp (so just `detail`) which for some reason worked, but @gaturchenko noticed that it doesn't when including the header in a plugin because it is ambiguous with NES::Nautilus::detail.

This PR makes all `NES::detail` usages in LogicalOperator.hpp qualified.

