### PR TITLE
Add dumpGraph option for the worker

### DIFF
--- a/nes-query-compiler/include/QueryCompiler.hpp
+++ b/nes-query-compiler/include/QueryCompiler.hpp
@@ -14,9 +14,11 @@
 #pragma once
 
 #include <memory>
+
 #include <Util/DumpMode.hpp>
 #include <CompiledQueryPlan.hpp>
 #include <PhysicalPlan.hpp>
+#include "Util/DumpMode.hpp"
 
 namespace NES::QueryCompilation
 {
@@ -28,8 +30,7 @@ struct QueryCompilationRequest
 
     /// IMPORTANT: only the queryPlan should influence the actual result, other request options only influence how much to debug print etc.
     bool debug = false;
-    DumpMode dumpCompilationResult = DumpMode::NONE;
-    bool dumpGraph = false;
+    DumpMode dumpCompilationResult = DumpMode{DumpMode::Options::NONE, false};
 };
 
 /// The query compiler behaves as a pure function: QueryPlan -> CompiledQueryPlan

--- a/nes-query-compiler/private/Phases/LowerToCompiledQueryPlanPhase.hpp
+++ b/nes-query-compiler/private/Phases/LowerToCompiledQueryPlanPhase.hpp
@@ -29,8 +29,8 @@ namespace NES
 class LowerToCompiledQueryPlanPhase
 {
 public:
-    explicit LowerToCompiledQueryPlanPhase(DumpMode dumpQueryCompilationIntermediateRepresentations, bool dumpGraph = false)
-        : dumpQueryCompilationIntermediateRepresentations(dumpQueryCompilationIntermediateRepresentations), dumpGraph(dumpGraph)
+    explicit LowerToCompiledQueryPlanPhase(DumpMode dumpQueryCompilationIntermediateRepresentations)
+        : dumpQueryCompilationIR(dumpQueryCompilationIntermediateRepresentations)
     {
     }
 
@@ -55,7 +55,6 @@ private:
     std::shared_ptr<PipelinedQueryPlan> pipelineQueryPlan;
 
     /// Config parameter
-    DumpMode dumpQueryCompilationIntermediateRepresentations;
-    bool dumpGraph;
+    DumpMode dumpQueryCompilationIR;
 };
 }

--- a/nes-query-compiler/src/Phases/LowerToCompiledQueryPlanPhase.cpp
+++ b/nes-query-compiler/src/Phases/LowerToCompiledQueryPlanPhase.cpp
@@ -105,37 +105,30 @@ std::unique_ptr<ExecutablePipelineStage> LowerToCompiledQueryPlanPhase::getStage
         }
     }
     /// See: https://github.com/nebulastream/nautilus/blob/main/docs/options.md
-    switch (dumpQueryCompilationIntermediateRepresentations)
+    switch (dumpQueryCompilationIR.getDumpOption())
     {
-        case DumpMode::NONE:
+        case DumpMode::Options::NONE:
             options.setOption("dump.all", false);
             options.setOption("dump.console", false);
             options.setOption("dump.file", false);
             break;
-        case DumpMode::CONSOLE:
+        case DumpMode::Options::CONSOLE:
             options.setOption("dump.all", true);
             options.setOption("dump.console", true);
             options.setOption("dump.file", false);
             break;
-        case DumpMode::FILE:
+        case DumpMode::Options::FILE:
             options.setOption("dump.all", true);
             options.setOption("dump.console", false);
             options.setOption("dump.file", true);
             break;
-        case DumpMode::FILE_AND_CONSOLE:
+        case DumpMode::Options::FILE_AND_CONSOLE:
             options.setOption("dump.all", true);
             options.setOption("dump.console", true);
             options.setOption("dump.file", true);
             break;
     }
-    if (dumpGraph)
-    {
-        options.setOption("dump.graph", true);
-    }
-    else
-    {
-        options.setOption("dump.graph", false);
-    }
+    options.setOption("dump.graph", dumpQueryCompilationIR.isDumpGraphEnabled());
     return std::make_unique<CompiledExecutablePipelineStage>(pipeline, pipeline->getOperatorHandlers(), options);
 }
 

--- a/nes-query-compiler/src/QueryCompiler.cpp
+++ b/nes-query-compiler/src/QueryCompiler.cpp
@@ -31,7 +31,7 @@ QueryCompiler::QueryCompiler() = default;
 /// This phase should be as dumb as possible and not further decisions should be made here.
 std::unique_ptr<CompiledQueryPlan> QueryCompiler::compileQuery(std::unique_ptr<QueryCompilationRequest> request)
 {
-    auto lowerToCompiledQueryPlanPhase = LowerToCompiledQueryPlanPhase(request->dumpCompilationResult, request->dumpGraph);
+    auto lowerToCompiledQueryPlanPhase = LowerToCompiledQueryPlanPhase(request->dumpCompilationResult);
     auto pipelinedQueryPlan = PipeliningPhase::apply(request->queryPlan);
     return lowerToCompiledQueryPlanPhase.apply(pipelinedQueryPlan);
 }

--- a/nes-runtime/include/Configuration/WorkerConfiguration.hpp
+++ b/nes-runtime/include/Configuration/WorkerConfiguration.hpp
@@ -52,10 +52,10 @@ public:
            "SourceDescriptor).",
            {std::make_shared<NumberValidation>()}};
 
-    EnumOption<DumpMode> dumpQueryCompilationIntermediateRepresentations
+    EnumOption<DumpMode::Options> dumpQueryCompilationIR
         = {"dump_compilation_result",
-           DumpMode::NONE,
-           fmt::format("If and where to dump query compilation results: {}", enumPipeList<DumpMode>())};
+           DumpMode::Options::NONE,
+           fmt::format("If and where to dump query compilation results: {}", enumPipeList<DumpMode::Options>())};
 
     BoolOption dumpGraph = {"dump_graph", "false", "If to dump graph of the compilation results"};
 
@@ -67,7 +67,7 @@ private:
             &defaultQueryExecution,
             &numberOfBuffersInGlobalBufferManager,
             &defaultMaxInflightBuffers,
-            &dumpQueryCompilationIntermediateRepresentations,
+            &dumpQueryCompilationIR,
             &dumpGraph};
     }
 };

--- a/nes-runtime/include/Util/DumpMode.hpp
+++ b/nes-runtime/include/Util/DumpMode.hpp
@@ -17,11 +17,25 @@
 
 namespace NES
 {
-enum class DumpMode : uint8_t
+class DumpMode
 {
-    NONE, /// Disables all dumping
-    CONSOLE, /// Dumps intermediate representations to console, std:out
-    FILE, /// Dumps intermediate representations to file
-    FILE_AND_CONSOLE /// Dumps intermediate representations to console and file
+public:
+    enum class Options : uint8_t
+    {
+        NONE, /// Disables all dumping
+        CONSOLE, /// Dumps intermediate representations to console, std:out
+        FILE, /// Dumps intermediate representations to file
+        FILE_AND_CONSOLE /// Dumps intermediate representations to console and file
+    };
+
+    DumpMode(Options option, bool dumpGraph) : option(option), dumpGraph(dumpGraph) { }
+
+    Options getDumpOption() const { return option; }
+
+    bool isDumpGraphEnabled() const { return option != Options::NONE && dumpGraph; }
+
+private:
+    Options option = Options::NONE;
+    bool dumpGraph = false;
 };
 }

--- a/nes-single-node-worker/src/SingleNodeWorker.cpp
+++ b/nes-single-node-worker/src/SingleNodeWorker.cpp
@@ -72,9 +72,10 @@ std::expected<QueryId, Exception> SingleNodeWorker::registerQuery(LogicalPlan pl
         plan.setQueryId(QueryId(queryIdCounter++));
         auto queryPlan = optimizer->optimize(plan);
         listener->onEvent(SubmitQuerySystemEvent{queryPlan.getQueryId(), explain(plan, ExplainVerbosity::Debug)});
+        DumpMode dumpMode(
+            configuration.workerConfiguration.dumpQueryCompilationIR.getValue(), configuration.workerConfiguration.dumpGraph.getValue());
         auto request = std::make_unique<QueryCompilation::QueryCompilationRequest>(queryPlan);
-        request->dumpCompilationResult = configuration.workerConfiguration.dumpQueryCompilationIntermediateRepresentations.getValue();
-        request->dumpGraph = configuration.workerConfiguration.dumpGraph.getValue();
+        request->dumpCompilationResult = dumpMode;
         auto result = compiler->compileQuery(std::move(request));
         INVARIANT(result, "expected successfull query compilation or exception, but got nothing");
         return nodeEngine->registerCompiledQueryPlan(std::move(result));


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Adds support for `--worker.dumpGraph [true|false]` boolean flag
The flag controls, whether the Nautilus compilation graph will be dumped 
Basically it sets the Nautilus option `dump.graph` to whatever value is passed (see docs [here](https://github.com/nebulastream/nautilus/blob/main/docs/options.md))

## Verifying this change
Run systest with the mentioned flag, you should see the dumped graph in the dump directory

## What components does this pull request potentially affect?
- Worker Configuration
- QueryCompiler

## Documentation
- The change is reflected in the Nautilus documentation, there is not seems to be a centralised documentation for all worker options in nebulastream repo
