### PR TITLE
Bump nautilus version fix

### DIFF
--- a/.nix/nautilus/package.nix
+++ b/.nix/nautilus/package.nix
@@ -53,8 +53,8 @@ let
   nautilusSrc = pkgs.fetchFromGitHub {
     owner = "nebulastream";
     repo = "nautilus";
-    rev = "598041b59644088ed431bb27a35e77f48c1e8bad";
-    hash = "sha512-/UXpeKTGNk+fd7ecSPP2RIJ8/hA7E602JnSi4K+s15YKYbKN+LaHSuAXgT3NaJqe3LqYD6NqaFUqMVGmf/6Q3g==";
+    rev = "5fa4c9043d961238d283bf129b82c59e1476974a";
+    hash = "sha512-woWgqYDU5SW2hqMh/VhDD9adUt1XFI2K75YOeIW7Yi/fDEmX59bOXmlk4z1nbPJqVFPip7pPJkCvWEZ+WmM/cg==";
   };
 
   nautilus = clangStdenv.mkDerivation rec {
@@ -62,6 +62,9 @@ let
     version = "0.1";
 
     src = nautilusSrc;
+    patches = [
+      ./patches/0002-fix-ambiguous-val-overload.patch
+    ];
 
     nativeBuildInputs = [
       pkgs.cmake

--- a/.nix/nautilus/patches/0002-fix-ambiguous-val-overload.patch
+++ b/.nix/nautilus/patches/0002-fix-ambiguous-val-overload.patch
@@ -1,0 +1,31 @@
+Subject: [PATCH] fix(VarVal): fixing ambiguous overload
+---
+Index: nautilus/include/nautilus/val.hpp
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/nautilus/include/nautilus/val.hpp b/nautilus/include/nautilus/val.hpp
+--- a/nautilus/include/nautilus/val.hpp	(revision 5fa4c9043d961238d283bf129b82c59e1476974a)
++++ b/nautilus/include/nautilus/val.hpp	(revision d4e4829c76299890d8fdded5291caa92300ca2fc)
+@@ -350,13 +350,13 @@
+ 		return details::FUNC(std::forward<decltype(lhsV)>(lhsV), std::forward<RHS>(right));                            \
+ 	}                                                                                                                  \
+                                                                                                                        \
+-	template <typename LHS, typename RHS>                                                                              \
+-	    requires(is_##CATEGORY##_val<LHS> && !is_##CATEGORY##_val<RHS> &&                                              \
+-	             !std::is_##CATEGORY##_v<std::remove_cvref_t<RHS>> && convertible_to_##CATEGORY##_val<RHS, LHS>)       \
+-	auto inline operator OP(LHS&& left, RHS&& right) {                                                                 \
+-		auto rV = static_cast<std::remove_cvref_t<LHS>>(right);                                                        \
+-		return left OP rV;                                                                                             \
+-	}
++    template <typename LHS, typename RHS>                                                                              \
++        requires(is_##CATEGORY##_val<LHS> && !is_##CATEGORY##_val<RHS> &&                                              \
++                 !std::is_##CATEGORY##_v<std::remove_cvref_t<RHS>> && convertible_to_##CATEGORY##_val<RHS, LHS>)       \
++    auto inline operator OP(LHS&& left, RHS&& right) {                                                                 \
++       auto rV = static_cast<std::remove_cvref_t<LHS>>(right);                                                         \
++       return details::FUNC(std::forward<LHS>(left), std::forward<decltype(rV)>(rV));                                  \
++    }
+
+ DEFINE_BINARY_OPERATOR(+, add, fundamental)
+


### PR DESCRIPTION
PR is a hotfix on the issue that the nautilus version was only dumped for the vcpkg but not the nix build in https://github.com/nebulastream/nebulastream/pull/1234.