### PR TITLE
Bump cpptrace to 1.x.x

### DIFF
--- a/.nix/cpptrace/package.nix
+++ b/.nix/cpptrace/package.nix
@@ -56,14 +56,18 @@ let
     in
     (if useLibcxx then libcxxStdenv else clangStdenv).mkDerivation rec {
       pname = "cpptrace";
-      version = "0.8.3";
+      version = "1.0.4";
 
-      src = fetchFromGitHub {
-        owner = "jeremy-rifkin";
-        repo = "cpptrace";
-        rev = "v${version}";
-        hash = "sha512-T+fmn1DvgAhUBjanRJBcXc3USAJe4Qs2v5UpiLj+HErLtRKoOCr9V/Pa5Nfpfla9v5H/q/2REKpBJ3r4exSSoQ==";
-      };
+  src = fetchFromGitHub {
+    owner = "jeremy-rifkin";
+    repo = "cpptrace";
+    rev = "v${version}";
+    hash = "sha512-jK2VnWtk7ovSFhgDkwqAlQ5REgVzyqU2nddySnuZZSIVLP5nW5EnOpfLGTpg65x+9ILaCm1UacouvIyJfzyYHQ==";
+  };
+
+   patches = [
+      ./patches/0001-bump-cxx-std.patch
+   ];
 
       nativeBuildInputs = [
         cmake

--- a/.nix/cpptrace/patches/0001-bump-cxx-std.patch
+++ b/.nix/cpptrace/patches/0001-bump-cxx-std.patch
@@ -1,0 +1,29 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d7bc6bc..55dfd45 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -15,6 +15,8 @@ project(
+   LANGUAGES C CXX
+ )
+ 
++set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
++
+ # Don't change include order, OptionVariables checks if project is top level
+ include(cmake/ProjectIsTopLevel.cmake)
+ include(cmake/OptionVariables.cmake)
+@@ -251,12 +253,14 @@ target_include_directories(
+     "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
+ )
+ 
++
+ # Require C++11 support
+ target_compile_features(
+     ${target_name}
+-    PRIVATE cxx_std_11
++    PRIVATE cxx_std_20
+ )
+ 
++
+ target_compile_definitions(${target_name} PRIVATE NOMINMAX)
+ 
+ if(HAS_ATTRIBUTE_PACKED)

--- a/nes-common/include/ErrorHandling.hpp
+++ b/nes-common/include/ErrorHandling.hpp
@@ -28,6 +28,7 @@
 #include <cpptrace/basic.hpp>
 #include <cpptrace/cpptrace.hpp>
 #include <cpptrace/exceptions.hpp>
+#include <cpptrace/formatting.hpp>
 #include <fmt/core.h>
 #include <fmt/format.h>
 
@@ -44,6 +45,8 @@ enum ErrorCode : uint16_t
 
 #define EXCEPTION(name, code, msg) name = (code),
 #include <ExceptionDefinitions.inc>
+
+
 #undef EXCEPTION
 };
 }
@@ -71,6 +74,17 @@ private:
     std::string message;
     ErrorCode errorCode;
 };
+
+/// helper function for formatting stacktraces
+/// currently only filters cpptrace's internal stackframes; can be extended later
+inline std::string formatStacktrace(const cpptrace::stacktrace& stacktrace, const bool color)
+{
+    static const cpptrace::formatter Formatter
+        = cpptrace::formatter{}
+              .filter([](const cpptrace::stacktrace_frame& frame) { return !frame.symbol.contains("try_catch_impl"); })
+              .filtered_frame_placeholders(false);
+    return Formatter.format(stacktrace, color);
+}
 
 /// This macro is used to define exceptions in <ExceptionDefinitions.hpp>
 /// @param name The name of the exception
@@ -115,7 +129,7 @@ private:
         { \
             if (!(condition)) \
             { \
-                auto trace = cpptrace::generate_trace().to_string(true); \
+                auto trace = NES::formatStacktrace(cpptrace::generate_trace(), true); \
                 NES_ERROR("Precondition violated: ({}): " formatString "\u001B[0m\n\n{}", #condition __VA_OPT__(, ) __VA_ARGS__, trace); \
                 if (auto logger = ::NES::Logger::getInstance()) \
                 { \
@@ -137,7 +151,7 @@ private:
         { \
             if (!(condition)) \
             { \
-                auto trace = cpptrace::generate_trace().to_string(true); \
+                auto trace = NES::formatStacktrace(cpptrace::generate_trace(), true); \
                 NES_ERROR("Invariant violated: ({}): " formatString "\u001B[0m\n\n{}", #condition __VA_OPT__(, ) __VA_ARGS__, trace); \
                 if (auto logger = ::NES::Logger::getInstance()) \
                 { \

--- a/nes-common/src/ErrorHandling.cpp
+++ b/nes-common/src/ErrorHandling.cpp
@@ -107,7 +107,7 @@ std::string formatLogMessage(const Exception& e)
     if (!e.where())
     {
         return fmt::format(
-            "failed to process with error code ({}) : {}\n\n{}{}\n", e.code(), e.what(), ansiColorReset, e.trace().to_string(true));
+            "failed to process with error code ({}) : {}\n\n{}{}\n", e.code(), e.what(), ansiColorReset, formatStacktrace(e.trace(), true));
     }
 
     auto exceptionLocation = e.where().value();
@@ -120,7 +120,7 @@ std::string formatLogMessage(const Exception& e)
         exceptionLocation.column,
         exceptionLocation.symbol,
         ansiColorReset,
-        e.trace().to_string(true));
+        formatStacktrace(e.trace(), true));
 }
 
 std::string formatLogMessage(const std::exception& e)
@@ -130,7 +130,7 @@ std::string formatLogMessage(const std::exception& e)
         return fmt::format("failed to process with error : {}", e.what());
     }
     constexpr auto ansiColorReset = "\u001B[0m";
-    const auto& trace = cpptrace::from_current_exception().to_string(true);
+    const auto& trace = formatStacktrace(cpptrace::from_current_exception(), true);
     return fmt::format("failed to process with error : {}\n{}{}", e.what(), ansiColorReset, trace);
 }
 

--- a/nes-common/src/Util/Signal.cpp
+++ b/nes-common/src/Util/Signal.cpp
@@ -19,9 +19,9 @@
 #include <unistd.h>
 #include <cpptrace/basic.hpp>
 #include <cpptrace/cpptrace.hpp>
+#include <cpptrace/utils.hpp>
 #include <fmt/base.h>
 #include <ErrorHandling.hpp>
-#include <utils.hpp>
 
 namespace
 {

--- a/nes-frontend/apps/repl/ReplStarter.cpp
+++ b/nes-frontend/apps/repl/ReplStarter.cpp
@@ -49,6 +49,7 @@
 #include <Util/Signal.hpp>
 #include <argparse/argparse.hpp>
 #include <cpptrace/from_current.hpp>
+#include <cpptrace/utils.hpp>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <magic_enum/magic_enum.hpp>
@@ -60,7 +61,6 @@
 #include <Repl.hpp>
 #include <Thread.hpp>
 #include <WorkerCatalog.hpp>
-#include <utils.hpp>
 
 #ifdef EMBED_ENGINE
     #include <Configurations/Util.hpp>

--- a/nes-input-formatters/src/SequenceShredder.cpp
+++ b/nes-input-formatters/src/SequenceShredder.cpp
@@ -29,12 +29,12 @@
 #include <Identifiers/Identifiers.hpp>
 #include <Runtime/BufferManager.hpp>
 #include <Util/Logger/Logger.hpp>
+#include <cpptrace/from_current.hpp>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <ErrorHandling.hpp>
 #include <RawTupleBuffer.hpp>
 #include <SpanningTupleBuffer.hpp>
-#include <from_current.hpp>
 
 namespace NES
 {

--- a/nes-logical-operators/src/Serialization/QueryPlanSerializationUtil.cpp
+++ b/nes-logical-operators/src/Serialization/QueryPlanSerializationUtil.cpp
@@ -26,12 +26,12 @@
 #include <Plans/LogicalPlan.hpp>
 #include <Serialization/OperatorSerializationUtil.hpp>
 #include <Util/Logger/Logger.hpp>
+#include <cpptrace/from_current.hpp>
 #include <rfl/json/read.hpp>
 #include <rfl/json/write.hpp>
 #include <ErrorHandling.hpp>
 #include <SerializableQueryId.pb.h>
 #include <SerializableQueryPlan.pb.h>
-#include <from_current.hpp>
 
 namespace NES
 {

--- a/nes-memory/TupleBufferImpl.cpp
+++ b/nes-memory/TupleBufferImpl.cpp
@@ -29,7 +29,7 @@
 #ifdef NES_DEBUG_TUPLE_BUFFER_LEAKS
     #include <mutex>
     #include <thread>
-    #include <cpptrace.hpp>
+    #include <cpptrace/cpptrace.hpp>
 #endif
 
 namespace NES::detail

--- a/nes-memory/TupleBufferImpl.hpp
+++ b/nes-memory/TupleBufferImpl.hpp
@@ -30,7 +30,7 @@
     #include <mutex>
     #include <thread>
     #include <unordered_map>
-    #include <cpptrace.hpp>
+    #include <cpptrace/cpptrace.hpp>
 #endif
 
 namespace NES

--- a/nes-query-engine/Task.hpp
+++ b/nes-query-engine/Task.hpp
@@ -211,24 +211,24 @@ void failTask(Task& task, Exception exception);
 
 void handleTask(const auto& handler, Task task)
 {
-    CPPTRACE_TRY
-    {
-        /// if handler returns true, the task has been successfully handled, which implies that the task has not been moved
-        if (std::visit(handler, task))
+    cpptrace::try_catch(
+        [&]
         {
-            succeedTask(task);
-        }
-    }
-    CPPTRACE_CATCH(const Exception& exception)
-    {
-        failTask(task, exception);
-    }
-    CPPTRACE_CATCH_ALT(...)
-    {
-        NES_ERROR("Worker thread produced unknown exception during processing");
-        tryLogCurrentException();
-        failTask(task, wrapExternalException());
-    }
+            /// if handler returns true, the task has been successfully handled, which implies that the task has not been moved
+            if (std::visit(handler, task))
+            {
+                succeedTask(task);
+            }
+        },
+        [&](const Exception& exception) { failTask(task, exception); },
+        [&]()
+        {
+            NES_ERROR("Worker thread produced unknown exception during processing");
+            auto exception = wrapExternalException();
+            tryLogCurrentException();
+            failTask(task, exception);
+        });
+
     completeTask(task);
 }
 

--- a/nes-single-node-worker/src/GrpcService.cpp
+++ b/nes-single-node-worker/src/GrpcService.cpp
@@ -60,7 +60,7 @@ grpc::Status handleError(const std::exception& exception, grpc::ServerContext* c
     NES_ERROR("GRPC Request failed with exception: {}", exception.what());
     context->AddTrailingMetadata("code", std::to_string(ErrorCode::UnknownException));
     context->AddTrailingMetadata("what", sanitizeForGrpcMetadata(exception.what()));
-    context->AddTrailingMetadata("trace", sanitizeForGrpcMetadata(cpptrace::from_current_exception().to_string(false)));
+    context->AddTrailingMetadata("trace", sanitizeForGrpcMetadata(formatStacktrace(cpptrace::from_current_exception(), false)));
     return {grpc::INTERNAL, sanitizeForGrpcMetadata(exception.what())};
 }
 
@@ -69,8 +69,17 @@ grpc::Status handleError(const Exception& exception, grpc::ServerContext* contex
     NES_ERROR("GRPC Request failed with exception: {}", exception.what());
     context->AddTrailingMetadata("code", std::to_string(exception.code()));
     context->AddTrailingMetadata("what", sanitizeForGrpcMetadata(exception.what()));
-    context->AddTrailingMetadata("trace", sanitizeForGrpcMetadata(cpptrace::from_current_exception().to_string(false)));
+    context->AddTrailingMetadata("trace", sanitizeForGrpcMetadata(formatStacktrace(exception.trace(), false)));
     return {grpc::INTERNAL, sanitizeForGrpcMetadata(exception.what())};
+}
+
+grpc::Status handleError(grpc::ServerContext* context)
+{
+    NES_ERROR("GRPC Request failed with unknown exception");
+    context->AddTrailingMetadata("code", std::to_string(ErrorCode::UnknownException));
+    context->AddTrailingMetadata("what", "unknown exception");
+    context->AddTrailingMetadata("trace", sanitizeForGrpcMetadata(formatStacktrace(cpptrace::from_current_exception(), false)));
+    return {grpc::INTERNAL, "unknown exception"};
 }
 
 template <typename T>
@@ -82,138 +91,120 @@ T getValueOrThrow(std::expected<T, Exception> expected)
     }
     throw std::move(expected.error());
 }
+
+grpc::Status tryWithDefaultHandling(const std::function<grpc::Status()>& f, grpc::ServerContext* context)
+{
+    grpc::Status status{};
+    cpptrace::try_catch(
+        [&] { status = f(); },
+        [&](const Exception& e) { status = handleError(e, context); },
+        [&](const std::exception& e) { status = handleError(e, context); },
+        [&]() { status = handleError(context); });
+    return status;
+}
+
 }
 
 grpc::Status GRPCServer::RegisterQuery(grpc::ServerContext* context, const RegisterQueryRequest* request, RegisterQueryReply* response)
 {
     auto fullySpecifiedQueryPlan = QueryPlanSerializationUtil::deserializeQueryPlan(request->queryplan());
-    CPPTRACE_TRY
-    {
-        auto result = delegate.registerQuery(std::move(fullySpecifiedQueryPlan));
-        if (result.has_value())
+    return tryWithDefaultHandling(
+        [&]
         {
-            *response->mutable_queryid() = QueryPlanSerializationUtil::serializeQueryId(*result);
-            return grpc::Status::OK;
-        }
-        return handleError(result.error(), context);
-    }
-    CPPTRACE_CATCH(const std::exception& e)
-    {
-        return handleError(e, context);
-    }
-    return {grpc::INTERNAL, "unknown exception"};
+            auto result = delegate.registerQuery(std::move(fullySpecifiedQueryPlan));
+            if (result.has_value())
+            {
+                *response->mutable_queryid() = QueryPlanSerializationUtil::serializeQueryId(*result);
+                return grpc::Status::OK;
+            }
+            return handleError(result.error(), context);
+        },
+        context);
 }
 
 grpc::Status GRPCServer::StartQuery(grpc::ServerContext* context, const StartQueryRequest* request, google::protobuf::Empty*)
 {
     const auto queryId = QueryPlanSerializationUtil::deserializeQueryId(request->queryid());
-    CPPTRACE_TRY
-    {
-        getValueOrThrow(delegate.startQuery(queryId));
-        return grpc::Status::OK;
-    }
-    CPPTRACE_CATCH(const Exception& e)
-    {
-        return handleError(e, context);
-    }
-    CPPTRACE_CATCH_ALT(const std::exception& e)
-    {
-        return handleError(e, context);
-    }
-    return {grpc::INTERNAL, "unknown exception"};
+    return tryWithDefaultHandling(
+        [&]
+        {
+            getValueOrThrow(delegate.startQuery(queryId));
+            return grpc::Status::OK;
+        },
+        context);
 }
 
 grpc::Status GRPCServer::StopQuery(grpc::ServerContext* context, const StopQueryRequest* request, google::protobuf::Empty*)
 {
     const auto queryId = QueryPlanSerializationUtil::deserializeQueryId(request->queryid());
-    CPPTRACE_TRY
-    {
-        getValueOrThrow(delegate.stopQuery(queryId));
-        return grpc::Status::OK;
-    }
-    CPPTRACE_CATCH(const Exception& e)
-    {
-        return handleError(e, context);
-    }
-    CPPTRACE_CATCH_ALT(const std::exception& e)
-    {
-        return handleError(e, context);
-    }
-    return {grpc::INTERNAL, "unknown exception"};
+    return tryWithDefaultHandling(
+        [&]
+        {
+            getValueOrThrow(delegate.stopQuery(queryId));
+            return grpc::Status::OK;
+        },
+        context);
 }
 
 grpc::Status GRPCServer::RequestQueryStatus(grpc::ServerContext* context, const QueryStatusRequest* request, QueryStatusReply* reply)
 {
-    CPPTRACE_TRY
-    {
-        const auto queryId = QueryPlanSerializationUtil::deserializeQueryId(request->queryid());
-        *reply->mutable_queryid() = QueryPlanSerializationUtil::serializeQueryId(queryId);
-        if (const auto queryStatus = delegate.getQueryStatus(queryId); queryStatus.has_value())
+    return tryWithDefaultHandling(
+        [&]
         {
-            const auto& [start, running, stop, error] = queryStatus->metrics;
-            reply->set_state(static_cast<::QueryState>(queryStatus->state));
-
-            if (start.has_value())
+            const auto queryId = QueryPlanSerializationUtil::deserializeQueryId(request->queryid());
+            *reply->mutable_queryid() = QueryPlanSerializationUtil::serializeQueryId(queryId);
+            if (const auto queryStatus = delegate.getQueryStatus(queryId); queryStatus.has_value())
             {
-                reply->mutable_metrics()->set_startunixtimeinms(
-                    std::chrono::duration_cast<std::chrono::milliseconds>(start->time_since_epoch()).count());
-            }
+                const auto& [start, running, stop, error] = queryStatus->metrics;
+                reply->set_state(static_cast<::QueryState>(queryStatus->state));
 
-            if (running.has_value())
-            {
-                reply->mutable_metrics()->set_runningunixtimeinms(
-                    std::chrono::duration_cast<std::chrono::milliseconds>(running->time_since_epoch()).count());
-            }
+                if (start.has_value())
+                {
+                    reply->mutable_metrics()->set_startunixtimeinms(
+                        std::chrono::duration_cast<std::chrono::milliseconds>(start->time_since_epoch()).count());
+                }
 
-            if (stop.has_value())
-            {
-                reply->mutable_metrics()->set_stopunixtimeinms(
-                    std::chrono::duration_cast<std::chrono::milliseconds>(stop->time_since_epoch()).count());
-            }
+                if (running.has_value())
+                {
+                    reply->mutable_metrics()->set_runningunixtimeinms(
+                        std::chrono::duration_cast<std::chrono::milliseconds>(running->time_since_epoch()).count());
+                }
 
-            if (error.has_value())
-            {
-                auto* errorProto = reply->mutable_metrics()->mutable_error();
-                errorProto->set_message(error->what());
-                errorProto->set_stacktrace(error->trace().to_string());
-                errorProto->set_code(error->code());
-                errorProto->set_location(std::string{error->where()->filename} + ":" + std::to_string(error->where()->line.value_or(0)));
+                if (stop.has_value())
+                {
+                    reply->mutable_metrics()->set_stopunixtimeinms(
+                        std::chrono::duration_cast<std::chrono::milliseconds>(stop->time_since_epoch()).count());
+                }
+
+                if (error.has_value())
+                {
+                    auto* errorProto = reply->mutable_metrics()->mutable_error();
+                    errorProto->set_message(error->what());
+                    errorProto->set_stacktrace(error->trace().to_string());
+                    errorProto->set_code(error->code());
+                    errorProto->set_location(
+                        std::string{error->where()->filename} + ":" + std::to_string(error->where()->line.value_or(0)));
+                }
+                return grpc::Status::OK;
             }
-            return grpc::Status::OK;
-        }
-        return {grpc::NOT_FOUND, "Query does not exist"};
-    }
-    CPPTRACE_CATCH(const Exception& e)
-    {
-        return handleError(e, context);
-    }
-    CPPTRACE_CATCH_ALT(const std::exception& e)
-    {
-        return handleError(e, context);
-    }
-    return {grpc::INTERNAL, "unknown exception"};
+            return grpc::Status{grpc::NOT_FOUND, "Query does not exist"};
+        },
+        context);
 }
 
 grpc::Status GRPCServer::RequestStatus(grpc::ServerContext* context, const WorkerStatusRequest* request, WorkerStatusResponse* response)
 {
-    CPPTRACE_TRY
-    {
-        const auto status = delegate.getWorkerStatus(
-            std::chrono::system_clock::time_point(std::chrono::milliseconds(request->after_unix_timestamp_in_milli_seconds())));
+    return tryWithDefaultHandling(
+        [&]
+        {
+            const auto status = delegate.getWorkerStatus(
+                std::chrono::system_clock::time_point(std::chrono::milliseconds(request->after_unix_timestamp_in_milli_seconds())));
 
-        serializeWorkerStatus(status, response);
+            serializeWorkerStatus(status, response);
 
-        return grpc::Status::OK;
-    }
-    CPPTRACE_CATCH(const Exception& e)
-    {
-        return handleError(e, context);
-    }
-    CPPTRACE_CATCH_ALT(const std::exception& e)
-    {
-        return handleError(e, context);
-    }
-    return {grpc::INTERNAL, "unknown exception"};
+            return grpc::Status::OK;
+        },
+        context);
 }
 
 }

--- a/nes-systests/systest/src/SystestExecutor.cpp
+++ b/nes-systests/systest/src/SystestExecutor.cpp
@@ -42,6 +42,7 @@
 #include <Util/Logger/LogLevel.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <Util/Logger/impl/NesLogger.hpp>
+#include <cpptrace/from_current.hpp>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <fmt/ranges.h>
@@ -57,7 +58,6 @@
 #include <SystestRunner.hpp>
 #include <SystestState.hpp>
 #include <WorkerCatalog.hpp>
-#include <from_current.hpp>
 
 /// Rust FFI function that enables in-memory communication channels for embedded multi-worker mode.
 /// Configures the network layer to use shared memory instead of real network sockets

--- a/scripts/check_preamble.py
+++ b/scripts/check_preamble.py
@@ -88,6 +88,7 @@ VENDORED_FILES = {
     "nes-systests/utils/SystestPlugin/NES-Systest-Runner/gradlew",
     "nes-systests/utils/SystestPlugin/NES-Systest-Runner/gradlew.bat",
     "vcpkg/vcpkg-registry/ports/llvm/portfile.cmake",
+    "vcpkg/vcpkg-registry/ports/cpptrace/portfile.cmake",
 }
 
 if __name__ == "__main__":

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -187,7 +187,7 @@ done
 # c.f. https://github.com/jeremy-rifkin/cpptrace?tab=readme-ov-file#traces-from-all-exceptions-cpptrace_try-and-cpptrace_catch
 if git grep "catch (\.\.\.)" -- ".hpp" "*.cpp" | grep -v "NOLINT(no-raw-catch-all)" > /dev/null
 then
-    log_error "Found catch (...). Please use CPPTRACE_TRY and CPPTRACE_CATCH to preserve stacktraces.\n$(git grep -n "catch (\.\.\.)" -- ".hpp" "*.cpp" | grep -v "NOLINT(no-raw-catch-all)")"
+    log_error "Found catch (...). Please use CPPTRACE_TRY and CPPTRACE_CATCH (or cpptrace::try_catch for multiple exception handlers) to preserve stacktraces, .\n$(git grep -n "catch (\.\.\.)" -- ".hpp" "*.cpp" | grep -v "NOLINT(no-raw-catch-all)")"
 fi
 
 python3 scripts/check_preamble.py || FAIL=1

--- a/vcpkg/vcpkg-registry/ports/cpptrace/0001-bump-cxx-std.patch
+++ b/vcpkg/vcpkg-registry/ports/cpptrace/0001-bump-cxx-std.patch
@@ -1,0 +1,29 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d7bc6bc..55dfd45 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -15,6 +15,8 @@ project(
+   LANGUAGES C CXX
+ )
+
++set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
++
+ # Don't change include order, OptionVariables checks if project is top level
+ include(cmake/ProjectIsTopLevel.cmake)
+ include(cmake/OptionVariables.cmake)
+@@ -251,12 +253,14 @@ target_include_directories(
+     "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
+ )
+
++
+ # Require C++11 support
+ target_compile_features(
+     ${target_name}
+-    PRIVATE cxx_std_11
++    PRIVATE cxx_std_20
+ )
+
++
+ target_compile_definitions(${target_name} PRIVATE NOMINMAX)
+ 
+ if(HAS_ATTRIBUTE_PACKED)

--- a/vcpkg/vcpkg-registry/ports/cpptrace/portfile.cmake
+++ b/vcpkg/vcpkg-registry/ports/cpptrace/portfile.cmake
@@ -1,0 +1,46 @@
+# MIT License
+#
+# Copyright (c) Microsoft Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this
+# software and associated documentation files (the "Software"), to deal in the Software
+# without restriction, including without limitation the rights to use, copy, modify,
+# merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies
+# or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+# PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+# OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO jeremy-rifkin/cpptrace
+        REF "v${VERSION}"
+        SHA512 e88edddbcdd423d49ed3adb02cf70580ee3a56065db4d81ca69d3f9f6d9b64ac27734842ca3b6d8ff45a548c25900a88f979e39d777af422a153e586d26ac5b5
+        HEAD_REF main
+        PATCHES
+        0001-bump-cxx-std.patch
+)
+
+vcpkg_cmake_configure(
+        SOURCE_PATH "${SOURCE_PATH}"
+        OPTIONS -DCPPTRACE_USE_EXTERNAL_LIBDWARF=ON -DCPPTRACE_USE_EXTERNAL_ZSTD=ON -DCPPTRACE_VCPKG=ON
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+        PACKAGE_NAME "cpptrace"
+        CONFIG_PATH "lib/cmake/cpptrace"
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg/vcpkg-registry/ports/cpptrace/usage
+++ b/vcpkg/vcpkg-registry/ports/cpptrace/usage
@@ -1,0 +1,4 @@
+cpptrace provides CMake targets:
+
+  find_package(cpptrace CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE cpptrace::cpptrace)

--- a/vcpkg/vcpkg-registry/ports/cpptrace/vcpkg.json
+++ b/vcpkg/vcpkg-registry/ports/cpptrace/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "cpptrace",
+  "version": "1.0.4",
+  "description": "Simple, portable, and self-contained stacktrace library for C++11 and newer",
+  "homepage": "https://github.com/jeremy-rifkin/cpptrace",
+  "license": "MIT",
+  "supports": "!(uwp | android)",
+  "dependencies": [
+    {
+      "name": "libdwarf",
+      "platform": "!windows | mingw"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/vcpkg/vcpkg.json
+++ b/vcpkg/vcpkg.json
@@ -53,12 +53,5 @@
     "simdjson",
     "spdlog",
     "yaml-cpp"
-  ],
-  "overrides": [
-    {
-      "name": "cpptrace",
-      "version": "0.8.3",
-      "port-version": 0
-    }
   ]
 }


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR bumps the version of cpptrace to 1.0.4. With version 1.x.x there is a breaking change which removes the CPPTRACE_CATCH_ALT makro, and replaces it with a lambda-based construct. This required rewriting some exception handlers, especially because it changes the behavior of return statements (return from the lambda vs return from the parent function). This is mainly relevant for our GrpcService, where there is now a utility function to add-in the default Grpc exception handling via cpptrace lambdas. The PR also includes a small change to the stacktrace formatting, as the new lambda construct bloats stacktraces with cpptrace internals. So, for readability, cpptrace internals are filtered out

## Verifying this change
This change is tested by
- manual testing (exception injection via throw)
- some recorded stacktraces to show that the tracing works as expected: 
[stacktraces.txt](https://github.com/user-attachments/files/23790155/stacktraces.txt)
- successful compilation 

## What components does this pull request potentially affect?
- error handling 
- grpc service 
- query engine


## Issue Closed by this pull request:

This PR closes #1193
