### PR TITLE
Fix undefined behavior in Nautilus

### DIFF
--- a/.nix/nautilus/package.nix
+++ b/.nix/nautilus/package.nix
@@ -63,7 +63,9 @@ let
 
     src = nautilusSrc;
     patches = [
+      ./patches/0001-disable-ubsan-function-call-check.patch
       ./patches/0002-fix-ambiguous-val-overload.patch
+      ./patches/0003-ubsan-fix-variadic-expansion.patch
     ];
 
     nativeBuildInputs = [

--- a/.nix/nautilus/patches/0001-disable-ubsan-function-call-check.patch
+++ b/.nix/nautilus/patches/0001-disable-ubsan-function-call-check.patch
@@ -1,0 +1,14 @@
+Index: nautilus/include/nautilus/Executable.hpp
+===================================================================
+diff --git a/nautilus/include/nautilus/Executable.hpp b/nautilus/include/nautilus/Executable.hpp
+--- a/nautilus/include/nautilus/Executable.hpp	(revision 8e822c5ace0ebd4fd11a49cd6c0bf29b622d7956)
++++ b/nautilus/include/nautilus/Executable.hpp	(date 1759779006981)
+@@ -68,7 +68,7 @@
+ 		 * @param arguments
+ 		 * @return returns the result of the function if any
+ 		 */
+-		R operator()(Args... arguments) {
++		__attribute__((no_sanitize("function"))) R operator()(Args... arguments) {
+ 			if (std::holds_alternative<FunctionType*>(func)) {
+ 				auto fptr = std::get<FunctionType*>(func);
+ 				if constexpr (!std::is_void_v<R>) {

--- a/.nix/nautilus/patches/0003-ubsan-fix-variadic-expansion.patch
+++ b/.nix/nautilus/patches/0003-ubsan-fix-variadic-expansion.patch
@@ -1,0 +1,18 @@
+diff --git a/nautilus/include/nautilus/function.hpp b/nautilus/include/nautilus/function.hpp
+--- a/nautilus/include/nautilus/function.hpp
++++ b/nautilus/include/nautilus/function.hpp
+@@ -11,13 +11,5 @@ namespace nautilus {
+
+ template <typename... ValueArguments>
+ auto getArgumentReferences(const ValueArguments&... arguments) {
+-	std::vector<tracing::TypedValueRef> functionArgumentReferences;
+-	if constexpr (sizeof...(ValueArguments) > 0) {
+-		functionArgumentReferences.reserve(sizeof...(ValueArguments));
+-		for (const tracing::TypedValueRef& p :
+-		     {details::StateResolver<const ValueArguments&>::getState(arguments)...}) {
+-			functionArgumentReferences.emplace_back(p);
+-		}
+-	}
+-	return functionArgumentReferences;
++	return std::vector<tracing::TypedValueRef> {details::StateResolver<const ValueArguments&>::getState(arguments)...};
+ }

--- a/vcpkg/vcpkg-registry/ports/nautilus/0003-ubsan-fix-variadic-expansion.patch
+++ b/vcpkg/vcpkg-registry/ports/nautilus/0003-ubsan-fix-variadic-expansion.patch
@@ -1,0 +1,18 @@
+diff --git a/nautilus/include/nautilus/function.hpp b/nautilus/include/nautilus/function.hpp
+--- a/nautilus/include/nautilus/function.hpp
++++ b/nautilus/include/nautilus/function.hpp
+@@ -11,13 +11,5 @@ namespace nautilus {
+ 
+ template <typename... ValueArguments>
+ auto getArgumentReferences(const ValueArguments&... arguments) {
+-	std::vector<tracing::TypedValueRef> functionArgumentReferences;
+-	if constexpr (sizeof...(ValueArguments) > 0) {
+-		functionArgumentReferences.reserve(sizeof...(ValueArguments));
+-		for (const tracing::TypedValueRef& p :
+-		     {details::StateResolver<const ValueArguments&>::getState(arguments)...}) {
+-			functionArgumentReferences.emplace_back(p);
+-		}
+-	}
+-	return functionArgumentReferences;
++	return std::vector<tracing::TypedValueRef> {details::StateResolver<const ValueArguments&>::getState(arguments)...};
+ }

--- a/vcpkg/vcpkg-registry/ports/nautilus/portfile.cmake
+++ b/vcpkg/vcpkg-registry/ports/nautilus/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_from_github(
 		PATCHES
 		0001-disable-ubsan-function-call-check.patch
 		0002-fix-ambiguous-val-overload.patch
+		0003-ubsan-fix-variadic-expansion.patch
 )
 
 set(ADDITIONAL_CMAKE_OPTIONS "")


### PR DESCRIPTION
This PR fixes a ubsan error that occurs when running (any) systest:

```
/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-14.3.0/include/c++/14.3.0/bits/stl_vector.h:1251:9: runtime error: reference binding to address 0x7fa868a6c3f0 with insufficient space for an object of type 'nautilus::tracing::TypedValueRef'
0x7fa868a6c3f0: note: pointer points here
00 00 00 00 20 00 0c 00 af 7f 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 e5 00 00 00
^
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-14.3.0/include/c++/14.3.0/bits/stl_vector.h:1251:9
/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-14.3.0/include/c++/14.3.0/bits/vector.tcc:125:9: runtime error: reference binding to address 0x7fa868a6c3f0 with insufficient space for an object of type 'value_type' (aka 'nautilus::tracing::TypedValueRef')
0x7fa868a6c3f0: note: pointer points here
00 00 00 00 20 00 0c 00 af 7f 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 e5 00 00 00
^
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-14.3.0/include/c++/14.3.0/bits/vector.tcc:125:9
```
with https://github.com/nebulastream/nebulastream/pull/1168

It also adds a missing patch to the nix build