### PR TITLE
feature: add TRIM function and documentation

### DIFF
--- a/docs/guide/how_to_add_a_function.md
+++ b/docs/guide/how_to_add_a_function.md
@@ -1,0 +1,184 @@
+# How to add a `Function` in NebulaStream
+
+Functions in NebulaStream are used to transform data within query plans. They can operate on various data types and are used in SQL expressions like `SELECT TRIM(name) FROM stream`.
+
+Functions in NebulaStream follow a two level architecture:
+1. **Logical Functions**: represent functions in the logical query plan, handling type inference and validation.
+2. **Physical Functions**: execute the actual computation at runtime using the Nautilus.
+
+Below guide will walk you through implementing a function using the `TRIM` function as an example. TRIM removes leading and trailing whitespace from variable-sized strings (VARSIZED).
+
+## 1. Overview
+
+Functions are implemented in two locations:
+- **Logical functions**: `nes-logical-operators/src/Functions/` and `nes-logical-operators/include/Functions/`
+- **Physical functions**: `nes-physical-operators/src/Functions/` and `nes-physical-operators/include/Functions/`
+
+For our TRIM example, we create:
+```
+nes-logical-operators/
+|── include/Functions/
+    ── TrimLogicalFunction.hpp
+|── src/Functions/
+    ── TrimLogicalFunction.cpp
+
+nes-physical-operators/
+|── include/Functions/
+    ── TrimPhysicalFunction.hpp
+|── src/Functions/
+    ── TrimPhysicalFunction.cpp
+```
+
+As a last step before build, you'll need to:
+- register the function in CMakeLists.txt files
+- create system tests in `nes-systests/function/`
+
+## 2. Logical Function 
+
+A logical function class must inherit from `LogicalFunctionConcept` and implement all required methods. Reference existing functions like `ConcatLogicalFunction` or `TrimLogicalFunction` for complete examples.
+
+### 2.1 Key Components
+
+**Header file** (`TrimLogicalFunction.hpp`):
+- inherit from `LogicalFunctionConcept`
+- define `static constexpr std::string_view NAME = "Trim"` (this should match SQL function name)
+- store child functions and data type as private members
+- declare all virtual methods from `LogicalFunctionConcept`
+- add `FMT_OSTREAM(NES::TrimLogicalFunction)` at the end for logging support
+
+**Implementation file** (`TrimLogicalFunction.cpp`):
+- Constructor: initialize with child function(s) and infer data type from children
+- withInferredDataType: validate argument types here (e.g., TRIM requires VARSIZED). This is where type checking should occur, not in the registry function.
+- withChildren: validate the number of children matches function requirements
+- serialize: serialize the function for query plan transmission (usually the same for all functions)
+- Register function: implement `LogicalFunctionGeneratedRegistrar::Register{FunctionName}LogicalFunction` following the exact naming pattern
+
+### 2.2 Notes
+
+- Type validation: do not validate data types in the registry function (`RegisterTrimLogicalFunction`), as types may be `UNDEFINED` during registration. Validation should occur in `withInferredDataType()`.
+- Error handling: always validate the number of arguments in `withChildren()` and types in `withInferredDataType()`.
+
+## 3. Physical Function
+
+A physical function class must inherit from `PhysicalFunctionConcept` and implement the `execute` method. Reference existing functions like `ConcatPhysicalFunction` or `TrimPhysicalFunction` for complete examples.
+
+### 3.1 Key Components
+
+**Header file** (`TrimPhysicalFunction.hpp`):
+- inherit from `PhysicalFunctionConcept`
+- declare constructor taking `PhysicalFunction` child(ren)
+- implement `execute(const Record& record, ArenaRef& arena) const override`
+- store child physical functions as private members
+
+**Implementation file** (`TrimPhysicalFunction.cpp`):
+- Constructor: store child physical function(s) using `std::move`
+- execute: implement the actual computation logic using the Nautilus API (core part of your contribution as other steps majorly similar to each other)
+- Register function: implement `PhysicalFunctionGeneratedRegistrar::Register{FunctionName}PhysicalFunction` following the exact naming pattern
+
+## 4. CMake Registration
+
+### 4.1 Logical Function Registration
+
+Add to `nes-logical-operators/src/Functions/CMakeLists.txt`:
+
+```cmake
+add_plugin(Trim LogicalFunction nes-logical-operators TrimLogicalFunction.cpp)
+```
+
+### 4.2 Physical Function Registration
+
+Add to `nes-physical-operators/src/Functions/CMakeLists.txt`:
+
+```cmake
+add_plugin(Trim PhysicalFunction nes-physical-operators TrimPhysicalFunction.cpp)
+```
+
+The `add_plugin` macro automatically will register the function in the registry (so your function will be recognized and can be called).
+
+## 5. Testing
+
+Create system tests in `nes-systests/function/`.
+
+Test file structure (the first three lines are important and should be part of every test file):
+
+```sql
+# name: Trim
+# description: Checks that trim in projections works as expected
+# groups: [Function, Text, Projection]
+
+CREATE LOGICAL SOURCE nameStream(fullName VARSIZED);
+CREATE PHYSICAL SOURCE FOR nameStream TYPE File;
+ATTACH INLINE
+ Edgar Codd
+        Jim Grey
+Michael Stonebraker
+
+CREATE SINK fullNameTrimmedSink(fullNameTrimmed VARSIZED) TYPE File;
+
+SELECT TRIM(fullName) as fullNameTrimmed FROM nameStream INTO fullNameTrimmedSink;
+----
+Edgar Codd
+Jim Grey
+Michael Stonebraker
+
+```
+See `docs/development/systests.md` for more details on writing system tests.
+
+## 6. Common Patterns
+
+### 6.1 Functions with Multiple Arguments
+
+For functions like `CONCAT` that take multiple arguments:
+
+```cpp
+class ConcatLogicalFunction final : public LogicalFunctionConcept
+{
+public:
+    ConcatLogicalFunction(const LogicalFunction& left, const LogicalFunction& right);
+    // ...
+private:
+    LogicalFunction left;
+    LogicalFunction right;
+};
+```
+
+In `withChildren`:
+```cpp
+LogicalFunction ConcatLogicalFunction::withChildren(const std::vector<LogicalFunction>& children) const
+{
+    if (children.size() < 2)
+    {
+        throw InvalidQuerySyntax("CONCAT requires at least two arguments, got {}", children.size());
+    }
+    // Handle multiple children
+}
+```
+
+### 6.2 Type Validation
+
+Always validate argument types in `withInferredDataType`:
+
+```cpp
+LogicalFunction MyFunction::withInferredDataType(const Schema& schema) const
+{
+    auto newChild = child.withInferredDataType(schema);
+    if (not newChild.getDataType().isType(DataType::Type::REQUIRED_TYPE))
+    {
+        throw CannotInferSchema("MyFunction requires a REQUIRED_TYPE argument, but got: {}", newChild.getDataType());
+    }
+    return withChildren({newChild});
+}
+```
+
+### 6.3 Data Type Inference
+
+For functions that change types (e.g., arithmetic operations):
+
+```cpp
+ConcatLogicalFunction::ConcatLogicalFunction(const LogicalFunction& left, const LogicalFunction& right)
+    : dataType(left.getDataType().join(right.getDataType()).value_or(DataType{DataType::Type::UNDEFINED})), 
+      left(left), right(right)
+{
+}
+```
+

--- a/nes-logical-operators/include/Functions/TrimLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/TrimLogicalFunction.hpp
@@ -1,0 +1,57 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/Schema.hpp>
+#include <Functions/LogicalFunction.hpp>
+#include <Util/Logger/Formatter.hpp>
+#include <Util/PlanRenderer.hpp>
+#include <SerializableVariantDescriptor.pb.h>
+
+namespace NES
+{
+
+class TrimLogicalFunction final : public LogicalFunctionConcept
+{
+public:
+    static constexpr std::string_view NAME = "Trim";
+
+    TrimLogicalFunction(const LogicalFunction& child);
+
+    [[nodiscard]] SerializableFunction serialize() const override;
+
+    [[nodiscard]] bool operator==(const LogicalFunctionConcept& rhs) const override;
+
+    [[nodiscard]] DataType getDataType() const override;
+    [[nodiscard]] LogicalFunction withDataType(const DataType& dataType) const override;
+    [[nodiscard]] LogicalFunction withInferredDataType(const Schema& schema) const override;
+
+    [[nodiscard]] std::vector<LogicalFunction> getChildren() const override;
+    [[nodiscard]] LogicalFunction withChildren(const std::vector<LogicalFunction>& children) const override;
+
+    [[nodiscard]] std::string_view getType() const override;
+    [[nodiscard]] std::string explain(ExplainVerbosity verbosity) const override;
+
+private:
+    DataType dataType;
+    LogicalFunction child;
+};
+}
+
+FMT_OSTREAM(NES::TrimLogicalFunction);

--- a/nes-logical-operators/src/Functions/CMakeLists.txt
+++ b/nes-logical-operators/src/Functions/CMakeLists.txt
@@ -25,3 +25,4 @@ add_plugin(FieldAssignment LogicalFunction nes-logical-operators FieldAssignment
 add_plugin(Rename LogicalFunction nes-logical-operators RenameLogicalFunction.cpp)
 add_plugin(Concat LogicalFunction nes-logical-operators ConcatLogicalFunction.cpp)
 add_plugin(CastToType LogicalFunction nes-logical-operators CastToTypeLogicalFunction.cpp)
+add_plugin(Trim LogicalFunction nes-logical-operators TrimLogicalFunction.cpp)

--- a/nes-logical-operators/src/Functions/TrimLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/TrimLogicalFunction.cpp
@@ -1,0 +1,115 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Functions/TrimLogicalFunction.hpp>
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/Schema.hpp>
+#include <ErrorHandling.hpp>
+#include <Functions/LogicalFunction.hpp>
+#include <LogicalFunctionRegistry.hpp>
+#include <Serialization/DataTypeSerializationUtil.hpp>
+#include <SerializableVariantDescriptor.pb.h>
+#include <Util/PlanRenderer.hpp>
+#include <fmt/format.h>
+
+namespace NES
+{
+
+TrimLogicalFunction::TrimLogicalFunction(const LogicalFunction& child)
+    : dataType(child.getDataType()), child(child)
+{
+}
+
+bool TrimLogicalFunction::operator==(const LogicalFunctionConcept& rhs) const
+{
+    if (const auto* other = dynamic_cast<const TrimLogicalFunction*>(&rhs))
+    {
+        return child == other->child;
+    }
+    return false;
+}
+
+std::string TrimLogicalFunction::explain(ExplainVerbosity verbosity) const
+{
+    return fmt::format("TRIM({})", child.explain(verbosity));
+}
+
+DataType TrimLogicalFunction::getDataType() const
+{
+    return dataType;
+}
+
+LogicalFunction TrimLogicalFunction::withDataType(const DataType& dataType) const
+{
+    auto copy = *this;
+    copy.dataType = dataType;
+    return copy;
+}
+
+LogicalFunction TrimLogicalFunction::withInferredDataType(const Schema& schema) const
+{
+    auto newChild = child.withInferredDataType(schema);
+    if (not newChild.getDataType().isType(DataType::Type::VARSIZED))
+    {
+        throw CannotInferSchema("TRIM function requires a VARSIZED argument, but got: {}", newChild.getDataType());
+    }
+    return withChildren({newChild});
+}
+
+std::vector<LogicalFunction> TrimLogicalFunction::getChildren() const
+{
+    return {child};
+}
+
+LogicalFunction TrimLogicalFunction::withChildren(const std::vector<LogicalFunction>& children) const
+{
+    if (children.size() != 1)
+    {
+        throw InvalidQuerySyntax("TRIM requires exactly one argument, got {}", children.size());
+    }
+    auto copy = *this;
+    copy.child = children[0];
+    copy.dataType = children[0].getDataType();
+    return copy;
+}
+
+std::string_view TrimLogicalFunction::getType() const
+{
+    return NAME;
+}
+
+SerializableFunction TrimLogicalFunction::serialize() const
+{
+    SerializableFunction serializedFunction;
+    serializedFunction.set_function_type(NAME);
+    serializedFunction.add_children()->CopyFrom(child.serialize());
+    DataTypeSerializationUtil::serializeDataType(getDataType(), serializedFunction.mutable_data_type());
+    return serializedFunction;
+}
+
+LogicalFunctionRegistryReturnType LogicalFunctionGeneratedRegistrar::RegisterTrimLogicalFunction(LogicalFunctionRegistryArguments arguments)
+{
+    if (arguments.children.size() != 1)
+    {
+        throw CannotDeserialize("TrimLogicalFunction requires exactly one child, but got {}", arguments.children.size());
+    }
+    return TrimLogicalFunction(arguments.children[0]);
+}
+
+}

--- a/nes-physical-operators/include/Functions/TrimPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/TrimPhysicalFunction.hpp
@@ -1,0 +1,36 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <Functions/PhysicalFunction.hpp>
+#include <Nautilus/DataTypes/VarVal.hpp>
+#include <Nautilus/Interface/Record.hpp>
+#include <ExecutionContext.hpp>
+
+namespace NES
+{
+
+class TrimPhysicalFunction final : public PhysicalFunctionConcept
+{
+public:
+    explicit TrimPhysicalFunction(PhysicalFunction childPhysicalFunction);
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override;
+
+private:
+    PhysicalFunction childPhysicalFunction;
+};
+
+
+}

--- a/nes-physical-operators/src/Functions/CMakeLists.txt
+++ b/nes-physical-operators/src/Functions/CMakeLists.txt
@@ -18,6 +18,7 @@ add_source_files(nes-physical-operators
         )
 
 add_plugin(Concat PhysicalFunction nes-physical-operators ConcatPhysicalFunction.cpp)
+add_plugin(Trim PhysicalFunction nes-physical-operators TrimPhysicalFunction.cpp)
 
 add_subdirectory(ArithmeticalFunctions)
 add_subdirectory(ComparisonFunctions)

--- a/nes-physical-operators/src/Functions/TrimPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Functions/TrimPhysicalFunction.cpp
@@ -1,0 +1,102 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Functions/TrimPhysicalFunction.hpp>
+
+#include <cstdint>
+#include <utility>
+
+#include <ErrorHandling.hpp>
+#include <ExecutionContext.hpp>
+#include <Functions/PhysicalFunction.hpp>
+#include <Nautilus/DataTypes/DataTypesUtil.hpp>
+#include <Nautilus/DataTypes/VarVal.hpp>
+#include <Nautilus/DataTypes/VariableSizedData.hpp>
+#include <Nautilus/Interface/Record.hpp>
+#include <PhysicalFunctionRegistry.hpp>
+#include <nautilus/std/cstring.h>
+#include <val.hpp>
+
+namespace NES
+{
+
+TrimPhysicalFunction::TrimPhysicalFunction(PhysicalFunction childPhysicalFunction)
+    : childPhysicalFunction(std::move(childPhysicalFunction))
+{
+}
+
+VarVal TrimPhysicalFunction::execute(const Record& record, ArenaRef& arena) const
+{
+    const auto childValue = childPhysicalFunction.execute(record, arena).cast<VariableSizedData>();
+    const auto childSize = childValue.getContentSize();
+    const auto childContent = childValue.getContent();
+
+    if (childSize == nautilus::val<uint32_t>(0))
+    {
+        auto emptyVarSizeData = arena.allocateVariableSizedData(nautilus::val<uint32_t>(0));
+        VarVal(nautilus::val<uint32_t>(0)).writeToMemory(emptyVarSizeData.getReference());
+        return emptyVarSizeData;
+    }
+
+    const auto space = nautilus::val<char>(' ');
+    const auto tab = nautilus::val<char>('\t');
+    const auto newline = nautilus::val<char>('\n');
+    const auto carriageReturn = nautilus::val<char>('\r');
+
+    nautilus::val<uint32_t> start = 0;
+    while (start < childSize)
+    {
+        const auto currentChar = readValueFromMemRef<char>(childContent + start);
+        const auto isWhiteSpace = (currentChar == space) || (currentChar == tab) || (currentChar == newline) || (currentChar == carriageReturn);
+        if (!isWhiteSpace)
+        {
+            break;
+        }
+        ++start;
+    }
+
+    auto end = childSize;
+    const auto one = nautilus::val<uint32_t>(1);
+    while (end > start)
+    {
+        const auto currentChar = readValueFromMemRef<char>(childContent + (end - one));
+        const auto isWhiteSpace = (currentChar == space) || (currentChar == tab) || (currentChar == newline) || (currentChar == carriageReturn);
+        if (!isWhiteSpace)
+        {
+            break;
+        }
+        --end;
+    }
+
+    const auto trimmedSize = end - start;
+    auto trimmedVarSizeData = arena.allocateVariableSizedData(trimmedSize);
+
+    if (trimmedSize > nautilus::val<uint32_t>(0))
+    {
+        nautilus::memcpy(trimmedVarSizeData.getContent(), childContent + start, trimmedSize);
+    }
+
+    VarVal(trimmedSize).writeToMemory(trimmedVarSizeData.getReference());
+    return trimmedVarSizeData;
+}
+
+PhysicalFunctionRegistryReturnType
+PhysicalFunctionGeneratedRegistrar::RegisterTrimPhysicalFunction(PhysicalFunctionRegistryArguments physicalFunctionRegistryArguments)
+{
+    PRECONDITION(physicalFunctionRegistryArguments.childFunctions.size() == 1,
+                 "Trim function must have exactly one sub-function");
+    return TrimPhysicalFunction(physicalFunctionRegistryArguments.childFunctions[0]);
+}
+
+}

--- a/nes-systests/function/varsized/Trim.test
+++ b/nes-systests/function/varsized/Trim.test
@@ -1,0 +1,43 @@
+# name: Trim
+# description: Checks that trim in projections works as expected
+# groups: [Function, Text, Projection]
+
+CREATE LOGICAL SOURCE nameStream(fullName VARSIZED);
+CREATE PHYSICAL SOURCE FOR nameStream TYPE File;
+ATTACH INLINE
+ Edgar Codd
+        Jim Grey
+Michael Stonebraker
+
+CREATE SINK fullNameTrimmedSink(fullNameTrimmed VARSIZED) TYPE File;
+
+SELECT TRIM(fullName) as fullNameTrimmed FROM nameStream INTO fullNameTrimmedSink;
+----
+Edgar Codd
+Jim Grey
+Michael Stonebraker
+
+CREATE LOGICAL SOURCE noWhiteSpaceStream(text VARSIZED);
+CREATE PHYSICAL SOURCE FOR noWhiteSpaceStream TYPE File;
+ATTACH INLINE
+EdgarCodd
+JimGrey
+MichaelStonebraker
+
+CREATE SINK noWhitespaceSink(trimmedText VARSIZED) TYPE File;
+
+SELECT TRIM(text) as trimmedText FROM noWhitespaceStream INTO noWhitespaceSink;
+----
+EdgarCodd
+JimGrey
+MichaelStonebraker
+
+CREATE LOGICAL SOURCE emptyStringStream(text VARSIZED);
+CREATE PHYSICAL SOURCE FOR emptyStringStream TYPE File;
+ATTACH INLINE
+
+CREATE SINK emptyStringSink(trimmedText VARSIZED) TYPE File;
+
+SELECT TRIM(text) as trimmedText FROM emptyStringStream INTO emptyStringSink;
+----
+


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

This pull request adds the TRIM function to NebulaStream, which removes leading and trailing whitespace from variable-sized strings (VARSIZED). The change list is as follows:

- added `TrimLogicalFunction` class in `nes-logical-operators` to handle type inference and validation for the TRIM function
- added `TrimPhysicalFunction` class in `nes-physical-operators` to execute the TRIM operation at runtime
- registered the TRIM function in both logical and physical function registries via CMakeLists.txt
- added system test for the TRIM function
- added documentation guide `how_to_add_a_function.md` to help future contributors implement new functions

## Verifying this change

This change is tested by:

- System tests in `nes-systests/function/varsized/Trim.test` that verify:
  - TRIM correctly removes leading and trailing whitespace 
  - TRIM handles strings without whitespace correctly
  - TRIM handles empty strings correctly
  - Type validation works correctly (only accepts VARSIZED arguments)

## What components does this pull request potentially affect?

- QueryCompiler: new logical function is available for SQL parsing and query plan generation
- QueryEngine: new physical function is available for query execution
- FunctionRegistry: both logical and physical function registries are extended
- documentation: new guide added for contributors

## Documentation

- added guide `docs/guide/how_to_add_a_function.md`