### PR TITLE
fix(Nightly): Fix bugprone-forward-declaration-namespace in NesLogger

### DIFF
--- a/nes-common/include/Util/Logger/impl/NesLogger.hpp
+++ b/nes-common/include/Util/Logger/impl/NesLogger.hpp
@@ -22,7 +22,6 @@
 
 namespace spdlog::details
 {
-class thread_pool;
 class periodic_worker;
 }
 


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR fixes a clang-tidy error detected in our nightly run
