### PR TITLE
feat(CI): add conditional workflow execution for forks

### DIFF
--- a/.github/workflows/clang_tidy_diff.yml
+++ b/.github/workflows/clang_tidy_diff.yml
@@ -23,68 +23,16 @@ on:
         required: false
         default: -1
 
-  # We need to use pull_request to run this workflow starting from our base repo and pull_request_target to run this
-  # workflow in our base repo (but starting from a fork), as clang-tidy-pr-comments needs 'write' permissions to our repo. This is solely possible
-  # with pull_request_target as pull_request provides 'read' permissions.
-  pull_request:
-    types: [ opened, synchronize, reopened ]
-  pull_request_target:
-    types: [ opened, synchronize, reopened ]
-
 permissions:
   contents: read
   pull-requests: write
   checks: write
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}-clang-tidy-diff
-  cancel-in-progress: true
-
 jobs:
-  get-dev-images:
-    uses: ./.github/workflows/get_dev_images.yml
-    secrets: inherit
-    with:
-      branch-name: ${{ github.head_ref }}
-      head_sha: ${{ github.event.pull_request.head.sha }}
-
-  setup:
-    needs: [get-dev-images]
-    name: Setup inputs
-    runs-on: ubuntu-latest
-    outputs:
-      dev_image_tag: ${{ steps.set_vars.outputs.dev_image_tag }}
-      head_sha: ${{ steps.set_vars.outputs.head_sha }}
-      base_sha: ${{ steps.set_vars.outputs.base_sha }}
-      number_of_commits: ${{ steps.set_vars.outputs.number_of_commits }}
-    steps:
-      - name: Set workflow inputs
-        id: set_vars
-        run: |
-          # If this workflow is called via workflow_call, we want to use the inputs.
-          # Otherwise, we want to use "default" values
-          if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "pull_request_target" ]]; then
-            echo "Running in PR context"
-            echo "dev_image_tag=${{ needs.get-dev-images.outputs.image-tag }}" >> $GITHUB_OUTPUT
-            echo "head_sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
-            echo "base_sha=${{ github.event.pull_request.base.sha }}" >> $GITHUB_OUTPUT
-            echo "number_of_commits=${{ github.event.pull_request.commits || -1 }}" >> $GITHUB_OUTPUT
-          else
-            echo "Running in workflow_call or non-PR context"
-            echo "dev_image_tag=${{ inputs.dev_image_tag }}" >> $GITHUB_OUTPUT
-            echo "head_sha=${{ inputs.head_sha || github.sha }}" >> $GITHUB_OUTPUT
-            echo "base_sha=${{ inputs.base_sha || github.event.before || github.sha }}" >> $GITHUB_OUTPUT
-            echo "number_of_commits=${{ inputs.number_of_commits || -1 }}" >> $GITHUB_OUTPUT
-          fi
-
   check-clang-tidy:
     timeout-minutes: 90
     name: Clang-Tidy Diff
-    needs: [setup, get-dev-images]
     runs-on: ${{ matrix.runner }}
-    if: >
-      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true) ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
     strategy:
       matrix:
         arch: [ x64 ]
@@ -97,20 +45,20 @@ jobs:
     steps:
       - name: Include base commit
         id: increment
-        run: echo "result=$((${{ needs.setup.outputs.number_of_commits }} + 1))" >> $GITHUB_OUTPUT
+        run: echo "result=$((${{ inputs.number_of_commits }} + 1))" >> $GITHUB_OUTPUT
       - name: Checkout Branch
         uses: actions/checkout@v4
         with:
           fetch-depth: ${{ steps.increment.outputs.result }}
-          ref: ${{ needs.setup.outputs.head_sha }}
+          ref: ${{ inputs.head_sha }}
       - uses: ./.github/steps/prepare-github
         with:
-          image_name: nebulastream/nes-ci:${{ needs.setup.outputs.dev_image_tag }}-${{ matrix.stdlib }}-${{matrix.sanitizer}}
+          image_name: nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{matrix.sanitizer}}
           ccache_key: ${{ matrix.arch }}-${{ matrix.build_type }}-${{matrix.sanitizer}}-${{matrix.stdlib}}
       - uses: ./.github/steps/run-in-container
         name: CMake Build
         with:
-          image_name: nebulastream/nes-ci:${{ needs.setup.outputs.dev_image_tag }}-${{ matrix.stdlib }}-${{matrix.sanitizer}}
+          image_name: nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{matrix.sanitizer}}
           run: |
             source .github/.env/test-${{matrix.sanitizer}}.env
             cmake -GNinja -B build -DUSE_SANITIZER=${{ matrix.sanitizer }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DNES_LOG_LEVEL=DEBUG
@@ -121,15 +69,15 @@ jobs:
       - uses: ./.github/steps/run-in-container
         name: Run Clang Tidy Pre-check
         with:
-          image_name: nebulastream/nes-ci:${{ needs.setup.outputs.dev_image_tag }}-${{ matrix.stdlib }}-${{matrix.sanitizer}}
+          image_name: nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{matrix.sanitizer}}
           run: |
-            git diff -U0 ${{ needs.setup.outputs.base_sha }} -- ':!*.inc' | clang-tidy-diff-19.py -clang-tidy-binary clang-tidy-19 -p1 -path build -export-fixes clang-tidy-result/fixes.yml  -checks='-*,readability-duplicate-include' -j $(nproc)
+            git diff -U0 ${{ inputs.base_sha }} -- ':!*.inc' | clang-tidy-diff-19.py -clang-tidy-binary clang-tidy-19 -p1 -path build -export-fixes clang-tidy-result/fixes.yml  -checks='-*,readability-duplicate-include' -j $(nproc)
       - uses: ./.github/steps/run-in-container
         name: Run Clang Tidy with all Checks
         with:
-          image_name: nebulastream/nes-ci:${{ needs.setup.outputs.dev_image_tag }}-${{ matrix.stdlib }}-${{matrix.sanitizer}}
+          image_name: nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{matrix.sanitizer}}
           run: |
-            git diff -U0 ${{ needs.setup.outputs.base_sha }} -- ':!*.inc' | clang-tidy-diff-19.py -clang-tidy-binary clang-tidy-19 -p1 -path build -export-fixes clang-tidy-result/fixes.yml -j $(nproc)
+            git diff -U0 ${{ inputs.base_sha }} -- ':!*.inc' | clang-tidy-diff-19.py -clang-tidy-binary clang-tidy-19 -p1 -path build -export-fixes clang-tidy-result/fixes.yml -j $(nproc)
       - name: Upload Clang-Tidy Results
         if: ${{ !cancelled() && !github.event.act }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-fork.yml
+++ b/.github/workflows/pr-fork.yml
@@ -1,0 +1,28 @@
+name: NES PR CI (Fork)
+description: |
+  This workflow is triggered for every pull request, however it is intended to be run from forks only, to give them 
+  additional permissions. Currently this includes only the clang-tidy-diff workflow which requires write permissions 
+  to add comments to the PR.
+on:
+  pull_request_target:
+    types: [ synchronize, opened, reopened ]
+
+jobs:
+  get-dev-images:
+    if: github.event.pull_request.head.repo.fork == true
+    uses: ./.github/workflows/get_dev_images.yml
+    secrets: inherit
+    with:
+      branch-name: ${{ github.head_ref }}
+      head_sha: ${{ github.event.pull_request.head.sha }}
+
+  clang-tidy-diff:
+    if: github.event.pull_request.head.repo.fork == true
+    needs: [ get-dev-images ]
+    uses: ./.github/workflows/clang_tidy_diff.yml
+    with:
+      dev_image_tag: ${{ needs.get-dev-images.outputs.image-tag }}
+      head_sha: ${{ github.event.pull_request.head.sha }}"
+      base_sha: ${{ github.event.pull_request.base.sha }}"
+      number_of_commits: ${{ github.event.pull_request.commits || -1 }}"
+    secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -77,6 +77,17 @@ jobs:
       runtime_seconds: '$((1*60))'
       arch: ${{ matrix.arch }}
 
+  clang-tidy-diff:
+    if: github.event.pull_request.head.repo.fork == false
+    needs: [ get-dev-images, smoke-tests ]
+    uses: ./.github/workflows/clang_tidy_diff.yml
+    with:
+      dev_image_tag: ${{ needs.get-dev-images.outputs.image-tag }}
+      head_sha: ${{ github.event.pull_request.head.sha }}"
+      base_sha: ${{ github.event.pull_request.base.sha }}"
+      number_of_commits: ${{ github.event.pull_request.commits || -1 }}"
+    secrets: inherit
+
   nix-build:
     needs: [ smoke-tests ]
     name: "Run Nix Build"


### PR DESCRIPTION
Currently the CI always displays a failed job. Which is caused by cancellation of the Clang-Tidy-Diff workflow which is intended to run for forks only, 

This PR changes our PR workflow to have a dedicated workflow files for PR and PR_TARGETs. Currently the PR_TARGETs is used to give additional write permissions to PRs from forks, for the clang-tidy check.

Creating a PR or pushing changes will always run both workflows, however only one clang-tidy-diff workflow will run due to the condition on the workflow call. The other one is skipped which is not displayed as a failed workflow.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
