### PR TITLE
skip differential and error queries in benchmark

### DIFF
--- a/nes-systests/systest/src/SystestRunner.cpp
+++ b/nes-systests/systest/src/SystestRunner.cpp
@@ -339,20 +339,6 @@ std::vector<RunningQuery> runQueriesAndBenchmark(
     progressTracker.setTotalQueries(queries.size());
     for (const auto& queryToRun : queries)
     {
-        if (queryToRun.differentialQueryPlan.has_value())
-        {
-            NES_INFO("Skipping differential test for benchmarking: {}", queryToRun.testName);
-            progressTracker.incrementQueryCounter();
-            continue;
-        }
-
-        if (std::holds_alternative<ExpectedError>(queryToRun.expectedResultsOrExpectedError))
-        {
-            NES_INFO("Skipping test expecting error for benchmarking: {}", queryToRun.testName);
-            progressTracker.incrementQueryCounter();
-            continue;
-        }
-
         if (not queryToRun.planInfoOrException.has_value())
         {
             NES_ERROR("skip failing query: {}", queryToRun.testName);


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This pull request fixes the current systest benchmark failing due to differential tests. Differential queries and queries expected to fail don't need to be benchmarked and are reserved for more internal testing.

 The change list is as follows:
-SystestExecutor now filters differential and error queries beforehand, adjusting the totalquery count for the benchmark.
-An additional line is printed at the start of the benchmark, explaining what kinds of tests are skipped: 
`Running systests in benchmarking mode. Only one query is run at a time!`
`Any included differential queries and queries expecting an error will be skipped.`
-The testname of each query skipped this way is printed for clarity like this: 
`Skipping differential query for benchmarking: JoinEquivalence:2`
 

## Verifying this change
This change is tested by running `systest -b -e large`

## Issue Closed by this pull request:

This PR closes #1276
