### PR TITLE
fix(test): Reduce the number of buffers allocated in large buffer json test

### DIFF
--- a/nes-systests/formatter/JSON/SIMDJSON.test
+++ b/nes-systests/formatter/JSON/SIMDJSON.test
@@ -8,6 +8,7 @@
 #      more than '1048576' bytes
 
 GlobalConfiguration worker.default_query_execution.operator_buffer_size: [1048576]
+GlobalConfiguration worker.number_of_buffers_in_global_buffer_manager: [1024]
 
 CREATE LOGICAL SOURCE windTurbines(producerId INT32, groupId INT32, producedPower FLOAT64, timestamp UINT64);
 CREATE PHYSICAL SOURCE FOR windTurbines TYPE File SET("JSON" AS PARSER.`TYPE`);


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Fixes an issue where the test would cause the worker to allocate 32gb of memory.
The systest overrides the default buffersize to test an edge case in the json parser, however it did not reduce the total number of buffers in the system.
This PR reduces the number of available buffers to 1024, reducing the allocation to 1gb.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
