### PR TITLE
fix(PipeliningPhase): Corrected access of Sink Format via wrong method

### DIFF
--- a/nes-query-compiler/src/Phases/PipeliningPhase.cpp
+++ b/nes-query-compiler/src/Phases/PipeliningPhase.cpp
@@ -17,6 +17,8 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <stdexcept>
+#include <string>
 #include <unordered_map>
 #include <utility>
 
@@ -208,7 +210,8 @@ void buildPipelineRecursively(
         {
             const auto sourceFormat = toUpperCase(
                 currentPipeline->getRootOperator().get<SourcePhysicalOperator>().getDescriptor().getParserConfig().parserType);
-            const auto sinkFormat = toUpperCase(sink->getDescriptor().getSinkType());
+
+            const auto sinkFormat = sink->getDescriptor().getFormatType() ? sink->getDescriptor().getFormatType().value() : "";
             /// Add a formatting pipeline if the source-sink pipelines do not simply forward natively formatted data
             /// Otherwise, even if both formats are, e.g., 'CSV', the source 'blindly' ingest buffers until they are full, meaning buffers
             /// may start and end with a cut-off tuples (rows in the CSV case)

--- a/nes-sinks/include/Sinks/SinkDescriptor.hpp
+++ b/nes-sinks/include/Sinks/SinkDescriptor.hpp
@@ -60,7 +60,8 @@ public:
     friend std::ostream& operator<<(std::ostream& out, const SinkDescriptor& sinkDescriptor);
     friend bool operator==(const SinkDescriptor& lhs, const SinkDescriptor& rhs);
 
-    [[nodiscard]] std::string_view getFormatType() const;
+    /// Optional, since not every sink type uses an INPUT_FORMAT parameter.
+    [[nodiscard]] std::optional<std::string_view> getFormatType() const;
     [[nodiscard]] std::string getSinkType() const;
     [[nodiscard]] std::shared_ptr<const Schema> getSchema() const;
     [[nodiscard]] std::string getSinkName() const;

--- a/nes-sinks/src/SinkDescriptor.cpp
+++ b/nes-sinks/src/SinkDescriptor.cpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <optional>
 #include <ostream>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -32,6 +33,7 @@
 #include <fmt/ostream.h>
 #include <magic_enum/magic_enum.hpp>
 
+#include <Util/Logger/Logger.hpp>
 #include <ErrorHandling.hpp>
 #include <ProtobufHelper.hpp> /// NOLINT
 #include <SerializableOperator.pb.h>
@@ -51,9 +53,17 @@ std::shared_ptr<const Schema> SinkDescriptor::getSchema() const
     return schema;
 }
 
-std::string_view SinkDescriptor::getFormatType() const
+std::optional<std::string_view> SinkDescriptor::getFormatType() const
 {
-    return magic_enum::enum_name(getFromConfig(INPUT_FORMAT));
+    try
+    {
+        return magic_enum::enum_name(getFromConfig(INPUT_FORMAT));
+    }
+    catch (std::out_of_range& e)
+    {
+        NES_WARNING("Sinks of the type {} do not have an INPUT_FORMAT parameter.", getSinkType());
+        return std::nullopt;
+    }
 }
 
 std::string SinkDescriptor::getSinkType() const


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This pull request fixes a small bug in which the the sink format is accessed via `getSinkType()` instead of `getFormatType()`.
Location: PipeliningPhase.cpp, Line 211

Even though getFormatType() can be called for any Sink Descriptor, Void and Checksum Sink do not include this parameter in their config (Even though the parameter itself is defined in `SinkDescriptor.hpp`). This is why must catch an out_of_range error here.

### Small changelog
- Calls `getFormatType()` instead 
- `getFormatType()` now is able to catch the out of range error that accurs for sinks that do not use an output format. Because of this, the return type has been changed to an optional string view

## Verifying this change
This change is tested by
- Nothing currently, it's relevant for Source - Sink Pipelines with nothing in between, where input and output format are "Native". This seems to mainly occur in a distributed setting on intermediate nodes.

## What components does this pull request potentially affect?
- QueryCompiler
- Sink Descriptor

## Documentation
- Not needed

## Issue Closed by this pull request:

This PR closes #1332 
