### PR TITLE
Time Controlled Emission via Source

### DIFF
--- a/nes-plugins/CMakeLists.txt
+++ b/nes-plugins/CMakeLists.txt
@@ -20,6 +20,7 @@ activate_optional_plugin("Sources/TCPSource" ON)
 activate_optional_plugin("Sources/GeneratorSource" ON)
 activate_optional_plugin("Sinks/VoidSink" ON)
 activate_optional_plugin("InputFormatters/JSONInputFormatter" ON)
+activate_optional_plugin("Sources/TimeControlledSource" ON)
 
 if (NES_ENABLES_TESTS)
   # ChecksumSink depends on Checksum.cpp from systest which is only added when tests are enabled.

--- a/nes-plugins/Sources/TimeControlledSource/CMakeLists.txt
+++ b/nes-plugins/Sources/TimeControlledSource/CMakeLists.txt
@@ -1,0 +1,50 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_plugin_as_library(
+        TimeControlled
+        Source
+        nes-sources-registry
+        time_controlled_source_plugin_library
+        TimeControlledSource.cpp)
+target_include_directories(
+        time_controlled_source_plugin_library
+        PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/
+)
+
+add_plugin_as_library(
+        TimeControlled
+        SourceValidation
+        nes-sources-registry
+        time_controlled_source_validation_plugin_library
+        TimeControlledSource.cpp
+)
+target_include_directories(
+        time_controlled_source_validation_plugin_library
+        PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/
+)
+
+add_plugin_as_library(
+        TimeControlled
+        InlineData
+        nes-sources-registry
+        time_controlled_inline_data_plugin_library
+        TimeControlledSource.cpp
+)
+
+add_plugin_as_library(
+        TimeControlled
+        FileData
+        nes-sources-registry
+        time_controlled_file_data_plugin_library
+        TimeControlledSource.cpp
+)

--- a/nes-plugins/Sources/TimeControlledSource/TimeControlledSource.cpp
+++ b/nes-plugins/Sources/TimeControlledSource/TimeControlledSource.cpp
@@ -1,0 +1,272 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <TimeControlledSource.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <ios>
+#include <memory>
+#include <ostream>
+#include <stop_token>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <Configurations/Descriptor.hpp>
+#include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/TupleBuffer.hpp>
+#include <Sources/Source.hpp>
+#include <Sources/SourceDescriptor.hpp>
+#include <Util/Files.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <Util/Strings.hpp>
+#include <magic_enum/magic_enum.hpp>
+#include <ErrorHandling.hpp>
+#include <FileDataRegistry.hpp>
+#include <InlineDataRegistry.hpp>
+#include <SourceRegistry.hpp>
+#include <SourceValidationRegistry.hpp>
+
+namespace NES
+{
+
+TimeControlledSource::TimeControlledSource(const SourceDescriptor& sourceDescriptor)
+    : filePath(sourceDescriptor.getFromConfig(ConfigParametersTimeControlled::FILEPATH))
+    , timestampMetric(sourceDescriptor.getFromConfig(ConfigParametersTimeControlled::TIMESTAMP_METRIC))
+    , timestampColumnIdx(sourceDescriptor.getFromConfig(ConfigParametersTimeControlled::TIMESTAMP_COLUMN_IDX))
+{
+    const auto realCSVPath = std::unique_ptr<char, decltype(std::free)*>{realpath(this->filePath.c_str(), nullptr), std::free};
+    this->inputFile = std::ifstream(realCSVPath.get(), std::ios::binary);
+    if (not this->inputFile)
+    {
+        throw InvalidConfigParameter("Could not determine absolute pathname: {} - {}", this->filePath.c_str(), getErrorMessageFromERRNO());
+    }
+    const auto logicalSourceFields = sourceDescriptor.getLogicalSource().getSchema()->getFields();
+    if (logicalSourceFields.size() <= this->timestampColumnIdx)
+    {
+        throw InvalidConfigParameter(
+            "Given TimestampColumnIdx {} > number of fields {}!", this->timestampColumnIdx, logicalSourceFields.size());
+    }
+    if (const auto& timestampField = logicalSourceFields[this->timestampColumnIdx]; not timestampField.dataType.isInteger())
+    {
+        throw InvalidConfigParameter("Timestamp Column {} needs to an integer type!", timestampField.name);
+    }
+}
+
+void TimeControlledSource::open(std::shared_ptr<AbstractBufferProvider>)
+{
+    this->openTime = std::chrono::system_clock::now();
+    NES_TRACE("Opening TimeControlledSource");
+}
+
+void TimeControlledSource::close(){NES_TRACE("Closing TimeControlledSource")}
+
+Source::FillTupleBufferResult TimeControlledSource::fillTupleBuffer(TupleBuffer& tupleBuffer, const std::stop_token& stopToken)
+{
+    const auto getScheduledTime = [&](const std::string& row) -> std::chrono::system_clock::time_point
+    {
+        const auto fields = splitWithStringDelimiter<std::string_view>(row, ",");
+        const auto timestamp = from_chars<int64_t>(fields[this->timestampColumnIdx]);
+        if (!timestamp)
+        {
+            throw InvalidConfigParameter("Cannot parse a timestamp from the row {}", row);
+        }
+        switch (this->timestampMetric)
+        {
+            case TimestampMetric::MILLISECOND: {
+                return openTime + std::chrono::milliseconds{*timestamp};
+            }
+            case TimestampMetric::SECOND: {
+                return openTime + std::chrono::seconds{*timestamp};
+            }
+            default: {
+                INVARIANT(
+                    magic_enum::enum_contains<TimestampMetric>(this->timestampMetric),
+                    "Unknown case {} for timestamp metric!",
+                    static_cast<int>(timestampMetric));
+                std::unreachable();
+            }
+        }
+    };
+
+    const auto checkAndUpdateHighestSeenTime = [&](const std::chrono::system_clock::time_point scheduledTime) -> void
+    {
+        if (this->highestSeenTime != std::chrono::time_point<std::chrono::system_clock>::min() && scheduledTime < this->highestSeenTime)
+        {
+            const auto highestMs = std::chrono::duration_cast<std::chrono::milliseconds>(this->highestSeenTime - this->openTime).count();
+            const auto currentMs = std::chrono::duration_cast<std::chrono::milliseconds>(scheduledTime - this->openTime).count();
+            NES_WARNING(
+                "Out-of-order timestamp detected in source CSV! Current timestamp: {} ms, "
+                "Highest seen timestamp: {} ms. Data is not chronologically ordered.",
+                currentMs,
+                highestMs);
+        }
+        if (scheduledTime > this->highestSeenTime)
+        {
+            this->highestSeenTime = scheduledTime;
+        }
+    };
+
+
+    const auto writeLineToTupleBuffer = [&tupleBuffer](const std::string& line, const size_t offset) -> bool
+    {
+        if (tupleBuffer.getAvailableMemoryArea<char>().size() < offset + line.size() + 1)
+        {
+            return false;
+        }
+        std::memcpy(tupleBuffer.getAvailableMemoryArea<char>().data() + offset, line.data(), line.size());
+        tupleBuffer.getAvailableMemoryArea<char>()[offset + line.size()] = '\n';
+        return true;
+    };
+
+    const auto sleepUntilScheduled = [&stopToken](std::chrono::system_clock::time_point scheduledTime) -> bool
+    {
+        const auto now = std::chrono::system_clock::now();
+        if (scheduledTime <= now)
+        {
+            return true;
+        }
+        const auto sleepDuration = std::chrono::duration_cast<std::chrono::milliseconds>(scheduledTime - now);
+        NES_INFO("Sleeping for  {} ms until scheduled time {}", sleepDuration.count(), scheduledTime);
+        constexpr auto checkIntervall = std::chrono::milliseconds(25);
+        auto remainingTime = sleepDuration;
+        while (remainingTime > std::chrono::milliseconds(0) && !stopToken.stop_requested())
+        {
+            auto sleepTime = std::min(remainingTime, checkIntervall);
+            std::this_thread::sleep_for(sleepTime);
+            remainingTime -= sleepTime;
+        }
+        return !stopToken.stop_requested();
+    };
+
+    uint32_t totalBytesWritten = 0;
+    if (not orphanedLine.empty())
+    {
+        NES_INFO("Orphaned line is not empty!")
+        const auto scheduledTime = getScheduledTime(orphanedLine);
+        checkAndUpdateHighestSeenTime(scheduledTime);
+        if (!sleepUntilScheduled(scheduledTime))
+        {
+            return FillTupleBufferResult::withBytes(0);
+        }
+        if (!writeLineToTupleBuffer(orphanedLine, 0))
+        {
+            throw TuplesTooLargeForPipelineBufferSize(
+                "Can not write a wellformed tuple with size {} into a tuple buffer of size {}",
+                orphanedLine.size(),
+                tupleBuffer.getBufferSize());
+        }
+        totalBytesWritten += orphanedLine.size() + 1;
+        orphanedLine.clear();
+        NES_INFO("Wrote orphaned line with size {} into tuplebuffer.", totalBytesWritten);
+    }
+
+    std::string line;
+    while (not stopToken.stop_requested() && std::getline(this->inputFile, line))
+    {
+        const auto scheduledTime = getScheduledTime(line);
+        checkAndUpdateHighestSeenTime(scheduledTime);
+        if (!sleepUntilScheduled(scheduledTime))
+        {
+            this->orphanedLine = line;
+            break;
+        }
+        if (!writeLineToTupleBuffer(line, totalBytesWritten))
+        {
+            this->orphanedLine = line;
+            return FillTupleBufferResult::withBytes(totalBytesWritten);
+        }
+        totalBytesWritten += line.size() + 1;
+    }
+    if (inputFile.eof() && totalBytesWritten == 0)
+    {
+        return FillTupleBufferResult::eos();
+    }
+    return FillTupleBufferResult::withBytes(totalBytesWritten);
+}
+
+std::ostream& TimeControlledSource::toString(std::ostream& str) const
+{
+    str << "\nTimeControlledSource(";
+    str << "\n\tFilepath: " << this->filePath;
+    str << "\n\ttimestampColumnIdx: " << this->timestampColumnIdx;
+    str << "\n\topenTIme: " << this->openTime;
+    str << ")\n";
+    return str;
+}
+
+DescriptorConfig::Config TimeControlledSource::validateAndFormat(std::unordered_map<std::string, std::string> config)
+{
+    return DescriptorConfig::validateAndFormat<ConfigParametersTimeControlled>(std::move(config), NAME);
+}
+
+SourceValidationRegistryReturnType
+///NOLINTNEXTLINE (performance-unnecessary-value-param)
+RegisterTimeControlledSourceValidation(SourceValidationRegistryArguments sourceConfig)
+{
+    return TimeControlledSource::validateAndFormat(sourceConfig.config);
+}
+
+SourceRegistryReturnType
+///NOLINTNEXTLINE (performance-unnecessary-value-param)
+SourceGeneratedRegistrar::RegisterTimeControlledSource(SourceRegistryArguments sourceRegistryArguments)
+{
+    return std::make_unique<TimeControlledSource>(sourceRegistryArguments.sourceDescriptor);
+}
+
+InlineDataRegistryReturnType
+InlineDataGeneratedRegistrar::RegisterTimeControlledInlineData(InlineDataRegistryArguments systestAdaptorArguments)
+{
+    if (systestAdaptorArguments.physicalSourceConfig.sourceConfig.contains(std::string(SYSTEST_FILE_PATH_PARAMETER)))
+    {
+        throw InvalidConfigParameter("Mock FileSource cannot use given inline data if a 'file_path' is set");
+    }
+
+    systestAdaptorArguments.physicalSourceConfig.sourceConfig.try_emplace(
+        std::string(SYSTEST_FILE_PATH_PARAMETER), systestAdaptorArguments.testFilePath.string());
+
+
+    if (std::ofstream testFile(systestAdaptorArguments.testFilePath); testFile.is_open())
+    {
+        /// Write inline tuples to test file.
+        for (const auto& tuple : systestAdaptorArguments.tuples)
+        {
+            testFile << tuple << "\n";
+        }
+        testFile.flush();
+        return systestAdaptorArguments.physicalSourceConfig;
+    }
+    throw TestException("Could not open source file \"{}\"", systestAdaptorArguments.testFilePath);
+}
+
+FileDataRegistryReturnType FileDataGeneratedRegistrar::RegisterTimeControlledFileData(FileDataRegistryArguments systestAdaptorArguments)
+{
+    if (systestAdaptorArguments.physicalSourceConfig.sourceConfig.contains(std::string(SYSTEST_FILE_PATH_PARAMETER)))
+    {
+        throw InvalidConfigParameter("The mock file data source cannot be used if the file_path parameter is already set.");
+    }
+
+    systestAdaptorArguments.physicalSourceConfig.sourceConfig.emplace(
+        std::string(SYSTEST_FILE_PATH_PARAMETER), systestAdaptorArguments.testFilePath.string());
+
+    return systestAdaptorArguments.physicalSourceConfig;
+}
+}

--- a/nes-plugins/Sources/TimeControlledSource/TimeControlledSource.hpp
+++ b/nes-plugins/Sources/TimeControlledSource/TimeControlledSource.hpp
@@ -1,0 +1,131 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <memory>
+#include <optional>
+#include <ostream>
+#include <stop_token>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <Configurations/Descriptor.hpp>
+#include <Configurations/Enums/EnumWrapper.hpp>
+#include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/TupleBuffer.hpp>
+#include <Sources/Source.hpp>
+#include <Sources/SourceDescriptor.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+static constexpr std::string_view SYSTEST_FILE_PATH_PARAMETER = "file_path";
+
+class TimeControlledSource : public Source
+{
+public:
+    constexpr static std::string_view NAME = "TimeControlled";
+
+    explicit TimeControlledSource(const SourceDescriptor& sourceDescriptor);
+    ~TimeControlledSource() override = default;
+
+    TimeControlledSource(const TimeControlledSource&) = delete;
+    TimeControlledSource& operator=(const TimeControlledSource&) = delete;
+    TimeControlledSource(TimeControlledSource&&) = delete;
+    TimeControlledSource& operator=(TimeControlledSource&&) = delete;
+
+    FillTupleBufferResult fillTupleBuffer(TupleBuffer& tupleBuffer, const std::stop_token& stopToken) override;
+    [[nodiscard]] std::ostream& toString(std::ostream& str) const override;
+
+    void open(std::shared_ptr<AbstractBufferProvider> bufferProvider) override;
+    void close() override;
+
+    static DescriptorConfig::Config validateAndFormat(std::unordered_map<std::string, std::string> config);
+
+    enum class TimestampMetric : uint8_t
+    {
+        MILLISECOND,
+        SECOND,
+    };
+
+private:
+    std::ifstream inputFile;
+    std::string filePath;
+    std::atomic<size_t> totalNumBytesRead;
+    TimestampMetric timestampMetric;
+    std::string orphanedLine; /// stores read line that did not fit into buffer / not emitted before stop token
+    uint32_t timestampColumnIdx;
+    std::chrono::time_point<std::chrono::system_clock> openTime;
+    std::chrono::time_point<std::chrono::system_clock> highestSeenTime{std::chrono::time_point<std::chrono::system_clock>::min()};
+};
+
+struct ConfigParametersTimeControlled
+{
+    static inline const DescriptorConfig::ConfigParameter<std::string> FILEPATH{
+        std::string(SYSTEST_FILE_PATH_PARAMETER),
+        std::nullopt,
+        [](const std::unordered_map<std::string, std::string>& config) { return DescriptorConfig::tryGet(FILEPATH, config); }};
+
+    static inline const DescriptorConfig::ConfigParameter<uint32_t> TIMESTAMP_COLUMN_IDX{
+        "timestamp_column_idx",
+        -1,
+        [](const std::unordered_map<std::string, std::string>& config)
+        {
+            const auto optTimestampColumnIdx = DescriptorConfig::tryGet(TIMESTAMP_COLUMN_IDX, config);
+            if (not optTimestampColumnIdx.has_value())
+            {
+                throw InvalidConfigParameter("TimeControlledSource requires TIMESTAMP_COLUMN_IDX to be set!");
+            }
+            return optTimestampColumnIdx.value();
+        }};
+
+    static inline const DescriptorConfig::ConfigParameter<EnumWrapper, TimeControlledSource::TimestampMetric> TIMESTAMP_METRIC{
+        "timestamp_metric",
+        std::optional(EnumWrapper(TimeControlledSource::TimestampMetric::MILLISECOND)),
+        [](const std::unordered_map<std::string, std::string>& config)
+        {
+            const auto optEmissionGranularity = DescriptorConfig::tryGet(TIMESTAMP_METRIC, config);
+            if (not optEmissionGranularity.has_value()
+                || not optEmissionGranularity.value().asEnum<TimeControlledSource::TimestampMetric>().has_value())
+            {
+                NES_ERROR("Cannot validate emission_granularity: {}!", config.at("emission_granularity"));
+                throw InvalidConfigParameter("Cannot validate emission_granularity: {}!", config.at("emission_granularity"));
+            }
+            switch (optEmissionGranularity.value().asEnum<TimeControlledSource::TimestampMetric>().value())
+            {
+                case TimeControlledSource::TimestampMetric::MILLISECOND: {
+                    return std::optional(EnumWrapper(TimeControlledSource::TimestampMetric::MILLISECOND));
+                }
+                case TimeControlledSource::TimestampMetric::SECOND: {
+                    return std::optional(EnumWrapper(TimeControlledSource::TimestampMetric::SECOND));
+                }
+                default: {
+                    NES_ERROR("Cannot validate emission_granularity: {}!", config.at("emission_granularity"));
+                    throw InvalidConfigParameter("Cannot validate emission_granularity: {}!", config.at("emission_granularity"));
+                }
+            }
+        }};
+
+    static inline std::unordered_map<std::string, DescriptorConfig::ConfigParameterContainer> parameterMap
+        = DescriptorConfig::createConfigParameterContainerMap(
+            SourceDescriptor::parameterMap, FILEPATH, TIMESTAMP_COLUMN_IDX, TIMESTAMP_METRIC);
+};
+
+}

--- a/nes-systests/time-controlled/InlineFileSource.test
+++ b/nes-systests/time-controlled/InlineFileSource.test
@@ -1,0 +1,32 @@
+# name: time-controlled/InlineFileSource.test
+# description: Simple test for time controlled emission on the inline file source
+# groups: [time-controlled]
+
+CREATE SINK sinkStreamWithText(streamWithText.timestamp_sec UINT64, streamWithText.value UINT64, streamWithText.text1 VARSIZED, streamWithText.text2 VARSIZED)  TYPE File;
+
+CREATE LOGICAL SOURCE streamWithText(timestamp_sec UINT64, value UINT64, text1 VARSIZED, text2 VARSIZED);
+CREATE PHYSICAL SOURCE FOR streamWithText TYPE TimeControlled SET(
+    '0' as `SOURCE`.TIMESTAMP_COLUMN_IDX,
+    'MILLISECOND' as `SOURCE`.TIMESTAMP_METRIC
+
+);
+ATTACH INLINE
+1,1,test1,test1
+2,1,test1,test2
+2,1,test2,test2
+2,2,test1,test1
+4,2,test3,test2
+5,2,test1,test1
+5,3,test1,test2
+10,3,test3,test1
+
+SELECT * FROM streamWithText INTO sinkStreamWithText;
+----
+1,1,test1,test1
+2,1,test1,test2
+2,1,test2,test2
+2,2,test1,test1
+4,2,test3,test2
+5,2,test1,test1
+5,3,test1,test2
+10,3,test3,test1


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR adds a new source as a plugin, the `TimeControlledSource`. This source functions similarly to the file source, but you can specify a integer column by id to be the timestamp column. The values of this column are then used as a time offset from the source opening time to control when that value's row is emitted.

The offsets should be monotonically increasing. If a tuple has a lower timestamp than the highest seen timestamp a warning is logged. 

## Issue Closed by this pull request:

This PR closes #1290 
