### PR TITLE
fix(PipeliningPhase): Converts sink format to uppercase again

### DIFF
--- a/nes-query-compiler/src/Phases/PipeliningPhase.cpp
+++ b/nes-query-compiler/src/Phases/PipeliningPhase.cpp
@@ -211,7 +211,7 @@ void buildPipelineRecursively(
             const auto sourceFormat = toUpperCase(
                 currentPipeline->getRootOperator().get<SourcePhysicalOperator>().getDescriptor().getParserConfig().parserType);
 
-            const auto sinkFormat = sink->getDescriptor().getFormatType() ? sink->getDescriptor().getFormatType().value() : "";
+            const auto sinkFormat = sink->getDescriptor().getFormatType() ? toUpperCase(sink->getDescriptor().getFormatType().value()) : "";
             /// Add a formatting pipeline if the source-sink pipelines do not simply forward natively formatted data
             /// Otherwise, even if both formats are, e.g., 'CSV', the source 'blindly' ingest buffers until they are full, meaning buffers
             /// may start and end with a cut-off tuples (rows in the CSV case)


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Followup to Pr #1333:
Re-adds accidentally deleted `toUpperCase()` call on the sink format type.