### PR TITLE
Adds Signal Handler with Stacktrace

### DIFF
--- a/nes-common/include/Util/Signal.hpp
+++ b/nes-common/include/Util/Signal.hpp
@@ -1,0 +1,22 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+namespace NES
+{
+/// Registers signal handler which will print a stacktrace for SIGSEGV and SIGFPE.
+/// Sets up cpptrace as the termination handler, which will print stacktraces if the program terminates with an exception
+void setupSignalHandlers();
+}

--- a/nes-common/src/Util/CMakeLists.txt
+++ b/nes-common/src/Util/CMakeLists.txt
@@ -15,5 +15,6 @@ add_source_files(nes-common
         Strings.cpp
         Files.cpp
         UUID.cpp
+        Signal.cpp
 )
 add_subdirectory(Logger)

--- a/nes-common/src/Util/Signal.cpp
+++ b/nes-common/src/Util/Signal.cpp
@@ -1,0 +1,70 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Util/Signal.hpp>
+
+#include <csignal>
+#include <tuple>
+#include <unistd.h>
+#include <cpptrace/basic.hpp>
+#include <cpptrace/cpptrace.hpp>
+#include <fmt/base.h>
+#include <ErrorHandling.hpp>
+#include <utils.hpp>
+
+namespace
+{
+void printStackTrace()
+{
+    auto trace = cpptrace::raw_trace::current(3);
+    trace.resolve().print_with_snippets();
+}
+
+const char* signalName(int signal)
+{
+    switch (signal)
+    {
+        case SIGSEGV:
+            return "SIGSEGV";
+        case SIGFPE:
+            return "SIGFPE";
+        default:
+            return "unknown signal";
+    }
+}
+
+/// Technically, it is unsafe to allocate in a signal handler. Collecting the stacktrace and resolving the stacktrace are thus also unsafe.
+/// However, using libunwind (which is required for signal safe backtraces) does not function with the jit compiled code.
+/// And resolving symbols would require fork/exec a new process with a dedicated binary which needs to be shipped alongside NebulaStream.
+/// For now the signal handler is unsafe and will potentially not work with a corrupted heap, which is still an improvement over not having
+/// any idea where the system has crashed.
+void SignalHandler(int signal)
+{
+    fmt::print(stderr, "Caught signal {}\n", signalName(signal));
+    printStackTrace();
+    _exit(signal);
+}
+
+void registerSignalHandler(int signalNo, void (*handler)(int))
+{
+    std::ignore = signal(signalNo, handler);
+}
+}
+
+void NES::setupSignalHandlers()
+{
+    cpptrace::register_terminate_handler();
+    registerSignalHandler(SIGSEGV, SignalHandler);
+    registerSignalHandler(SIGFPE, SignalHandler);
+}

--- a/nes-single-node-worker/src/SingleNodeWorkerStarter.cpp
+++ b/nes-single-node-worker/src/SingleNodeWorkerStarter.cpp
@@ -19,6 +19,7 @@
 #include <Util/Logger/LogLevel.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <Util/Logger/impl/NesLogger.hpp>
+#include <Util/Signal.hpp>
 #include <cpptrace/from_current.hpp>
 #include <grpcpp/security/server_credentials.h>
 #include <grpcpp/server_builder.h>
@@ -57,6 +58,7 @@ int main(const int argc, const char* argv[])
 {
     CPPTRACE_TRY
     {
+        NES::setupSignalHandlers();
         NES::Logger::setupLogging("singleNodeWorker.log", NES::LogLevel::LOG_DEBUG);
         if (std::signal(SIGINT, signalHandler) == SIG_ERR)
         {

--- a/nes-systests/systest/src/SystestStarter.cpp
+++ b/nes-systests/systest/src/SystestStarter.cpp
@@ -26,6 +26,7 @@
 #include <Configurations/Util.hpp>
 #include <Util/Logger/LogLevel.hpp>
 #include <Util/Logger/Logger.hpp>
+#include <Util/Signal.hpp>
 #include <argparse/argparse.hpp>
 #include <fmt/format.h>
 #include <ErrorHandling.hpp>
@@ -348,6 +349,7 @@ NES::SystestConfiguration parseConfiguration(int argc, const char** argv)
 
 int main(int argc, const char** argv)
 {
+    NES::setupSignalHandlers();
     const auto startTime = std::chrono::high_resolution_clock::now();
     NES::Thread::initializeThread(NES::WorkerId("systest"), "main");
 


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR adds a setupSignalHandlers() function, which should be called by any application.
The signal handler will print stack traces on segmentation faults or floating point errors (the list can be extended).
cpptrace is also registered as a termination handler, which means uncaught exceptions are logged.

It's currently enabled for systest and single-node, but the refactor of cli and repl will also use them.

Technically, our implementation is not safe: cpptrace states that resolving symbol names in a signal handler is unsafe; the alternative offered would use a second application started in the signal handler. The alternative is not very ergonomic, as we would need to install the signal resolver binary properly.
Experimentation revealed that it does work to resolve the symbols within the signal handler. Since the program is about to crash anyway, we are not risking anything.

## Verifying this change
If the system crashes with a segmentation fault a stacktrace where the fault occured is printed.
I have not experimented with what happens if the fault occurs in a JIT-compiled function.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"vcpkg-binary-cache","parentHead":"d3a7b158b2bc9b1bec6a7e0225759eaa12d6a191","parentPull":1315,"trunk":"main"}
```
-->

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 11 in a stack** made with GitButler:
- <kbd>&nbsp;11&nbsp;</kbd> #1182 
- <kbd>&nbsp;10&nbsp;</kbd> #1212 
- <kbd>&nbsp;9&nbsp;</kbd> #1210 
- <kbd>&nbsp;8&nbsp;</kbd> #1178 
- <kbd>&nbsp;7&nbsp;</kbd> #1211 
- <kbd>&nbsp;6&nbsp;</kbd> #1250 
- <kbd>&nbsp;5&nbsp;</kbd> #1208 
- <kbd>&nbsp;4&nbsp;</kbd> #1350 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #1315 
- <kbd>&nbsp;2&nbsp;</kbd> #1206 
- <kbd>&nbsp;1&nbsp;</kbd> #1273 
<!-- GitButler Footer Boundary Bottom -->

