### PR TITLE
fix(Deps Lock): Cancelling in progress dep builds with the same tag

### DIFF
--- a/.github/workflows/get_dev_images.yml
+++ b/.github/workflows/get_dev_images.yml
@@ -144,6 +144,11 @@ jobs:
     needs: [ detect-dependency-changes, lock ]
     if: needs.detect-dependency-changes.outputs.build-dependency == 'true'
     runs-on: [ self-hosted, linux, Build, "${{ matrix.arch }}", dep-builder ]
+    concurrency:
+      group: build-dev-image-lock-${{ needs.detect-dependency-changes.outputs.tag }}
+      # To reduce the amount of work, i.e., building the same deps multiple times, we only allow one job to continue.
+      # We do not cancel the in progress one, as it might have run for quite some time and is close to finishing.
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:
@@ -237,7 +242,7 @@ jobs:
     # This Job merges platform specific images into a single multi-platform image
     name: "Merge Dev Images"
     needs: [ build-dev-images, detect-dependency-changes ]
-    if: needs.detect-dependency-changes.outputs.build-dependency == 'true'
+    if: needs.detect-dependency-changes.outputs.build-dependency == 'true' && needs.build-dev-images.result == 'success'
     runs-on: [ self-hosted, linux, Build, x64 ]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Cancelling in progress dep builds with the same tag to not duplicate work

## Verifying this change
This change is tested by running our CI