### PR TITLE
fix(LogicalFunctions): fix type inference and logical function validation for AND/OR logical functions

### DIFF
--- a/nes-logical-operators/src/Functions/BooleanFunctions/AndLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/BooleanFunctions/AndLogicalFunction.cpp
@@ -92,13 +92,13 @@ LogicalFunction AndLogicalFunction::withInferredDataType(const Schema& schema) c
         newChildren.push_back(node.withInferredDataType(schema));
     }
     /// check if children dataType is correct
-    if (not left.getDataType().isType(DataType::Type::BOOLEAN))
+    if (not newChildren.at(0).getDataType().isType(DataType::Type::BOOLEAN))
     {
-        throw CannotDeserialize("the dataType of left child must be boolean, but was: {}", left.getDataType());
+        throw CannotDeserialize("the dataType of left child must be boolean, but was: {}", newChildren.at(0).getDataType());
     }
-    if (not left.getDataType().isType(DataType::Type::BOOLEAN))
+    if (not newChildren.at(1).getDataType().isType(DataType::Type::BOOLEAN))
     {
-        throw CannotDeserialize("the dataType of right child must be boolean, but was: {}", right.getDataType());
+        throw CannotDeserialize("the dataType of right child must be boolean, but was: {}", newChildren.at(1).getDataType());
     }
     return this->withChildren(newChildren);
 }
@@ -118,12 +118,6 @@ LogicalFunctionRegistryReturnType LogicalFunctionGeneratedRegistrar::RegisterAnd
     if (arguments.children.size() != 2)
     {
         throw CannotDeserialize("AndLogicalFunction requires exactly two children, but got {}", arguments.children.size());
-    }
-    if (arguments.children[0].getDataType().type != DataType::Type::BOOLEAN
-        || arguments.children[1].getDataType().type != DataType::Type::BOOLEAN)
-    {
-        throw CannotDeserialize(
-            "requires children of type bool, but got {} and {}", arguments.children[0].getDataType(), arguments.children[1].getDataType());
     }
     return AndLogicalFunction(arguments.children[0], arguments.children[1]);
 }

--- a/nes-logical-operators/src/Functions/BooleanFunctions/OrLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/BooleanFunctions/OrLogicalFunction.cpp
@@ -93,11 +93,13 @@ LogicalFunction OrLogicalFunction::withInferredDataType(const Schema& schema) co
     }
     /// check if children dataType is correct
     INVARIANT(
-        left.getDataType().isType(DataType::Type::BOOLEAN), "the dataType of left child must be boolean, but was: {}", left.getDataType());
+        children.at(0).getDataType().isType(DataType::Type::BOOLEAN),
+        "the dataType of left child must be boolean, but was: {}",
+        children.at(0).getDataType());
     INVARIANT(
-        right.getDataType().isType(DataType::Type::BOOLEAN),
+        children.at(1).getDataType().isType(DataType::Type::BOOLEAN),
         "the dataType of right child must be boolean, but was: {}",
-        right.getDataType());
+        children.at(1).getDataType());
     return this->withChildren(children);
 }
 
@@ -116,14 +118,6 @@ LogicalFunctionRegistryReturnType LogicalFunctionGeneratedRegistrar::RegisterOrL
     if (arguments.children.size() != 2)
     {
         throw CannotDeserialize("OrLogicalFunction requires exactly two children, but got {}", arguments.children.size());
-    }
-    if (arguments.children[0].getDataType().type != DataType::Type::BOOLEAN
-        || arguments.children[1].getDataType().type != DataType::Type::BOOLEAN)
-    {
-        throw CannotDeserialize(
-            "OrLogicalFunction requires children of type bool, but got {} and {}",
-            arguments.children[0].getDataType(),
-            arguments.children[1].getDataType());
     }
     return OrLogicalFunction(arguments.children[0], arguments.children[1]);
 }

--- a/nes-systests/function/boolean/FunctionAnd.test
+++ b/nes-systests/function/boolean/FunctionAnd.test
@@ -1,4 +1,4 @@
-# name: function/logical/FunctionAnd.test
+# name: function/boolean/FunctionAnd.test
 # description: Simple function and tests
 # groups: [Function, FunctionAnd]
 
@@ -66,3 +66,25 @@ SELECT
 FROM stream INTO sink8Booleans;
 ----
 1,1,1,1,0,0,1,1
+
+# Check that AND works with raw boolean fields
+CREATE LOGICAL SOURCE boolStream(flag1 BOOLEAN, flag2 BOOLEAN, value INT32);
+CREATE PHYSICAL SOURCE FOR boolStream TYPE File;
+ATTACH INLINE
+true,true,1
+true,false,2
+false,true,3
+false,false,4
+
+CREATE SINK sinkBoolAnd(a BOOLEAN, b BOOLEAN, c BOOLEAN) TYPE File;
+
+SELECT
+    flag1 AND flag2 AS a,
+    flag1 AND (value == INT32(1)) AS b,
+    (value > INT32(2)) AND flag2 AS c
+FROM boolStream INTO sinkBoolAnd;
+----
+1,1,0
+0,0,0
+0,0,1
+0,0,0

--- a/nes-systests/function/boolean/FunctionEqual.test
+++ b/nes-systests/function/boolean/FunctionEqual.test
@@ -1,4 +1,4 @@
-# name: function/logical/FunctionEqual.test
+# name: function/boolean/FunctionEqual.test
 # description: Simple function Equal tests
 # groups: [Function, FunctionEqual]
 

--- a/nes-systests/function/boolean/FunctionNotEqual.test
+++ b/nes-systests/function/boolean/FunctionNotEqual.test
@@ -1,4 +1,4 @@
-# name: function/logical/FunctionNotEqual.test
+# name: function/boolean/FunctionNotEqual.test
 # description: Simple function NotEqual tests
 # groups: [Function, FunctionNotEqual]
 

--- a/nes-systests/function/boolean/FunctionOr.test
+++ b/nes-systests/function/boolean/FunctionOr.test
@@ -58,3 +58,25 @@ SELECT
 FROM stream INTO sink5Booleans;
 ----
 0,1,1,1,1
+
+# Check that OR works with raw boolean fields (regression test for withInferredDataType checking pre-inference types)
+CREATE LOGICAL SOURCE boolStream(flag1 BOOLEAN, flag2 BOOLEAN, value INT32);
+CREATE PHYSICAL SOURCE FOR boolStream TYPE File;
+ATTACH INLINE
+true,true,1
+true,false,2
+false,true,3
+false,false,4
+
+CREATE SINK sinkBoolOr(a BOOLEAN, b BOOLEAN, c BOOLEAN) TYPE File;
+
+SELECT
+    flag1 OR flag2 AS a,
+    flag1 OR (value == INT32(3)) AS b,
+    (value > INT32(3)) OR flag2 AS c
+FROM boolStream INTO sinkBoolOr;
+----
+1,1,1
+1,1,0
+1,1,1
+0,0,1


### PR DESCRIPTION

## Purpose of the Change and Brief Change Log
- Removed data type validation logic from AND/OR logical function registration functions
- Fixed check in type inference to use newly created child functions

## Verifying this change
This change is tested by
- Added e2e tests that use these functions with boolean fields

## What components does this pull request potentially affect?
- nes-logical-operators


## Issue Closed by this pull request:

This PR closes #1371 
