### PR TITLE
make PhyscialFunction Concept Based

### DIFF
--- a/nes-physical-operators/include/Functions/ArithmeticalFunctions/AbsolutePhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/ArithmeticalFunctions/AbsolutePhysicalFunction.hpp
@@ -23,15 +23,17 @@
 namespace NES
 {
 
-class AbsolutePhysicalFunction final : public PhysicalFunctionConcept
+class AbsolutePhysicalFunction final
 {
 public:
     explicit AbsolutePhysicalFunction(PhysicalFunction childFunction, DataType inputType);
-    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override;
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
 
 private:
     PhysicalFunction childFunction;
     DataType inputType;
 };
+
+static_assert(PhysicalFunctionConcept<AbsolutePhysicalFunction>);
 
 }

--- a/nes-physical-operators/include/Functions/ArithmeticalFunctions/AddPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/ArithmeticalFunctions/AddPhysicalFunction.hpp
@@ -17,21 +17,24 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Nautilus/DataTypes/VarVal.hpp>
 #include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
 #include <ExecutionContext.hpp>
 
 namespace NES
 {
 
 /// Performs leftPhysicalFunction + rightPhysicalFunction
-class AddPhysicalFunction final : public PhysicalFunctionConcept
+class AddPhysicalFunction final
 {
 public:
     AddPhysicalFunction(PhysicalFunction leftPhysicalFunction, PhysicalFunction rightPhysicalFunction);
-    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override;
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
 
 private:
     PhysicalFunction leftPhysicalFunction;
     PhysicalFunction rightPhysicalFunction;
 };
+
+static_assert(PhysicalFunctionConcept<AddPhysicalFunction>);
 
 }

--- a/nes-physical-operators/include/Functions/ArithmeticalFunctions/CeilPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/ArithmeticalFunctions/CeilPhysicalFunction.hpp
@@ -22,16 +22,18 @@
 namespace NES
 {
 
-class CeilPhysicalFunction final : public PhysicalFunctionConcept
+class CeilPhysicalFunction final
 {
 public:
     explicit CeilPhysicalFunction(PhysicalFunction childFunction, DataType inputType, DataType outputType);
-    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override;
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
 
 private:
     PhysicalFunction childFunction;
     DataType inputType;
     DataType outputType;
 };
+
+static_assert(PhysicalFunctionConcept<CeilPhysicalFunction>);
 
 }

--- a/nes-physical-operators/include/Functions/ArithmeticalFunctions/DivPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/ArithmeticalFunctions/DivPhysicalFunction.hpp
@@ -17,21 +17,24 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Nautilus/DataTypes/VarVal.hpp>
 #include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
 #include <ExecutionContext.hpp>
 
 namespace NES
 {
 
 /// Performs leftPhysicalFunction / rightPhysicalFunction
-class DivPhysicalFunction final : public PhysicalFunctionConcept
+class DivPhysicalFunction final
 {
 public:
     DivPhysicalFunction(PhysicalFunction leftPhysicalFunction, PhysicalFunction rightPhysicalFunction);
-    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override;
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
 
 private:
     PhysicalFunction leftPhysicalFunction;
     PhysicalFunction rightPhysicalFunction;
 };
+
+static_assert(PhysicalFunctionConcept<DivPhysicalFunction>);
 
 }

--- a/nes-physical-operators/include/Functions/ArithmeticalFunctions/FloorPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/ArithmeticalFunctions/FloorPhysicalFunction.hpp
@@ -23,16 +23,18 @@
 namespace NES
 {
 
-class FloorPhysicalFunction final : public PhysicalFunctionConcept
+class FloorPhysicalFunction final
 {
 public:
     explicit FloorPhysicalFunction(PhysicalFunction childFunction, DataType inputType, DataType outputType);
-    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override;
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
 
 private:
     PhysicalFunction childFunction;
     DataType inputType;
     DataType outputType;
 };
+
+static_assert(PhysicalFunctionConcept<FloorPhysicalFunction>);
 
 }

--- a/nes-physical-operators/include/Functions/ArithmeticalFunctions/ModPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/ArithmeticalFunctions/ModPhysicalFunction.hpp
@@ -17,21 +17,24 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Nautilus/DataTypes/VarVal.hpp>
 #include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
 #include <ExecutionContext.hpp>
 
 namespace NES
 {
 
 /// Performs leftSubPhysicalFunction % rightSubPhysicalFunction
-class ModPhysicalFunction : public PhysicalFunctionConcept
+class ModPhysicalFunction
 {
 public:
     ModPhysicalFunction(PhysicalFunction leftPhysicalFunction, PhysicalFunction rightPhysicalFunction);
-    VarVal execute(const Record& record, ArenaRef& arena) const override;
+    VarVal execute(const Record& record, ArenaRef& arena) const;
 
 private:
     PhysicalFunction leftPhysicalFunction;
     PhysicalFunction rightPhysicalFunction;
 };
+
+static_assert(PhysicalFunctionConcept<ModPhysicalFunction>);
 
 }

--- a/nes-physical-operators/include/Functions/ArithmeticalFunctions/MulPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/ArithmeticalFunctions/MulPhysicalFunction.hpp
@@ -18,21 +18,24 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Nautilus/DataTypes/VarVal.hpp>
 #include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
 #include <ExecutionContext.hpp>
 
 namespace NES
 {
 
 /// Performs leftPhysicalFunction * rightPhysicalFunction
-class MulPhysicalFunction final : public PhysicalFunctionConcept
+class MulPhysicalFunction final
 {
 public:
     MulPhysicalFunction(PhysicalFunction leftPhysicalFunction, PhysicalFunction rightPhysicalFunction);
-    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override;
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
 
 private:
     PhysicalFunction leftPhysicalFunction;
     PhysicalFunction rightPhysicalFunction;
 };
+
+static_assert(PhysicalFunctionConcept<MulPhysicalFunction>);
 
 }

--- a/nes-physical-operators/include/Functions/ArithmeticalFunctions/PowPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/ArithmeticalFunctions/PowPhysicalFunction.hpp
@@ -23,16 +23,18 @@
 namespace NES
 {
 
-class PowPhysicalFunction final : public PhysicalFunctionConcept
+class PowPhysicalFunction final
 {
 public:
     explicit PowPhysicalFunction(PhysicalFunction leftPhysicalFunction, PhysicalFunction rightPhysicalFunction, DataType outputType);
-    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override;
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
 
 private:
     PhysicalFunction leftPhysicalFunction;
     PhysicalFunction rightPhysicalFunction;
     DataType outputType;
 };
+
+static_assert(PhysicalFunctionConcept<PowPhysicalFunction>);
 
 }

--- a/nes-physical-operators/include/Functions/ArithmeticalFunctions/RoundPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/ArithmeticalFunctions/RoundPhysicalFunction.hpp
@@ -22,15 +22,18 @@
 
 namespace NES
 {
-class RoundPhysicalFunction final : public PhysicalFunctionConcept
+class RoundPhysicalFunction final
 {
 public:
     explicit RoundPhysicalFunction(PhysicalFunction childFunction, DataType inputType, DataType outputType);
-    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override;
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
 
 private:
     PhysicalFunction childFunction;
     DataType inputType;
     DataType outputType;
 };
+
+static_assert(PhysicalFunctionConcept<RoundPhysicalFunction>);
+
 }

--- a/nes-physical-operators/include/Functions/ArithmeticalFunctions/SqrtPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/ArithmeticalFunctions/SqrtPhysicalFunction.hpp
@@ -23,15 +23,17 @@
 namespace NES
 {
 
-class SqrtPhysicalFunction final : public PhysicalFunctionConcept
+class SqrtPhysicalFunction final
 {
 public:
     explicit SqrtPhysicalFunction(PhysicalFunction childFunction, DataType outputType);
-    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override;
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
 
 private:
     PhysicalFunction childFunction;
     DataType outputType;
 };
+
+static_assert(PhysicalFunctionConcept<SqrtPhysicalFunction>);
 
 }

--- a/nes-physical-operators/include/Functions/ArithmeticalFunctions/SubPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/ArithmeticalFunctions/SubPhysicalFunction.hpp
@@ -18,21 +18,24 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Nautilus/DataTypes/VarVal.hpp>
 #include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
 #include <ExecutionContext.hpp>
 
 namespace NES
 {
 
 /// Performs leftPhysicalFunction - rightPhysicalFunction
-class SubPhysicalFunction final : public PhysicalFunctionConcept
+class SubPhysicalFunction final
 {
 public:
     SubPhysicalFunction(PhysicalFunction leftPhysicalFunction, PhysicalFunction rightPhysicalFunction);
-    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override;
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
 
 private:
     PhysicalFunction leftPhysicalFunction;
     PhysicalFunction rightPhysicalFunction;
 };
+
+static_assert(PhysicalFunctionConcept<SubPhysicalFunction>);
 
 }

--- a/nes-physical-operators/include/Functions/BooleanFunctions/AndPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/BooleanFunctions/AndPhysicalFunction.hpp
@@ -17,19 +17,23 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Nautilus/DataTypes/VarVal.hpp>
 #include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
 #include <ExecutionContext.hpp>
 
 namespace NES
 {
 
-class AndPhysicalFunction final : public PhysicalFunctionConcept
+class AndPhysicalFunction final
 {
 public:
     AndPhysicalFunction(PhysicalFunction leftPhysicalFunction, PhysicalFunction rightPhysicalFunction);
-    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override;
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
 
 private:
     PhysicalFunction leftPhysicalFunction;
     PhysicalFunction rightPhysicalFunction;
 };
+
+static_assert(PhysicalFunctionConcept<AndPhysicalFunction>);
+
 }

--- a/nes-physical-operators/include/Functions/BooleanFunctions/EqualsPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/BooleanFunctions/EqualsPhysicalFunction.hpp
@@ -17,19 +17,23 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Nautilus/DataTypes/VarVal.hpp>
 #include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
 #include <ExecutionContext.hpp>
 
 namespace NES
 {
 
-class EqualsPhysicalFunction final : public PhysicalFunctionConcept
+class EqualsPhysicalFunction final
 {
 public:
     EqualsPhysicalFunction(PhysicalFunction leftPhysicalFunction, PhysicalFunction rightPhysicalFunction);
-    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override;
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
 
 private:
     PhysicalFunction leftPhysicalFunction;
     PhysicalFunction rightPhysicalFunction;
 };
+
+static_assert(PhysicalFunctionConcept<EqualsPhysicalFunction>);
+
 }

--- a/nes-physical-operators/include/Functions/BooleanFunctions/NegatePhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/BooleanFunctions/NegatePhysicalFunction.hpp
@@ -17,19 +17,23 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Nautilus/DataTypes/VarVal.hpp>
 #include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
 #include <ExecutionContext.hpp>
 
 namespace NES
 {
 
 /// Negates the result of the childFunction
-class NegatePhysicalFunction final : public PhysicalFunctionConcept
+class NegatePhysicalFunction final
 {
 public:
     explicit NegatePhysicalFunction(PhysicalFunction childFunction);
-    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override;
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
 
 private:
     PhysicalFunction childFunction;
 };
+
+static_assert(PhysicalFunctionConcept<NegatePhysicalFunction>);
+
 }

--- a/nes-physical-operators/include/Functions/BooleanFunctions/OrPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/BooleanFunctions/OrPhysicalFunction.hpp
@@ -17,19 +17,23 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Nautilus/DataTypes/VarVal.hpp>
 #include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
 #include <ExecutionContext.hpp>
 
 namespace NES
 {
 
-class OrPhysicalFunction final : public PhysicalFunctionConcept
+class OrPhysicalFunction final
 {
 public:
     OrPhysicalFunction(PhysicalFunction leftPhysicalFunction, PhysicalFunction rightPhysicalFunction);
-    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override;
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
 
 private:
     PhysicalFunction leftPhysicalFunction;
     PhysicalFunction rightPhysicalFunction;
 };
+
+static_assert(PhysicalFunctionConcept<OrPhysicalFunction>);
+
 }

--- a/nes-physical-operators/include/Functions/CastFieldPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/CastFieldPhysicalFunction.hpp
@@ -17,20 +17,23 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Nautilus/DataTypes/VarVal.hpp>
 #include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
 #include <ExecutionContext.hpp>
 
 namespace NES
 {
 
-class CastFieldPhysicalFunction : public PhysicalFunctionConcept
+class CastFieldPhysicalFunction
 {
 public:
     explicit CastFieldPhysicalFunction(PhysicalFunction childFunction, DataType castToType);
-    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override;
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
 
 private:
     DataType castToType;
     PhysicalFunction childFunction;
 };
+
+static_assert(PhysicalFunctionConcept<CastFieldPhysicalFunction>);
 
 }

--- a/nes-physical-operators/include/Functions/ComparisonFunctions/GreaterEqualsPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/ComparisonFunctions/GreaterEqualsPhysicalFunction.hpp
@@ -17,19 +17,24 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Nautilus/DataTypes/VarVal.hpp>
 #include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
 #include <ExecutionContext.hpp>
 
 namespace NES
 {
 
-class GreaterEqualsPhysicalFunction final : public PhysicalFunctionConcept
+class GreaterEqualsPhysicalFunction final
 {
 public:
     GreaterEqualsPhysicalFunction(PhysicalFunction leftPhysicalFunction, PhysicalFunction rightPhysicalFunction);
-    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override;
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
 
 private:
     PhysicalFunction leftPhysicalFunction;
     PhysicalFunction rightPhysicalFunction;
 };
+
+static_assert(PhysicalFunctionConcept<GreaterEqualsPhysicalFunction>);
+
+
 }

--- a/nes-physical-operators/include/Functions/ComparisonFunctions/GreaterPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/ComparisonFunctions/GreaterPhysicalFunction.hpp
@@ -17,19 +17,23 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Nautilus/DataTypes/VarVal.hpp>
 #include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
 #include <ExecutionContext.hpp>
 
 namespace NES
 {
 
-class GreaterPhysicalFunction final : public PhysicalFunctionConcept
+class GreaterPhysicalFunction final
 {
 public:
     GreaterPhysicalFunction(PhysicalFunction leftPhysicalFunction, PhysicalFunction rightPhysicalFunction);
-    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override;
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
 
 private:
     PhysicalFunction leftPhysicalFunction;
     PhysicalFunction rightPhysicalFunction;
 };
+
+static_assert(PhysicalFunctionConcept<GreaterPhysicalFunction>);
+
 }

--- a/nes-physical-operators/include/Functions/ComparisonFunctions/LessEqualsPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/ComparisonFunctions/LessEqualsPhysicalFunction.hpp
@@ -18,20 +18,24 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Nautilus/DataTypes/VarVal.hpp>
 #include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
 #include <ExecutionContext.hpp>
 
 namespace NES
 {
 
 /// Performs leftPhysicalFunctionSub % rightPhysicalFunctionSub
-class LessEqualsPhysicalFunction final : public PhysicalFunctionConcept
+class LessEqualsPhysicalFunction final
 {
 public:
     LessEqualsPhysicalFunction(PhysicalFunction leftPhysicalFunction, PhysicalFunction rightPhysicalFunction);
-    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override;
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
 
 private:
     PhysicalFunction leftPhysicalFunction;
     PhysicalFunction rightPhysicalFunction;
 };
+
+static_assert(PhysicalFunctionConcept<LessEqualsPhysicalFunction>);
+
 }

--- a/nes-physical-operators/include/Functions/ComparisonFunctions/LessPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/ComparisonFunctions/LessPhysicalFunction.hpp
@@ -17,19 +17,23 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Nautilus/DataTypes/VarVal.hpp>
 #include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
 #include <ExecutionContext.hpp>
 
 namespace NES
 {
 
-class LessPhysicalFunction final : public PhysicalFunctionConcept
+class LessPhysicalFunction final
 {
 public:
     LessPhysicalFunction(PhysicalFunction leftPhysicalFunction, PhysicalFunction rightPhysicalFunction);
-    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override;
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
 
 private:
     PhysicalFunction leftPhysicalFunction;
     PhysicalFunction rightPhysicalFunction;
 };
+
+static_assert(PhysicalFunctionConcept<LessPhysicalFunction>);
+
 }

--- a/nes-physical-operators/include/Functions/ConcatPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/ConcatPhysicalFunction.hpp
@@ -17,20 +17,23 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Nautilus/DataTypes/VarVal.hpp>
 #include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
 #include <ExecutionContext.hpp>
 
 namespace NES
 {
 
-class ConcatPhysicalFunction final : public PhysicalFunctionConcept
+class ConcatPhysicalFunction final
 {
 public:
     ConcatPhysicalFunction(PhysicalFunction leftPhysicalFunction, PhysicalFunction rightPhysicalFunction);
-    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override;
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
 
 private:
     PhysicalFunction leftPhysicalFunction;
     PhysicalFunction rightPhysicalFunction;
 };
+
+static_assert(PhysicalFunctionConcept<ConcatPhysicalFunction>);
 
 }

--- a/nes-physical-operators/include/Functions/ConstantValuePhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/ConstantValuePhysicalFunction.hpp
@@ -19,6 +19,7 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Nautilus/DataTypes/VarVal.hpp>
 #include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
 #include <ExecutionContext.hpp>
 
 namespace NES
@@ -26,12 +27,12 @@ namespace NES
 
 template <typename T>
 requires std::is_integral_v<T> || std::is_floating_point_v<T>
-class ConstantValuePhysicalFunction final : public PhysicalFunctionConcept
+class ConstantValuePhysicalFunction final
 {
 public:
     explicit ConstantValuePhysicalFunction(T value) : value(value) { }
 
-    VarVal execute(const Record&, ArenaRef&) const override { return VarVal(value); }
+    VarVal execute(const Record&, ArenaRef&) const { return VarVal(value); }
 
 private:
     const T value;

--- a/nes-physical-operators/include/Functions/ConstantValueVariableSizePhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/ConstantValueVariableSizePhysicalFunction.hpp
@@ -21,19 +21,22 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Nautilus/DataTypes/VarVal.hpp>
 #include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
 #include <ExecutionContext.hpp>
 
 namespace NES
 {
 
 /// A function that represents a constant value of variable size, e.g., a string.
-class ConstantValueVariableSizePhysicalFunction final : public PhysicalFunctionConcept
+class ConstantValueVariableSizePhysicalFunction final
 {
 public:
     explicit ConstantValueVariableSizePhysicalFunction(const int8_t* value, size_t size);
-    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override;
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
 
 private:
     std::vector<int8_t> data;
 };
+
+static_assert(PhysicalFunctionConcept<ConstantValueVariableSizePhysicalFunction>);
 }

--- a/nes-physical-operators/include/Functions/FieldAccessPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/FieldAccessPhysicalFunction.hpp
@@ -16,19 +16,23 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Nautilus/DataTypes/VarVal.hpp>
 #include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
 #include <ExecutionContext.hpp>
 
 namespace NES
 {
 
-class FieldAccessPhysicalFunction : public PhysicalFunctionConcept
+class FieldAccessPhysicalFunction
 {
 public:
     explicit FieldAccessPhysicalFunction(Record::RecordFieldIdentifier field);
-    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override;
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
 
 private:
     const Record::RecordFieldIdentifier field;
 };
+
+static_assert(PhysicalFunctionConcept<FieldAccessPhysicalFunction>);
+
 
 }

--- a/nes-physical-operators/include/Functions/PhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/PhysicalFunction.hpp
@@ -12,11 +12,15 @@
     limitations under the License.
 */
 #pragma once
+#include <concepts>
 #include <memory>
 #include <optional>
 #include <type_traits>
+#include <utility>
 #include <Nautilus/DataTypes/VarVal.hpp>
 #include <Nautilus/Interface/Record.hpp>
+#include <Util/DynamicBase.hpp>
+#include <Arena.hpp>
 #include <ErrorHandling.hpp>
 #include <ExecutionContext.hpp>
 #include <nameof.hpp>
@@ -24,99 +28,223 @@
 namespace NES
 {
 
-/// Concept defining the interface for all physical functions.
-struct PhysicalFunctionConcept
+namespace detail
 {
-    virtual ~PhysicalFunctionConcept() = default;
+struct ErasedPhysicalFunction;
+}
 
+template <typename Checked = NES::detail::ErasedPhysicalFunction>
+struct TypedPhysicalFunction;
+using PhysicalFunction = TypedPhysicalFunction<>;
+
+/// Concept defining the interface for all physical functions in the query plan.
+/// This concept defines the common interface that all physical functions must implement.
+/// Physical functions represent functions in the query plan and are used during query
+/// planning and optimization.
+/// Concept defining the interface for all physical functions.
+template <typename T>
+concept PhysicalFunctionConcept = requires(const T& thisFunction, const Record& record, ArenaRef& arena) {
     /// Executes the function on the given record.
     /// @param record The record to evaluate the function on.
     /// @param arena The arena to allocate memory from.
     /// @return The result of the function evaluation.
-    [[nodiscard]] virtual VarVal execute(const Record& record, ArenaRef& arena) const = 0;
+    { thisFunction.execute(record, arena) } -> std::convertible_to<VarVal>;
 };
 
-/// A type-erased wrapper for physical functions.
-/// C.f.: https://sean-parent.stlab.cc/presentations/2017-01-18-runtime-polymorphism/2017-01-18-runtime-polymorphism.pdf
-/// This class provides type erasure for physical functions, allowing them to be stored
-/// and manipulated without knowing their concrete type. It uses the PIMPL pattern
-/// to store the actual function implementation.
-/// @tparam T The type of the physical function. Must inherit from PhysicalFunctionConcept.
-template <typename T>
-concept IsPhysicalFunction = std::is_base_of_v<PhysicalFunctionConcept, std::remove_cv_t<std::remove_reference_t<T>>>;
-
-/// Type-erased physical function that can be used to evaluate expressions on records.
-struct PhysicalFunction
+namespace detail
 {
-    /// Constructs a PhysicalFunction from a concrete function type.
-    /// @tparam FunctionType The type of the function. Must satisfy IsPhysicalFunction concept.
-    /// @param fn The function to wrap.
-    template <IsPhysicalFunction FunctionType>
-    PhysicalFunction(const FunctionType& fn) /// NOLINT
-        : self(std::make_shared<Model<FunctionType>>(fn))
+/// @brief A type erased wrapper for physical functions
+struct ErasedPhysicalFunction
+{
+    virtual ~ErasedPhysicalFunction() = default;
+
+    [[nodiscard]] virtual VarVal execute(const Record& record, ArenaRef& arena) const = 0;
+
+private:
+    template <typename T>
+    friend struct NES::TypedPhysicalFunction;
+    ///If the function inherits from DynamicBase (over Castable), then returns a pointer to the wrapped operator as DynamicBase,
+    ///so that we can then safely try to dyncast the DynamicBase* to Castable<T>*
+    [[nodiscard]] virtual std::optional<const DynamicBase*> getImpl() const = 0;
+};
+
+template <PhysicalFunctionConcept PhysicalFunctionType>
+struct PhysicalFunctionModel;
+}
+
+/// @brief A type erased wrapper for heap-allocated physical functions.
+/// @tparam Checked A physical function type that this wrapper guarantees it contains.
+/// Either a type erased virtual physical function class or the actual type.
+/// You can cast with TypedPhysicalFunction::tryGetAs, to try to get a TypedPhysicalFunction for a specific type.
+template <typename Checked>
+struct TypedPhysicalFunction
+{
+    template <PhysicalFunctionConcept T>
+    requires std::same_as<Checked, NES::detail::ErasedPhysicalFunction>
+    TypedPhysicalFunction(TypedPhysicalFunction<T> other) : self(other.self) /// NOLINT(google-explicit-constructor)
     {
     }
 
-    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const { return self->execute(record, arena); }
-
-    /// Attempts to get the underlying function as type FunctionType.
-    /// @tparam FunctionType The type to try to get the function as.
-    /// @return std::optional<FunctionType> The function if it is of type FunctionType, nullopt otherwise.
-    template <IsPhysicalFunction FunctionType>
-    [[nodiscard]] std::optional<FunctionType> tryGet() const
+    /// Constructs a PhysicalFunction from a concrete function type.
+    /// @tparam T The type of the function. Must satisfy PhysicalFunctionConcept concept.
+    /// @param fn The function to wrap.
+    template <PhysicalFunctionConcept T>
+    TypedPhysicalFunction(const T& fn) /// NOLINT(google-explicit-constructor)
+        : self(std::make_shared<NES::detail::PhysicalFunctionModel<T>>(fn))
     {
-        if (auto p = dynamic_cast<const Model<FunctionType>*>(self.get()))
+    }
+
+    template <PhysicalFunctionConcept T>
+    TypedPhysicalFunction(const NES::detail::PhysicalFunctionModel<T>& fn) /// NOLINT(google-explicit-constructor)
+        : self(std::make_shared<NES::detail::PhysicalFunctionModel<T>>(fn.impl))
+    {
+    }
+
+    explicit TypedPhysicalFunction(std::shared_ptr<const NES::detail::ErasedPhysicalFunction> fn) : self(std::move(fn)) { }
+
+    TypedPhysicalFunction() = delete;
+
+    ///@brief Alternative to operator*
+    [[nodiscard]] const Checked& get() const
+    {
+        if constexpr (std::is_same_v<NES::detail::ErasedPhysicalFunction, Checked>)
         {
-            return p->data;
+            return *std::dynamic_pointer_cast<const NES::detail::ErasedPhysicalFunction>(self);
+        }
+        else
+        {
+            return std::dynamic_pointer_cast<const NES::detail::PhysicalFunctionModel<Checked>>(self)->impl;
+        }
+    }
+
+    const Checked& operator*() const
+    {
+        if constexpr (std::is_same_v<NES::detail::ErasedPhysicalFunction, Checked>)
+        {
+            return *std::dynamic_pointer_cast<const NES::detail::ErasedPhysicalFunction>(self);
+        }
+        else
+        {
+            return std::dynamic_pointer_cast<const NES::detail::PhysicalFunctionModel<Checked>>(self)->impl;
+        }
+    }
+
+    const Checked* operator->() const
+    {
+        if constexpr (std::is_same_v<NES::detail::ErasedPhysicalFunction, Checked>)
+        {
+            return std::dynamic_pointer_cast<const NES::detail::ErasedPhysicalFunction>(self).get();
+        }
+        else
+        {
+            auto casted = std::dynamic_pointer_cast<const NES::detail::PhysicalFunctionModel<Checked>>(self);
+            return &casted->impl;
+        }
+    }
+
+    /// Attempts to get the underlying function as type T.
+    /// @tparam T The type to try to get the function as.
+    /// @return std::optional<TypedPhysicalFunction<T>> The function if it is of type T, nullopt otherwise.
+    template <PhysicalFunctionConcept T>
+    std::optional<TypedPhysicalFunction<T>> tryGetAs() const
+    {
+        if (auto model = std::dynamic_pointer_cast<const NES::detail::PhysicalFunctionModel<T>>(self))
+        {
+            return TypedPhysicalFunction<T>{std::static_pointer_cast<const NES::detail::ErasedPhysicalFunction>(model)};
+        }
+        return std::nullopt;
+    }
+
+    /// Attempts to get the underlying function as type T.
+    /// @tparam T The type to try to get the function as.
+    /// @return std::optional<std::shared_ptr<const Castable<T>>> The function if it is of type T and Castable<T>, nullopt otherwise.
+    template <typename T>
+    requires(!PhysicalFunctionConcept<T>)
+    std::optional<std::shared_ptr<const Castable<T>>> tryGetAs() const
+    {
+        if (auto castable = self->getImpl(); castable.has_value())
+        {
+            if (auto ptr = dynamic_cast<const Castable<T>*>(castable.value()))
+            {
+                return std::shared_ptr<const Castable<T>>{self, ptr};
+            }
         }
         return std::nullopt;
     }
 
     /// Gets the underlying function as type T.
-    /// @tparam FunctionType The type to get the function as.
-    /// @return const FunctionType The function.
-    /// @throw InvalidDynamicCast If the function is not of type FunctionType.
-    template <typename FunctionType>
-    [[nodiscard]] FunctionType get() const
+    /// @tparam T The type to get the function as.
+    /// @return TypedPhysicalFunction<T> The function.
+    /// @throw InvalidDynamicCast If the function is not of type T.
+    template <PhysicalFunctionConcept T>
+    TypedPhysicalFunction<T> getAs() const
     {
-        if (auto p = dynamic_cast<const Model<FunctionType>*>(self.get()))
+        if (auto model = std::dynamic_pointer_cast<const NES::detail::PhysicalFunctionModel<T>>(self))
         {
-            return p->data;
+            return TypedPhysicalFunction<T>{std::static_pointer_cast<const NES::detail::ErasedPhysicalFunction>(model)};
         }
-        throw InvalidDynamicCast("requested type {} , but stored type is {}", NAMEOF_TYPE(FunctionType), NAMEOF_TYPE_EXPR(self));
+        PRECONDITION(false, "requested type {} , but stored type is {}", typeid(T).name(), typeid(self).name());
+        std::unreachable();
     }
 
-    PhysicalFunction(PhysicalFunction&&) noexcept = default;
-
-    PhysicalFunction(const PhysicalFunction& other) = default;
-
-    PhysicalFunction& operator=(const PhysicalFunction& other)
+    /// Gets the underlying function as type T.
+    /// @tparam T The type to get the function as.
+    /// @return std::shared_ptr<const Castable<T>> The function.
+    /// @throw InvalidDynamicCast If the function is not of type T or does not inherit from Castable<T>.
+    template <typename T>
+    requires(!PhysicalFunctionConcept<T>)
+    std::shared_ptr<const Castable<T>> getAs() const
     {
-        if (this != &other)
+        if (auto castable = self->getImpl(); castable.has_value())
         {
-            self = other.self;
+            if (auto ptr = dynamic_cast<const Castable<T>*>(castable.value()))
+            {
+                return std::shared_ptr<const Castable<T>>{self, ptr};
+            }
         }
-        return *this;
+        PRECONDITION(false, "requested type {} , but stored type is {}", NAMEOF_TYPE(T), NAMEOF_TYPE_EXPR(self));
+        std::unreachable();
     }
+
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const { return self->execute(record, arena); }
 
 private:
-    struct Concept : PhysicalFunctionConcept
-    {
-        [[nodiscard]] virtual std::shared_ptr<Concept> clone() const = 0;
-    };
+    template <typename FriendChecked>
+    friend struct TypedPhysicalFunction;
 
-    template <IsPhysicalFunction FunctionType>
-    struct Model : Concept
-    {
-        FunctionType data;
-
-        explicit Model(FunctionType d) : data(std::move(d)) { }
-
-        [[nodiscard]] std::shared_ptr<Concept> clone() const override { return std::make_shared<Model>(data); }
-
-        [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override { return data.execute(record, arena); }
-    };
-
-    std::shared_ptr<Concept> self;
+    std::shared_ptr<const NES::detail::ErasedPhysicalFunction> self;
 };
+
+namespace detail
+{
+
+/// @brief Wrapper type that acts as a bridge between a type satisfying PhysicalFunctionConcept and TypedPhysicalFunction
+template <PhysicalFunctionConcept PhysicalFunctionType>
+struct PhysicalFunctionModel : ErasedPhysicalFunction
+{
+    PhysicalFunctionType impl;
+
+    explicit PhysicalFunctionModel(PhysicalFunctionType impl) : impl(std::move(impl)) { }
+
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const override { return impl.execute(record, arena); }
+
+    [[nodiscard]] PhysicalFunctionType get() const { return impl; }
+
+private:
+    template <typename T>
+    friend struct TypedPhysicalFunction;
+
+    [[nodiscard]] std::optional<const DynamicBase*> getImpl() const override
+    {
+        if constexpr (std::is_base_of_v<DynamicBase, PhysicalFunctionType>)
+        {
+            return static_cast<const DynamicBase*>(&impl);
+        }
+        else
+        {
+            return std::nullopt;
+        }
+    }
+};
+}
 }


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Refactored PhysicalFunction to use the same concept-based Type Erasure pattern as LogicalOperator.

Replaced inheritance with TypedPhysicalFunction wrapper and PhysicalFunctionModel.

## Issue refecenced by this pull request:
References #1150 
