### PR TITLE
Track and report total compilation time in systest

### DIFF
--- a/grpc/SingleNodeWorkerRPCService.proto
+++ b/grpc/SingleNodeWorkerRPCService.proto
@@ -47,9 +47,10 @@ message StopQueryRequest {
 enum QueryState {
     Registered = 0;
     Started = 1;
-    Running = 2;
-    Stopped = 3;
-    Failed = 4;
+    Compiling = 2;
+    Running = 3;
+    Stopped = 4;
+    Failed = 5;
 }
 
 message Error {
@@ -65,9 +66,10 @@ message QueryStatusRequest {
 
 message QueryMetrics {
    optional uint64 startUnixTimeInMs = 1;
-   optional uint64 runningUnixTimeInMs = 2;
-   optional uint64 stopUnixTimeInMs = 3;
-   optional Error error = 4;
+   optional uint64 compilingUnixTimeInMs = 2;
+   optional uint64 runningUnixTimeInMs = 3;
+   optional uint64 stopUnixTimeInMs = 4;
+   optional Error error = 5;
 }
 
 message QueryStatusReply {

--- a/nes-executable/include/ExecutablePipelineStage.hpp
+++ b/nes-executable/include/ExecutablePipelineStage.hpp
@@ -43,7 +43,7 @@ public:
     virtual void execute(const TupleBuffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext) = 0;
 
     /// Stops the ExecutablePipelineStage allowing it to flush left over state.
-    /// QueryEngine only stops pipelines that have previously been `started`.
+    /// `stop` should never be called on a pipeline that has not previously been `compiled`.
     /// `stop` is not guaranteed to be called, thus the destructor should take care of cleanup.
     /// `stop` may throw to indicate an error.
     virtual void stop(PipelineExecutionContext& pipelineExecutionContext) = 0;

--- a/nes-frontend/src/QueryManager/GRPCQuerySubmissionBackend.cpp
+++ b/nes-frontend/src/QueryManager/GRPCQuerySubmissionBackend.cpp
@@ -117,6 +117,12 @@ std::expected<LocalQueryStatus, Exception> GRPCQuerySubmissionBackend::status(Qu
         const std::chrono::system_clock::time_point startTimePoint(std::chrono::milliseconds(response.metrics().startunixtimeinms()));
         metrics.start = startTimePoint;
     }
+    if (response.metrics().has_compilingunixtimeinms())
+    {
+        const std::chrono::system_clock::time_point compilingTimePoint(
+            std::chrono::milliseconds(response.metrics().compilingunixtimeinms()));
+        metrics.compiling = compilingTimePoint;
+    }
     if (response.metrics().has_runningunixtimeinms())
     {
         const std::chrono::system_clock::time_point runningTimePoint(std::chrono::milliseconds(response.metrics().runningunixtimeinms()));

--- a/nes-frontend/src/Statements/StatementHandler.cpp
+++ b/nes-frontend/src/Statements/StatementHandler.cpp
@@ -306,6 +306,6 @@ std::expected<ShowQueriesStatementResult, Exception> QueryStatementHandler::oper
          LocalQueryStatus{
              .queryId = statement.id.value(),
              .state = QueryState::Failed,
-             .metrics = QueryMetrics{.start = {}, .running = {}, .stop = {}, .error = statusOpt.error()}}}}};
+             .metrics = QueryMetrics{.start = {}, .compiling = {}, .running = {}, .stop = {}, .error = statusOpt.error()}}}}};
 }
 }

--- a/nes-query-engine/QueryEngine.cpp
+++ b/nes-query-engine/QueryEngine.cpp
@@ -575,6 +575,7 @@ bool ThreadPool::WorkerThread::operator()(CompilePipelineTask& compilePipeline) 
         pipeline->stage->compile(pec);
         const auto wasCompiled = pipeline->isCompiled.exchange(true);
         INVARIANT(!wasCompiled, "Pipeline {}-{} must not be compiled multiple times", compilePipeline.queryId, pipeline->id);
+        pool.statistic->onEvent(PipelineCompile{WorkerThread::id, compilePipeline.queryId, pipeline->id});
         return true;
     }
 
@@ -1003,6 +1004,7 @@ void QueryCatalog::start(
                           { return Starting{std::move(runningQueryPlan)}; })) /// NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
     {
         listener->logQueryStatusChange(queryId, QueryState::Started, startTimestamp);
+        listener->logQueryStatusChange(queryId, QueryState::Compiling, std::chrono::system_clock::now());
     }
     else
     {

--- a/nes-query-engine/include/QueryEngineStatisticListener.hpp
+++ b/nes-query-engine/include/QueryEngineStatisticListener.hpp
@@ -119,8 +119,9 @@ struct QueryFail : EventBase
 
 struct PipelineCompile : EventBase
 {
-    PipelineCompile(WorkerThreadId threadId, QueryId queryId, PipelineId pipelineId)
-        : EventBase(threadId, queryId), pipelineId(pipelineId) { }
+    PipelineCompile(WorkerThreadId threadId, QueryId queryId, PipelineId pipelineId) : EventBase(threadId, queryId), pipelineId(pipelineId)
+    {
+    }
 
     PipelineCompile() = default;
 

--- a/nes-query-engine/include/QueryEngineStatisticListener.hpp
+++ b/nes-query-engine/include/QueryEngineStatisticListener.hpp
@@ -117,6 +117,16 @@ struct QueryFail : EventBase
     QueryFail() = default;
 };
 
+struct PipelineCompile : EventBase
+{
+    PipelineCompile(WorkerThreadId threadId, QueryId queryId, PipelineId pipelineId)
+        : EventBase(threadId, queryId), pipelineId(pipelineId) { }
+
+    PipelineCompile() = default;
+
+    PipelineId pipelineId = INVALID<PipelineId>;
+};
+
 struct PipelineStart : EventBase
 {
     PipelineStart(WorkerThreadId threadId, QueryId queryId, PipelineId pipelineId)
@@ -143,6 +153,7 @@ using Event = std::variant<
     TaskEmit,
     TaskExecutionComplete,
     TaskExpired,
+    PipelineCompile,
     PipelineStart,
     PipelineStop,
     QueryStart,

--- a/nes-query-engine/tests/QueryEngineTest.cpp
+++ b/nes-query-engine/tests/QueryEngineTest.cpp
@@ -776,7 +776,8 @@ TEST_F(QueryEngineTest, ManyQueriesWithTwoSources)
         sinkCtrls.push_back(test.sinkControls[sinks[index]]);
         test.expectSourceTermination(QueryId(1 + index), sources[index * 2], QueryTerminationType::Graceful);
         test.expectSourceTermination(QueryId(1 + index), sources[(index * 2) + 1], QueryTerminationType::Graceful);
-        test.expectQueryStatusEvents(QueryId(1 + index), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Stopped});
+        test.expectQueryStatusEvents(
+            QueryId(1 + index), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Stopped});
     }
 
     test.start();
@@ -865,7 +866,8 @@ TEST_F(QueryEngineTest, ManyQueriesWithTwoSourcesOneSourceFails)
         sinkCtrls.push_back(test.sinkControls[sinks[index]]);
         test.expectSourceTermination(QueryId(1 + index), sources[index * 2], QueryTerminationType::Graceful);
         test.expectSourceTermination(QueryId(1 + index), sources[(index * 2) + 1], QueryTerminationType::Graceful);
-        test.expectQueryStatusEvents(QueryId(1 + index), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Stopped});
+        test.expectQueryStatusEvents(
+            QueryId(1 + index), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Stopped});
         index++;
     }
 
@@ -1340,7 +1342,8 @@ TEST_F(QueryEngineTest, ManyQueriesWithTwoSourcesAndPipelineFailures)
         sourcesCtrls.push_back(test.sourceControls[sources[index * 2]]);
         sourcesCtrls.push_back(test.sourceControls[sources[(index * 2) + 1]]);
         sinkCtrls.push_back(test.sinkControls[sinks[index]]);
-        test.expectQueryStatusEvents(QueryId(1 + index), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Failed});
+        test.expectQueryStatusEvents(
+            QueryId(1 + index), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Failed});
         index++;
     }
 

--- a/nes-query-engine/tests/QueryEngineTest.cpp
+++ b/nes-query-engine/tests/QueryEngineTest.cpp
@@ -72,11 +72,12 @@ TEST_F(QueryEngineTest, singleQueryWithShutdown)
     /// Statistics. Note: No Pipeline Terminate and no QueryStop because engine shutdown does not gracefully terminate any query.
     test.stats.expect(
         ExpectStats::QueryStart(1),
+        ExpectStats::PipelineCompile(1),
         ExpectStats::PipelineStart(1),
         ExpectStats::TaskExecutionStart(4),
         ExpectStats::TaskExecutionComplete(4));
 
-    test.expectQueryStatusEvents(queryId, {QueryState::Started, QueryState::Running});
+    test.expectQueryStatusEvents(queryId, {QueryState::Started, QueryState::Compiling, QueryState::Running});
 
     test.start();
     {
@@ -117,12 +118,13 @@ TEST_F(QueryEngineTest, singleQueryWithSystemShutdown)
     /// Statistics. Note: No Pipeline Terminate and no QueryStop because engine shutdown does not gracefully terminate any query.
     test.stats.expect(
         ExpectStats::QueryStart(1),
+        ExpectStats::PipelineCompile(2),
         ExpectStats::PipelineStart(2),
         ExpectStats::TaskExecutionStart(8),
         ExpectStats::TaskExecutionComplete(8),
         ExpectStats::TaskEmit(4));
 
-    test.expectQueryStatusEvents(id, {QueryState::Started, QueryState::Running});
+    test.expectQueryStatusEvents(id, {QueryState::Started, QueryState::Compiling, QueryState::Running});
 
     test.start();
     {
@@ -173,7 +175,7 @@ TEST_F(QueryEngineTest, singleQueryWithExternalStop)
         ExpectStats::TaskExecutionComplete(8),
         ExpectStats::TaskEmit(4));
 
-    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Stopped});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Stopped});
     test.expectSourceTermination(QueryId(1), source, QueryTerminationType::Graceful);
 
     test.start();
@@ -213,7 +215,7 @@ TEST_F(QueryEngineTest, singleQueryWithSystemStop)
 
     auto ctrl = test.sourceControls[source];
     auto sinkCtrl = test.sinkControls[sink];
-    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Stopped});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Stopped});
 
     /// Statistics.
     ///     Note: Pipelines are terminated because the query is gracefully stopped.
@@ -268,7 +270,7 @@ TEST_F(QueryEngineTest, singleQueryWithSourceFailure)
 
     auto ctrl = test.sourceControls[source];
     auto sinkCtrl = test.sinkControls[sink];
-    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Failed});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Failed});
     test.expectSourceTermination(QueryId(1), source, QueryTerminationType::Failure);
 
     test.start();
@@ -311,7 +313,7 @@ TEST_F(QueryEngineTest, singleQueryWithTwoSourcesShutdown)
     auto ctrl1 = test.sourceControls[source1];
     auto ctrl2 = test.sourceControls[source2];
     auto sinkCtrl = test.sinkControls[sink];
-    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Compiling, QueryState::Running});
 
     /// Statistics.
     ///     Note: Pipelines are not terminated, due to system shutdown
@@ -386,7 +388,7 @@ TEST_F(QueryEngineTest, failureDuringPipelineStop)
 
     test.pipelineControls[fail]->failOnStop = true;
 
-    test.expectQueryStatusEvents(id, {QueryState::Started, QueryState::Running, QueryState::Failed});
+    test.expectQueryStatusEvents(id, {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Failed});
     test.expectSourceTermination(id, src, QueryTerminationType::Graceful);
 
     test.start();
@@ -437,7 +439,7 @@ TEST_F(QueryEngineTest, failureDuringPipelineStopMultipleSources)
     auto id = query->queryId;
     test.pipelineControls[fail]->failOnStop = true;
 
-    test.expectQueryStatusEvents(id, {QueryState::Started, QueryState::Running, QueryState::Failed});
+    test.expectQueryStatusEvents(id, {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Failed});
     test.expectSourceTermination(id, src1, QueryTerminationType::Graceful);
     test.expectSourceTermination(id, src2, QueryTerminationType::Graceful);
 
@@ -499,7 +501,7 @@ TEST_F(QueryEngineTest, failureDuringPipelineStopMultipleSourcesRaceBetweenFailA
     auto id = query->queryId;
     test.pipelineControls[fail]->failOnStop = true;
 
-    test.expectQueryStatusEvents(id, {QueryState::Started, QueryState::Running, QueryState::Failed});
+    test.expectQueryStatusEvents(id, {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Failed});
     test.expectSourceTermination(id, src1, QueryTerminationType::Graceful);
 
     /// The query engine does not explicitly notify src2 so it cannot report query failure. This could arguably be improved.
@@ -593,7 +595,7 @@ TEST_F(QueryEngineTest, singleQueryWithTwoSourcesWaitingForTwoStops)
     auto ctrl1 = test.sourceControls[source1];
     auto ctrl2 = test.sourceControls[source2];
     auto sinkCtrl = test.sinkControls[sink];
-    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Stopped});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Stopped});
     test.expectSourceTermination(QueryId(1), source1, QueryTerminationType::Graceful);
     test.expectSourceTermination(QueryId(1), source2, QueryTerminationType::Graceful);
 
@@ -658,7 +660,7 @@ TEST_F(QueryEngineTest, singleQueryWithManySources)
         });
 
     auto sinkCtrl = test.sinkControls[sink];
-    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Stopped});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Stopped});
 
     test.start();
     {
@@ -695,7 +697,7 @@ TEST_F(QueryEngineTest, singleQueryWithManySourcesOneOfThemFails)
     std::vector<std::shared_ptr<TestSourceControl>> sourcesCtrls;
     std::ranges::transform(sources, std::back_inserter(sourcesCtrls), [&](auto identifier) { return test.sourceControls[identifier]; });
 
-    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Failed});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Failed});
     /// Overwrite Source 0 to expect source failure.
     test.expectSourceTermination(QueryId(1), sources[0], QueryTerminationType::Failure);
 
@@ -729,7 +731,7 @@ TEST_F(QueryEngineTest, RaceBetweenFailureAndEOS)
 
     auto query = test.addNewQuery(std::move(builder));
     test.pipelineControls[failingPipeline]->throwOnNthInvocation = 1;
-    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Failed});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Failed});
 
     test.start();
     {
@@ -774,7 +776,7 @@ TEST_F(QueryEngineTest, ManyQueriesWithTwoSources)
         sinkCtrls.push_back(test.sinkControls[sinks[index]]);
         test.expectSourceTermination(QueryId(1 + index), sources[index * 2], QueryTerminationType::Graceful);
         test.expectSourceTermination(QueryId(1 + index), sources[(index * 2) + 1], QueryTerminationType::Graceful);
-        test.expectQueryStatusEvents(QueryId(1 + index), {QueryState::Started, QueryState::Running, QueryState::Stopped});
+        test.expectQueryStatusEvents(QueryId(1 + index), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Stopped});
     }
 
     test.start();
@@ -847,13 +849,13 @@ TEST_F(QueryEngineTest, ManyQueriesWithTwoSourcesOneSourceFails)
     sourcesCtrls.push_back(test.sourceControls[sources[1]]);
     sinkCtrls.push_back(test.sinkControls[sinks[0]]);
     test.expectSourceTermination(QueryId(1), sources[0], QueryTerminationType::Failure);
-    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Failed});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Failed});
 
     /// Query 2 is terminated by an internal stop
     sourcesCtrls.push_back(test.sourceControls[sources[2]]);
     sourcesCtrls.push_back(test.sourceControls[sources[3]]);
     sinkCtrls.push_back(test.sinkControls[sinks[1]]);
-    test.expectQueryStatusEvents(QueryId(2), {QueryState::Started, QueryState::Running, QueryState::Stopped});
+    test.expectQueryStatusEvents(QueryId(2), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Stopped});
 
     /// Rest of the queries are terminated by external stop via eos
     for (size_t index = 2; const auto& query : queryPlans | std::ranges::views::drop(2))
@@ -863,7 +865,7 @@ TEST_F(QueryEngineTest, ManyQueriesWithTwoSourcesOneSourceFails)
         sinkCtrls.push_back(test.sinkControls[sinks[index]]);
         test.expectSourceTermination(QueryId(1 + index), sources[index * 2], QueryTerminationType::Graceful);
         test.expectSourceTermination(QueryId(1 + index), sources[(index * 2) + 1], QueryTerminationType::Graceful);
-        test.expectQueryStatusEvents(QueryId(1 + index), {QueryState::Started, QueryState::Running, QueryState::Stopped});
+        test.expectQueryStatusEvents(QueryId(1 + index), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Stopped});
         index++;
     }
 
@@ -922,7 +924,7 @@ TEST_F(QueryEngineTest, singleQueryWithTwoSourceExternalStop)
     auto sink = builder.addSink({pipeline});
     auto query = test.addNewQuery(std::move(builder));
 
-    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Stopped});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Stopped});
 
     test.start();
     {
@@ -965,7 +967,7 @@ TEST_F(QueryEngineTest, singleQueryWithSlowlyFailingSourceDuringEngineTerminatio
         ExpectStats::TaskEmit(0));
 
     test.sourceControls[source]->failDuringOpen(DEFAULT_AWAIT_TIMEOUT);
-    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Compiling, QueryState::Running});
 
     test.start();
     {
@@ -998,7 +1000,7 @@ TEST_F(QueryEngineTest, singleQueryWithSlowlyFailingSourceDuringQueryPlanTermina
         ExpectStats::TaskEmit(0));
 
     test.sourceControls[source]->failDuringOpen(DEFAULT_LONG_AWAIT_TIMEOUT);
-    test.expectQueryStatusEvents(query->queryId, {QueryState::Started, QueryState::Running, QueryState::Stopped});
+    test.expectQueryStatusEvents(query->queryId, {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Stopped});
 
     test.start();
     {
@@ -1028,7 +1030,7 @@ TEST_F(QueryEngineTest, singleQueryWithPipelineFailure)
     auto sink = builder.addSink({pipeline});
     auto query = test.addNewQuery(std::move(builder));
 
-    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Failed});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Failed});
     test.pipelineControls[pipeline]->throwOnNthInvocation = 2;
 
     test.start();
@@ -1064,7 +1066,7 @@ TEST_F(QueryEngineTest, singleSourceWithMultipleSuccessors)
     auto sink = builder.addSink({pipeline1, pipeline2, pipeline3});
 
     auto query = test.addNewQuery(std::move(builder));
-    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Stopped});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Stopped});
     test.expectSourceTermination(QueryId(1), source, QueryTerminationType::Graceful);
 
     test.start();
@@ -1100,7 +1102,7 @@ TEST_F(QueryEngineTest, singleSourceWithMultipleSuccessorsSourceFailure)
     auto sink = builder.addSink({pipeline1, pipeline2, pipeline3});
 
     auto query = test.addNewQuery(std::move(builder));
-    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Failed});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Failed});
     test.expectSourceTermination(QueryId(1), source, QueryTerminationType::Failure);
 
 
@@ -1167,7 +1169,7 @@ TEST_F(QueryEngineTest, SingleQueryWithRepeatingSink)
     auto sink = builder.addSink({source});
     auto query = test.addNewQuery(std::move(builder));
     test.sinkControls[sink]->repeatCount = 3;
-    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Stopped});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Stopped});
     test.expectSourceTermination(QueryId(1), source, QueryTerminationType::Graceful);
 
     test.stats.expect(
@@ -1199,7 +1201,7 @@ TEST_F(QueryEngineTest, SingleQueryWithRepeatingPipeline)
     builder.addSink({pipeline});
     auto query = test.addNewQuery(std::move(builder));
     test.pipelineControls[pipeline]->repeatCount = 3;
-    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Stopped});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Stopped});
     test.expectSourceTermination(QueryId(1), source, QueryTerminationType::Graceful);
 
     /// NOLINTBEGIN(readability-magic-numbers) These are the results I expect
@@ -1233,7 +1235,7 @@ TEST_F(QueryEngineTest, SingleQueryWithRepeatingSinkDuringQueryStop)
     auto query = test.addNewQuery(std::move(builder));
     test.sinkControls[sink]->repeatCountDuringStop = 3;
 
-    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Stopped});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Stopped});
     test.expectSourceTermination(QueryId(1), source, QueryTerminationType::Graceful);
     /// NOLINTBEGIN(readability-magic-numbers) These are the results I expect
     test.stats.expect(
@@ -1268,7 +1270,7 @@ TEST_F(QueryEngineTest, SingleQueryWithMultipleSinksDuringQueryStopOneIsRepeated
     auto query = test.addNewQuery(std::move(builder));
     test.sinkControls[sink1]->repeatCountDuringStop = 2;
 
-    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Stopped});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Stopped});
     test.expectSourceTermination(QueryId(1), source, QueryTerminationType::Graceful);
     /// NOLINTBEGIN(readability-magic-numbers) These are the results I expect
     test.stats.expect(
@@ -1329,7 +1331,7 @@ TEST_F(QueryEngineTest, ManyQueriesWithTwoSourcesAndPipelineFailures)
     sinkCtrls.push_back(test.sinkControls[sinks[0]]);
     test.expectSourceTermination(QueryId(1), sources[0], QueryTerminationType::Graceful);
     test.expectSourceTermination(QueryId(1), sources[1], QueryTerminationType::Graceful);
-    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Running, QueryState::Stopped});
+    test.expectQueryStatusEvents(QueryId(1), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Stopped});
 
     /// Rest of the queries are failing due to pipeline errors on pipeline 1
     for (size_t index = 1; const auto& query : queryPlans | std::ranges::views::drop(1))
@@ -1338,7 +1340,7 @@ TEST_F(QueryEngineTest, ManyQueriesWithTwoSourcesAndPipelineFailures)
         sourcesCtrls.push_back(test.sourceControls[sources[index * 2]]);
         sourcesCtrls.push_back(test.sourceControls[sources[(index * 2) + 1]]);
         sinkCtrls.push_back(test.sinkControls[sinks[index]]);
-        test.expectQueryStatusEvents(QueryId(1 + index), {QueryState::Started, QueryState::Running, QueryState::Failed});
+        test.expectQueryStatusEvents(QueryId(1 + index), {QueryState::Started, QueryState::Compiling, QueryState::Running, QueryState::Failed});
         index++;
     }
 

--- a/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.cpp
+++ b/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.cpp
@@ -305,6 +305,11 @@ void TestingHarness::expectQueryStatusEvents(QueryId id, std::initializer_list<Q
                     .Times(1)
                     .WillOnce(::testing::Invoke([](auto, auto, auto) { return true; }));
                 break;
+            case QueryState::Compiling:
+                EXPECT_CALL(*status, logQueryStatusChange(id, QueryState::Compiling, ::testing::_))
+                    .Times(1)
+                    .WillOnce(::testing::Invoke([](auto, auto, auto) { return true; }));
+                break;
             case QueryState::Running:
                 queryRunning.emplace(id, std::make_unique<std::promise<void>>());
                 EXPECT_CALL(*status, logQueryStatusChange(id, QueryState::Running, ::testing::_))

--- a/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.hpp
+++ b/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.hpp
@@ -100,7 +100,7 @@ struct ExpectStats
         Name(size_t lower, size_t upper) : lower(lower), upper(upper) \
         { \
         } \
-        Name(size_t exact) : lower(exact), upper(exact) \
+        explicit Name(size_t exact) : lower(exact), upper(exact) \
         { \
         } \
     }; \

--- a/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.hpp
+++ b/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.hpp
@@ -113,6 +113,7 @@ struct ExpectStats
     STAT_TYPE(QueryStop);
     STAT_TYPE(QueryStopRequest);
     STAT_TYPE(QueryFail);
+    STAT_TYPE(PipelineCompile);
     STAT_TYPE(PipelineStart);
     STAT_TYPE(PipelineStop);
     STAT_TYPE(TaskExecutionStart);
@@ -125,6 +126,8 @@ struct ExpectStats
         EXPECT_CALL(*this->listener, onEvent(::testing::VariantWith<NES::QueryStart>(::testing::_))) /// needed because not in ExpectStats
             .WillRepeatedly(::testing::Invoke([](auto) { }));
         EXPECT_CALL(*this->listener, onEvent(::testing::VariantWith<NES::QueryStop>(::testing::_)))
+            .WillRepeatedly(::testing::Invoke([](auto) { }));
+        EXPECT_CALL(*this->listener, onEvent(::testing::VariantWith<NES::PipelineCompile>(::testing::_)))
             .WillRepeatedly(::testing::Invoke([](auto) { }));
         EXPECT_CALL(*this->listener, onEvent(::testing::VariantWith<NES::PipelineStart>(::testing::_)))
             .WillRepeatedly(::testing::Invoke([](auto) { }));

--- a/nes-runtime/include/Listeners/QueryLog.hpp
+++ b/nes-runtime/include/Listeners/QueryLog.hpp
@@ -32,6 +32,7 @@ namespace NES
 struct QueryMetrics
 {
     std::optional<std::chrono::system_clock::time_point> start;
+    std::optional<std::chrono::system_clock::time_point> compiling;
     std::optional<std::chrono::system_clock::time_point> running;
     std::optional<std::chrono::system_clock::time_point> stop;
     std::optional<Exception> error;

--- a/nes-runtime/include/Runtime/Execution/QueryStatus.hpp
+++ b/nes-runtime/include/Runtime/Execution/QueryStatus.hpp
@@ -24,7 +24,8 @@ enum class QueryState : uint8_t
 {
     Registered,
     Started,
-    Running, /// Deployed->Running when calling start()
+    Compiling,
+    Running, /// Compiling->Running when pipeline compilation and startup completed
     Stopped, /// Running->Stopped when calling stop() and in Running state
     Failed,
 };

--- a/nes-runtime/src/Listeners/QueryLog.cpp
+++ b/nes-runtime/src/Listeners/QueryLog.cpp
@@ -98,7 +98,7 @@ std::optional<LocalQueryStatus> getQueryStatusImpl(const auto& log, QueryId quer
     {
         /// Unfortunately the multithreaded nature of the query engine cannot guarantee event ordering.
         /// We handle out-of-order events by keeping the most recent timestamp for each event type.
-        /// Final state is determined by priority: Failed > Stopped > Running > Started > Registered.
+        /// Final state is determined by priority: Failed > Stopped > Running > Compiling > Started > Registered.
         LocalQueryStatus status;
         status.queryId = queryId;
 
@@ -115,6 +115,9 @@ std::optional<LocalQueryStatus> getQueryStatusImpl(const auto& log, QueryId quer
                     break;
                 case QueryState::Started:
                     status.metrics.start = statusChange.timestamp;
+                    break;
+                case QueryState::Compiling:
+                    status.metrics.compiling = statusChange.timestamp;
                     break;
                 case QueryState::Running:
                     status.metrics.running = statusChange.timestamp;
@@ -137,6 +140,10 @@ std::optional<LocalQueryStatus> getQueryStatusImpl(const auto& log, QueryId quer
         else if (status.metrics.running.has_value())
         {
             state = QueryState::Running;
+        }
+        else if (status.metrics.compiling.has_value())
+        {
+            state = QueryState::Compiling;
         }
         else if (status.metrics.start.has_value())
         {

--- a/nes-runtime/tests/UnitTests/Runtime/QueryLogTest.cpp
+++ b/nes-runtime/tests/UnitTests/Runtime/QueryLogTest.cpp
@@ -92,6 +92,31 @@ TEST_F(QueryLogTest, GetQuerySummarySuccessfulExecution)
     EXPECT_EQ(*status->metrics.stop, testTime + 200ms);
 }
 
+TEST_F(QueryLogTest, GetQuerySummaryWithCompilationPhase)
+{
+    queryLog->logQueryStatusChange(testQueryId, QueryState::Started, testTime);
+    queryLog->logQueryStatusChange(testQueryId, QueryState::Compiling, testTime + 25ms);
+    queryLog->logQueryStatusChange(testQueryId, QueryState::Running, testTime + 100ms);
+    queryLog->logQueryStatusChange(testQueryId, QueryState::Stopped, testTime + 200ms);
+
+    const auto status = queryLog->getQueryStatus(testQueryId);
+    ASSERT_TRUE(status.has_value());
+
+    EXPECT_EQ(status->queryId, testQueryId);
+    EXPECT_EQ(status->state, QueryState::Stopped);
+
+    EXPECT_TRUE(status->metrics.start.has_value());
+    EXPECT_TRUE(status->metrics.compiling.has_value());
+    EXPECT_TRUE(status->metrics.running.has_value());
+    EXPECT_TRUE(status->metrics.stop.has_value());
+    EXPECT_FALSE(status->metrics.error.has_value());
+
+    EXPECT_EQ(*status->metrics.start, testTime);
+    EXPECT_EQ(*status->metrics.compiling, testTime + 25ms);
+    EXPECT_EQ(*status->metrics.running, testTime + 100ms);
+    EXPECT_EQ(*status->metrics.stop, testTime + 200ms);
+}
+
 TEST_F(QueryLogTest, GetQuerySummaryWithFailure)
 {
     const Exception testError{"Test error", 500};

--- a/nes-single-node-worker/src/GoogleEventTracePrinter.cpp
+++ b/nes-single-node-worker/src/GoogleEventTracePrinter.cpp
@@ -214,6 +214,19 @@ void GoogleEventTracePrinter::threadRoutine(const std::stop_token& token)
                     /// Remove from active queries
                     activeQueries.erase(queryStop.queryId);
                 },
+                [&](const PipelineCompile& pipelineCompile)
+                {
+                    printComma();
+                    fmt::print(
+                        file,
+                        R"x(    {{"args":{{"pipeline_id":{}}},"cat":"pipeline","name":"Pipeline Compile {} (Query {})","ph":"i","pid":{},"tid":{},"ts":{}}})x",
+                        pipelineCompile.pipelineId.getRawValue(),
+                        pipelineCompile.pipelineId,
+                        pipelineCompile.queryId,
+                        pid,
+                        pipelineCompile.threadId.getRawValue(),
+                        timestampToMicroseconds(pipelineCompile.timestamp));
+                },
                 [&](const PipelineStart& pipelineStart)
                 {
                     printComma();

--- a/nes-single-node-worker/src/GrpcService.cpp
+++ b/nes-single-node-worker/src/GrpcService.cpp
@@ -132,13 +132,19 @@ grpc::Status GRPCServer::RequestQueryStatus(grpc::ServerContext* context, const 
         reply->set_queryid(queryId.getRawValue());
         if (const auto queryStatus = delegate.getQueryStatus(queryId); queryStatus.has_value())
         {
-            const auto& [start, running, stop, error] = queryStatus->metrics;
+            const auto& [start, compiling, running, stop, error] = queryStatus->metrics;
             reply->set_state(static_cast<::QueryState>(queryStatus->state));
 
             if (start.has_value())
             {
                 reply->mutable_metrics()->set_startunixtimeinms(
                     std::chrono::duration_cast<std::chrono::milliseconds>(start->time_since_epoch()).count());
+            }
+
+            if (compiling.has_value())
+            {
+                reply->mutable_metrics()->set_compilingunixtimeinms(
+                    std::chrono::duration_cast<std::chrono::milliseconds>(compiling->time_since_epoch()).count());
             }
 
             if (running.has_value())

--- a/nes-single-node-worker/src/SingleNodeWorker.cpp
+++ b/nes-single-node-worker/src/SingleNodeWorker.cpp
@@ -178,6 +178,13 @@ WorkerStatus SingleNodeWorker::getWorkerStatus(std::chrono::system_clock::time_p
                     status.activeQueries.emplace_back(queryId, std::nullopt);
                 }
                 break;
+            case QueryState::Compiling:
+                INVARIANT(metrics.compiling.has_value(), "If query is compiling, it should have a compile timestamp");
+                if (metrics.compiling.value() >= after)
+                {
+                    status.activeQueries.emplace_back(queryId, std::nullopt);
+                }
+                break;
             case QueryState::Running: {
                 INVARIANT(metrics.running.has_value(), "If query is running, it should have a running timestamp");
                 if (metrics.running.value() >= after)
@@ -187,7 +194,6 @@ WorkerStatus SingleNodeWorker::getWorkerStatus(std::chrono::system_clock::time_p
                 break;
             }
             case QueryState::Stopped: {
-                INVARIANT(metrics.running.has_value(), "If query is stopped, it should have a running timestamp");
                 INVARIANT(metrics.stop.has_value(), "If query is stopped, it should have a stopped timestamp");
                 if (metrics.stop.value() >= after)
                 {

--- a/nes-systests/systest/include/SystestRunner.hpp
+++ b/nes-systests/systest/include/SystestRunner.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <expected>
@@ -100,5 +101,11 @@ void printQueryResultToStdOut(
     const std::string& errorMessage,
     SystestProgressTracker& progressTracker,
     std::string_view queryPerformanceMessage);
+
+void resetQueryCompilationMetrics();
+[[nodiscard]] std::chrono::nanoseconds getQueryCompilationSum();
+
+void resetQueryRuntimeMetrics();
+[[nodiscard]] std::chrono::nanoseconds getQueryRuntimeSum();
 
 }

--- a/nes-systests/systest/include/SystestState.hpp
+++ b/nes-systests/systest/include/SystestState.hpp
@@ -219,6 +219,7 @@ struct RunningQuery
     std::optional<Exception> exception;
 
     std::chrono::duration<double> getElapsedTime() const;
+    std::chrono::duration<double> getCompilationTime() const;
     [[nodiscard]] std::string getThroughput() const;
 };
 

--- a/nes-systests/systest/src/SystestExecutor.cpp
+++ b/nes-systests/systest/src/SystestExecutor.cpp
@@ -90,7 +90,7 @@ SingleNodeWorkerConfiguration resolveSingleNodeWorkerConfiguration(const Systest
     auto singleNodeWorkerConfiguration = config.singleNodeWorkerConfig.value_or(SingleNodeWorkerConfiguration{});
     if (not config.workerConfig.getValue().empty())
     {
-        singleNodeWorkerConfiguration.workerConfiguration.overwriteConfigWithYAMLFileInput(config.workerConfig);
+        singleNodeWorkerConfiguration.workerConfiguration.overwriteConfigWithYAMLFileInput(config.workerConfig.getValue());
     }
     else if (config.singleNodeWorkerConfig.has_value())
     {
@@ -99,8 +99,8 @@ SingleNodeWorkerConfiguration resolveSingleNodeWorkerConfiguration(const Systest
     return singleNodeWorkerConfiguration;
 }
 
-SingleNodeWorkerConfiguration applyConfigurationOverride(
-    const SingleNodeWorkerConfiguration& baseConfiguration, const Systest::ConfigurationOverride& overrideConfig)
+SingleNodeWorkerConfiguration
+applyConfigurationOverride(const SingleNodeWorkerConfiguration& baseConfiguration, const Systest::ConfigurationOverride& overrideConfig)
 {
     auto configCopy = baseConfiguration;
     for (const auto& [key, value] : overrideConfig.overrideParameters)
@@ -294,6 +294,8 @@ void setupLogging(const SystestConfiguration& config)
 SystestExecutorResult SystestExecutor::executeSystests()
 {
     setupLogging(config);
+    Systest::resetQueryCompilationMetrics();
+    Systest::resetQueryRuntimeMetrics();
 
     CPPTRACE_TRY
     {

--- a/nes-systests/systest/src/SystestExecutor.cpp
+++ b/nes-systests/systest/src/SystestExecutor.cpp
@@ -38,6 +38,7 @@
 #include <QueryManager/EmbeddedWorkerQuerySubmissionBackend.hpp>
 #include <QueryManager/GRPCQuerySubmissionBackend.hpp>
 #include <QueryManager/QueryManager.hpp>
+#include <Util/ExecutionMode.hpp>
 #include <Util/Logger/LogLevel.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <Util/Logger/impl/NesLogger.hpp>
@@ -82,6 +83,48 @@ void exitOnFailureIfNeeded(const std::vector<Systest::RunningQuery>& failedQueri
     NES_ERROR("{}", outputMessage.str());
     std::cout << '\n' << outputMessage.str() << '\n';
     std::exit(1); ///NOLINT(concurrency-mt-unsafe)
+}
+
+SingleNodeWorkerConfiguration resolveSingleNodeWorkerConfiguration(const SystestConfiguration& config)
+{
+    auto singleNodeWorkerConfiguration = config.singleNodeWorkerConfig.value_or(SingleNodeWorkerConfiguration{});
+    if (not config.workerConfig.getValue().empty())
+    {
+        singleNodeWorkerConfiguration.workerConfiguration.overwriteConfigWithYAMLFileInput(config.workerConfig);
+    }
+    else if (config.singleNodeWorkerConfig.has_value())
+    {
+        singleNodeWorkerConfiguration = config.singleNodeWorkerConfig.value();
+    }
+    return singleNodeWorkerConfiguration;
+}
+
+SingleNodeWorkerConfiguration applyConfigurationOverride(
+    const SingleNodeWorkerConfiguration& baseConfiguration, const Systest::ConfigurationOverride& overrideConfig)
+{
+    auto configCopy = baseConfiguration;
+    for (const auto& [key, value] : overrideConfig.overrideParameters)
+    {
+        configCopy.overwriteConfigWithCommandLineInput({{key, value}});
+    }
+    return configCopy;
+}
+
+Systest::QueryPerformanceMessageBuilder createPerformanceMessageBuilder(const bool showPerformance, const ExecutionMode executionMode)
+{
+    if (!showPerformance)
+    {
+        return Systest::QueryPerformanceMessageBuilder{Systest::discardPerformanceMessage};
+    }
+
+    if (executionMode == ExecutionMode::COMPILER)
+    {
+        return Systest::QueryPerformanceMessageBuilder{[](Systest::RunningQuery& runningQuery)
+                                                       { return fmt::format(" compiled in {}", runningQuery.getCompilationTime()); }};
+    }
+
+    return Systest::QueryPerformanceMessageBuilder{[](Systest::RunningQuery& runningQuery)
+                                                   { return fmt::format(" in {}", runningQuery.getElapsedTime()); }};
 }
 
 [[noreturn]] void runEndlessRemote(
@@ -132,11 +175,7 @@ void exitOnFailureIfNeeded(const std::vector<Systest::RunningQuery>& failedQueri
         progressTracker.setTotalQueries(totalLocal);
         for (const auto& [overrideConfig, queriesForConfig] : queriesByOverride)
         {
-            auto configCopy = baseConfiguration;
-            for (const auto& [key, value] : overrideConfig.overrideParameters)
-            {
-                configCopy.overwriteConfigWithCommandLineInput({{key, value}});
-            }
+            auto configCopy = applyConfigurationOverride(baseConfiguration, overrideConfig);
 
             auto queryManager = std::make_unique<QueryManager>(std::make_unique<EmbeddedWorkerQuerySubmissionBackend>(
                 WorkerConfig{.grpc = GrpcAddr("localhost:8080"), .config = {}}, configCopy));
@@ -162,15 +201,7 @@ void SystestExecutor::runEndlessMode(const std::vector<Systest::SystestQuery>& q
     std::cout << std::format("Running endlessly over a total of {} queries (across all configuration overrides).", queries.size()) << '\n';
 
     const auto numberConcurrentQueries = config.numberConcurrentQueries.getValue();
-    auto singleNodeWorkerConfiguration = config.singleNodeWorkerConfig.value_or(SingleNodeWorkerConfiguration{});
-    if (not config.workerConfig.getValue().empty())
-    {
-        singleNodeWorkerConfiguration.workerConfiguration.overwriteConfigWithYAMLFileInput(config.workerConfig);
-    }
-    else if (config.singleNodeWorkerConfig.has_value())
-    {
-        singleNodeWorkerConfiguration = config.singleNodeWorkerConfig.value();
-    }
+    auto singleNodeWorkerConfiguration = resolveSingleNodeWorkerConfiguration(config);
 
     OverrideQueriesMap queriesByOverride;
     for (const auto& query : queries)
@@ -310,29 +341,20 @@ SystestExecutorResult SystestExecutor::executeSystests()
             std::ranges::shuffle(queries, rng);
         }
         const auto numberConcurrentQueries = config.numberConcurrentQueries.getValue();
+        auto singleNodeWorkerConfiguration = resolveSingleNodeWorkerConfiguration(config);
         std::vector<Systest::RunningQuery> failedQueries;
         if (const auto grpcURI = config.grpcAddressUri.getValue(); config.remoteTestExecution.getValue())
         {
             progressTracker.reset();
             progressTracker.setTotalQueries(queries.size());
-            const Systest::QueryPerformanceMessageBuilder performanceMessage = config.showQueryPerformance.getValue()
-                ? Systest::QueryPerformanceMessageBuilder{[](Systest::RunningQuery& runningQuery)
-                                                          { return fmt::format(" in {}", runningQuery.getElapsedTime()); }}
-                : Systest::QueryPerformanceMessageBuilder{Systest::discardPerformanceMessage};
+            const auto performanceMessage = createPerformanceMessageBuilder(
+                config.showQueryPerformance.getValue(),
+                singleNodeWorkerConfiguration.workerConfiguration.defaultQueryExecution.executionMode.getValue());
             auto failed = runQueriesAtRemoteWorker(queries, numberConcurrentQueries, grpcURI, progressTracker, performanceMessage);
             failedQueries.insert(failedQueries.end(), failed.begin(), failed.end());
         }
         else
         {
-            auto singleNodeWorkerConfiguration = config.singleNodeWorkerConfig.value_or(SingleNodeWorkerConfiguration{});
-            if (not config.workerConfig.getValue().empty())
-            {
-                singleNodeWorkerConfiguration.workerConfiguration.overwriteConfigWithYAMLFileInput(config.workerConfig);
-            }
-            else if (config.singleNodeWorkerConfig.has_value())
-            {
-                singleNodeWorkerConfiguration = config.singleNodeWorkerConfig.value();
-            }
             if (config.benchmark)
             {
                 nlohmann::json benchmarkResults;
@@ -381,15 +403,10 @@ SystestExecutorResult SystestExecutor::executeSystests()
                 progressTracker.setTotalQueries(queries.size());
                 for (const auto& [overrideConfig, queriesForConfig] : queriesByOverride)
                 {
-                    auto configCopy = singleNodeWorkerConfiguration;
-                    for (const auto& [key, value] : overrideConfig.overrideParameters)
-                    {
-                        configCopy.overwriteConfigWithCommandLineInput({{key, value}});
-                    }
-                    const Systest::QueryPerformanceMessageBuilder performanceMessage = config.showQueryPerformance.getValue()
-                        ? Systest::QueryPerformanceMessageBuilder{[](Systest::RunningQuery& runningQuery)
-                                                                  { return fmt::format(" in {}", runningQuery.getElapsedTime()); }}
-                        : Systest::QueryPerformanceMessageBuilder{Systest::discardPerformanceMessage};
+                    auto configCopy = applyConfigurationOverride(singleNodeWorkerConfiguration, overrideConfig);
+                    const auto performanceMessage = createPerformanceMessageBuilder(
+                        config.showQueryPerformance.getValue(),
+                        configCopy.workerConfiguration.defaultQueryExecution.executionMode.getValue());
                     auto failed = runQueriesAtLocalWorker(
                         queriesForConfig, numberConcurrentQueries, configCopy, progressTracker, performanceMessage);
                     failedQueries.insert(failedQueries.end(), failed.begin(), failed.end());

--- a/nes-systests/systest/src/SystestRunner.cpp
+++ b/nes-systests/systest/src/SystestRunner.cpp
@@ -40,6 +40,7 @@
 #include <vector>
 #include <Identifiers/Identifiers.hpp>
 #include <Identifiers/NESStrongType.hpp>
+#include <Listeners/QueryLog.hpp>
 #include <QueryManager/EmbeddedWorkerQuerySubmissionBackend.hpp>
 #include <QueryManager/GRPCQuerySubmissionBackend.hpp>
 #include <QueryManager/QueryManager.hpp>
@@ -59,6 +60,36 @@ namespace NES::Systest
 {
 namespace
 {
+std::atomic<int64_t> queryCompilationSumNanoseconds{0};
+std::atomic<int64_t> queryRuntimeSumNanoseconds{0};
+
+void recordDuration(
+    std::atomic<int64_t>& totalNanoseconds,
+    const std::optional<std::chrono::system_clock::time_point>& start,
+    const std::optional<std::chrono::system_clock::time_point>& end)
+{
+    if (not start.has_value() || not end.has_value() || end.value() < start.value())
+    {
+        return;
+    }
+
+    const auto elapsedTime = std::chrono::duration_cast<std::chrono::nanoseconds>(end.value() - start.value());
+    totalNanoseconds.fetch_add(elapsedTime.count());
+}
+
+void recordQueryCompilation(const LocalQueryStatus& queryStatus)
+{
+    recordDuration(
+        queryCompilationSumNanoseconds,
+        queryStatus.metrics.compiling,
+        queryStatus.metrics.running.has_value() ? queryStatus.metrics.running : queryStatus.metrics.stop);
+}
+
+void recordQueryRuntime(const LocalQueryStatus& queryStatus)
+{
+    recordDuration(queryRuntimeSumNanoseconds, queryStatus.metrics.running, queryStatus.metrics.stop);
+}
+
 template <typename ErrorCallable>
 void reportResult(
     std::shared_ptr<RunningQuery>& runningQuery,
@@ -115,6 +146,26 @@ void processQueryWithError(
         performanceMessageBuilder);
 }
 
+}
+
+void resetQueryCompilationMetrics()
+{
+    queryCompilationSumNanoseconds.store(0);
+}
+
+std::chrono::nanoseconds getQueryCompilationSum()
+{
+    return std::chrono::nanoseconds(queryCompilationSumNanoseconds.load());
+}
+
+void resetQueryRuntimeMetrics()
+{
+    queryRuntimeSumNanoseconds.store(0);
+}
+
+std::chrono::nanoseconds getQueryRuntimeSum()
+{
+    return std::chrono::nanoseconds(queryRuntimeSumNanoseconds.load());
 }
 
 /// NOLINTBEGIN(readability-function-cognitive-complexity)
@@ -274,6 +325,8 @@ std::vector<RunningQuery> runQueries(
             }
 
             auto& runningQuery = it->second;
+            recordQueryCompilation(queryStatus);
+            recordQueryRuntime(queryStatus);
 
             if (queryStatus.state == QueryState::Failed)
             {
@@ -426,6 +479,8 @@ std::vector<RunningQuery> runQueriesAndBenchmark(
         ranQueries.emplace_back(runningQueryPtr);
         submitter.startQuery(queryId);
         const auto summary = submitter.finishedQueries().at(0);
+        recordQueryCompilation(summary);
+        recordQueryRuntime(summary);
 
         if (summary.state == QueryState::Failed)
         {

--- a/nes-systests/systest/src/SystestStarter.cpp
+++ b/nes-systests/systest/src/SystestStarter.cpp
@@ -30,6 +30,7 @@
 #include <Util/Logger/Logger.hpp>
 #include <Util/Signal.hpp>
 #include <argparse/argparse.hpp>
+#include <fmt/base.h>
 #include <fmt/format.h>
 #include <yaml-cpp/node/node.h>
 #include <yaml-cpp/node/parse.h>
@@ -38,6 +39,7 @@
 #include <SingleNodeWorkerConfiguration.hpp>
 #include <SystestConfiguration.hpp>
 #include <SystestExecutor.hpp>
+#include <SystestRunner.hpp>
 #include <SystestState.hpp>
 #include <Thread.hpp>
 
@@ -469,27 +471,31 @@ int main(int argc, const char** argv)
     NES::SystestExecutor executor(std::move(config));
     const auto result = executor.executeSystests();
 
+    const auto endTime = std::chrono::high_resolution_clock::now();
+    const auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime);
+    const auto compilationSumTime = NES::Systest::getQueryCompilationSum();
+    const auto runtimeSumTime = NES::Systest::getQueryRuntimeSum();
+    const auto totalWorkNanoseconds = compilationSumTime.count() + runtimeSumTime.count();
+    const auto compilationShare = totalWorkNanoseconds > 0
+        ? (100.0 * static_cast<double>(compilationSumTime.count()) / static_cast<double>(totalWorkNanoseconds))
+        : 0.0;
+    const auto totalExecutionTimeMessage = fmt::format(
+        "Total execution time: {} ms ({:.3f} seconds) [Compilation(sum): {} ms ({:.1f}%), Runtime(sum): {} ms]",
+        duration.count(),
+        std::chrono::duration_cast<std::chrono::duration<double>>(duration).count(),
+        std::chrono::duration_cast<std::chrono::milliseconds>(compilationSumTime).count(),
+        compilationShare,
+        std::chrono::duration_cast<std::chrono::milliseconds>(runtimeSumTime).count());
+
     switch (result.returnType)
     {
-        case SystestExecutorResult::ReturnType::SUCCESS: {
-            const auto endTime = std::chrono::high_resolution_clock::now();
-            const auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime);
-            fmt::print(
-                "{}\nTotal execution time: {} ms ({:.3f} seconds)\n",
-                result.outputMessage,
-                duration.count(),
-                std::chrono::duration_cast<std::chrono::duration<double>>(duration).count());
+        case SystestExecutorResult::ReturnType::SUCCESS:
+            fmt::print("{}\n{}\n", result.outputMessage, totalExecutionTimeMessage);
             return 0;
-        }
-        case SystestExecutorResult::ReturnType::FAILED: {
-            auto endTime = std::chrono::high_resolution_clock::now();
-            auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime);
+        case SystestExecutorResult::ReturnType::FAILED:
             PRECONDITION(result.errorCode, "Returning with as 'FAILED_WITH_EXCEPTION_CODE', but did not provide error code");
             NES_ERROR("{}", result.outputMessage);
-            std::cout << result.outputMessage << '\n';
-            std::cout << "Total execution time: " << duration.count() << " ms ("
-                      << std::chrono::duration_cast<std::chrono::duration<double>>(duration).count() << " seconds)" << '\n';
+            std::cout << result.outputMessage << '\n' << totalExecutionTimeMessage << '\n';
             return result.errorCode.value();
-        }
     }
 }

--- a/nes-systests/systest/src/SystestState.cpp
+++ b/nes-systests/systest/src/SystestState.cpp
@@ -390,6 +390,16 @@ std::chrono::duration<double> RunningQuery::getElapsedTime() const
     return std::chrono::duration_cast<std::chrono::duration<double>>(stop.value() - running.value());
 }
 
+std::chrono::duration<double> RunningQuery::getCompilationTime() const
+{
+    INVARIANT(queryId != INVALID_QUERY_ID, "QueryId should not be invalid");
+
+    const auto compiling = queryStatus.metrics.compiling;
+    const auto running = queryStatus.metrics.running;
+    INVARIANT(compiling.has_value() && running.has_value(), "Query {} has no compilation timestamps attached", queryId);
+    return std::chrono::duration_cast<std::chrono::duration<double>>(running.value() - compiling.value());
+}
+
 std::string RunningQuery::getThroughput() const
 {
     INVARIANT(queryId != INVALID_QUERY_ID, "QueryId should not be invalid");


### PR DESCRIPTION
Systest now reports after a run:
`Total execution time: 2355 ms (2 seconds) [Compilation(sum): 3079 ms (30.1%), Runtime(sum): 7161 ms]`

Compilation(sum) and Runtime(sum) are normalized runtimes as single-threaded execution

