### PR TITLE
Time stamp convert function

### DIFF
--- a/docs/guide/query_api.md
+++ b/docs/guide/query_api.md
@@ -522,12 +522,14 @@ Functions are either unary (one input) or binary (two inputs).
 
 #### **Base**
 
-| Function                 | Example                             |
-|--------------------------|-------------------------------------|
-| Access a field           | `SELECT x FROM s INTO sink`         |
-| Define a constant        | `SELECT INT32(42) FROM s INTO sink` |
-| Rename an input function | `SELECT x AS x1 FROM s INTO sink`   |
-| Cast an input function   | `SELECT x FROM s INTO sink`         |
+| Function                      | Example                                      |
+|-------------------------------|----------------------------------------------|
+| Access a field                | `SELECT x FROM s INTO sink`                  |
+| Define a constant             | `SELECT INT32(42) FROM s INTO sink`          |
+| Rename an input function      | `SELECT x AS x1 FROM s INTO sink`            |
+| Cast an input function        | `SELECT x FROM s INTO sink`                  |
+| Cast string to unix timestamp | `SELECT CASTTOUNIXTS(ts) FROM s INTO sink`   |
+| Cast unix timestamp to string | `SELECT CASTFROMUNIXTS(ts) FROM s INTO sink` |
 
 #### **Arithmetical**
 

--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,7 @@
           tbb
           python3
           openjdk21
+          howard-hinnant-date
           reflect_cppPkg
         ]);
 

--- a/nes-logical-operators/include/Functions/CastFromUnixTimestampLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/CastFromUnixTimestampLogicalFunction.hpp
@@ -1,0 +1,85 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/Schema.hpp>
+#include <Functions/LogicalFunction.hpp>
+#include <Util/Logger/Formatter.hpp>
+#include <Util/PlanRenderer.hpp>
+#include <Util/Reflection.hpp>
+
+namespace NES
+{
+
+/// Converts a unix timestamp in milliseconds (UINT64) to an ISO-8601 UTC timestamp string (VARSIZED).
+class CastFromUnixTimestampLogicalFunction final
+{
+public:
+    static constexpr std::string_view NAME = "CastFromUnixTs";
+
+    explicit CastFromUnixTimestampLogicalFunction(LogicalFunction child);
+
+    [[nodiscard]] bool operator==(const CastFromUnixTimestampLogicalFunction& rhs) const;
+
+    [[nodiscard]] DataType getDataType() const;
+    [[nodiscard]] CastFromUnixTimestampLogicalFunction withDataType(const DataType& dataType) const;
+
+    [[nodiscard]] LogicalFunction withInferredDataType(const Schema& schema) const;
+
+    [[nodiscard]] std::vector<LogicalFunction> getChildren() const;
+    [[nodiscard]] CastFromUnixTimestampLogicalFunction withChildren(const std::vector<LogicalFunction>& children) const;
+
+    [[nodiscard]] static std::string_view getType();
+    [[nodiscard]] std::string explain(ExplainVerbosity verbosity) const;
+
+private:
+    DataType outputType;
+    LogicalFunction child;
+
+    friend Reflector<CastFromUnixTimestampLogicalFunction>;
+};
+
+template <>
+struct Reflector<CastFromUnixTimestampLogicalFunction>
+{
+    Reflected operator()(const CastFromUnixTimestampLogicalFunction& function) const;
+};
+
+template <>
+struct Unreflector<CastFromUnixTimestampLogicalFunction>
+{
+    CastFromUnixTimestampLogicalFunction operator()(const Reflected& reflected) const;
+};
+
+static_assert(LogicalFunctionConcept<CastFromUnixTimestampLogicalFunction>);
+
+}
+
+namespace NES::detail
+{
+struct ReflectedCastFromUnixTimestampLogicalFunction
+{
+    std::optional<LogicalFunction> child;
+    /// NOTE: intentionally NO outputType here (we infer it)
+};
+}
+
+FMT_OSTREAM(NES::CastFromUnixTimestampLogicalFunction);

--- a/nes-logical-operators/include/Functions/CastToUnixTimestampLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/CastToUnixTimestampLogicalFunction.hpp
@@ -1,0 +1,82 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/Schema.hpp>
+#include <Functions/LogicalFunction.hpp>
+#include <Util/Logger/Formatter.hpp>
+#include <Util/PlanRenderer.hpp>
+#include <Util/Reflection.hpp>
+
+namespace NES
+{
+
+/// Casts the input to a unix timestamp in milliseconds.
+class CastToUnixTimestampLogicalFunction final
+{
+public:
+    static constexpr std::string_view NAME = "CastToUnixTs";
+
+    explicit CastToUnixTimestampLogicalFunction(LogicalFunction child);
+
+    [[nodiscard]] bool operator==(const CastToUnixTimestampLogicalFunction& rhs) const;
+
+    [[nodiscard]] DataType getDataType() const;
+    [[nodiscard]] CastToUnixTimestampLogicalFunction withDataType(const DataType& dataType) const;
+
+    [[nodiscard]] LogicalFunction withInferredDataType(const Schema& schema) const;
+
+    [[nodiscard]] std::vector<LogicalFunction> getChildren() const;
+    [[nodiscard]] CastToUnixTimestampLogicalFunction withChildren(const std::vector<LogicalFunction>& children) const;
+    [[nodiscard]] static std::string_view getType();
+    [[nodiscard]] std::string explain(ExplainVerbosity verbosity) const;
+
+private:
+    DataType outputType;
+    LogicalFunction child;
+
+    friend Reflector<CastToUnixTimestampLogicalFunction>;
+};
+
+static_assert(LogicalFunctionConcept<CastToUnixTimestampLogicalFunction>);
+
+template <>
+struct Reflector<CastToUnixTimestampLogicalFunction>
+{
+    Reflected operator()(const CastToUnixTimestampLogicalFunction& function) const;
+};
+
+template <>
+struct Unreflector<CastToUnixTimestampLogicalFunction>
+{
+    CastToUnixTimestampLogicalFunction operator()(const Reflected& reflected) const;
+};
+
+}
+
+namespace NES::detail
+{
+struct ReflectedCastToUnixTimestampLogicalFunction
+{
+    std::optional<LogicalFunction> child;
+};
+}
+
+FMT_OSTREAM(NES::CastToUnixTimestampLogicalFunction);

--- a/nes-logical-operators/src/Functions/CMakeLists.txt
+++ b/nes-logical-operators/src/Functions/CMakeLists.txt
@@ -22,3 +22,5 @@ add_plugin(ConstantValue LogicalFunction nes-logical-operators ConstantValueLogi
 add_plugin(FieldAccess LogicalFunction nes-logical-operators FieldAccessLogicalFunction.cpp)
 add_plugin(Concat LogicalFunction nes-logical-operators ConcatLogicalFunction.cpp)
 add_plugin(CastToType LogicalFunction nes-logical-operators CastToTypeLogicalFunction.cpp)
+add_plugin(CastToUnixTs LogicalFunction nes-logical-operators CastToUnixTimestampLogicalFunction.cpp)
+add_plugin(CastFromUnixTs LogicalFunction nes-logical-operators CastFromUnixTimestampLogicalFunction.cpp)

--- a/nes-logical-operators/src/Functions/CastFromUnixTimestampLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/CastFromUnixTimestampLogicalFunction.cpp
@@ -1,0 +1,130 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Functions/CastFromUnixTimestampLogicalFunction.hpp>
+
+#include <algorithm>
+#include <ranges>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/DataTypeProvider.hpp>
+#include <DataTypes/Schema.hpp>
+#include <Functions/LogicalFunction.hpp>
+#include <Serialization/LogicalFunctionReflection.hpp>
+#include <Util/PlanRenderer.hpp>
+#include <Util/Reflection.hpp>
+#include <fmt/format.h>
+#include <ErrorHandling.hpp>
+#include <LogicalFunctionRegistry.hpp>
+
+namespace NES
+{
+
+CastFromUnixTimestampLogicalFunction::CastFromUnixTimestampLogicalFunction(LogicalFunction child)
+    : outputType(DataTypeProvider::provideDataType(DataType::Type::UNDEFINED)), child(std::move(child))
+{
+}
+
+bool CastFromUnixTimestampLogicalFunction::operator==(const CastFromUnixTimestampLogicalFunction& rhs) const
+{
+    return this->outputType == rhs.outputType && this->child == rhs.child;
+}
+
+DataType CastFromUnixTimestampLogicalFunction::getDataType() const
+{
+    return outputType;
+}
+
+CastFromUnixTimestampLogicalFunction CastFromUnixTimestampLogicalFunction::withDataType(const DataType& dataType) const
+{
+    auto copy = *this;
+    copy.outputType = dataType;
+    return copy;
+}
+
+LogicalFunction CastFromUnixTimestampLogicalFunction::withInferredDataType(const Schema& schema) const
+{
+    const auto newChildren = getChildren() | std::views::transform([&schema](auto& child) { return child.withInferredDataType(schema); })
+        | std::ranges::to<std::vector>();
+    INVARIANT(newChildren.size() == 1, "CeilLogicalFunction expects exactly one child function but has {}", newChildren.size());
+    auto newDataType = newChildren[0].getDataType();
+    if (newDataType.type != DataType::Type::UNDEFINED && newDataType.type != DataType::Type::UINT64)
+    {
+        throw DifferentFieldTypeExpected("CASTFROMUNIXTS expects a UINT64 input, but got {}", newDataType);
+    }
+
+    /// Output is ISO-8601 UTC string => VARSIZED
+    newDataType.type = DataType::Type::VARSIZED;
+    newDataType.nullable = std::ranges::any_of(newChildren, [](const auto& child) { return child.getDataType().nullable; });
+    return withDataType(newDataType).withChildren(newChildren);
+}
+
+std::vector<LogicalFunction> CastFromUnixTimestampLogicalFunction::getChildren() const
+{
+    return {child};
+}
+
+CastFromUnixTimestampLogicalFunction CastFromUnixTimestampLogicalFunction::withChildren(const std::vector<LogicalFunction>& children) const
+{
+    PRECONDITION(children.size() == 1, "CastFromUnixTimestampLogicalFunction requires exactly one child, but got {}", children.size());
+    auto copy = *this;
+    copy.child = children[0];
+    return copy;
+}
+
+std::string_view CastFromUnixTimestampLogicalFunction::getType()
+{
+    return NAME;
+}
+
+std::string CastFromUnixTimestampLogicalFunction::explain(ExplainVerbosity) const
+{
+    return fmt::format("Cast from unix timestamp (ms) to ISO-8601 UTC, outputType={}", outputType);
+}
+
+Reflected Reflector<CastFromUnixTimestampLogicalFunction>::operator()(const CastFromUnixTimestampLogicalFunction& function) const
+{
+    return reflect(detail::ReflectedCastFromUnixTimestampLogicalFunction{.child = function.child});
+}
+
+CastFromUnixTimestampLogicalFunction Unreflector<CastFromUnixTimestampLogicalFunction>::operator()(const Reflected& reflected) const
+{
+    auto [function] = unreflect<detail::ReflectedCastFromUnixTimestampLogicalFunction>(reflected);
+
+    if (!function.has_value())
+    {
+        throw CannotDeserialize("Failed to deserialize child of CastFromUnixTimestampLogicalFunction");
+    }
+    return CastFromUnixTimestampLogicalFunction(std::move(function.value()));
+}
+
+LogicalFunctionRegistryReturnType
+LogicalFunctionGeneratedRegistrar::RegisterCastFromUnixTsLogicalFunction(LogicalFunctionRegistryArguments arguments)
+{
+    if (!arguments.reflected.isEmpty())
+    {
+        return unreflect<CastFromUnixTimestampLogicalFunction>(arguments.reflected);
+    }
+    if (arguments.children.size() != 1)
+    {
+        throw CannotDeserialize("CastFromUnixTimestampLogicalFunction requires exactly one child, but got {}", arguments.children.size());
+    }
+    return CastFromUnixTimestampLogicalFunction(arguments.children[0]);
+}
+
+}

--- a/nes-logical-operators/src/Functions/CastToUnixTimestampLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/CastToUnixTimestampLogicalFunction.cpp
@@ -1,0 +1,131 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Functions/CastToUnixTimestampLogicalFunction.hpp>
+
+#include <algorithm>
+#include <ranges>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/DataTypeProvider.hpp>
+#include <DataTypes/Schema.hpp>
+#include <Functions/LogicalFunction.hpp>
+#include <Serialization/LogicalFunctionReflection.hpp>
+#include <Util/PlanRenderer.hpp>
+#include <Util/Reflection.hpp>
+#include <fmt/format.h>
+#include <ErrorHandling.hpp>
+#include <LogicalFunctionRegistry.hpp>
+
+namespace NES
+{
+
+CastToUnixTimestampLogicalFunction::CastToUnixTimestampLogicalFunction(LogicalFunction child)
+    : outputType(DataTypeProvider::provideDataType(DataType::Type::UNDEFINED)), child(std::move(child))
+{
+}
+
+bool CastToUnixTimestampLogicalFunction::operator==(const CastToUnixTimestampLogicalFunction& rhs) const
+{
+    return this->outputType == rhs.outputType && this->child == rhs.child;
+}
+
+DataType CastToUnixTimestampLogicalFunction::getDataType() const
+{
+    return outputType;
+}
+
+CastToUnixTimestampLogicalFunction CastToUnixTimestampLogicalFunction::withDataType(const DataType& dataType) const
+{
+    auto copy = *this;
+    copy.outputType = dataType;
+    return copy;
+}
+
+LogicalFunction CastToUnixTimestampLogicalFunction::withInferredDataType(const Schema& schema) const
+{
+    const auto newChildren = getChildren() | std::views::transform([&schema](auto& child) { return child.withInferredDataType(schema); })
+        | std::ranges::to<std::vector>();
+    INVARIANT(newChildren.size() == 1, "CeilLogicalFunction expects exactly one child function but has {}", newChildren.size());
+    auto newDataType = newChildren[0].getDataType();
+    if (newDataType.type != DataType::Type::UNDEFINED && newDataType.type != DataType::Type::VARSIZED)
+    {
+        throw DifferentFieldTypeExpected("CASTTOUNIXTS expects a VARSIZED (string) input, but got {}", newDataType);
+    }
+
+
+    newDataType.type = DataType::Type::UINT64;
+    newDataType.nullable = std::ranges::any_of(newChildren, [](const auto& child) { return child.getDataType().nullable; });
+    return withDataType(newDataType).withChildren(newChildren);
+}
+
+std::vector<LogicalFunction> CastToUnixTimestampLogicalFunction::getChildren() const
+{
+    return {child};
+}
+
+CastToUnixTimestampLogicalFunction CastToUnixTimestampLogicalFunction::withChildren(const std::vector<LogicalFunction>& children) const
+{
+    PRECONDITION(children.size() == 1, "CastToUnixTimestampLogicalFunction requires exactly one child, but got {}", children.size());
+    auto copy = *this;
+    copy.child = children[0];
+    return copy;
+}
+
+std::string_view CastToUnixTimestampLogicalFunction::getType()
+{
+    return NAME;
+}
+
+std::string CastToUnixTimestampLogicalFunction::explain(ExplainVerbosity) const
+{
+    return fmt::format("Cast to unix timestamp (ms), outputType={}", outputType);
+}
+
+Reflected Reflector<CastToUnixTimestampLogicalFunction>::operator()(const CastToUnixTimestampLogicalFunction& function) const
+{
+    return reflect(detail::ReflectedCastToUnixTimestampLogicalFunction{.child = function.child});
+}
+
+CastToUnixTimestampLogicalFunction Unreflector<CastToUnixTimestampLogicalFunction>::operator()(const Reflected& reflected) const
+{
+    auto [function] = unreflect<detail::ReflectedCastToUnixTimestampLogicalFunction>(reflected);
+
+    if (!function.has_value())
+    {
+        throw CannotDeserialize("Failed to deserialize child of CastToUnixTimestampLogicalFunction");
+    }
+    return CastToUnixTimestampLogicalFunction(std::move(function.value()));
+}
+
+LogicalFunctionRegistryReturnType
+LogicalFunctionGeneratedRegistrar::RegisterCastToUnixTsLogicalFunction(LogicalFunctionRegistryArguments arguments)
+{
+    if (!arguments.reflected.isEmpty())
+    {
+        return unreflect<CastToUnixTimestampLogicalFunction>(arguments.reflected);
+    }
+
+    if (arguments.children.size() != 1)
+    {
+        throw CannotDeserialize("CastToUnixTimestampLogicalFunction requires exactly one child, but got {}", arguments.children.size());
+    }
+    return CastToUnixTimestampLogicalFunction(arguments.children[0]);
+}
+
+}

--- a/nes-physical-operators/include/Functions/CastFromUnixTimestampPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/CastFromUnixTimestampPhysicalFunction.hpp
@@ -1,0 +1,40 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <DataTypes/DataType.hpp>
+#include <Functions/PhysicalFunction.hpp>
+#include <Nautilus/DataTypes/VarVal.hpp>
+#include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
+
+namespace NES
+{
+
+/// Converts a unix timestamp in milliseconds (UINT64) to a human-readable UTC timestamp string (VARSIZED),
+/// formatted as: YYYY-MM-DDTHH:MM:SS.mmmZ (ISO-8601 UTC)
+class CastFromUnixTimestampPhysicalFunction
+{
+public:
+    explicit CastFromUnixTimestampPhysicalFunction(PhysicalFunction childFunction, DataType outputType);
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
+
+private:
+    DataType outputType;
+    PhysicalFunction childFunction;
+};
+
+static_assert(PhysicalFunctionConcept<CastFromUnixTimestampPhysicalFunction>);
+}

--- a/nes-physical-operators/include/Functions/CastToUnixTimestampPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Functions/CastToUnixTimestampPhysicalFunction.hpp
@@ -1,0 +1,38 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <DataTypes/DataType.hpp>
+#include <Functions/PhysicalFunction.hpp>
+#include <Nautilus/DataTypes/VarVal.hpp>
+#include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
+
+namespace NES
+{
+
+class CastToUnixTimestampPhysicalFunction
+{
+public:
+    explicit CastToUnixTimestampPhysicalFunction(PhysicalFunction childFunction, DataType outputType);
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
+
+private:
+    DataType outputType;
+    PhysicalFunction childFunction;
+};
+
+static_assert(PhysicalFunctionConcept<CastToUnixTimestampPhysicalFunction>);
+}

--- a/nes-physical-operators/src/Functions/CMakeLists.txt
+++ b/nes-physical-operators/src/Functions/CMakeLists.txt
@@ -19,6 +19,8 @@ add_source_files(nes-physical-operators
 
 add_plugin(Concat PhysicalFunction nes-physical-operators ConcatPhysicalFunction.cpp)
 add_plugin(Cast PhysicalFunction nes-physical-operators CastFieldPhysicalFunction.cpp)
+add_plugin(CastToUnixTs PhysicalFunction nes-physical-operators CastToUnixTimestampPhysicalFunction.cpp)
+add_plugin(CastFromUnixTs PhysicalFunction nes-physical-operators CastFromUnixTimestampPhysicalFunction.cpp)
 
 add_subdirectory(ArithmeticalFunctions)
 add_subdirectory(ComparisonFunctions)

--- a/nes-physical-operators/src/Functions/CastFromUnixTimestampPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Functions/CastFromUnixTimestampPhysicalFunction.cpp
@@ -1,0 +1,79 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Functions/CastFromUnixTimestampPhysicalFunction.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <format>
+#include <utility>
+
+#include <DataTypes/DataType.hpp>
+#include <Functions/PhysicalFunction.hpp>
+#include <Nautilus/DataTypes/VarVal.hpp>
+#include <Nautilus/DataTypes/VariableSizedData.hpp>
+#include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
+#include <ErrorHandling.hpp>
+#include <PhysicalFunctionRegistry.hpp>
+#include <function.hpp>
+#include <val_arith.hpp>
+
+namespace NES
+{
+
+CastFromUnixTimestampPhysicalFunction::CastFromUnixTimestampPhysicalFunction(PhysicalFunction childFunction, DataType outputType)
+    : outputType(std::move(outputType)), childFunction(std::move(childFunction))
+{
+}
+
+VarVal CastFromUnixTimestampPhysicalFunction::execute(const Record& record, ArenaRef& arena) const
+{
+    const auto value = childFunction.execute(record, arena);
+    if (value.isNullable())
+    {
+        if (value.isNull())
+        {
+            return VarVal{VariableSizedData{nullptr, 0}, true, true};
+        }
+    }
+
+    /// ISO-8601 UTC format: YYYY-MM-DDTHH:MM:SS.mmmZ (24 chars)
+    const auto milliSeconds = value.getRawValueAs<nautilus::val<uint64_t>>();
+    constexpr uint32_t iso8601OutputLen = 24;
+    const nautilus::val<uint32_t> isoTimestampLength{iso8601OutputLen};
+    auto timestampAsIso8601 = arena.allocateVariableSizedData(isoTimestampLength);
+    const auto payload = timestampAsIso8601.getContent();
+
+    nautilus::invoke(
+        +[](const uint64_t milliSecondsSinceEpoch, char* outTimestampIso8601Utc)
+        {
+            const std::chrono::sys_time utcTimePoint{std::chrono::milliseconds{milliSecondsSinceEpoch}};
+            std::format_to(outTimestampIso8601Utc, "{:%FT%T}Z", utcTimePoint);
+        },
+        milliSeconds,
+        payload);
+
+    return VarVal{timestampAsIso8601, value.isNullable(), false};
+}
+
+PhysicalFunctionRegistryReturnType
+PhysicalFunctionGeneratedRegistrar::RegisterCastFromUnixTsPhysicalFunction(PhysicalFunctionRegistryArguments args)
+{
+    PRECONDITION(args.childFunctions.size() == 1, "CastFromUnixTimestampPhysicalFunction must have exactly one child function");
+
+    return CastFromUnixTimestampPhysicalFunction(args.childFunctions[0], args.outputType);
+}
+
+}

--- a/nes-physical-operators/src/Functions/CastToUnixTimestampPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Functions/CastToUnixTimestampPhysicalFunction.cpp
@@ -1,0 +1,165 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Functions/CastToUnixTimestampPhysicalFunction.hpp>
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <istream>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include <DataTypes/DataType.hpp>
+#include <Functions/PhysicalFunction.hpp>
+#include <Nautilus/DataTypes/VarVal.hpp>
+#include <Nautilus/DataTypes/VariableSizedData.hpp>
+#include <Nautilus/Interface/Record.hpp>
+#include <Util/Strings.hpp>
+#include <date/date.h>
+#include <Arena.hpp>
+#include <ErrorHandling.hpp>
+#include <PhysicalFunctionRegistry.hpp>
+#include <function.hpp>
+
+namespace NES
+{
+namespace
+{
+
+/// Checks that from_stream consumed the entire input and returns the parsed milliseconds.
+/// Returns std::nullopt on parse failure or trailing non-whitespace characters.
+std::optional<uint64_t>
+toMilliSecondsIfFullyParsed(std::istringstream& iss, std::chrono::milliseconds epochDuration, std::string_view input)
+{
+    if (iss.fail())
+    {
+        return std::nullopt;
+    }
+    /// from_stream may leave trailing whitespace; consume it so only real leftovers fail.
+    iss >> std::ws;
+    if (!iss.eof())
+    {
+        return std::nullopt;
+    }
+    if (epochDuration.count() < 0)
+    {
+        throw FormattingError("CastToUnixTs: pre-epoch timestamp is not supported: '{}'", input);
+    }
+    return static_cast<uint64_t>(epochDuration.count());
+}
+
+uint64_t parseISO8601TimestampToUnixMilliSeconds(std::string_view iso8601Timestamp)
+{
+    const auto trimmed = NES::trimWhiteSpaces(iso8601Timestamp);
+    if (trimmed.empty())
+    {
+        throw FormattingError("CastToUnixTs: cannot convert empty timestamp: '{}'", iso8601Timestamp);
+    }
+
+    static constexpr std::array<std::string_view, 5> FormatsWithTz = {
+        "%FT%T%Ez",
+        "%FT%T.%f%Ez",
+        "%FT%TZ",
+        "%FT%T.%fZ",
+        "%a, %d %b %Y %T GMT",
+    };
+
+    static constexpr std::array<std::string_view, 4> FormatsWithoutTz = {
+        "%F %T",
+        "%F %T.%f",
+        "%FT%T",
+        "%FT%T.%f",
+    };
+
+    /// Try formats that carry an explicit timezone / offset
+    for (const auto& fmt : FormatsWithTz)
+    {
+        std::istringstream iss{std::string{trimmed}};
+        std::string abbrev;
+        std::chrono::minutes offset{0};
+        date::sys_time<std::chrono::milliseconds> timepoint;
+        /// NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage) not possible to provide size information to from_stream
+        date::from_stream(iss, fmt.data(), timepoint, &abbrev, &offset);
+        if (auto milliSeconds = toMilliSecondsIfFullyParsed(iss, timepoint.time_since_epoch(), iso8601Timestamp))
+        {
+            return *milliSeconds;
+        }
+    }
+
+    /// Try timezone-free formats (interpreted as UTC)
+    for (const auto& fmt : FormatsWithoutTz)
+    {
+        std::istringstream iss{std::string{trimmed}};
+        date::local_time<std::chrono::milliseconds> timepoint;
+        /// NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage) not possible to provide size information to from_stream
+        date::from_stream(iss, fmt.data(), timepoint);
+        if (auto milliSeconds = toMilliSecondsIfFullyParsed(iss, timepoint.time_since_epoch(), iso8601Timestamp))
+        {
+            return *milliSeconds;
+        }
+    }
+
+    throw FormattingError("CastToUnixTs: unsupported timestamp format: '{}'", iso8601Timestamp);
+}
+
+}
+
+CastToUnixTimestampPhysicalFunction::CastToUnixTimestampPhysicalFunction(PhysicalFunction childFunction, DataType outputType)
+    : outputType(std::move(outputType)), childFunction(std::move(childFunction))
+{
+}
+
+VarVal CastToUnixTimestampPhysicalFunction::execute(const Record& record, ArenaRef& arena) const
+{
+    const auto value = childFunction.execute(record, arena);
+    if (value.isNullable())
+    {
+        if (value.isNull())
+        {
+            return VarVal{0, true, true}.castToType(outputType.type);
+        }
+    }
+
+    const auto var = value.getRawValueAs<VariableSizedData>();
+    const auto size = var.getSize();
+    const auto ptr = var.getContent();
+
+    const auto parsedMilliSeconds = nautilus::invoke(
+        +[](const uint32_t size, const char* iso8601String) -> uint64_t
+        {
+            const std::string_view iso8601StringView{iso8601String, size};
+            return parseISO8601TimestampToUnixMilliSeconds(iso8601StringView);
+        },
+        size,
+        ptr);
+
+    return VarVal{parsedMilliSeconds, value.isNullable(), false}.castToType(outputType.type);
+}
+
+PhysicalFunctionRegistryReturnType PhysicalFunctionGeneratedRegistrar::RegisterCastToUnixTsPhysicalFunction(
+    PhysicalFunctionRegistryArguments physicalFunctionRegistryArguments)
+{
+    PRECONDITION(
+        physicalFunctionRegistryArguments.childFunctions.size() == 1,
+        "CastToUnixTimestampPhysicalFunction must have exactly one child function");
+
+    return CastToUnixTimestampPhysicalFunction(
+        physicalFunctionRegistryArguments.childFunctions[0], physicalFunctionRegistryArguments.outputType);
+}
+
+}

--- a/nes-systests/function/FromUnixTimestampConversion.test
+++ b/nes-systests/function/FromUnixTimestampConversion.test
@@ -1,0 +1,48 @@
+# name: Unix to Timestamp conversion
+# description: Checks if the conversion from unix timestamps (ms) to UTC zulu timestamp strings works
+# groups: [Function]
+
+CREATE LOGICAL SOURCE timestampsStream(timestamp UINT64);
+CREATE PHYSICAL SOURCE FOR timestampsStream TYPE File;
+ATTACH INLINE
+0
+1000
+1234
+0
+1639494303000
+1771243200000
+253402300799999
+
+# different data type than a uint64_t
+CREATE LOGICAL SOURCE WrongDataType(timestamp VARSIZED);
+CREATE PHYSICAL SOURCE FOR WrongDataType TYPE File;
+ATTACH INLINE
+1970-01-01T00:00:00.000Z
+
+# Error, wrong data type
+SELECT CASTFROMUNIXTS(timestamp) AS timestampsStream FROM WrongDataType INTO FILE();
+----
+Error 2006
+
+
+SELECT CASTFROMUNIXTS(timestamp) AS timestampsStream FROM timestampsStream INTO FILE();
+----
+1970-01-01T00:00:00.000Z
+1970-01-01T00:00:01.000Z
+1970-01-01T00:00:01.234Z
+1970-01-01T00:00:00.000Z
+2021-12-14T15:05:03.000Z
+2026-02-16T12:00:00.000Z
+9999-12-31T23:59:59.999Z
+
+
+# NULL CASES
+
+CREATE LOGICAL SOURCE timestampsStream_NULL(V1 UINT64 NOT NULL, timestamp UINT64);
+CREATE PHYSICAL SOURCE FOR timestampsStream_NULL TYPE File;
+ATTACH INLINE
+0,
+
+SELECT CASTFROMUNIXTS(timestamp) AS timestampsStream FROM timestampsStream_NULL INTO FILE();
+----
+NULL

--- a/nes-systests/function/ToUnixTimestampConversion.test
+++ b/nes-systests/function/ToUnixTimestampConversion.test
@@ -1,0 +1,167 @@
+# name: TimestampTo unix conversion
+# description: Checks if the conversion from human readable timestamp formats to unix timestamps works
+# groups: [Function]
+
+# SUCCESS CASES
+
+CREATE LOGICAL SOURCE timestampsStream(timestamp VARSIZED NOT NULL);
+CREATE PHYSICAL SOURCE FOR timestampsStream TYPE File;
+ATTACH INLINE
+1970-01-01T00:00:00Z
+1970-01-01T00:00:01Z
+1970-01-01T00:00:01.234Z
+1970-01-01T01:00:00+01:00
+2021-12-14T15:05:03
+2026-02-16T12:00:00Z
+9999-12-31T23:59:59.999Z
+1970-01-01T00:00:00-01:00
+1970-01-01T01:00:00.123+01:00
+1970-01-01T00:00:00+00:00
+2024-02-29T12:00:00Z
+
+
+SELECT CASTTOUNIXTS(timestamp) AS timestamp_out FROM timestampsStream INTO FILE();
+----
+0
+1000
+1234
+0
+1639494303000
+1771243200000
+253402300799999
+3600000
+123
+0
+1709208000000
+
+
+# ERROR CASES
+
+# different data type than a var sized
+CREATE LOGICAL SOURCE WrongDataType(timestamp UINT64);
+CREATE PHYSICAL SOURCE FOR WrongDataType TYPE File;
+ATTACH INLINE
+1639494303000
+
+SELECT CASTTOUNIXTS(timestamp) AS TSMS FROM WrongDataType INTO File();
+----
+Error 2006
+
+# just a string no timestamp
+CREATE LOGICAL SOURCE timestampsStream_ERR1(timestamp VARSIZED);
+CREATE PHYSICAL SOURCE FOR timestampsStream_ERR1 TYPE File;
+ATTACH INLINE
+not-a-timestamp
+
+
+SELECT CASTTOUNIXTS(timestamp) AS TSMS FROM timestampsStream_ERR1 INTO FILE();
+----
+Error 4003
+
+# illegal tailing string
+CREATE LOGICAL SOURCE timestampsStream_ERR2(timestamp VARSIZED);
+CREATE PHYSICAL SOURCE FOR timestampsStream_ERR2 TYPE File;
+ATTACH INLINE
+1970-01-01T00:00:00Zabc
+
+
+SELECT CASTTOUNIXTS(timestamp) AS TSMS FROM timestampsStream_ERR2 INTO FILE();
+----
+Error 4003
+
+
+# illegal format
+CREATE LOGICAL SOURCE timestampsStream_ERR3(timestamp VARSIZED);
+CREATE PHYSICAL SOURCE FOR timestampsStream_ERR3 TYPE File;
+ATTACH INLINE
+1969-12-31T23:59:59Z
+
+
+SELECT CASTTOUNIXTS(timestamp) AS TSMS FROM timestampsStream_ERR3 INTO FILE();
+----
+Error 4003
+
+
+
+# empty string as timestamp
+CREATE LOGICAL SOURCE timestampsStream_ERR4(timestamp VARSIZED);
+CREATE PHYSICAL SOURCE FOR timestampsStream_ERR4 TYPE File;
+ATTACH INLINE
+" "
+
+SELECT CASTTOUNIXTS(timestamp) AS TSMS FROM timestampsStream_ERR4 INTO FILE();
+----
+Error 4003
+
+
+
+# invalid leap-day date
+CREATE LOGICAL SOURCE timestampsStream_ERR5(timestamp VARSIZED);
+CREATE PHYSICAL SOURCE FOR timestampsStream_ERR5 TYPE File;
+ATTACH INLINE
+2023-02-29T12:00:00Z
+
+
+SELECT CASTTOUNIXTS(timestamp) AS TSMS FROM timestampsStream_ERR5 INTO FILE();
+----
+Error 4003
+
+
+# invalid timezone offset without colon
+CREATE LOGICAL SOURCE timestampsStream_ERR6(timestamp VARSIZED);
+CREATE PHYSICAL SOURCE FOR timestampsStream_ERR6 TYPE File;
+ATTACH INLINE
+1970-01-01T00:00:00+0100
+
+
+SELECT CASTTOUNIXTS(timestamp) AS TSMS FROM timestampsStream_ERR6 INTO FILE();
+----
+Error 4003
+
+
+# invalid timezone offset with hour only
+CREATE LOGICAL SOURCE timestampsStream_ERR7(timestamp VARSIZED);
+CREATE PHYSICAL SOURCE FOR timestampsStream_ERR7 TYPE File;
+ATTACH INLINE
+1970-01-01T00:00:00+01
+
+
+SELECT CASTTOUNIXTS(timestamp) AS TSMS FROM timestampsStream_ERR7 INTO FILE();
+----
+Error 4003
+
+
+# invalid timezone offset with malformed minute part
+CREATE LOGICAL SOURCE timestampsStream_ERR8(timestamp VARSIZED);
+CREATE PHYSICAL SOURCE FOR timestampsStream_ERR8 TYPE File;
+ATTACH INLINE
+1970-01-01T00:00:00+01:0
+
+
+SELECT CASTTOUNIXTS(timestamp) AS TSMS FROM timestampsStream_ERR8 INTO FILE();
+----
+Error 4003
+
+
+
+# date-only string without time part
+CREATE LOGICAL SOURCE timestampsStream_ERR9(timestamp VARSIZED);
+CREATE PHYSICAL SOURCE FOR timestampsStream_ERR9 TYPE File;
+ATTACH INLINE
+1970-01-01
+
+
+SELECT CASTTOUNIXTS(timestamp) AS TSMS FROM timestampsStream_ERR9 INTO FILE();
+----
+Error 4003
+
+
+# NULL CASES
+CREATE LOGICAL SOURCE timestampsStream_NULL(V1 UINT64 NOT NULL, timestamp VARSIZED);
+CREATE PHYSICAL SOURCE FOR timestampsStream_NULL TYPE File;
+ATTACH INLINE
+0,
+
+SELECT CASTTOUNIXTS(timestamp) AS TSMS FROM timestampsStream_NULL INTO FILE();
+----
+NULL

--- a/vcpkg/vcpkg.json
+++ b/vcpkg/vcpkg.json
@@ -46,7 +46,8 @@
     "nameof",
     "scope-guard",
     "boost-url",
-    "simdjson"
+    "simdjson",
+    "date"
   ],
   "overrides": [
     {


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
These changes add a new operator which can convert incoming string based timestamps to UNIX based timestamps. And for outgoing data it can convert it back from UNIX to a string based format: ISO 8601 UTC.



## Verifying this change
nes-systests/function/FromUnixTimestampConversion.test
nes-systests/function/ToUnixTimestampConversion.test


This PR closes #<issue number>
