### PR TITLE
Fix(#1378): harden PhysicalPlanBuilder::flip() with cycle detection and post-flip assertions

### DIFF
--- a/nes-query-optimizer/src/PhysicalPlanBuilder.cpp
+++ b/nes-query-optimizer/src/PhysicalPlanBuilder.cpp
@@ -13,8 +13,11 @@
 */
 #include <PhysicalPlanBuilder.hpp>
 
+#include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
+#include <queue>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -58,64 +61,26 @@ PhysicalPlan PhysicalPlanBuilder::finalize() &&
 
 using PhysicalOpPtr = std::shared_ptr<PhysicalOperatorWrapper>;
 
-PhysicalPlanBuilder::Roots PhysicalPlanBuilder::flip(const Roots& rootOperators)
+/// Custom hasher for shared_ptr keys — hashes the underlying raw pointer value.
+struct SharedPtrHash
 {
-    PRECONDITION(rootOperators.size() == 1, "For now we can only flip graphs with a single root");
+    size_t operator()(const PhysicalOpPtr& ptr) const { return std::hash<PhysicalOperatorWrapper*>{}(ptr.get()); }
+};
 
-    std::unordered_set<PhysicalOperatorWrapper*> visited;
-    std::vector<PhysicalOpPtr> allNodes;
+/// Custom equality for shared_ptr keys — compares underlying raw pointer identity.
+struct SharedPtrEqual
+{
+    bool operator()(const PhysicalOpPtr& lhs, const PhysicalOpPtr& rhs) const { return lhs.get() == rhs.get(); }
+};
 
-    auto collectNodes = [&visited, &allNodes](const PhysicalOpPtr& node, auto&& self) -> void
-    {
-        if (node and not visited.contains(node.get()))
-        {
-            visited.insert(node.get());
-            allNodes.push_back(node);
-            for (const auto& child : node->getChildren())
-            {
-                self(child, self);
-            }
-        }
-    };
-    collectNodes(rootOperators[0], collectNodes);
-
-    std::unordered_map<PhysicalOperatorWrapper*, std::vector<PhysicalOpPtr>> reversedEdges;
-    std::unordered_map<PhysicalOperatorWrapper*, int> inDegree;
-    for (const auto& node : allNodes)
-    {
-        reversedEdges.try_emplace(node.get(), std::vector<PhysicalOpPtr>{});
-        for (const auto& child : node->getChildren())
-        {
-            reversedEdges.try_emplace(child.get(), std::vector<PhysicalOpPtr>{});
-            reversedEdges[child.get()].push_back(node);
-        }
-        /// clear
-        node->setChildren(std::vector<PhysicalOpPtr>{});
-        inDegree[node.get()] = 0;
-    }
-
-    for (const auto& pair : reversedEdges)
-    {
-        for (const auto& child : pair.second)
-        {
-            inDegree[child.get()]++;
-        }
-    }
-
-    std::vector<PhysicalOpPtr> newRoots;
-    for (const auto& node : allNodes)
-    {
-        if (inDegree[node.get()] == 0)
-        {
-            newRoots.push_back(node);
-        }
-    }
-
-    for (const auto& node : allNodes)
-    {
-        node->setChildren(reversedEdges[node.get()]);
-    }
-
+namespace
+{
+/// Verifies post-flip invariants: roots are sources, leaves are sinks, edge count preserved, all nodes reachable.
+void verifyFlippedGraph(
+    [[maybe_unused]] const std::vector<PhysicalOpPtr>& newRoots,
+    [[maybe_unused]] const std::vector<PhysicalOpPtr>& allNodes,
+    [[maybe_unused]] size_t edgeCountBefore)
+{
     for (const auto& rootOperator : newRoots)
     {
         INVARIANT(
@@ -123,6 +88,128 @@ PhysicalPlanBuilder::Roots PhysicalPlanBuilder::flip(const Roots& rootOperators)
             "Expects SourceOperators as roots after flip but got {}",
             rootOperator->getPhysicalOperator());
     }
+
+    size_t edgeCountAfter = 0;
+    for (const auto& node : allNodes)
+    {
+        edgeCountAfter += node->getChildren().size();
+    }
+    INVARIANT(edgeCountBefore == edgeCountAfter, "Edge count mismatch after flip: before={} after={}", edgeCountBefore, edgeCountAfter);
+
+    std::unordered_set<PhysicalOpPtr, SharedPtrHash, SharedPtrEqual> reachable;
+    std::queue<PhysicalOpPtr> bfsQueue;
+    for (const auto& root : newRoots)
+    {
+        bfsQueue.push(root);
+        reachable.insert(root);
+    }
+    while (!bfsQueue.empty())
+    {
+        auto current = bfsQueue.front();
+        bfsQueue.pop();
+        for (const auto& child : current->getChildren())
+        {
+            if (reachable.insert(child).second)
+            {
+                bfsQueue.push(child);
+            }
+        }
+    }
+    INVARIANT(
+        reachable.size() == allNodes.size(),
+        "Not all nodes reachable after flip: reachable={} total={}",
+        reachable.size(),
+        allNodes.size());
+
+    for (const auto& node : allNodes)
+    {
+        if (node->getChildren().empty())
+        {
+            INVARIANT(
+                node->getPhysicalOperator().tryGet<SinkPhysicalOperator>(),
+                "Expects SinkOperators as leaves after flip but got {}",
+                node->getPhysicalOperator());
+        }
+    }
+}
+}
+
+PhysicalPlanBuilder::Roots PhysicalPlanBuilder::flip(const Roots& rootOperators)
+{
+    PRECONDITION(rootOperators.size() == 1, "For now we can only flip graphs with a single root");
+
+    /// DFS visit states for cycle detection.
+    enum class VisitState : uint8_t
+    {
+        Unvisited,
+        InProgress,
+        Completed
+    };
+
+    std::unordered_map<PhysicalOpPtr, VisitState, SharedPtrHash, SharedPtrEqual> visitStateMap;
+    std::vector<PhysicalOpPtr> allNodes;
+
+    auto collectNodes = [&visitStateMap, &allNodes](const PhysicalOpPtr& node, auto&& self) -> void
+    {
+        auto [it, inserted] = visitStateMap.try_emplace(node, VisitState::Unvisited);
+        PRECONDITION(
+            it->second != VisitState::InProgress,
+            "Cycle detected in physical plan DAG during flip — node visited twice on the same DFS path");
+        if (it->second == VisitState::Completed)
+        {
+            return; /// already fully processed
+        }
+        it->second = VisitState::InProgress;
+        allNodes.push_back(node);
+        for (const auto& child : node->getChildren())
+        {
+            self(child, self);
+        }
+        it->second = VisitState::Completed;
+    };
+    collectNodes(rootOperators[0], collectNodes);
+
+    /// Count edges before clearing children.
+    size_t edgeCountBefore = 0;
+    std::unordered_map<PhysicalOpPtr, std::vector<PhysicalOpPtr>, SharedPtrHash, SharedPtrEqual> reversedEdges;
+    std::unordered_map<PhysicalOpPtr, int, SharedPtrHash, SharedPtrEqual> inDegree;
+    for (const auto& node : allNodes)
+    {
+        reversedEdges.try_emplace(node, std::vector<PhysicalOpPtr>{});
+        for (const auto& child : node->getChildren())
+        {
+            reversedEdges.try_emplace(child, std::vector<PhysicalOpPtr>{});
+            reversedEdges[child].push_back(node);
+            ++edgeCountBefore;
+        }
+        /// clear
+        node->setChildren(std::vector<PhysicalOpPtr>{});
+        inDegree[node] = 0;
+    }
+
+    for (const auto& [parent, children] : reversedEdges)
+    {
+        for (const auto& child : children)
+        {
+            inDegree[child]++;
+        }
+    }
+
+    std::vector<PhysicalOpPtr> newRoots;
+    for (const auto& node : allNodes)
+    {
+        if (inDegree[node] == 0)
+        {
+            newRoots.push_back(node);
+        }
+    }
+
+    for (const auto& node : allNodes)
+    {
+        node->setChildren(reversedEdges[node]);
+    }
+
+    verifyFlippedGraph(newRoots, allNodes, edgeCountBefore);
     return newRoots;
 }
 }

--- a/nes-query-optimizer/tests/CMakeLists.txt
+++ b/nes-query-optimizer/tests/CMakeLists.txt
@@ -19,3 +19,4 @@ endfunction()
 
 add_nes_optimizer_test(DecideJoinTypesTest UnitTests/DecideJoinTypesTest.cpp)
 add_nes_optimizer_test(DecideMemoryLayoutTest UnitTests/DecideMemoryLayoutTest.cpp)
+add_nes_optimizer_test(PhysicalPlanBuilderFlipTest UnitTests/PhysicalPlanBuilderFlipTest.cpp)

--- a/nes-query-optimizer/tests/UnitTests/PhysicalPlanBuilderFlipTest.cpp
+++ b/nes-query-optimizer/tests/UnitTests/PhysicalPlanBuilderFlipTest.cpp
@@ -1,0 +1,283 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <queue>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <Util/Logger/LogLevel.hpp>
+#include <Util/Logger/impl/NesLogger.hpp>
+#include <gtest/gtest.h>
+#include <BaseUnitTest.hpp>
+
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/DataTypeProvider.hpp>
+#include <DataTypes/Schema.hpp>
+#include <Identifiers/Identifiers.hpp>
+#include <Nautilus/Interface/BufferRef/LowerSchemaProvider.hpp>
+#include <Sinks/SinkCatalog.hpp>
+#include <Sources/SourceCatalog.hpp>
+#include <PhysicalOperator.hpp>
+#include <PhysicalPlan.hpp>
+#include <PhysicalPlanBuilder.hpp>
+#include <SinkPhysicalOperator.hpp>
+#include <SourcePhysicalOperator.hpp>
+#include <UnionPhysicalOperator.hpp>
+
+namespace NES
+{
+namespace
+{
+
+using PipelineLocation = PhysicalOperatorWrapper::PipelineLocation;
+
+class PhysicalPlanBuilderFlipTest : public Testing::BaseUnitTest
+{
+public:
+    static void SetUpTestSuite() { Logger::setupLogging("PhysicalPlanBuilderFlipTest.log", LogLevel::LOG_DEBUG); }
+
+    void SetUp() override { BaseUnitTest::SetUp(); }
+
+    static Schema createSchema()
+    {
+        Schema schema;
+        schema.addField("test.id", DataTypeProvider::provideDataType(DataType::Type::UINT64));
+        schema.addField("test.value", DataTypeProvider::provideDataType(DataType::Type::UINT64));
+        return schema;
+    }
+
+    /// Creates a PhysicalOperatorWrapper holding a SourcePhysicalOperator.
+    std::shared_ptr<PhysicalOperatorWrapper> makeSourceWrapper()
+    {
+        auto schema = createSchema();
+        auto descriptor = sourceCatalog.getInlineSource("File", schema, {{"type", "CSV"}}, {{"file_path", "/dev/null"}});
+        EXPECT_TRUE(descriptor.has_value());
+        auto sourceOp = SourcePhysicalOperator(
+            std::move(descriptor.value()), /// NOLINT(bugprone-unchecked-optional-access)
+            OriginId(nextOriginId++));
+        return std::make_shared<PhysicalOperatorWrapper>(
+            PhysicalOperator{sourceOp}, schema, schema, MemoryLayoutType::ROW_LAYOUT, MemoryLayoutType::ROW_LAYOUT, PipelineLocation::SCAN);
+    }
+
+    /// Creates a PhysicalOperatorWrapper holding a SinkPhysicalOperator.
+    std::shared_ptr<PhysicalOperatorWrapper> makeSinkWrapper() const
+    {
+        auto schema = createSchema();
+        auto descriptor = sinkCatalog.getInlineSink(schema, "Print", {{"input_format", "CSV"}});
+        EXPECT_TRUE(descriptor.has_value());
+        auto sinkOp = SinkPhysicalOperator(descriptor.value()); /// NOLINT(bugprone-unchecked-optional-access)
+        return std::make_shared<PhysicalOperatorWrapper>(
+            PhysicalOperator{sinkOp}, schema, schema, MemoryLayoutType::ROW_LAYOUT, MemoryLayoutType::ROW_LAYOUT, PipelineLocation::EMIT);
+    }
+
+    /// Creates a PhysicalOperatorWrapper holding a UnionPhysicalOperator.
+    static std::shared_ptr<PhysicalOperatorWrapper> makeUnionWrapper()
+    {
+        auto schema = createSchema();
+        auto unionOp = UnionPhysicalOperator();
+        return std::make_shared<PhysicalOperatorWrapper>(
+            PhysicalOperator{unionOp},
+            schema,
+            schema,
+            MemoryLayoutType::ROW_LAYOUT,
+            MemoryLayoutType::ROW_LAYOUT,
+            PipelineLocation::INTERMEDIATE);
+    }
+
+    /// Counts total edges (parent->child links) in a plan by BFS from roots.
+    static size_t countEdges(const PhysicalPlan& plan)
+    {
+        size_t edges = 0;
+        std::queue<std::shared_ptr<PhysicalOperatorWrapper>> queue;
+        std::unordered_set<PhysicalOperatorWrapper*> visited;
+        for (const auto& root : plan.getRootOperators())
+        {
+            queue.push(root);
+            visited.insert(root.get());
+        }
+        while (!queue.empty())
+        {
+            auto current = queue.front();
+            queue.pop();
+            for (const auto& child : current->getChildren())
+            {
+                ++edges;
+                if (visited.insert(child.get()).second)
+                {
+                    queue.push(child);
+                }
+            }
+        }
+        return edges;
+    }
+
+    /// Counts total nodes reachable from roots by BFS.
+    static size_t countNodes(const PhysicalPlan& plan)
+    {
+        std::queue<std::shared_ptr<PhysicalOperatorWrapper>> queue;
+        std::unordered_set<PhysicalOperatorWrapper*> visited;
+        for (const auto& root : plan.getRootOperators())
+        {
+            queue.push(root);
+            visited.insert(root.get());
+        }
+        while (!queue.empty())
+        {
+            auto current = queue.front();
+            queue.pop();
+            for (const auto& child : current->getChildren())
+            {
+                if (visited.insert(child.get()).second)
+                {
+                    queue.push(child);
+                }
+            }
+        }
+        return visited.size();
+    }
+
+    SourceCatalog sourceCatalog;
+    SinkCatalog sinkCatalog;
+    uint64_t nextOriginId = 1;
+};
+
+/// Sink -> Source. After finalize(), verify source is root with sink as descendant.
+TEST_F(PhysicalPlanBuilderFlipTest, LinearChainFlip)
+{
+    auto source = makeSourceWrapper();
+    auto sink = makeSinkWrapper();
+
+    /// Build sink->source graph: sink is root, source is child.
+    sink->addChild(source);
+
+    auto builder = PhysicalPlanBuilder(QueryId(1));
+    builder.addSinkRoot(sink);
+    auto plan = std::move(builder).finalize();
+
+    /// After flip, source should be root.
+    ASSERT_EQ(plan.getRootOperators().size(), 1U);
+    const auto& root = plan.getRootOperators()[0];
+    EXPECT_TRUE(root->getPhysicalOperator().tryGet<SourcePhysicalOperator>());
+
+    /// Root's child should be the sink.
+    ASSERT_EQ(root->getChildren().size(), 1U);
+    EXPECT_TRUE(root->getChildren()[0]->getPhysicalOperator().tryGet<SinkPhysicalOperator>());
+
+    /// Sink (now a leaf) should have no children.
+    EXPECT_TRUE(root->getChildren()[0]->getChildren().empty());
+}
+
+/// Sink -> Union -> [Source1, Source2]. Verify two source roots, both eventually reach sink.
+TEST_F(PhysicalPlanBuilderFlipTest, DiamondShapeFlip)
+{
+    auto source1 = makeSourceWrapper();
+    auto source2 = makeSourceWrapper();
+    auto unionOp = makeUnionWrapper();
+    auto sink = makeSinkWrapper();
+
+    /// Build sink->source graph: sink -> union -> {source1, source2}.
+    unionOp->addChild(source1);
+    unionOp->addChild(source2);
+    sink->addChild(unionOp);
+
+    auto builder = PhysicalPlanBuilder(QueryId(2));
+    builder.addSinkRoot(sink);
+    auto plan = std::move(builder).finalize();
+
+    /// After flip, there should be 2 source roots.
+    ASSERT_EQ(plan.getRootOperators().size(), 2U);
+    for (const auto& root : plan.getRootOperators())
+    {
+        EXPECT_TRUE(root->getPhysicalOperator().tryGet<SourcePhysicalOperator>());
+    }
+
+    /// All 4 nodes must be reachable.
+    EXPECT_EQ(countNodes(plan), 4U);
+
+    /// Both source roots should reach the sink (via union).
+    for (const auto& root : plan.getRootOperators())
+    {
+        ASSERT_EQ(root->getChildren().size(), 1U);
+        auto child = root->getChildren()[0];
+        EXPECT_TRUE(child->getPhysicalOperator().tryGet<UnionPhysicalOperator>());
+        ASSERT_EQ(child->getChildren().size(), 1U);
+        EXPECT_TRUE(child->getChildren()[0]->getPhysicalOperator().tryGet<SinkPhysicalOperator>());
+    }
+}
+
+/// Sink -> Union1 -> Union2 -> Source. Verify correct depth after flip.
+TEST_F(PhysicalPlanBuilderFlipTest, MultiOperatorChainFlip)
+{
+    auto source = makeSourceWrapper();
+    auto union1 = makeUnionWrapper();
+    auto union2 = makeUnionWrapper();
+    auto sink = makeSinkWrapper();
+
+    /// Build sink->source chain: sink -> union1 -> union2 -> source.
+    union2->addChild(source);
+    union1->addChild(union2);
+    sink->addChild(union1);
+
+    auto builder = PhysicalPlanBuilder(QueryId(3));
+    builder.addSinkRoot(sink);
+    auto plan = std::move(builder).finalize();
+
+    /// After flip: source -> union2 -> union1 -> sink.
+    ASSERT_EQ(plan.getRootOperators().size(), 1U);
+    auto current = plan.getRootOperators()[0];
+    EXPECT_TRUE(current->getPhysicalOperator().tryGet<SourcePhysicalOperator>());
+
+    ASSERT_EQ(current->getChildren().size(), 1U);
+    current = current->getChildren()[0];
+    EXPECT_TRUE(current->getPhysicalOperator().tryGet<UnionPhysicalOperator>());
+
+    ASSERT_EQ(current->getChildren().size(), 1U);
+    current = current->getChildren()[0];
+    EXPECT_TRUE(current->getPhysicalOperator().tryGet<UnionPhysicalOperator>());
+
+    ASSERT_EQ(current->getChildren().size(), 1U);
+    current = current->getChildren()[0];
+    EXPECT_TRUE(current->getPhysicalOperator().tryGet<SinkPhysicalOperator>());
+
+    EXPECT_TRUE(current->getChildren().empty());
+}
+
+/// Build a graph, count edges before finalize, verify same count in the resulting PhysicalPlan.
+TEST_F(PhysicalPlanBuilderFlipTest, EdgeCountPreserved)
+{
+    auto source1 = makeSourceWrapper();
+    auto source2 = makeSourceWrapper();
+    auto unionOp = makeUnionWrapper();
+    auto sink = makeSinkWrapper();
+
+    /// Sink -> Union -> {Source1, Source2}: 3 edges total.
+    unionOp->addChild(source1);
+    unionOp->addChild(source2);
+    sink->addChild(unionOp);
+
+    const size_t expectedEdges = 3;
+
+    auto builder = PhysicalPlanBuilder(QueryId(4));
+    builder.addSinkRoot(sink);
+    auto plan = std::move(builder).finalize();
+
+    EXPECT_EQ(countEdges(plan), expectedEdges);
+}
+
+}
+}


### PR DESCRIPTION
Cherry-pick of #1382 (which was accidentally merged into `test-query-optimizer-phases` instead of `main`).

## Summary
- DFS coloring (White/Gray/Black) cycle detection in `flip()` to prevent infinite loops on buggy input
- Replace raw pointer keys with `shared_ptr`-based keys (custom hasher/equality) to eliminate dangling pointer risk
- Post-flip `INVARIANT` assertions: edge count preservation, full node reachability from new roots, sink-leaf verification
- 4 unit tests: `LinearChainFlip`, `DiamondShapeFlip`, `MultiOperatorChainFlip`, `EdgeCountPreserved`

🤖 Generated with [Claude Code](https://claude.com/claude-code)