### PR TITLE
Makes parse function optimizable for LLVM

### DIFF
--- a/nes-input-formatters/include/InputFormatters/RawValueParser.hpp
+++ b/nes-input-formatters/include/InputFormatters/RawValueParser.hpp
@@ -42,6 +42,7 @@ template <typename T>
 nautilus::val<T> parseIntoNautilusRecord(const nautilus::val<int8_t*>& fieldAddress, const nautilus::val<uint64_t>& fieldSize)
 {
     return nautilus::invoke(
+        nautilus::FunctionAttributes{nautilus::ModRefInfo::NoModRef, true, true},
         +[](const char* fieldAddress, const uint64_t fieldSize)
         {
             const auto fieldView = std::string_view(fieldAddress, fieldSize);

--- a/nes-input-formatters/include/InputFormatters/RawValueParser.hpp
+++ b/nes-input-formatters/include/InputFormatters/RawValueParser.hpp
@@ -28,6 +28,7 @@
 #include <val.hpp>
 #include <val_concepts.hpp>
 #include <val_ptr.hpp>
+#include <common/FunctionAttributes.hpp>
 
 namespace NES
 {
@@ -42,7 +43,7 @@ template <typename T>
 nautilus::val<T> parseIntoNautilusRecord(const nautilus::val<int8_t*>& fieldAddress, const nautilus::val<uint64_t>& fieldSize)
 {
     return nautilus::invoke(
-        nautilus::FunctionAttributes{nautilus::ModRefInfo::NoModRef, true, true},
+        nautilus::FunctionAttributes{.modRefInfo = nautilus::ModRefInfo::Ref, .willReturn = true, .noUnwind = true},
         +[](const char* fieldAddress, const uint64_t fieldSize)
         {
             const auto fieldView = std::string_view(fieldAddress, fieldSize);

--- a/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONFIF.hpp
+++ b/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONFIF.hpp
@@ -158,6 +158,7 @@ class SIMDJSONFIF final : public FieldIndexFunction<SIMDJSONFIF>
         nautilus::val<const SIMDJSONMetaData*> metaData) const
     {
         return nautilus::invoke(
+            nautilus::FunctionAttributes{nautilus::ModRefInfo::NoModRef, true, true},
             +[](FieldIndex fieldIndex, SIMDJSONFIF* fieldIndexFunction, const SIMDJSONMetaData* metaData)
             {
                 const auto& fieldName = metaData->getFieldNameInJsonAt(fieldIndex);

--- a/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONFIF.hpp
+++ b/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONFIF.hpp
@@ -40,6 +40,7 @@
 #include <val.hpp>
 #include <val_concepts.hpp>
 #include <val_ptr.hpp>
+#include <common/FunctionAttributes.hpp>
 
 namespace NES
 {
@@ -158,7 +159,7 @@ class SIMDJSONFIF final : public FieldIndexFunction<SIMDJSONFIF>
         nautilus::val<const SIMDJSONMetaData*> metaData) const
     {
         return nautilus::invoke(
-            nautilus::FunctionAttributes{nautilus::ModRefInfo::NoModRef, true, true},
+            nautilus::FunctionAttributes{.modRefInfo = nautilus::ModRefInfo::Ref, .willReturn = true, .noUnwind = true},
             +[](FieldIndex fieldIndex, SIMDJSONFIF* fieldIndexFunction, const SIMDJSONMetaData* metaData)
             {
                 const auto& fieldName = metaData->getFieldNameInJsonAt(fieldIndex);


### PR DESCRIPTION
Adds nomodref, willReturn, and noUnwind attribute to parse function which allows LLVM to optimize out unused parse functions and to move it around (essentially treats it as pure function).

Prior to this change, LLVM treated the parse call as conservative as possible, meaning that even if the return value of the parse call was not used at all in the code (dead code elimination), it would keep the parse calls, because of possible side-effects.
