### PR TITLE
doc(reflection) Improved Refection Documentation

### DIFF
--- a/docs/development/serialization.md
+++ b/docs/development/serialization.md
@@ -6,7 +6,8 @@ a custom interface (see `Utils/Reflection.hpp` in nes-commons).
 
 ## Adding reflection to a Logical Operator, Logical Function, Trait, or other 
 
-1. In the class header, add the following structs, assuming the class has the name `CLASS_NAME`.
+1. In the class header you must declare a `Reflector` and `Unreflector` struct. Following is an example declaration which
+   assumes the class to reflect has the name `CLASS_NAME`.
     ```cpp
     template <>
     struct Reflector<CLASS_NAME>
@@ -21,12 +22,21 @@ a custom interface (see `Utils/Reflection.hpp` in nes-commons).
     };
     ```
 2. In the class source file, you need to implement the above-mentioned struct functions. In the 
-   Reflector function, you need to call the `reflect` function on a reflectable data type or struct only consisting
+   `Reflector` struct function, you need to call the `reflect` function on a reflectable data type or struct only consisting
    of reflectable data types. By default, the types `bool, int, double, std::string, std::map, std::vector, std::nullopt_t` 
-   are reflectable, and all types where a custom Reflector and Unreflector are defined. If a struct of reflectable 
+   are reflectable, and all types where a custom `Reflector` and `Unreflector` are defined. If a struct of reflectable 
    objects is used, the struct should be defined within the classes header file within the namespace `NES::detail` and
    follow the naming pattern `ReflectedCLASS_NAME`. See the existing logical operators, logical functions, or 
    traits for example implementations.
+   To be able to automatically reflect and unreflect objects, a header which declares the `Reflector` and the `Unreflector` must be 
+   included. In most cases, the `Reflector` and `Unreflector` of a class are defined in the same header as the class itself and thus
+   no additional header is required to be included. There are some exceptions, most notably 
+   * LogicalFunctions -> use `#include <Serialization/LogicalFunctionReflection.hpp>`
+   * WindowTypes -> use `#include <Serialization/WindowTypeReflection.hpp>`
+   
+   If the relevant header is not included, you'll get a compiler error similar to `error: static assertion failed due to requirement 'always_false_v<NES::TypedLogicalFunction<NES::detail::ErasedLogicalFunction>>': Unsupported type` 
+   
+   Following is an example implementation of a `Reflector` and `Unreflector` which assumes the class to reflect has the name `CLASS_NAME`.
    ```cpp
    Reflected Reflector<CLASS_NAME>::operator()(const CLASS_NAME& op) const
    {


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
The current documentation did not explicitly mention what headers need to be included when reflecting specific classes. This is fixed in this PR.     

## Documentation
- The change is reflected in the necessary documentation, e.g., design document, in-code documentation.
- All necessary methods (no getter, setter, or constructor) have a documentation.

## Issue Closed by this pull request:

This PR closes #1406