### PR TITLE
chore(Format): Added to log_warn message if file ends on Test

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -135,7 +135,11 @@ do
     # check if corresponding header file exists
     if ! git ls-files | grep "$basename.hpp" > /dev/null
     then
-        log_warn "file has no corresponding header file: $file"
+        if [[ "$basename" =~ (test|Test|tests|Tests)$ ]]; then
+            log_warn "file has no corresponding header file: $file (fine for tests)"
+        else
+            log_warn "file has no corresponding header file: $file"
+        fi
         continue
     fi
     # error if the first include does not contain the basename


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR adds a small change to the `log_warn` message in our `format.sh` script. If the file ends with `(test|Test|tests|Tests)`, it adds `(most probably fine, as it seems to be a unit test file)`
