### PR TITLE
feat(LogicalOperator): Add weak self reference

### DIFF
--- a/nes-logical-operators/include/Operators/EventTimeWatermarkAssignerLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/EventTimeWatermarkAssignerLogicalOperator.hpp
@@ -35,10 +35,10 @@
 namespace NES
 {
 
-class EventTimeWatermarkAssignerLogicalOperator
+class EventTimeWatermarkAssignerLogicalOperator : public ManagedByOperator
 {
 public:
-    EventTimeWatermarkAssignerLogicalOperator(LogicalFunction onField, const Windowing::TimeUnit& unit);
+    EventTimeWatermarkAssignerLogicalOperator(WeakLogicalOperator self, LogicalFunction onField, const Windowing::TimeUnit& unit);
 
     LogicalFunction onField;
     Windowing::TimeUnit unit;

--- a/nes-logical-operators/include/Operators/InferModelLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/InferModelLogicalOperator.hpp
@@ -36,10 +36,10 @@ namespace NES
 /// field schema so the two cannot drift — plus the list of upstream field
 /// names bound to the model's inputs. Compilation to executable bytecode is
 /// deferred to worker-side lowering (`LowerToPhysicalInferModel`).
-class InferModelLogicalOperator
+class InferModelLogicalOperator : public ManagedByOperator
 {
 public:
-    InferModelLogicalOperator(RegisteredModel model, std::vector<std::string> inputFieldNames);
+    InferModelLogicalOperator(WeakLogicalOperator self, RegisteredModel model, std::vector<std::string> inputFieldNames);
 
     [[nodiscard]] const RegisteredModel& getModel() const;
     [[nodiscard]] std::vector<std::string> getInputFieldNames() const;
@@ -77,18 +77,6 @@ private:
     std::vector<LogicalOperator> children;
     TraitSet traitSet;
     Schema inputSchema, outputSchema;
-};
-
-template <>
-struct Reflector<InferModelLogicalOperator>
-{
-    Reflected operator()(const InferModelLogicalOperator& op) const;
-};
-
-template <>
-struct Unreflector<InferModelLogicalOperator>
-{
-    InferModelLogicalOperator operator()(const Reflected& rfl, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Operators/InferModelNameLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/InferModelNameLogicalOperator.hpp
@@ -31,10 +31,10 @@ namespace NES
 
 /// Name-based ML inference operator that holds a model name string for deferred model resolution.
 /// Schema inference requires the actual model; attempting withInferredSchema throws CannotInferSchema.
-class InferModelNameLogicalOperator
+class InferModelNameLogicalOperator : public ManagedByOperator
 {
 public:
-    explicit InferModelNameLogicalOperator(std::string modelName, std::vector<std::string> inputFieldNames);
+    explicit InferModelNameLogicalOperator(WeakLogicalOperator self, std::string modelName, std::vector<std::string> inputFieldNames);
 
     [[nodiscard]] std::string getModelName() const;
     [[nodiscard]] std::vector<std::string> getInputFieldNames() const;
@@ -66,18 +66,6 @@ private:
     std::vector<LogicalOperator> children;
     TraitSet traitSet;
     Schema inputSchema, outputSchema;
-};
-
-template <>
-struct Reflector<InferModelNameLogicalOperator>
-{
-    Reflected operator()(const InferModelNameLogicalOperator& op) const;
-};
-
-template <>
-struct Unreflector<InferModelNameLogicalOperator>
-{
-    InferModelNameLogicalOperator operator()(const Reflected& rfl, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Operators/IngestionTimeWatermarkAssignerLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/IngestionTimeWatermarkAssignerLogicalOperator.hpp
@@ -28,10 +28,10 @@
 namespace NES
 {
 
-class IngestionTimeWatermarkAssignerLogicalOperator final
+class IngestionTimeWatermarkAssignerLogicalOperator final : public ManagedByOperator
 {
 public:
-    IngestionTimeWatermarkAssignerLogicalOperator();
+    explicit IngestionTimeWatermarkAssignerLogicalOperator(WeakLogicalOperator self);
 
     [[nodiscard]] bool operator==(const IngestionTimeWatermarkAssignerLogicalOperator& rhs) const;
 
@@ -48,7 +48,6 @@ public:
     [[nodiscard]] std::string_view getName() const noexcept;
 
     [[nodiscard]] IngestionTimeWatermarkAssignerLogicalOperator withInferredSchema(std::vector<Schema> inputSchemas) const;
-
 
 protected:
     static constexpr std::string_view NAME = "IngestionTimeWatermarkAssigner";

--- a/nes-logical-operators/include/Operators/LogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/LogicalOperator.hpp
@@ -103,6 +103,12 @@ concept LogicalOperatorConcept = requires(
     { thisOperator.withInferredSchema(inputSchemas) } -> std::convertible_to<T>;
 };
 
+template <typename WeakChecked>
+requires(std::is_same_v<WeakChecked, NES::detail::ErasedLogicalOperator> || LogicalOperatorConcept<WeakChecked>)
+struct WeakTypedLogicalOperator;
+
+using WeakLogicalOperator = WeakTypedLogicalOperator<NES::detail::ErasedLogicalOperator>;
+
 namespace detail
 {
 /// @brief A type erased wrapper for logical operators
@@ -130,6 +136,9 @@ struct ErasedLogicalOperator : std::enable_shared_from_this<ErasedLogicalOperato
 private:
     template <typename T>
     friend struct NES::TypedLogicalOperator;
+    template <typename T>
+    requires(std::is_same_v<T, detail::ErasedLogicalOperator> || LogicalOperatorConcept<T>)
+    friend struct NES::WeakTypedLogicalOperator;
     ///If the operator inherits from DynamicBase (over Castable), then returns a pointer to the wrapped operator as DynamicBase,
     ///so that we can then safely try to dyncast the DynamicBase* to Castable<T>*
     [[nodiscard]] virtual std::optional<const DynamicBase*> getImpl() const = 0;
@@ -168,6 +177,12 @@ struct TypedLogicalOperator
     }
 
     explicit TypedLogicalOperator(std::shared_ptr<const NES::detail::ErasedLogicalOperator> op) : self(std::move(op)) { }
+
+    template <typename... Args>
+    requires(!std::is_same_v<Checked, detail::ErasedLogicalOperator>)
+    explicit TypedLogicalOperator(Args&&... args) : self(std::make_shared<detail::OperatorModel<Checked>>(std::forward<Args>(args)...))
+    {
+    }
 
     template <LogicalOperatorConcept T>
     requires(std::same_as<T, Checked>)
@@ -213,7 +228,8 @@ struct TypedLogicalOperator
         }
     }
 
-    TypedLogicalOperator() = delete;
+    /// I am not quite sure how do only allow "empty" ctors for concrete operators that take no arguments
+    /// TypedLogicalOperator() = delete;
 
     /// Attempts to get the underlying operator as type T.
     /// @tparam T The type to try to get the operator as.
@@ -293,7 +309,14 @@ struct TypedLogicalOperator
 
     [[nodiscard]] OperatorId getId() const { return self->getOperatorId(); }
 
-    [[nodiscard]] bool operator==(const LogicalOperator& other) const { return self->equals(*other.self); }
+    [[nodiscard]] bool operator==(const LogicalOperator& other) const
+    {
+        if (self == other.self)
+        {
+            return true;
+        }
+        return self->equals(*other.self);
+    }
 
     [[nodiscard]] std::string_view getName() const noexcept { return self->getName(); }
 
@@ -308,6 +331,10 @@ struct TypedLogicalOperator
         return self->withInferredSchema(std::move(inputSchemas));
     }
 
+    using WeakSelfRefType = WeakLogicalOperator;
+    template <LogicalOperatorConcept T>
+    using ModelType = detail::OperatorModel<T>;
+
 private:
     friend class QueryPlanSerializationUtil;
     friend class OperatorSerializationUtil;
@@ -315,9 +342,119 @@ private:
     template <typename FriendChecked>
     friend struct TypedLogicalOperator;
 
+    template <typename WeakChecked>
+    requires(std::is_same_v<WeakChecked, detail::ErasedLogicalOperator> || LogicalOperatorConcept<WeakChecked>)
+    friend struct WeakTypedLogicalOperator;
+
     [[nodiscard]] TypedLogicalOperator withOperatorId(const OperatorId id) const { return self->withOperatorId(id); };
 
     std::shared_ptr<const NES::detail::ErasedLogicalOperator> self;
+};
+
+namespace detail
+{
+template <typename Checked>
+struct SelfRef
+{
+    std::optional<OperatorModel<Checked>*> self;
+
+    explicit SelfRef(OperatorModel<Checked>* ptr) : self(ptr) { }
+};
+}
+
+template <typename Checked>
+requires(std::is_same_v<Checked, detail::ErasedLogicalOperator> || LogicalOperatorConcept<Checked>)
+struct WeakTypedLogicalOperator
+{
+private:
+    using PtrType = std::conditional_t<
+        std::is_same_v<Checked, detail::ErasedLogicalOperator>,
+        std::weak_ptr<const detail::ErasedLogicalOperator>,
+        std::shared_ptr<detail::SelfRef<Checked>>>;
+
+public:
+    WeakTypedLogicalOperator() = default;
+
+    explicit WeakTypedLogicalOperator(const LogicalOperator& owningOperator) : self(owningOperator.self) { }
+
+    explicit WeakTypedLogicalOperator(PtrType weakPtr) : self(std::move(weakPtr)) { }
+
+    ///Unwrap the (shared pointer to a pointer to an operator model) to (a shared pointer to the operator model).
+    ///In other words, this removes one layer of pointer indirection and makes it non-owning to avoid reference counting cycles.
+    ///It has to keep using the control block of the passed shared ptr, since the control block of the owning shared pointer is not accessible yet.
+    template <typename OtherChecked>
+    requires(std::is_same_v<Checked, detail::ErasedLogicalOperator> && LogicalOperatorConcept<OtherChecked>)
+    explicit WeakTypedLogicalOperator(const std::shared_ptr<detail::SelfRef<OtherChecked>>& other)
+        : self(std::shared_ptr<detail::ErasedLogicalOperator>{other, static_cast<detail::ErasedLogicalOperator*>(other->self.value())})
+    {
+    }
+
+    [[nodiscard]] std::optional<TypedLogicalOperator<Checked>> tryLock() const
+    {
+        if constexpr (std::is_same_v<Checked, detail::ErasedLogicalOperator>)
+        {
+            if (auto ptr = self.lock())
+            {
+                return TypedLogicalOperator<Checked>{ptr->shared_from_this()};
+            }
+            return std::nullopt;
+        }
+        else if constexpr (LogicalOperatorConcept<Checked>)
+        {
+            if (const auto ptrOpt = self->self; ptrOpt->has_value())
+            {
+                return TypedLogicalOperator<Checked>{ptrOpt->value()->shared_from_this()};
+            }
+            return std::nullopt;
+        }
+        else
+        {
+            static_assert(false, "Non exhaustive tryLock for WeakOperators");
+            std::unreachable();
+        }
+    }
+
+    [[nodiscard]] TypedLogicalOperator<Checked> lock() const
+    {
+        if constexpr (std::is_same_v<Checked, detail::ErasedLogicalOperator>)
+        {
+            auto ptr = self.lock();
+            if (ptr)
+            {
+                return TypedLogicalOperator<Checked>{ptr->shared_from_this()};
+            }
+            PRECONDITION(false, "Operator has been destroyed");
+            std::unreachable();
+        }
+        else if constexpr (LogicalOperatorConcept<Checked>)
+        {
+            if (const auto ptrOpt = self->self; ptrOpt->has_value())
+            {
+                return TypedLogicalOperator<Checked>{ptrOpt->value()->shared_from_this()};
+            }
+            PRECONDITION(false, "Operator has been destroyed");
+            std::unreachable();
+        }
+        else
+        {
+            static_assert(false, "Non exhaustive lock for WeakOperators");
+            std::unreachable();
+        }
+    }
+
+private:
+    PtrType self;
+};
+
+class ManagedByOperator
+{
+protected:
+    WeakLogicalOperator self;
+
+    explicit ManagedByOperator(WeakLogicalOperator self) : self(std::move(self)) { }
+
+    template <LogicalOperatorConcept T>
+    friend struct detail::OperatorModel;
 };
 
 namespace detail
@@ -327,12 +464,40 @@ namespace detail
 template <LogicalOperatorConcept OperatorType>
 struct OperatorModel : ErasedLogicalOperator
 {
-    OperatorType impl;
     OperatorId id;
+    std::shared_ptr<SelfRef<OperatorType>> selfRef;
+    OperatorType impl;
 
-    explicit OperatorModel(OperatorType impl) : impl(std::move(impl)), id(getNextLogicalOperatorId()) { }
+    explicit OperatorModel(OperatorType impl)
+        : id(getNextLogicalOperatorId()), selfRef(std::make_shared<SelfRef<OperatorType>>(this)), impl(std::move(impl))
+    {
+        this->impl.self = WeakLogicalOperator{selfRef};
+    }
 
-    OperatorModel(OperatorType impl, const OperatorId existingId) : impl(std::move(impl)), id(existingId) { }
+    OperatorModel(OperatorType impl, const OperatorId existingId)
+        : id(existingId), selfRef(std::make_shared<SelfRef<OperatorType>>(this)), impl(std::move(impl))
+    {
+        this->impl.self = WeakLogicalOperator{selfRef};
+    }
+
+    template <typename... Args>
+    explicit OperatorModel(Args&&... args)
+        : id(getNextLogicalOperatorId())
+        , selfRef(std::make_shared<SelfRef<OperatorType>>(this))
+        , impl(WeakLogicalOperator{selfRef}, std::forward<Args>(args)...)
+    {
+    }
+
+    OperatorModel(const OperatorModel& other) : id(other.id), selfRef(std::make_shared<SelfRef<OperatorType>>(this)), impl(other.impl)
+    {
+        impl.self = WeakLogicalOperator{selfRef};
+    }
+
+    OperatorModel(OperatorModel&& other) noexcept = delete;
+
+    OperatorModel& operator=(const OperatorModel& other) = delete;
+
+    ~OperatorModel() override { selfRef->self = std::nullopt; }
 
     [[nodiscard]] std::string explain(ExplainVerbosity verbosity) const override { return impl.explain(verbosity, id); }
 
@@ -387,7 +552,16 @@ private:
     {
         if constexpr (std::is_base_of_v<DynamicBase, OperatorType>)
         {
-            return static_cast<const DynamicBase*>(&impl);
+            if constexpr (requires() { static_cast<const DynamicBase*>(&impl); })
+            {
+                return static_cast<const DynamicBase*>(&impl);
+            }
+            else if constexpr (requires() {
+                                   { impl.getDynamicBase() } -> std::same_as<const DynamicBase*>;
+                               })
+            {
+                return impl.getDynamicBase();
+            }
         }
         else
         {
@@ -397,6 +571,11 @@ private:
 };
 
 }
+
+#define SELF_REF \
+    template <LogicalOperatorConcept T> \
+    friend struct NES::detail::OperatorModel; \
+    WeakLogicalOperator self;
 
 inline std::ostream& operator<<(std::ostream& os, const LogicalOperator& op)
 {

--- a/nes-logical-operators/include/Operators/ProjectionLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/ProjectionLogicalOperator.hpp
@@ -34,7 +34,7 @@ namespace NES
 {
 
 /// Combines both selecting the fields to project and renaming/mapping of fields
-class ProjectionLogicalOperator
+class ProjectionLogicalOperator : public ManagedByOperator
 {
 public:
     class Asterisk
@@ -48,7 +48,7 @@ public:
     };
 
     using Projection = std::pair<std::optional<FieldIdentifier>, LogicalFunction>;
-    ProjectionLogicalOperator(std::vector<Projection> projections, Asterisk asterisk);
+    ProjectionLogicalOperator(WeakLogicalOperator self, std::vector<Projection> projections, Asterisk asterisk);
 
     [[nodiscard]] const std::vector<Projection>& getProjections() const;
 

--- a/nes-logical-operators/include/Operators/SelectionLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/SelectionLogicalOperator.hpp
@@ -34,10 +34,10 @@ namespace NES
 {
 
 /// Selection operator, which contains an function as a predicate.
-class SelectionLogicalOperator
+class SelectionLogicalOperator : public ManagedByOperator
 {
 public:
-    explicit SelectionLogicalOperator(LogicalFunction predicate);
+    explicit SelectionLogicalOperator(WeakLogicalOperator self, LogicalFunction predicate);
 
     [[nodiscard]] LogicalFunction getPredicate() const;
 

--- a/nes-logical-operators/include/Operators/Sinks/InlineSinkLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Sinks/InlineSinkLogicalOperator.hpp
@@ -30,10 +30,11 @@ namespace NES
 /// InlineSinkLogicalOperator objects represent sinks in the logical query plan that are defined within a query as opposed to
 /// sinks defined in separate create statements. The InlineSinkLogicalOperator objects contain all necessary configurations to
 /// build a SinkLogicalOperator within the InlineSinkBindingPhase of the optimizer.
-class InlineSinkLogicalOperator
+class InlineSinkLogicalOperator : public ManagedByOperator
 {
 public:
     explicit InlineSinkLogicalOperator(
+        WeakLogicalOperator self,
         std::string sinkType,
         const Schema& schema,
         std::unordered_map<std::string, std::string> config,

--- a/nes-logical-operators/include/Operators/Sinks/SinkLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Sinks/SinkLogicalOperator.hpp
@@ -20,6 +20,7 @@
 #include <string_view>
 #include <unordered_map>
 #include <vector>
+
 #include <Configurations/Descriptor.hpp>
 #include <DataTypes/Schema.hpp>
 #include <Identifiers/Identifiers.hpp>
@@ -33,13 +34,13 @@
 namespace NES
 {
 
-struct SinkLogicalOperator final
+struct SinkLogicalOperator final : public ManagedByOperator
 {
     /// During deserialization, we don't need to know/use the name of the sink anymore.
-    SinkLogicalOperator() = default;
+    explicit SinkLogicalOperator(WeakLogicalOperator self);
     /// During query parsing, we require the name of the sink and need to assign it an id.
-    explicit SinkLogicalOperator(std::string sinkName);
-    explicit SinkLogicalOperator(SinkDescriptor sinkDescriptor);
+    explicit SinkLogicalOperator(WeakLogicalOperator self, std::string sinkName);
+    explicit SinkLogicalOperator(WeakLogicalOperator self, SinkDescriptor sinkDescriptor);
 
     [[nodiscard]] bool operator==(const SinkLogicalOperator& rhs) const;
 
@@ -85,6 +86,7 @@ private:
     std::optional<SinkDescriptor> sinkDescriptor;
 
     friend class OperatorSerializationUtil;
+
     friend Reflector<TypedLogicalOperator<SinkLogicalOperator>>;
 };
 

--- a/nes-logical-operators/include/Operators/Sources/InlineSourceLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Sources/InlineSourceLogicalOperator.hpp
@@ -31,10 +31,11 @@ namespace NES
 /// sources defined in separate create statements. The InlineSourceLogicalOperator objects contain all necessary configurations to
 /// build a SourceDescriptorLogicalOperator within the InlineSourceBindingPhase of the optimizer.
 
-class InlineSourceLogicalOperator
+class InlineSourceLogicalOperator : public ManagedByOperator
 {
 public:
     explicit InlineSourceLogicalOperator(
+        WeakLogicalOperator self,
         std::string type,
         const Schema& schema,
         std::unordered_map<std::string, std::string> sourceConfig,

--- a/nes-logical-operators/include/Operators/Sources/SourceDescriptorLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Sources/SourceDescriptorLogicalOperator.hpp
@@ -23,7 +23,6 @@
 #include <Operators/LogicalOperator.hpp>
 #include <Operators/OriginIdAssigner.hpp>
 #include <Sources/SourceDescriptor.hpp>
-#include <Traits/Trait.hpp>
 #include <Traits/TraitSet.hpp>
 #include <Util/PlanRenderer.hpp>
 #include <Util/Reflection.hpp>
@@ -36,10 +35,10 @@ namespace NES
 /// The logical source is then used as key to a multimap, with all descriptors that name the logical source as values.
 /// In the LogicalSourceExpansionRule, we take the keys from SourceNameLogicalOperator operators, get all corresponding (physical) source
 /// descriptors from the catalog, construct SourceDescriptorLogicalOperators from the descriptors and attach them to the query plan.
-class SourceDescriptorLogicalOperator final : public OriginIdAssigner
+class SourceDescriptorLogicalOperator final : public OriginIdAssigner, public ManagedByOperator
 {
 public:
-    explicit SourceDescriptorLogicalOperator(SourceDescriptor sourceDescriptor);
+    explicit SourceDescriptorLogicalOperator(WeakLogicalOperator self, SourceDescriptor sourceDescriptor);
 
     [[nodiscard]] SourceDescriptor getSourceDescriptor() const;
 
@@ -58,7 +57,6 @@ public:
     [[nodiscard]] std::string_view getName() const noexcept;
 
     [[nodiscard]] SourceDescriptorLogicalOperator withInferredSchema(const std::vector<Schema>& inputSchemas) const;
-
 
 private:
     static constexpr std::string_view NAME = "Source";

--- a/nes-logical-operators/include/Operators/Sources/SourceNameLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Sources/SourceNameLogicalOperator.hpp
@@ -32,11 +32,11 @@ namespace NES
 /// In the LogicalSourceExpansionRule, we use the logical source name as input to the source catalog, to retrieve all (physical) source descriptors
 /// configured for the specific logical source name. We then expand 1 SourceNameLogicalOperator to N SourceDescriptorLogicalOperators,
 /// one SourceDescriptorLogicalOperator for each descriptor found in the source catalog with the logical source name as input.
-class SourceNameLogicalOperator
+class SourceNameLogicalOperator : public ManagedByOperator
 {
 public:
-    explicit SourceNameLogicalOperator(std::string logicalSourceName);
-    explicit SourceNameLogicalOperator(std::string logicalSourceName, Schema schema);
+    explicit SourceNameLogicalOperator(WeakLogicalOperator self, std::string logicalSourceName);
+    explicit SourceNameLogicalOperator(WeakLogicalOperator self, std::string logicalSourceName, const Schema& schema);
 
     static void inferInputOrigins();
 

--- a/nes-logical-operators/include/Operators/UnionLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/UnionLogicalOperator.hpp
@@ -28,10 +28,10 @@
 namespace NES
 {
 
-class UnionLogicalOperator
+class UnionLogicalOperator : public ManagedByOperator
 {
 public:
-    explicit UnionLogicalOperator();
+    explicit UnionLogicalOperator(WeakLogicalOperator self);
 
     [[nodiscard]] bool operator==(const UnionLogicalOperator& rhs) const;
 

--- a/nes-logical-operators/include/Operators/Windows/JoinLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Windows/JoinLogicalOperator.hpp
@@ -38,7 +38,7 @@ namespace NES
 {
 class SerializableOperator;
 
-class JoinLogicalOperator final : public OriginIdAssigner
+class JoinLogicalOperator final : public OriginIdAssigner, public ManagedByOperator
 {
 public:
     enum class JoinType : uint8_t
@@ -47,7 +47,8 @@ public:
         CARTESIAN_PRODUCT
     };
 
-    explicit JoinLogicalOperator(LogicalFunction joinFunction, std::shared_ptr<Windowing::WindowType> windowType, JoinType joinType);
+    explicit JoinLogicalOperator(
+        WeakLogicalOperator self, LogicalFunction joinFunction, std::shared_ptr<Windowing::WindowType> windowType, JoinType joinType);
 
     [[nodiscard]] LogicalFunction getJoinFunction() const;
     [[nodiscard]] Schema getLeftSchema() const;

--- a/nes-logical-operators/include/Operators/Windows/WindowedAggregationLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Windows/WindowedAggregationLogicalOperator.hpp
@@ -40,10 +40,11 @@
 namespace NES
 {
 
-class WindowedAggregationLogicalOperator final : public OriginIdAssigner
+class WindowedAggregationLogicalOperator final : public OriginIdAssigner, public ManagedByOperator
 {
 public:
     WindowedAggregationLogicalOperator(
+        WeakLogicalOperator self,
         std::vector<FieldAccessLogicalFunction> groupingKey,
         std::vector<std::shared_ptr<WindowAggregationLogicalFunction>> aggregationFunctions,
         std::shared_ptr<Windowing::WindowType> windowType);

--- a/nes-logical-operators/src/Operators/EventTimeWatermarkAssignerLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/EventTimeWatermarkAssignerLogicalOperator.cpp
@@ -42,8 +42,8 @@ namespace NES
 {
 
 EventTimeWatermarkAssignerLogicalOperator::EventTimeWatermarkAssignerLogicalOperator(
-    LogicalFunction onField, const Windowing::TimeUnit& unit)
-    : onField(std::move(onField)), unit(unit)
+    WeakLogicalOperator self, LogicalFunction onField, const Windowing::TimeUnit& unit)
+    : ManagedByOperator(std::move(self)), onField(std::move(onField)), unit(unit)
 {
 }
 
@@ -134,7 +134,7 @@ Unreflector<TypedLogicalOperator<EventTimeWatermarkAssignerLogicalOperator>>::op
     const Reflected& reflected, const ReflectionContext& context) const
 {
     auto [onField, timeUnit] = context.unreflect<detail::ReflectedEventTimeWatermarkAssignerLogicalOperator>(reflected);
-    return TypedLogicalOperator<EventTimeWatermarkAssignerLogicalOperator>{EventTimeWatermarkAssignerLogicalOperator{onField, timeUnit}};
+    return TypedLogicalOperator<EventTimeWatermarkAssignerLogicalOperator>{onField, timeUnit};
 }
 
 LogicalOperatorRegistryReturnType

--- a/nes-logical-operators/src/Operators/InferModelLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/InferModelLogicalOperator.cpp
@@ -38,8 +38,9 @@
 namespace NES
 {
 
-InferModelLogicalOperator::InferModelLogicalOperator(RegisteredModel model, std::vector<std::string> inputFieldNames)
-    : model(std::move(model)), inputFieldNames(std::move(inputFieldNames))
+InferModelLogicalOperator::InferModelLogicalOperator(
+    WeakLogicalOperator self, RegisteredModel model, std::vector<std::string> inputFieldNames)
+    : ManagedByOperator(std::move(self)), model(std::move(model)), inputFieldNames(std::move(inputFieldNames))
 {
 }
 
@@ -185,17 +186,6 @@ std::vector<LogicalOperator> InferModelLogicalOperator::getChildren() const
     return children;
 }
 
-Reflected Reflector<InferModelLogicalOperator>::operator()(const InferModelLogicalOperator& op) const
-{
-    return reflect(detail::ReflectedInferModelLogicalOperator{.model = reflect(op.getModel()), .inputFieldNames = op.getInputFieldNames()});
-}
-
-InferModelLogicalOperator Unreflector<InferModelLogicalOperator>::operator()(const Reflected& rfl, const ReflectionContext& context) const
-{
-    auto [model, inputFieldNames] = context.unreflect<detail::ReflectedInferModelLogicalOperator>(rfl);
-    return {context.unreflect<RegisteredModel>(model), std::move(inputFieldNames)};
-}
-
 Reflected
 Reflector<TypedLogicalOperator<InferModelLogicalOperator>>::operator()(const TypedLogicalOperator<InferModelLogicalOperator>& op) const
 {
@@ -207,7 +197,7 @@ TypedLogicalOperator<InferModelLogicalOperator>
 Unreflector<TypedLogicalOperator<InferModelLogicalOperator>>::operator()(const Reflected& rfl, const ReflectionContext& context) const
 {
     auto [model, inputFieldNames] = context.unreflect<detail::ReflectedInferModelLogicalOperator>(rfl);
-    return InferModelLogicalOperator{context.unreflect<RegisteredModel>(model), std::move(inputFieldNames)};
+    return TypedLogicalOperator<InferModelLogicalOperator>{context.unreflect<RegisteredModel>(model), std::move(inputFieldNames)};
 }
 
 /// generated registry interface requires by-value argument
@@ -217,7 +207,7 @@ LogicalOperatorGeneratedRegistrar::RegisterInferModelLogicalOperator(LogicalOper
 {
     if (!arguments.reflected.isEmpty())
     {
-        return ReflectionContext{}.unreflect<InferModelLogicalOperator>(arguments.reflected);
+        return ReflectionContext{}.unreflect<TypedLogicalOperator<InferModelLogicalOperator>>(arguments.reflected);
     }
     PRECONDITION(false, "Operator is only built directly or via reflection, not using the registry");
     std::unreachable();

--- a/nes-logical-operators/src/Operators/InferModelNameLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/InferModelNameLogicalOperator.cpp
@@ -35,8 +35,9 @@
 namespace NES
 {
 
-InferModelNameLogicalOperator::InferModelNameLogicalOperator(std::string modelName, std::vector<std::string> inputFieldNames)
-    : modelName(std::move(modelName)), inputFieldNames(std::move(inputFieldNames))
+InferModelNameLogicalOperator::InferModelNameLogicalOperator(
+    WeakLogicalOperator self, std::string modelName, std::vector<std::string> inputFieldNames)
+    : ManagedByOperator(std::move(self)), modelName(std::move(modelName)), inputFieldNames(std::move(inputFieldNames))
 {
 }
 
@@ -117,25 +118,6 @@ std::vector<LogicalOperator> InferModelNameLogicalOperator::getChildren() const
     return children;
 }
 
-Reflected Reflector<InferModelNameLogicalOperator>::operator()(const InferModelNameLogicalOperator& op) const
-{
-    return reflect(detail::ReflectedInferModelNameLogicalOperator{
-        .modelName = std::make_optional(op.getModelName()), .inputFieldNames = std::make_optional(op.getInputFieldNames())});
-}
-
-InferModelNameLogicalOperator
-Unreflector<InferModelNameLogicalOperator>::operator()(const Reflected& rfl, const ReflectionContext& context) const
-{
-    auto [modelNameOpt, inputFieldNamesOpt] = context.unreflect<detail::ReflectedInferModelNameLogicalOperator>(rfl);
-
-    if (!modelNameOpt.has_value() || !inputFieldNamesOpt.has_value())
-    {
-        throw CannotDeserialize("Failed to deserialize InferModelNameLogicalOperator");
-    }
-
-    return InferModelNameLogicalOperator(modelNameOpt.value(), inputFieldNamesOpt.value());
-}
-
 Reflected Reflector<TypedLogicalOperator<InferModelNameLogicalOperator>>::operator()(
     const TypedLogicalOperator<InferModelNameLogicalOperator>& op) const
 {
@@ -153,8 +135,7 @@ Unreflector<TypedLogicalOperator<InferModelNameLogicalOperator>>::operator()(con
         throw CannotDeserialize("Failed to deserialize TypedLogicalOperator<InferModelNameLogicalOperator>");
     }
 
-    return TypedLogicalOperator<InferModelNameLogicalOperator>{
-        InferModelNameLogicalOperator(modelNameOpt.value(), inputFieldNamesOpt.value())};
+    return TypedLogicalOperator<InferModelNameLogicalOperator>{modelNameOpt.value(), inputFieldNamesOpt.value()};
 }
 
 /// generated registry interface requires by-value argument
@@ -164,7 +145,7 @@ LogicalOperatorGeneratedRegistrar::RegisterInferModelNameLogicalOperator(Logical
 {
     if (!arguments.reflected.isEmpty())
     {
-        return ReflectionContext{}.unreflect<InferModelNameLogicalOperator>(arguments.reflected);
+        return ReflectionContext{}.unreflect<TypedLogicalOperator<InferModelNameLogicalOperator>>(arguments.reflected);
     }
     PRECONDITION(false, "Operator is only built directly or via reflection, not using the registry");
     std::unreachable();

--- a/nes-logical-operators/src/Operators/IngestionTimeWatermarkAssignerLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/IngestionTimeWatermarkAssignerLogicalOperator.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include <fmt/format.h>
@@ -33,7 +34,10 @@
 namespace NES
 {
 
-IngestionTimeWatermarkAssignerLogicalOperator::IngestionTimeWatermarkAssignerLogicalOperator() = default;
+IngestionTimeWatermarkAssignerLogicalOperator::IngestionTimeWatermarkAssignerLogicalOperator(WeakLogicalOperator self)
+    : ManagedByOperator(std::move(self))
+{
+}
 
 std::string_view IngestionTimeWatermarkAssignerLogicalOperator::getName() const noexcept
 {
@@ -111,14 +115,14 @@ TypedLogicalOperator<IngestionTimeWatermarkAssignerLogicalOperator>
 Unreflector<TypedLogicalOperator<IngestionTimeWatermarkAssignerLogicalOperator>>::operator()(
     const Reflected&, const ReflectionContext&) const
 {
-    return TypedLogicalOperator<IngestionTimeWatermarkAssignerLogicalOperator>{IngestionTimeWatermarkAssignerLogicalOperator{}};
+    return TypedLogicalOperator<IngestionTimeWatermarkAssignerLogicalOperator>{};
 }
 
 LogicalOperatorRegistryReturnType
 LogicalOperatorGeneratedRegistrar::RegisterIngestionTimeWatermarkAssignerLogicalOperator(LogicalOperatorRegistryArguments arguments)
 {
-    auto logicalOperator = IngestionTimeWatermarkAssignerLogicalOperator();
-    return logicalOperator.withInferredSchema(arguments.inputSchemas);
+    auto logicalOperator = TypedLogicalOperator<IngestionTimeWatermarkAssignerLogicalOperator>{};
+    return logicalOperator->withInferredSchema(arguments.inputSchemas);
 }
 
 }

--- a/nes-logical-operators/src/Operators/ProjectionLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/ProjectionLogicalOperator.cpp
@@ -59,8 +59,8 @@ std::string explainProjection(const ProjectionLogicalOperator::Projection& proje
 }
 }
 
-ProjectionLogicalOperator::ProjectionLogicalOperator(std::vector<Projection> projections, Asterisk asterisk)
-    : projections(std::move(projections)), asterisk(asterisk.value)
+ProjectionLogicalOperator::ProjectionLogicalOperator(WeakLogicalOperator self, std::vector<Projection> projections, Asterisk asterisk)
+    : ManagedByOperator(std::move(self)), projections(std::move(projections)), asterisk(asterisk.value)
 {
 }
 
@@ -262,8 +262,7 @@ Unreflector<TypedLogicalOperator<ProjectionLogicalOperator>>::operator()(const R
         parsedProjections.emplace_back(identifier, function);
     }
 
-    return TypedLogicalOperator<ProjectionLogicalOperator>{
-        ProjectionLogicalOperator{std::move(parsedProjections), ProjectionLogicalOperator::Asterisk(asterisk)}};
+    return TypedLogicalOperator<ProjectionLogicalOperator>{std::move(parsedProjections), ProjectionLogicalOperator::Asterisk(asterisk)};
 }
 
 LogicalOperatorRegistryReturnType

--- a/nes-logical-operators/src/Operators/SelectionLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/SelectionLogicalOperator.cpp
@@ -39,7 +39,8 @@
 namespace NES
 {
 
-SelectionLogicalOperator::SelectionLogicalOperator(LogicalFunction predicate) : predicate(std::move(predicate))
+SelectionLogicalOperator::SelectionLogicalOperator(WeakLogicalOperator self, LogicalFunction predicate)
+    : ManagedByOperator(std::move(self)), predicate(std::move(predicate))
 {
 }
 
@@ -140,7 +141,7 @@ TypedLogicalOperator<SelectionLogicalOperator>
 Unreflector<TypedLogicalOperator<SelectionLogicalOperator>>::operator()(const Reflected& rfl, const ReflectionContext& context) const
 {
     auto [predicate] = context.unreflect<detail::ReflectedSelectionLogicalOperator>(rfl);
-    return TypedLogicalOperator<SelectionLogicalOperator>{SelectionLogicalOperator(predicate)};
+    return TypedLogicalOperator<SelectionLogicalOperator>{predicate};
 }
 
 LogicalOperatorRegistryReturnType

--- a/nes-logical-operators/src/Operators/Sinks/InlineSinkLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Sinks/InlineSinkLogicalOperator.cpp
@@ -113,11 +113,16 @@ std::vector<LogicalOperator> InlineSinkLogicalOperator::getChildren() const
 }
 
 InlineSinkLogicalOperator::InlineSinkLogicalOperator(
+    WeakLogicalOperator self,
     std::string type,
     const Schema& schema,
     std::unordered_map<std::string, std::string> config,
     std::unordered_map<std::string, std::string> formatConfig)
-    : schema(schema), sinkType(std::move(type)), sinkConfig(std::move(config)), formatConfig(std::move(formatConfig))
+    : ManagedByOperator(std::move(self))
+    , schema(schema)
+    , sinkType(std::move(type))
+    , sinkConfig(std::move(config))
+    , formatConfig(std::move(formatConfig))
 {
 }
 

--- a/nes-logical-operators/src/Operators/Sinks/SinkLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Sinks/SinkLogicalOperator.cpp
@@ -39,10 +39,17 @@
 namespace NES
 {
 
-SinkLogicalOperator::SinkLogicalOperator(std::string sinkName) : sinkName(std::move(sinkName)) { };
+SinkLogicalOperator::SinkLogicalOperator(WeakLogicalOperator self) : ManagedByOperator(std::move(self))
+{
+}
 
-SinkLogicalOperator::SinkLogicalOperator(SinkDescriptor sinkDescriptor)
-    : sinkName(sinkDescriptor.getSinkName()), sinkDescriptor(std::move(sinkDescriptor))
+SinkLogicalOperator::SinkLogicalOperator(WeakLogicalOperator self, std::string sinkName)
+    : ManagedByOperator(std::move(self)), sinkName(std::move(sinkName))
+{
+}
+
+SinkLogicalOperator::SinkLogicalOperator(WeakLogicalOperator self, SinkDescriptor sinkDescriptor)
+    : ManagedByOperator(std::move(self)), sinkName(sinkDescriptor.getSinkName()), sinkDescriptor(std::move(sinkDescriptor))
 {
 }
 
@@ -217,8 +224,8 @@ Unreflector<TypedLogicalOperator<SinkLogicalOperator>>::operator()(const Reflect
                 name);
         }
 
-        return TypedLogicalOperator<SinkLogicalOperator>{SinkLogicalOperator{descriptor.value()}};
+        return TypedLogicalOperator<SinkLogicalOperator>{descriptor.value()};
     }
-    return TypedLogicalOperator<SinkLogicalOperator>{SinkLogicalOperator{name}};
+    return TypedLogicalOperator<SinkLogicalOperator>{name};
 }
 }

--- a/nes-logical-operators/src/Operators/Sources/InlineSourceLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Sources/InlineSourceLogicalOperator.cpp
@@ -115,11 +115,16 @@ std::vector<LogicalOperator> InlineSourceLogicalOperator::getChildren() const
 }
 
 InlineSourceLogicalOperator::InlineSourceLogicalOperator(
+    WeakLogicalOperator self,
     std::string type,
     const Schema& schema,
     std::unordered_map<std::string, std::string> sourceConfig,
     std::unordered_map<std::string, std::string> parserConfig)
-    : schema(schema), sourceType(std::move(type)), sourceConfig(std::move(sourceConfig)), parserConfig(std::move(parserConfig))
+    : ManagedByOperator(std::move(self))
+    , schema(schema)
+    , sourceType(std::move(type))
+    , sourceConfig(std::move(sourceConfig))
+    , parserConfig(std::move(parserConfig))
 {
 }
 

--- a/nes-logical-operators/src/Operators/Sources/SourceDescriptorLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Sources/SourceDescriptorLogicalOperator.cpp
@@ -34,8 +34,8 @@
 
 namespace NES
 {
-SourceDescriptorLogicalOperator::SourceDescriptorLogicalOperator(SourceDescriptor sourceDescriptor)
-    : sourceDescriptor(std::move(sourceDescriptor))
+SourceDescriptorLogicalOperator::SourceDescriptorLogicalOperator(WeakLogicalOperator self, SourceDescriptor sourceDescriptor)
+    : ManagedByOperator(std::move(self)), sourceDescriptor(std::move(sourceDescriptor))
 {
 }
 
@@ -115,6 +115,6 @@ TypedLogicalOperator<SourceDescriptorLogicalOperator>
 Unreflector<TypedLogicalOperator<SourceDescriptorLogicalOperator>>::operator()(const Reflected& rfl, const ReflectionContext& context) const
 {
     auto sourceDescriptor = context.unreflect<SourceDescriptor>(rfl);
-    return TypedLogicalOperator<SourceDescriptorLogicalOperator>{SourceDescriptorLogicalOperator(std::move(sourceDescriptor))};
+    return TypedLogicalOperator<SourceDescriptorLogicalOperator>{std::move(sourceDescriptor)};
 }
 }

--- a/nes-logical-operators/src/Operators/Sources/SourceNameLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Sources/SourceNameLogicalOperator.cpp
@@ -36,12 +36,13 @@
 namespace NES
 {
 
-SourceNameLogicalOperator::SourceNameLogicalOperator(std::string logicalSourceName) : logicalSourceName(std::move(logicalSourceName))
+SourceNameLogicalOperator::SourceNameLogicalOperator(WeakLogicalOperator self, std::string logicalSourceName)
+    : ManagedByOperator(std::move(self)), logicalSourceName(std::move(logicalSourceName))
 {
 }
 
-SourceNameLogicalOperator::SourceNameLogicalOperator(std::string logicalSourceName, Schema schema)
-    : logicalSourceName(std::move(logicalSourceName)), schema(std::move(schema))
+SourceNameLogicalOperator::SourceNameLogicalOperator(WeakLogicalOperator self, std::string logicalSourceName, const Schema& schema)
+    : ManagedByOperator(std::move(self)), logicalSourceName(std::move(logicalSourceName)), schema(schema)
 {
 }
 

--- a/nes-logical-operators/src/Operators/UnionLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/UnionLogicalOperator.cpp
@@ -37,7 +37,9 @@
 namespace NES
 {
 
-UnionLogicalOperator::UnionLogicalOperator() = default;
+UnionLogicalOperator::UnionLogicalOperator(WeakLogicalOperator self) : ManagedByOperator(std::move(self))
+{
+}
 
 std::string_view UnionLogicalOperator::getName() const noexcept
 {
@@ -154,7 +156,7 @@ Reflected Reflector<TypedLogicalOperator<UnionLogicalOperator>>::operator()(cons
 TypedLogicalOperator<UnionLogicalOperator>
 Unreflector<TypedLogicalOperator<UnionLogicalOperator>>::operator()(const Reflected&, const ReflectionContext&) const
 {
-    return TypedLogicalOperator<UnionLogicalOperator>{UnionLogicalOperator{}};
+    return TypedLogicalOperator<UnionLogicalOperator>{};
 }
 
 LogicalOperatorRegistryReturnType
@@ -164,13 +166,13 @@ LogicalOperatorGeneratedRegistrar::RegisterUnionLogicalOperator(LogicalOperatorR
     {
         return ReflectionContext{}.unreflect<TypedLogicalOperator<UnionLogicalOperator>>(arguments.reflected);
     }
-    auto logicalOperator = UnionLogicalOperator();
+    auto logicalOperator = TypedLogicalOperator<UnionLogicalOperator>{};
     if (arguments.inputSchemas.empty())
     {
         throw CannotDeserialize("Union expects at least one child but got {} inputSchemas!", arguments.inputSchemas.size());
     }
-    auto logicalOp = logicalOperator.setInputSchemas(std::move(arguments.inputSchemas)).setOutputSchema(arguments.outputSchema);
-    return logicalOp;
+    auto withSchemas = logicalOperator->setInputSchemas(std::move(arguments.inputSchemas)).setOutputSchema(arguments.outputSchema);
+    return TypedLogicalOperator<UnionLogicalOperator>{withSchemas};
 }
 
 }

--- a/nes-logical-operators/src/Operators/Windows/JoinLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Windows/JoinLogicalOperator.cpp
@@ -50,8 +50,9 @@
 namespace NES
 {
 
-JoinLogicalOperator::JoinLogicalOperator(LogicalFunction joinFunction, std::shared_ptr<Windowing::WindowType> windowType, JoinType joinType)
-    : joinFunction(std::move(joinFunction)), windowType(std::move(windowType)), joinType(joinType)
+JoinLogicalOperator::JoinLogicalOperator(
+    WeakLogicalOperator self, LogicalFunction joinFunction, std::shared_ptr<Windowing::WindowType> windowType, JoinType joinType)
+    : ManagedByOperator(std::move(self)), joinFunction(std::move(joinFunction)), windowType(std::move(windowType)), joinType(joinType)
 {
 }
 
@@ -206,7 +207,7 @@ Unreflector<TypedLogicalOperator<JoinLogicalOperator>>::operator()(const Reflect
 
     const auto windowType = unreflectWindowType(reflectedWindowType, context);
 
-    return TypedLogicalOperator<JoinLogicalOperator>{JoinLogicalOperator(joinFunction, windowType, joinType)};
+    return TypedLogicalOperator<JoinLogicalOperator>{joinFunction, windowType, joinType};
 }
 
 LogicalOperatorRegistryReturnType LogicalOperatorGeneratedRegistrar::RegisterJoinLogicalOperator(LogicalOperatorRegistryArguments arguments)

--- a/nes-logical-operators/src/Operators/Windows/WindowedAggregationLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Windows/WindowedAggregationLogicalOperator.cpp
@@ -50,10 +50,14 @@ namespace NES
 {
 
 WindowedAggregationLogicalOperator::WindowedAggregationLogicalOperator(
+    WeakLogicalOperator self,
     std::vector<FieldAccessLogicalFunction> groupingKey,
     std::vector<std::shared_ptr<WindowAggregationLogicalFunction>> aggregationFunctions,
     std::shared_ptr<Windowing::WindowType> windowType)
-    : aggregationFunctions(std::move(aggregationFunctions)), windowType(std::move(windowType)), groupingKey(std::move(groupingKey))
+    : ManagedByOperator(std::move(self))
+    , aggregationFunctions(std::move(aggregationFunctions))
+    , windowType(std::move(windowType))
+    , groupingKey(std::move(groupingKey))
 {
 }
 
@@ -291,8 +295,7 @@ TypedLogicalOperator<WindowedAggregationLogicalOperator> Unreflector<TypedLogica
     }
 
 
-    return TypedLogicalOperator<WindowedAggregationLogicalOperator>{
-        WindowedAggregationLogicalOperator{keys, aggregationFunctions, windowType}};
+    return TypedLogicalOperator<WindowedAggregationLogicalOperator>{keys, aggregationFunctions, windowType};
 }
 
 LogicalOperatorRegistryReturnType

--- a/nes-logical-operators/src/Plans/LogicalPlanBuilder.cpp
+++ b/nes-logical-operators/src/Plans/LogicalPlanBuilder.cpp
@@ -32,6 +32,7 @@
 #include <Operators/EventTimeWatermarkAssignerLogicalOperator.hpp>
 #include <Operators/InferModelNameLogicalOperator.hpp>
 #include <Operators/IngestionTimeWatermarkAssignerLogicalOperator.hpp>
+#include <Operators/LogicalOperator.hpp>
 #include <Operators/ProjectionLogicalOperator.hpp>
 #include <Operators/SelectionLogicalOperator.hpp>
 #include <Operators/Sinks/InlineSinkLogicalOperator.hpp>
@@ -56,7 +57,7 @@ LogicalPlan LogicalPlanBuilder::createLogicalPlan(std::string logicalSourceName)
 {
     NES_TRACE("LogicalPlanBuilder: create query plan for input source  {}", logicalSourceName);
     const DescriptorConfig::Config sourceDescriptorConfig{};
-    return LogicalPlan(INVALID_QUERY_ID, {SourceNameLogicalOperator(logicalSourceName)});
+    return LogicalPlan(INVALID_QUERY_ID, {TypedLogicalOperator<SourceNameLogicalOperator>{logicalSourceName}});
 }
 
 LogicalPlan LogicalPlanBuilder::createLogicalPlan(
@@ -67,7 +68,8 @@ LogicalPlan LogicalPlanBuilder::createLogicalPlan(
 {
     return LogicalPlan(
         INVALID_QUERY_ID,
-        {InlineSourceLogicalOperator{std::move(inlineSourceType), schema, std::move(sourceConfig), std::move(parserConfig)}});
+        {TypedLogicalOperator<InlineSourceLogicalOperator>{
+            std::move(inlineSourceType), schema, std::move(sourceConfig), std::move(parserConfig)}});
 }
 
 LogicalPlan LogicalPlanBuilder::addProjection(
@@ -75,13 +77,13 @@ LogicalPlan LogicalPlanBuilder::addProjection(
 {
     NES_TRACE("LogicalPlanBuilder: add projection operator to query plan");
     return promoteOperatorToRoot(
-        queryPlan, ProjectionLogicalOperator(std::move(projections), ProjectionLogicalOperator::Asterisk(asterisk)));
+        queryPlan, TypedLogicalOperator<ProjectionLogicalOperator>{std::move(projections), ProjectionLogicalOperator::Asterisk(asterisk)});
 }
 
 LogicalPlan LogicalPlanBuilder::addSelection(LogicalFunction selectionFunction, const LogicalPlan& queryPlan)
 {
     NES_TRACE("LogicalPlanBuilder: add selection operator to query plan");
-    return promoteOperatorToRoot(queryPlan, SelectionLogicalOperator(std::move(selectionFunction)));
+    return promoteOperatorToRoot(queryPlan, TypedLogicalOperator<SelectionLogicalOperator>{std::move(selectionFunction)});
 }
 
 LogicalPlan LogicalPlanBuilder::addWindowAggregation(
@@ -97,14 +99,14 @@ LogicalPlan LogicalPlanBuilder::addWindowAggregation(
         switch (timeBasedWindowType->getTimeCharacteristic().getType())
         {
             case Windowing::TimeCharacteristic::Type::IngestionTime:
-                queryPlan = promoteOperatorToRoot(queryPlan, IngestionTimeWatermarkAssignerLogicalOperator());
+                queryPlan = promoteOperatorToRoot(queryPlan, TypedLogicalOperator<IngestionTimeWatermarkAssignerLogicalOperator>{});
                 break;
             case Windowing::TimeCharacteristic::Type::EventTime:
                 queryPlan = promoteOperatorToRoot(
                     queryPlan,
-                    EventTimeWatermarkAssignerLogicalOperator(
+                    TypedLogicalOperator<EventTimeWatermarkAssignerLogicalOperator>{
                         FieldAccessLogicalFunction(timeBasedWindowType->getTimeCharacteristic().field.name),
-                        timeBasedWindowType->getTimeCharacteristic().getTimeUnit()));
+                        timeBasedWindowType->getTimeCharacteristic().getTimeUnit()});
                 break;
         }
     }
@@ -114,13 +116,14 @@ LogicalPlan LogicalPlanBuilder::addWindowAggregation(
     }
 
     auto inputSchema = queryPlan.getRootOperators().front().getOutputSchema();
-    return promoteOperatorToRoot(queryPlan, WindowedAggregationLogicalOperator(std::move(onKeys), std::move(windowAggs), windowType));
+    return promoteOperatorToRoot(
+        queryPlan, TypedLogicalOperator<WindowedAggregationLogicalOperator>{std::move(onKeys), std::move(windowAggs), windowType});
 }
 
 LogicalPlan LogicalPlanBuilder::addUnion(LogicalPlan leftLogicalPlan, LogicalPlan rightLogicalPlan)
 {
     NES_TRACE("LogicalPlanBuilder: unionWith the subQuery to current query plan");
-    leftLogicalPlan = addBinaryOperatorAndUpdateSource(UnionLogicalOperator(), leftLogicalPlan, std::move(rightLogicalPlan));
+    leftLogicalPlan = addBinaryOperatorAndUpdateSource(TypedLogicalOperator<UnionLogicalOperator>{}, leftLogicalPlan, rightLogicalPlan);
     return leftLogicalPlan;
 }
 
@@ -175,7 +178,7 @@ LogicalPlan LogicalPlanBuilder::addJoin(
 
     NES_TRACE("LogicalPlanBuilder: add join operator to query plan");
     leftLogicalPlan = addBinaryOperatorAndUpdateSource(
-        JoinLogicalOperator(joinFunction, std::move(windowType), joinType), leftLogicalPlan, rightLogicalPlan);
+        TypedLogicalOperator<JoinLogicalOperator>{joinFunction, std::move(windowType), joinType}, leftLogicalPlan, rightLogicalPlan);
     return leftLogicalPlan;
 }
 
@@ -183,12 +186,13 @@ LogicalPlan LogicalPlanBuilder::addInferModel(std::string modelName, const Logic
 {
     NES_TRACE("LogicalPlanBuilder: add infer model operator to query plan for model {}", modelName);
     /// inputFieldNames is intentionally empty here — resolved later during InferModelResolutionRule
-    return promoteOperatorToRoot(childPlan, InferModelNameLogicalOperator(std::move(modelName), {}));
+    return promoteOperatorToRoot(
+        childPlan, TypedLogicalOperator<InferModelNameLogicalOperator>{std::move(modelName), std::vector<std::string>{}});
 }
 
 LogicalPlan LogicalPlanBuilder::addSink(std::string sinkName, const LogicalPlan& queryPlan)
 {
-    return promoteOperatorToRoot(queryPlan, SinkLogicalOperator(std::move(sinkName)));
+    return promoteOperatorToRoot(queryPlan, TypedLogicalOperator<SinkLogicalOperator>{std::move(sinkName)});
 }
 
 LogicalPlan LogicalPlanBuilder::addInlineSink(
@@ -199,7 +203,8 @@ LogicalPlan LogicalPlanBuilder::addInlineSink(
     const LogicalPlan& queryPlan)
 {
     return promoteOperatorToRoot(
-        queryPlan, InlineSinkLogicalOperator(std::move(type), schema, std::move(sinkConfig), std::move(formatConfig)));
+        queryPlan,
+        TypedLogicalOperator<InlineSinkLogicalOperator>{std::move(type), schema, std::move(sinkConfig), std::move(formatConfig)});
 }
 
 LogicalPlan
@@ -213,13 +218,13 @@ LogicalPlanBuilder::checkAndAddWatermarkAssigner(LogicalPlan queryPlan, const st
     {
         if (timeBasedWindowType->getTimeCharacteristic().getType() == Windowing::TimeCharacteristic::Type::IngestionTime)
         {
-            return promoteOperatorToRoot(queryPlan, IngestionTimeWatermarkAssignerLogicalOperator());
+            return promoteOperatorToRoot(queryPlan, TypedLogicalOperator<IngestionTimeWatermarkAssignerLogicalOperator>{});
         }
         if (timeBasedWindowType->getTimeCharacteristic().getType() == Windowing::TimeCharacteristic::Type::EventTime)
         {
             auto logicalFunction = FieldAccessLogicalFunction(timeBasedWindowType->getTimeCharacteristic().field.name);
-            auto assigner
-                = EventTimeWatermarkAssignerLogicalOperator(logicalFunction, timeBasedWindowType->getTimeCharacteristic().getTimeUnit());
+            auto assigner = TypedLogicalOperator<EventTimeWatermarkAssignerLogicalOperator>{
+                logicalFunction, timeBasedWindowType->getTimeCharacteristic().getTimeUnit()};
             return promoteOperatorToRoot(queryPlan, assigner);
         }
     }

--- a/nes-logical-operators/tests/InferModelLogicalOperatorTest.cpp
+++ b/nes-logical-operators/tests/InferModelLogicalOperatorTest.cpp
@@ -69,14 +69,14 @@ protected:
     }
 
     /// Default operator: 1 FLOAT32 input "in_0", 1 FLOAT32 output "prediction" — backed by tiny_1_to_1.onnx.
-    static InferModelLogicalOperator makeOp()
+    static TypedLogicalOperator<InferModelLogicalOperator> makeOp()
     {
-        return InferModelLogicalOperator{
+        return TypedLogicalOperator<InferModelLogicalOperator>{
             loadModel(
                 "tiny_1_to_1.onnx",
                 Schema{}.addField("in_0", DataType::Type::FLOAT32),
                 Schema{}.addField("prediction", DataType::Type::FLOAT32)),
-            {"value"}};
+            std::vector<std::string>{"value"}};
     }
 };
 
@@ -94,18 +94,18 @@ TEST_F(InferModelLogicalOperatorTest, BasicProperties)
     EXPECT_EQ(op.getName(), "InferModel");
 
     /// explain() short verbosity
-    auto description = op.explain(ExplainVerbosity::Short, OperatorId{1});
+    auto description = op->explain(ExplainVerbosity::Short, OperatorId{1});
     EXPECT_FALSE(description.empty());
     EXPECT_TRUE(description.find("INFER_MODEL") != std::string::npos);
 
     /// explain() debug verbosity includes opId and traitSet
-    auto debugDesc = op.explain(ExplainVerbosity::Debug, OperatorId{42});
+    auto debugDesc = op->explain(ExplainVerbosity::Debug, OperatorId{42});
     EXPECT_TRUE(debugDesc.find("42") != std::string::npos);
 
     /// Getters
-    EXPECT_EQ(op.getInputFieldNames(), std::vector<std::string>{"value"});
-    EXPECT_EQ(op.getModel().getSchema().inputs.getNumberOfFields(), 1U);
-    EXPECT_EQ(op.getModel().getSchema().outputs.getNumberOfFields(), 1U);
+    EXPECT_EQ(op->getInputFieldNames(), std::vector<std::string>{"value"});
+    EXPECT_EQ(op->getModel().getSchema().inputs.getNumberOfFields(), 1U);
+    EXPECT_EQ(op->getModel().getSchema().outputs.getNumberOfFields(), 1U);
 }
 
 /// withChildren/getChildren and withTraitSet/getTraitSet — immutable copy semantics
@@ -116,15 +116,16 @@ TEST_F(InferModelLogicalOperatorTest, ImmutableCopySemantics)
     /// Children round-trip
     EXPECT_TRUE(op.getChildren().empty());
     const InferModelLogicalOperator childOp{
+        WeakLogicalOperator{},
         loadModel("tiny_1_to_1.onnx", Schema{}.addField("in", DataType::Type::FLOAT32), Schema{}.addField("out", DataType::Type::FLOAT32)),
         {"x"}};
-    auto withChild = op.withChildren({LogicalOperator{childOp}});
+    auto withChild = op->withChildren({LogicalOperator{childOp}});
     ASSERT_EQ(withChild.getChildren().size(), 1U);
     EXPECT_TRUE(op.getChildren().empty());
 
     /// TraitSet round-trip
     const TraitSet emptySet = op.getTraitSet();
-    auto opWithTraits = op.withTraitSet(emptySet);
+    auto opWithTraits = op->withTraitSet(emptySet);
     EXPECT_EQ(opWithTraits.getTraitSet(), emptySet);
 
     /// Equality: two operators built against the same catalog entry and the same field names compare equal.
@@ -132,6 +133,7 @@ TEST_F(InferModelLogicalOperatorTest, ImmutableCopySemantics)
     auto op2 = op;
     EXPECT_EQ(op, op2);
     const InferModelLogicalOperator op3{
+        WeakLogicalOperator{},
         loadModel(
             "tiny_1_to_1.onnx",
             Schema{}.addField("in_0", DataType::Type::FLOAT32),
@@ -143,7 +145,7 @@ TEST_F(InferModelLogicalOperatorTest, ImmutableCopySemantics)
 /// InferModelNameLogicalOperator construction, getName, explain, and wrapping
 TEST_F(InferModelLogicalOperatorTest, NameVariantConstructionAndExplain)
 {
-    const InferModelNameLogicalOperator nameOp{"myModel", {"feature1", "feature2"}};
+    const InferModelNameLogicalOperator nameOp{WeakLogicalOperator{}, "myModel", {"feature1", "feature2"}};
 
     EXPECT_EQ(std::string{nameOp.getName()}, "InferModelName");
 
@@ -163,11 +165,11 @@ TEST_F(InferModelLogicalOperatorTest, ReflectionRoundTrip)
     const auto op = makeOp();
 
     const auto reflected = reflect(op);
-    const auto restored = ReflectionContext{}.unreflect<InferModelLogicalOperator>(reflected);
+    const auto restored = ReflectionContext{}.unreflect<TypedLogicalOperator<InferModelLogicalOperator>>(reflected);
 
     /// Verify preserved state
-    EXPECT_EQ(restored.getInputFieldNames(), op.getInputFieldNames());
-    EXPECT_EQ(restored.getModel(), op.getModel());
+    EXPECT_EQ(restored->getInputFieldNames(), op->getInputFieldNames());
+    EXPECT_EQ(restored->getModel(), op->getModel());
     EXPECT_EQ(restored.getName(), op.getName());
 }
 
@@ -176,6 +178,7 @@ TEST_F(InferModelLogicalOperatorTest, SchemaInferenceHappyPath)
 {
     /// Model: 1 FLOAT32 input, 2 FLOAT32 outputs (tiny_1_to_2.onnx has output shape [1,2])
     const InferModelLogicalOperator op{
+        WeakLogicalOperator{},
         loadModel(
             "tiny_1_to_2.onnx",
             Schema{}.addField("in_0", DataType::Type::FLOAT32),
@@ -208,10 +211,11 @@ TEST_F(InferModelLogicalOperatorTest, SchemaInferenceErrors)
 {
     /// Empty input schemas
     auto op = makeOp();
-    ASSERT_EXCEPTION_ERRORCODE((void)op.withInferredSchema({}), NES::ErrorCode::CannotInferSchema);
+    ASSERT_EXCEPTION_ERRORCODE((void)op->withInferredSchema({}), NES::ErrorCode::CannotInferSchema);
 
     /// Field count mismatch: model expects 2, operator has 1
     const InferModelLogicalOperator op1{
+        WeakLogicalOperator{},
         loadModel(
             "tiny_2_to_1.onnx",
             Schema{}.addField("a", DataType::Type::FLOAT32).addField("b", DataType::Type::FLOAT32),
@@ -222,6 +226,7 @@ TEST_F(InferModelLogicalOperatorTest, SchemaInferenceErrors)
 
     /// Missing field in schema
     const InferModelLogicalOperator op2{
+        WeakLogicalOperator{},
         loadModel(
             "tiny_2_to_1.onnx",
             Schema{}.addField("a", DataType::Type::FLOAT32).addField("b", DataType::Type::FLOAT32),
@@ -232,6 +237,7 @@ TEST_F(InferModelLogicalOperatorTest, SchemaInferenceErrors)
 
     /// Type mismatch: model expects Float32, schema has Int32
     const InferModelLogicalOperator op3{
+        WeakLogicalOperator{},
         loadModel(
             "tiny_1_to_1.onnx",
             Schema{}.addField("in_0", DataType::Type::FLOAT32),
@@ -245,6 +251,7 @@ TEST_F(InferModelLogicalOperatorTest, SchemaInferenceErrors)
 TEST_F(InferModelLogicalOperatorTest, VarsizedInputAccepted)
 {
     const InferModelLogicalOperator op{
+        WeakLogicalOperator{},
         loadModel(
             "tiny_1_to_1.onnx",
             Schema{}.addField("text", DataType::Type::VARSIZED),
@@ -259,6 +266,7 @@ TEST_F(InferModelLogicalOperatorTest, VarsizedInputAccepted)
 TEST_F(InferModelLogicalOperatorTest, VarsizedOutputAccepted)
 {
     const InferModelLogicalOperator op{
+        WeakLogicalOperator{},
         loadModel(
             "tiny_1_to_1.onnx",
             Schema{}.addField("input_blob", DataType::Type::VARSIZED),
@@ -278,6 +286,7 @@ TEST_F(InferModelLogicalOperatorTest, NullableInputHandling)
 {
     /// Single nullable field — rejected
     const InferModelLogicalOperator op1{
+        WeakLogicalOperator{},
         loadModel(
             "tiny_1_to_1.onnx",
             Schema{}.addField("in_0", DataType::Type::FLOAT32),
@@ -288,6 +297,7 @@ TEST_F(InferModelLogicalOperatorTest, NullableInputHandling)
 
     /// Multiple inputs, one nullable — rejected
     const InferModelLogicalOperator op2{
+        WeakLogicalOperator{},
         loadModel(
             "tiny_2_to_1.onnx",
             Schema{}.addField("a", DataType::Type::FLOAT32).addField("b", DataType::Type::FLOAT32),
@@ -300,6 +310,7 @@ TEST_F(InferModelLogicalOperatorTest, NullableInputHandling)
 
     /// Multiple non-nullable inputs — accepted
     const InferModelLogicalOperator op3{
+        WeakLogicalOperator{},
         loadModel(
             "tiny_2_to_1.onnx",
             Schema{}.addField("a", DataType::Type::FLOAT32).addField("b", DataType::Type::FLOAT32),
@@ -316,6 +327,7 @@ TEST_F(InferModelLogicalOperatorTest, NullableInputHandling)
 TEST_F(InferModelLogicalOperatorTest, NameCollisionReplacesFieldType)
 {
     const InferModelLogicalOperator op{
+        WeakLogicalOperator{},
         loadModel(
             "tiny_1_to_1.onnx", Schema{}.addField("in_0", DataType::Type::FLOAT32), Schema{}.addField("value", DataType::Type::FLOAT32)),
         {"input_field"}};

--- a/nes-logical-operators/tests/LogicalPlanTest.cpp
+++ b/nes-logical-operators/tests/LogicalPlanTest.cpp
@@ -13,11 +13,14 @@
 */
 
 #include <cstddef>
+#include <optional>
 #include <ranges>
 #include <sstream>
 
+#include <string>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
@@ -35,6 +38,8 @@
 #include <Sources/SourceCatalog.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Traits/Trait.hpp>
+#include <Traits/TraitSet.hpp>
+#include <Util/PlanRenderer.hpp>
 #include <Util/Reflection.hpp>
 #include <Util/UUID.hpp>
 #include <QueryId.hpp>
@@ -50,7 +55,7 @@ class LogicalPlanTest : public ::testing::Test
 {
 protected:
     LogicalPlanTest()
-        : sourceOp{SourceNameLogicalOperator("Source")}
+        : sourceOp{TypedLogicalOperator<SourceNameLogicalOperator>{"Source"}}
         , sourceOp2(
               [this]
               {
@@ -62,10 +67,10 @@ protected:
                       = sourceCatalog
                             .addPhysicalSource(logicalSource, "File", Host("localhost"), {{"file_path", "/dev/null"}}, dummyParserConfig)
                             .value();
-                  return LogicalOperator{SourceDescriptorLogicalOperator(std::move(dummySourceDescriptor))};
+                  return LogicalOperator{TypedLogicalOperator<SourceDescriptorLogicalOperator>(std::move(dummySourceDescriptor))};
               }())
-        , selectionOp{SelectionLogicalOperator(FieldAccessLogicalFunction("logicalfunction"))}
-        , sinkOp{SinkLogicalOperator()}
+        , selectionOp{TypedLogicalOperator<SelectionLogicalOperator>(FieldAccessLogicalFunction("logicalfunction"))}
+        , sinkOp{TypedLogicalOperator<SinkLogicalOperator>()}
     {
     }
 
@@ -104,8 +109,8 @@ TEST_F(LogicalPlanTest, CopyConstructor)
 
 TEST_F(LogicalPlanTest, PromoteOperatorToRoot)
 {
-    const LogicalOperator sourceOp{SourceNameLogicalOperator("source")};
-    const LogicalOperator selectionOp{SelectionLogicalOperator(FieldAccessLogicalFunction("field"))};
+    const LogicalOperator sourceOp{TypedLogicalOperator<SourceNameLogicalOperator>("source")};
+    const LogicalOperator selectionOp{TypedLogicalOperator<SelectionLogicalOperator>(FieldAccessLogicalFunction("field"))};
     const auto plan = LogicalPlan(INVALID_QUERY_ID, {sourceOp});
     const auto promoteResultPlan = promoteOperatorToRoot(plan, selectionOp);
     EXPECT_EQ(*promoteResultPlan.getRootOperators()[0], *selectionOp);
@@ -114,8 +119,8 @@ TEST_F(LogicalPlanTest, PromoteOperatorToRoot)
 
 TEST_F(LogicalPlanTest, ReplaceOperator)
 {
-    const LogicalOperator sourceOp{SourceNameLogicalOperator("source")};
-    const LogicalOperator sourceOp2{SourceNameLogicalOperator("source2")};
+    const LogicalOperator sourceOp{TypedLogicalOperator<SourceNameLogicalOperator>("source")};
+    const LogicalOperator sourceOp2{TypedLogicalOperator<SourceNameLogicalOperator>("source2")};
     const auto plan = LogicalPlan(INVALID_QUERY_ID, {sourceOp});
     const auto result = replaceOperator(plan, sourceOp.getId(), sourceOp2);
     EXPECT_TRUE(result.has_value());
@@ -124,8 +129,8 @@ TEST_F(LogicalPlanTest, ReplaceOperator)
 
 TEST_F(LogicalPlanTest, replaceSubtree)
 {
-    const LogicalOperator sourceOp{SourceNameLogicalOperator("source")};
-    const LogicalOperator sourceOp2{SourceNameLogicalOperator("source2")};
+    const LogicalOperator sourceOp{TypedLogicalOperator<SourceNameLogicalOperator>("source")};
+    const LogicalOperator sourceOp2{TypedLogicalOperator<SourceNameLogicalOperator>("source2")};
     const auto plan = LogicalPlan(INVALID_QUERY_ID, {sourceOp});
     const auto result = replaceSubtree(plan, sourceOp.getId(), sourceOp2);
     EXPECT_TRUE(result.has_value());
@@ -134,8 +139,8 @@ TEST_F(LogicalPlanTest, replaceSubtree)
 
 TEST_F(LogicalPlanTest, GetParents)
 {
-    const LogicalOperator sourceOp{SourceNameLogicalOperator("source")};
-    const LogicalOperator selectionOp{SelectionLogicalOperator(FieldAccessLogicalFunction("field"))};
+    const LogicalOperator sourceOp{TypedLogicalOperator<SourceNameLogicalOperator>("source")};
+    const LogicalOperator selectionOp{TypedLogicalOperator<SelectionLogicalOperator>(FieldAccessLogicalFunction("field"))};
     const auto plan = LogicalPlan(INVALID_QUERY_ID, {sourceOp});
     const auto promoteResult = promoteOperatorToRoot(plan, selectionOp);
     const auto parents = getParents(promoteResult, sourceOp);
@@ -145,7 +150,7 @@ TEST_F(LogicalPlanTest, GetParents)
 
 TEST_F(LogicalPlanTest, GetOperatorByType)
 {
-    const auto sourceOp = LogicalOperator{SourceNameLogicalOperator("source")};
+    const auto sourceOp = LogicalOperator{TypedLogicalOperator<SourceNameLogicalOperator>("source")};
     const auto plan = LogicalPlan(INVALID_QUERY_ID, {sourceOp});
     const auto sourceOperators = getOperatorByType<SourceNameLogicalOperator>(plan);
     EXPECT_EQ(sourceOperators.size(), 1);
@@ -154,9 +159,10 @@ TEST_F(LogicalPlanTest, GetOperatorByType)
 
 TEST_F(LogicalPlanTest, GetOperatorsById)
 {
-    const LogicalOperator sourceOp{SourceNameLogicalOperator{"TestSource"}};
-    const LogicalOperator selectionOp{SelectionLogicalOperator{FieldAccessLogicalFunction{"fn"}}.withChildren({sourceOp})};
-    const LogicalOperator sinkOp{SinkLogicalOperator{"TestSink"}.withChildren({selectionOp})};
+    const LogicalOperator sourceOp{TypedLogicalOperator<SourceNameLogicalOperator>{"TestSource"}};
+    const LogicalOperator selectionOp{TypedLogicalOperator<SelectionLogicalOperator>{FieldAccessLogicalFunction{"fn"}}
+                                      -> withChildren({sourceOp})};
+    const LogicalOperator sinkOp{TypedLogicalOperator<SinkLogicalOperator>{"TestSink"} -> withChildren({selectionOp})};
     const LogicalPlan plan(INVALID_QUERY_ID, {sinkOp});
     const auto op1 = getOperatorById(plan, sourceOp.getId());
     EXPECT_TRUE(op1.has_value());
@@ -178,6 +184,7 @@ struct TestTrait final : DefaultTrait<TestTrait>
 
     [[nodiscard]] std::string_view getName() const override { return NAME; }
 };
+
 }
 
 template <>
@@ -246,3 +253,100 @@ TEST_F(LogicalPlanTest, OutputOperator)
     ss << plan;
     EXPECT_FALSE(ss.str().empty());
 }
+
+namespace
+{
+/// Test operator that exposes the self reference for testing
+/// NOLINTBEGIN(readability-convert-member-functions-to-static)
+struct TestOperatorWithSelfAccess final : public ManagedByOperator
+{
+    explicit TestOperatorWithSelfAccess(WeakLogicalOperator self) : ManagedByOperator(std::move(self)) { };
+
+    [[nodiscard]] bool operator==(const TestOperatorWithSelfAccess& rhs) const { return this == &rhs; }
+
+    [[nodiscard]] TestOperatorWithSelfAccess withTraitSet(TraitSet traitSet) const
+    {
+        auto copy = *this;
+        copy.traitSet = std::move(traitSet);
+        return copy;
+    }
+
+    [[nodiscard]] TraitSet getTraitSet() const { return traitSet; }
+
+    [[nodiscard]] TestOperatorWithSelfAccess withChildren(std::vector<LogicalOperator> children) const
+    {
+        auto copy = *this;
+        copy.children = std::move(children);
+        return copy;
+    }
+
+    [[nodiscard]] std::vector<LogicalOperator> getChildren() const { return children; }
+
+    [[nodiscard]] std::vector<Schema> getInputSchemas() const { return {}; }
+
+    [[nodiscard]] Schema getOutputSchema() const { return Schema{}; }
+
+    [[nodiscard]] std::string explain(ExplainVerbosity, OperatorId id) const
+    {
+        return "TestOperator(id=" + std::to_string(id.getRawValue()) + ")";
+    }
+
+    [[nodiscard]] std::string_view getName() const noexcept { return NAME; }
+
+    [[nodiscard]] TestOperatorWithSelfAccess withInferredSchema(const std::vector<Schema>&) const { return *this; }
+
+    [[nodiscard]] std::optional<LogicalOperator> getSelf() const { return self.tryLock(); }
+
+private:
+    static constexpr std::string_view NAME = "TestOperatorWithSelfAccess";
+    std::vector<LogicalOperator> children;
+    TraitSet traitSet;
+};
+
+///NOLINTEND(readability-convert-member-functions-to-static)
+}
+
+template <>
+struct Reflector<TypedLogicalOperator<TestOperatorWithSelfAccess>>
+{
+    Reflected operator()(const TypedLogicalOperator<TestOperatorWithSelfAccess>&) const { return Reflected{}; };
+};
+
+template <>
+struct Unreflector<TypedLogicalOperator<TestOperatorWithSelfAccess>>
+{
+    TypedLogicalOperator<TestOperatorWithSelfAccess> operator()(const Reflected&) const
+    {
+        return TypedLogicalOperator<TestOperatorWithSelfAccess>{};
+    };
+};
+
+///NOLINTBEGIN(bugprone-unchecked-optional-access)
+TEST_F(LogicalPlanTest, WeakSelfReferenceReturnsCorrectOperator)
+{
+    const TypedLogicalOperator<TestOperatorWithSelfAccess> testOp{};
+    const auto typedOp = testOp.getAs<TestOperatorWithSelfAccess>();
+    const auto selfOpt = typedOp->getSelf();
+
+    ASSERT_TRUE(selfOpt.has_value());
+    EXPECT_EQ(selfOpt->getId(), testOp.getId());
+    EXPECT_EQ(selfOpt.value(), testOp);
+}
+
+TEST_F(LogicalPlanTest, WeakSelfReferenceAfterCopy)
+{
+    const TypedLogicalOperator<TestOperatorWithSelfAccess> originalOp{};
+    const LogicalOperator copiedOp = originalOp->withChildren({sourceOp});
+    const auto typedCopied = copiedOp.withChildren({}).getAs<TestOperatorWithSelfAccess>();
+
+    const auto selfOpt = typedCopied->getSelf();
+    ASSERT_TRUE(selfOpt.has_value());
+
+    EXPECT_EQ(typedCopied, selfOpt.value());
+    EXPECT_EQ(typedCopied.getId(), selfOpt.value().getId());
+
+    EXPECT_NE(originalOp, selfOpt.value());
+    EXPECT_NE(originalOp.getId(), selfOpt.value().getId());
+}
+
+///NOLINTEND(bugprone-unchecked-optional-access)

--- a/nes-logical-operators/tests/ProjectionLogicalOperatorTest.cpp
+++ b/nes-logical-operators/tests/ProjectionLogicalOperatorTest.cpp
@@ -39,92 +39,92 @@ protected:
 /// Two projections with the same explicit alias must be rejected with CannotInferSchema (code 2003).
 TEST_F(ProjectionLogicalOperatorTest, DuplicateExplicitAliasThrows)
 {
-    const ProjectionLogicalOperator op(
-        {
+    const TypedLogicalOperator<ProjectionLogicalOperator> op{
+        std::vector<ProjectionLogicalOperator::Projection>{
             {FieldIdentifier("x"), LogicalFunction(FieldAccessLogicalFunction("stream.a"))},
             {FieldIdentifier("x"), LogicalFunction(FieldAccessLogicalFunction("stream.b"))},
         },
-        ProjectionLogicalOperator::Asterisk(false));
+        ProjectionLogicalOperator::Asterisk(false)};
 
-    ASSERT_EXCEPTION_ERRORCODE((void)op.withInferredSchema({schema}), ErrorCode::CannotInferSchema);
+    ASSERT_EXCEPTION_ERRORCODE((void)op->withInferredSchema({schema}), ErrorCode::CannotInferSchema);
 }
 
 /// Two unaliased projections accessing the same field are allowed per standard SQL behavior.
 TEST_F(ProjectionLogicalOperatorTest, DuplicateUnaliasedFieldSucceeds)
 {
-    const ProjectionLogicalOperator op(
-        {
+    const TypedLogicalOperator<ProjectionLogicalOperator> op(
+        std::vector<ProjectionLogicalOperator::Projection>{
             {std::nullopt, LogicalFunction(FieldAccessLogicalFunction("stream.a"))},
             {std::nullopt, LogicalFunction(FieldAccessLogicalFunction("stream.a"))},
         },
         ProjectionLogicalOperator::Asterisk(false));
 
-    EXPECT_NO_THROW((void)op.withInferredSchema({schema}));
+    EXPECT_NO_THROW((void)op->withInferredSchema({schema}));
 }
 
 /// An explicit alias that collides with an unaliased field is allowed (only duplicate explicit aliases are rejected).
 TEST_F(ProjectionLogicalOperatorTest, AliasCollidingWithUnaliasedFieldSucceeds)
 {
-    const ProjectionLogicalOperator op(
-        {
+    const TypedLogicalOperator<ProjectionLogicalOperator> op(
+        std::vector<ProjectionLogicalOperator::Projection>{
             {std::nullopt, LogicalFunction(FieldAccessLogicalFunction("stream.a"))},
             {FieldIdentifier("stream.a"), LogicalFunction(FieldAccessLogicalFunction("stream.b"))},
         },
         ProjectionLogicalOperator::Asterisk(false));
 
-    EXPECT_NO_THROW((void)op.withInferredSchema({schema}));
+    EXPECT_NO_THROW((void)op->withInferredSchema({schema}));
 }
 
 /// Projections with distinct aliases must succeed.
 TEST_F(ProjectionLogicalOperatorTest, UniqueAliasesSucceeds)
 {
-    const ProjectionLogicalOperator op(
-        {
+    const TypedLogicalOperator<ProjectionLogicalOperator> op(
+        std::vector<ProjectionLogicalOperator::Projection>{
             {FieldIdentifier("x"), LogicalFunction(FieldAccessLogicalFunction("stream.a"))},
             {FieldIdentifier("y"), LogicalFunction(FieldAccessLogicalFunction("stream.b"))},
         },
         ProjectionLogicalOperator::Asterisk(false));
 
-    EXPECT_NO_THROW((void)op.withInferredSchema({schema}));
+    EXPECT_NO_THROW((void)op->withInferredSchema({schema}));
 }
 
 /// Asterisk plus an unaliased projection that duplicates an input field name is allowed.
 TEST_F(ProjectionLogicalOperatorTest, AsteriskPlusDuplicateUnaliasedProjectionSucceeds)
 {
-    const ProjectionLogicalOperator op(
-        {
+    const TypedLogicalOperator<ProjectionLogicalOperator> op(
+        std::vector<ProjectionLogicalOperator::Projection>{
             {std::nullopt, LogicalFunction(FieldAccessLogicalFunction("stream.a"))},
         },
         ProjectionLogicalOperator::Asterisk(true));
 
-    EXPECT_NO_THROW((void)op.withInferredSchema({schema}));
+    EXPECT_NO_THROW((void)op->withInferredSchema({schema}));
 }
 
 /// Known limitation: an explicit alias matching the auto-derived name is treated as auto-derived.
 /// SELECT stream.a AS stream.a, stream.b AS stream.a only detects the second alias as explicit.
 TEST_F(ProjectionLogicalOperatorTest, ExplicitAliasMatchingAutoDerivedNameTreatedAsAutoDerived)
 {
-    const ProjectionLogicalOperator op(
-        {
+    const TypedLogicalOperator<ProjectionLogicalOperator> op(
+        std::vector<ProjectionLogicalOperator::Projection>{
             {FieldIdentifier("stream.a"), LogicalFunction(FieldAccessLogicalFunction("stream.a"))},
             {FieldIdentifier("stream.a"), LogicalFunction(FieldAccessLogicalFunction("stream.b"))},
         },
         ProjectionLogicalOperator::Asterisk(false));
 
     /// Only one alias differs from the auto-derived name, so no duplicate is detected.
-    EXPECT_NO_THROW((void)op.withInferredSchema({schema}));
+    EXPECT_NO_THROW((void)op->withInferredSchema({schema}));
 }
 
 /// Asterisk plus a distinctly aliased projection must succeed.
 TEST_F(ProjectionLogicalOperatorTest, AsteriskPlusNewAliasSucceeds)
 {
-    const ProjectionLogicalOperator op(
-        {
+    const TypedLogicalOperator<ProjectionLogicalOperator> op(
+        std::vector<ProjectionLogicalOperator::Projection>{
             {FieldIdentifier("new_a"), LogicalFunction(FieldAccessLogicalFunction("stream.a"))},
         },
         ProjectionLogicalOperator::Asterisk(true));
 
-    EXPECT_NO_THROW((void)op.withInferredSchema({schema}));
+    EXPECT_NO_THROW((void)op->withInferredSchema({schema}));
 }
 
 /// Duplicate unaliased projections must survive a reflection round-trip (regression for serialization bug).
@@ -133,15 +133,15 @@ TEST_F(ProjectionLogicalOperatorTest, AsteriskPlusNewAliasSucceeds)
 /// reject auto-derived duplicates.
 TEST_F(ProjectionLogicalOperatorTest, DuplicateUnaliasedFieldSurvivesReflectionRoundTrip)
 {
-    const ProjectionLogicalOperator op(
-        {
+    const TypedLogicalOperator<ProjectionLogicalOperator> op(
+        std::vector<ProjectionLogicalOperator::Projection>{
             {std::nullopt, LogicalFunction(FieldAccessLogicalFunction("stream.a"))},
             {std::nullopt, LogicalFunction(FieldAccessLogicalFunction("stream.a"))},
         },
         ProjectionLogicalOperator::Asterisk(false));
 
     /// First inference (simulates the optimization phase).
-    const auto inferred = TypedLogicalOperator<ProjectionLogicalOperator>(op.withInferredSchema({schema}));
+    const auto inferred = TypedLogicalOperator<ProjectionLogicalOperator>(op->withInferredSchema({schema}));
 
     /// Simulate serialization round-trip: reflect → unreflect.
     const auto reflected = NES::reflect(inferred);
@@ -154,8 +154,8 @@ TEST_F(ProjectionLogicalOperatorTest, DuplicateUnaliasedFieldSurvivesReflectionR
 /// Explicit aliases must still be detected as duplicates after a reflection round-trip.
 TEST_F(ProjectionLogicalOperatorTest, DuplicateExplicitAliasSurvivesReflectionRoundTrip)
 {
-    const ProjectionLogicalOperator op(
-        {
+    const TypedLogicalOperator<ProjectionLogicalOperator> op(
+        std::vector<ProjectionLogicalOperator::Projection>{
             {FieldIdentifier("x"), LogicalFunction(FieldAccessLogicalFunction("stream.a"))},
             {FieldIdentifier("x"), LogicalFunction(FieldAccessLogicalFunction("stream.b"))},
         },

--- a/nes-query-optimizer/src/Placement/QueryDecomposition.cpp
+++ b/nes-query-optimizer/src/Placement/QueryDecomposition.cpp
@@ -138,8 +138,9 @@ Bridge connect(const DecompositionContext& context, const NetworkChannel& channe
     INVARIANT(traitInserted, "Failed to add memory layout");
 
     return Bridge{
-        SourceDescriptorLogicalOperator{networkSourceDescriptor}.withTraitSet(ts),
-        SinkLogicalOperator{networkSinkDescriptor.value()}.withTraitSet(ts).withInferredSchema({channel.upstreamOp.getOutputSchema()})};
+        TypedLogicalOperator<SourceDescriptorLogicalOperator>{networkSourceDescriptor} -> withTraitSet(ts),
+        TypedLogicalOperator<SinkLogicalOperator>{networkSinkDescriptor.value()} -> withTraitSet(ts).withInferredSchema(
+            {channel.upstreamOp.getOutputSchema()})};
 }
 
 LogicalOperator createNetworkChannel(

--- a/nes-query-optimizer/src/Rules/Semantic/InferModelResolutionRule.cpp
+++ b/nes-query-optimizer/src/Rules/Semantic/InferModelResolutionRule.cpp
@@ -52,10 +52,9 @@ LogicalPlan InferModelResolutionRule::apply(LogicalPlan queryPlan) const
                 inputFieldNames.push_back(field.name);
             }
         }
-        auto inferModelOp = InferModelLogicalOperator(std::move(loaded), std::move(inputFieldNames));
+        auto inferModelOp = TypedLogicalOperator<InferModelLogicalOperator>{std::move(loaded), std::move(inputFieldNames)};
         /// Preserve children from the original operator
-        inferModelOp = inferModelOp.withChildren(op.getChildren());
-        auto replacement = LogicalOperator(inferModelOp);
+        auto replacement = LogicalOperator{inferModelOp->withChildren(op.getChildren())};
 
         auto replaceResult = replaceSubtree(queryPlan, inferModelNameOp.getId(), replacement);
         INVARIANT(replaceResult.has_value(), "Failed to replace InferModelNameLogicalOperator with InferModelLogicalOperator");

--- a/nes-query-optimizer/src/Rules/Semantic/InlineSinkBindingRule.cpp
+++ b/nes-query-optimizer/src/Rules/Semantic/InlineSinkBindingRule.cpp
@@ -85,8 +85,8 @@ LogicalPlan InlineSinkBindingRule::apply(const LogicalPlan& queryPlan) const
                 throw InvalidConfigParameter("Failed to create inline sink descriptor");
             }
 
-            SinkLogicalOperator sinkOperator{sinkDescriptor.value()};
-            sinkOperator = sinkOperator.withChildren(sink.value().getChildren());
+            TypedLogicalOperator<SinkLogicalOperator> sinkOperator{sinkDescriptor.value()};
+            sinkOperator = sinkOperator->withChildren(sink.value().getChildren());
             newRootOperators.emplace_back(sinkOperator);
         }
         else

--- a/nes-query-optimizer/src/Rules/Semantic/InlineSourceBindingRule.cpp
+++ b/nes-query-optimizer/src/Rules/Semantic/InlineSourceBindingRule.cpp
@@ -88,8 +88,8 @@ LogicalOperator InlineSourceBindingRule::bindInlineSourceLogicalOperators(const 
             throw InvalidConfigParameter("Could not create an inline source descriptor because of invalid config parameters");
         }
         const auto& descriptor = descriptorOpt.value();
-        const SourceDescriptorLogicalOperator sourceDescriptorLogicalOperator{descriptor};
-        return sourceDescriptorLogicalOperator.withChildren(newChildren);
+        const TypedLogicalOperator<SourceDescriptorLogicalOperator> sourceDescriptorLogicalOperator{descriptor};
+        return sourceDescriptorLogicalOperator->withChildren(newChildren);
     }
 
     return current.withChildren(newChildren);

--- a/nes-query-optimizer/src/Rules/Semantic/LogicalSourceExpansionRule.cpp
+++ b/nes-query-optimizer/src/Rules/Semantic/LogicalSourceExpansionRule.cpp
@@ -84,7 +84,8 @@ LogicalPlan LogicalSourceExpansionRule::apply(LogicalPlan queryPlan) const
         }
 
         auto expandedSourceOperators = entries
-            | std::views::transform([](const auto& entry) { return LogicalOperator{SourceDescriptorLogicalOperator{entry}}; })
+            | std::views::transform([](const auto& entry) -> LogicalOperator
+                                    { return TypedLogicalOperator<SourceDescriptorLogicalOperator>{entry}; })
             | std::ranges::to<std::vector>();
 
         INVARIANT(getParents(queryPlan, sourceOp).size() == 1, "Source name operator must have exactly one parent");
@@ -93,7 +94,8 @@ LogicalPlan LogicalSourceExpansionRule::apply(LogicalPlan queryPlan) const
             parent.getChildren().size() == 1 && parent.getChildren().front() == sourceOp,
             "Parent of source name operator must have exactly one child, the source itself");
 
-        auto newParent = parent.withChildren({UnionLogicalOperator{}.withChildren(std::move(expandedSourceOperators))});
+        auto newParent
+            = parent.withChildren({TypedLogicalOperator<UnionLogicalOperator>{} -> withChildren(std::move(expandedSourceOperators))});
         auto replaceResult = replaceSubtree(queryPlan, parent.getId(), newParent);
 
         INVARIANT(

--- a/nes-systests/systest/src/SystestBinder.cpp
+++ b/nes-systests/systest/src/SystestBinder.cpp
@@ -707,10 +707,10 @@ struct SystestBinder::Impl
 
             if (sourceConfig != inlineSource.value()->getSourceConfig() || parserConfig != inlineSource.value()->getParserConfig())
             {
-                const InlineSourceLogicalOperator newOperator{
+                const TypedLogicalOperator<InlineSourceLogicalOperator> newOperator{
                     inlineSource.value()->getSourceType(), inlineSource.value()->getSchema(), sourceConfig, parserConfig};
 
-                return newOperator.withChildren(newChildren);
+                return newOperator->withChildren(newChildren);
             }
         }
 
@@ -759,9 +759,9 @@ struct SystestBinder::Impl
         {
             throw InvalidConfigParameter("Failed to create inline sink of type {}", sinkOperator->getSinkType());
         }
-        const auto newOperator = SinkLogicalOperator{sinkDescriptor.value()};
+        const auto newOperator = TypedLogicalOperator<SinkLogicalOperator>{sinkDescriptor.value()};
 
-        return newOperator.withChildren(sinkOperator->getChildren());
+        return newOperator->withChildren(sinkOperator->getChildren());
     }
 
     LogicalOperator setNamedSink(
@@ -786,9 +786,9 @@ struct SystestBinder::Impl
             currentBuilder.setException(sinkExpected.error());
         }
 
-        const auto newOperator = SinkLogicalOperator{sinkExpected.value()};
+        const auto newOperator = TypedLogicalOperator<SinkLogicalOperator>{sinkExpected.value()};
 
-        return newOperator.withChildren(sinkOperator->getChildren());
+        return newOperator->withChildren(sinkOperator->getChildren());
     }
 
     void setSinks(

--- a/nes-systests/systest/tests/SystestRunnerTest.cpp
+++ b/nes-systests/systest/tests/SystestRunnerTest.cpp
@@ -30,6 +30,7 @@
 #include <Identifiers/Identifiers.hpp>
 #include <Identifiers/NESStrongType.hpp>
 #include <Listeners/QueryLog.hpp>
+#include <Operators/LogicalOperator.hpp>
 #include <Operators/Sinks/SinkLogicalOperator.hpp>
 #include <Operators/Sources/SourceDescriptorLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
@@ -186,8 +187,9 @@ TEST_F(SystestRunnerTest, RuntimeFailureWithUnexpectedCode)
     const std::unordered_map<std::string, std::string> parserConfig{{"type", "CSV"}};
     auto testPhysicalSource
         = sourceCatalog.addPhysicalSource(testLogicalSource.value(), "File", Host("localhost"), {{"file_path", "/dev/null"}}, parserConfig);
-    auto sourceOperator = SourceDescriptorLogicalOperator{testPhysicalSource.value()};
-    const LogicalPlan plan{INVALID_QUERY_ID, {SinkLogicalOperator{dummySinkDescriptor}.withChildren({sourceOperator})}};
+    auto sourceOperator = TypedLogicalOperator<SourceDescriptorLogicalOperator>{testPhysicalSource.value()};
+    const LogicalPlan plan{
+        INVALID_QUERY_ID, {TypedLogicalOperator<SinkLogicalOperator>{dummySinkDescriptor} -> withChildren({sourceOperator})}};
     const DistributedLogicalPlan distributedPlan{{{Host("localhost:8080"), std::vector{plan}}}, plan};
 
     const auto result = runQueries(
@@ -221,8 +223,9 @@ TEST_F(SystestRunnerTest, MissingExpectedRuntimeError)
     const std::unordered_map<std::string, std::string> parserConfig{{"type", "CSV"}};
     auto testPhysicalSource
         = sourceCatalog.addPhysicalSource(testLogicalSource.value(), "File", Host("localhost"), {{"file_path", "/dev/null"}}, parserConfig);
-    auto sourceOperator = SourceDescriptorLogicalOperator{testPhysicalSource.value()};
-    const LogicalPlan plan{INVALID_QUERY_ID, {SinkLogicalOperator{dummySinkDescriptor}.withChildren({sourceOperator})}};
+    auto sourceOperator = TypedLogicalOperator<SourceDescriptorLogicalOperator>{testPhysicalSource.value()};
+    const LogicalPlan plan{
+        INVALID_QUERY_ID, {TypedLogicalOperator<SinkLogicalOperator>{dummySinkDescriptor} -> withChildren({sourceOperator})}};
     const DistributedLogicalPlan distributedPlan{{{Host("localhost:8080"), std::vector{plan}}}, plan};
 
     const auto result = runQueries(
@@ -252,8 +255,9 @@ TEST_F(SystestRunnerTest, SequentialExecutionThrowOnNonExistentDependency)
     const std::unordered_map<std::string, std::string> parserConfig{{"type", "CSV"}};
     auto testPhysicalSource
         = sourceCatalog.addPhysicalSource(testLogicalSource.value(), "File", Host("localhost"), {{"file_path", "/dev/null"}}, parserConfig);
-    auto sourceOperator = SourceDescriptorLogicalOperator{testPhysicalSource.value()};
-    const LogicalPlan plan{INVALID_QUERY_ID, {SinkLogicalOperator{dummySinkDescriptor}.withChildren({sourceOperator})}};
+    auto sourceOperator = TypedLogicalOperator<SourceDescriptorLogicalOperator>{testPhysicalSource.value()};
+    const LogicalPlan plan{
+        INVALID_QUERY_ID, {TypedLogicalOperator<SinkLogicalOperator>{dummySinkDescriptor} -> withChildren({sourceOperator})}};
     const DistributedLogicalPlan distributedPlan{{{Host("localhost:8080"), std::vector{plan}}}, plan};
 
     auto runAfter = std::make_pair(std::string{"test_query"}, SystestQueryId(std::numeric_limits<uint64_t>::max()));
@@ -308,8 +312,9 @@ TEST_F(SystestRunnerTest, SequentialExecutionOrderTest)
     const std::unordered_map<std::string, std::string> parserConfig{{"type", "CSV"}};
     auto testPhysicalSource
         = sourceCatalog.addPhysicalSource(testLogicalSource.value(), "File", Host("localhost"), {{"file_path", "/dev/null"}}, parserConfig);
-    auto sourceOperator = SourceDescriptorLogicalOperator{testPhysicalSource.value()};
-    const LogicalPlan plan{INVALID_QUERY_ID, {SinkLogicalOperator{dummySinkDescriptor}.withChildren({sourceOperator})}};
+    auto sourceOperator = TypedLogicalOperator<SourceDescriptorLogicalOperator>{testPhysicalSource.value()};
+    const LogicalPlan plan{
+        INVALID_QUERY_ID, {TypedLogicalOperator<SinkLogicalOperator>{dummySinkDescriptor} -> withChildren({sourceOperator})}};
     const DistributedLogicalPlan distributedPlan{{{Host("localhost:8080"), std::vector{plan}}}, plan};
 
     auto query1 = makeQuery(SystestQuery::PlanInfo{distributedPlan, Schema{}}, std::vector<std::string>{}, std::nullopt, SystestQueryId(1));


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This is a spinoff PR of the schema inference branch that @gustafsa extracted.
One of the main concepts of the schema inference branch is that every output schema of a logical operator, consists of fields that are essentially a pair of an unqualified identifier and a pointer to the operator that has produced it.

This allows us to keep track of the origin of fields, even in binary operators like a join, without having to rely on source prefixing, which breaks easily (and does lead us to produce wrong results at times), prohibits lexical scopes and makes relation aliasing in queries next to impossible.

The problem is, that for this we need to allow an operator to get its owning `LogicalOperator` instance, so that it can attach it to the `Field` objects (or other objects that need to be _bound_).
But since the logical operator class instances are not directly instantiated in a `std::shared_ptr`, but rather wrapped in the `OperatorModel`, we cannot use `std::enable_shared_from_this` to insert a weak_this member field.
Also, the weak_this member is only available _after_ the constructor has run through, which makes this unsuitable for later on giving Traits access to the full Operator/Traitset to validate themselves in the ctor. 

We solve this, by introducing a WeakTypedLogicalOperator, add a member of it to every logical operator and use the operator model to keep the self reference inside the wrapped instance up-to-date.

The only change in the logical operator necessary is to add `SELF_REF` in the member fields, which is just a convenience macro that expands to:
```c++
template <LogicalOperatorConcept T>
friend struct NES::detail::OperatorModel;
WeakLogicalOperator self;
```

You can then access the owning logical operator with `self.lock()` or `self.tryLock()` where the first will segfault with the precondition if the self is invalid, while the try lock will return an empty optional.
In the schema inference branch it is then used like 
```c++
Schema<Field, Unordered> bind(LogicalOperator op, Schema<UnboundUnqualifiedField, Unordered> unboundSchema) {
   return unboundSchema 
        | std::views::transform([&op](const UnboundUnqualifiedField& unboundField){ return Field{op, unboundField.getName(), unboundField.getDataType()}; ) 
        | std::ranges::to<Schema<Field, Unordered>>();
}

Schema<Field, Unordered> JoinLogicalOperator::getOutputSchema() const {
    return bind(self.lock(), unboundSchema);
}
```


## Verifying this change
I added a unit test that tests if the locking works and the self is is updated correctly.

## What components does this pull request potentially affect?
LogicalOperators