### PR TITLE
feat(CI/HashMapTests): Reduces the no. chained hashmap tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -59,7 +59,7 @@ jobs:
           image_name: nebulastream/nes-development:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{matrix.sanitizer}}
           run: |
             source .github/.env/test-${{matrix.sanitizer}}.env
-            cmake -GNinja -B build -DUSE_SANITIZER=${{ matrix.sanitizer }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DNES_LOG_LEVEL=DEBUG
+            cmake -GNinja -B build -DUSE_SANITIZER=${{ matrix.sanitizer }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DNES_LOG_LEVEL=DEBUG -DALL_HASHMAP_TESTS=1
             cmake --build build -j  -- -k 0
       - uses: ./.github/steps/run-in-container
         name: Run Tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ option(NES_ENABLE_EXPERIMENTAL_EXECUTION_MLIR "Enables the MLIR backend." ON)
 option(NES_LOG_WITH_STACKTRACE "Log exceptions with stacktrace" ON)
 option(ENABLE_LARGE_TESTS "Runs testcases with larger input data" OFF)
 option(NES_DEBUG_TUPLE_BUFFER_LEAKS "Heavyweight instrumentation for Tuplebuffer debugging" OFF)
+option(ALL_HASHMAP_TESTS "Run all hashmap test combinations." OFF)
 
 
 if (CMAKE_BUILD_TYPE STREQUAL "Benchmark")

--- a/nes-nautilus/tests/CMakeLists.txt
+++ b/nes-nautilus/tests/CMakeLists.txt
@@ -27,3 +27,8 @@ target_link_libraries(chained-hashmap-unit-tests nes-nautilus-test-util)
 
 add_nes_unit_test(chained-hashmap-unit-tests-custom-value "UnitTests/ChainedHashMapCustomValueTest.cpp")
 target_link_libraries(chained-hashmap-unit-tests-custom-value nes-nautilus-test-util)
+
+if(ALL_HASHMAP_TESTS)
+    target_compile_definitions(chained-hashmap-unit-tests PRIVATE ALL_HASHMAP_TESTS)
+    target_compile_definitions(chained-hashmap-unit-tests-custom-value PRIVATE ALL_HASHMAP_TESTS)
+endif()

--- a/nes-nautilus/tests/UnitTests/ChainedHashMapCustomValueTest.cpp
+++ b/nes-nautilus/tests/UnitTests/ChainedHashMapCustomValueTest.cpp
@@ -203,14 +203,21 @@ TEST_P(ChainedHashMapCustomValueTest, pagedVector)
 
     hashMap.clear();
 }
+#ifdef ALL_HASHMAP_TESTS
+/// Running the test for 3 times for each key, value schema and backend.
+/// This entails three different random number of items, number of buckets and page size.
+constexpr auto noIterations = 3;
+#else
+/// Running the test for 1 time for each key, value schema and backend.
+/// This entails three different random number of items, number of buckets and page size.
+constexpr auto noIterations = 1;
+#endif
 
 INSTANTIATE_TEST_CASE_P(
     ChainedHashMapCustomValue,
     ChainedHashMapCustomValueTest,
     ::testing::Combine(
-        /// Running the test for 3 times for each key, value schema and backend.
-        /// This entails three different random number of items, number of buckets and page size.
-        ::testing::Range(0, 3),
+        ::testing::Range(0, noIterations),
         ::testing::ValuesIn<std::vector<DataType::Type>>(
             {{DataType::Type::UINT8},
              {DataType::Type::INT64, DataType::Type::UINT64, DataType::Type::INT8, DataType::Type::INT16, DataType::Type::INT32},

--- a/nes-nautilus/tests/UnitTests/ChainedHashMapTest.cpp
+++ b/nes-nautilus/tests/UnitTests/ChainedHashMapTest.cpp
@@ -120,44 +120,52 @@ TEST_P(ChainedHashMapTest, update)
     /// Check if our entry iterator reads all the entries
     checkEntryIterator(hashMap, exactMap);
 }
+#ifdef ALL_HASHMAP_TESTS
+/// Running the test for 3 times for each key, value schema and backend.
+/// This entails three different random number of items, number of buckets and page size.
+constexpr auto noIterations = 3;
+static auto keyTypes = ::testing::ValuesIn<std::vector<DataType::Type>>(
+    {{DataType::Type::UINT8},
+     {DataType::Type::VARSIZED},
+     {DataType::Type::VARSIZED, DataType::Type::INT8},
+     {DataType::Type::VARSIZED, DataType::Type::INT8, DataType::Type::INT64},
+     {DataType::Type::INT64, DataType::Type::UINT64, DataType::Type::INT8, DataType::Type::INT16, DataType::Type::INT32},
+     {DataType::Type::INT64,
+      DataType::Type::INT32,
+      DataType::Type::INT16,
+      DataType::Type::INT8,
+      DataType::Type::UINT64,
+      DataType::Type::UINT32,
+      DataType::Type::UINT16,
+      DataType::Type::UINT8}});
+static auto valTypes = ::testing::ValuesIn<std::vector<DataType::Type>>(
+    {{DataType::Type::INT8},
+     {DataType::Type::VARSIZED},
+     {DataType::Type::VARSIZED, DataType::Type::INT8},
+     {DataType::Type::VARSIZED, DataType::Type::INT8, DataType::Type::INT64},
+     {DataType::Type::INT64,
+      DataType::Type::INT32,
+      DataType::Type::INT16,
+      DataType::Type::INT8,
+      DataType::Type::FLOAT32,
+      DataType::Type::UINT64,
+      DataType::Type::UINT32,
+      DataType::Type::UINT16,
+      DataType::Type::UINT8,
+      DataType::Type::FLOAT64}});
+#else
+/// Running the test for 1 time for each key, value schema and backend.
+/// This entails one random number of items, number of buckets and page size.
+constexpr auto noIterations = 1;
+static auto keyTypes = ::testing::ValuesIn<std::vector<DataType::Type>>({{DataType::Type::UINT8}, {DataType::Type::VARSIZED}});
+static auto valTypes = ::testing::ValuesIn<std::vector<DataType::Type>>({{DataType::Type::INT8}, {DataType::Type::VARSIZED}});
+#endif
 
 INSTANTIATE_TEST_CASE_P(
     ChainedHashMapTest,
     ChainedHashMapTest,
     ::testing::Combine(
-        /// Running the test for 3 times for each key, value schema and backend.
-        /// This entails three different random number of items, number of buckets and page size.
-        ::testing::Range(0, 3),
-        ::testing::ValuesIn<std::vector<DataType::Type>>(
-            {{DataType::Type::UINT8},
-             {DataType::Type::VARSIZED},
-             {DataType::Type::VARSIZED, DataType::Type::INT8},
-             {DataType::Type::VARSIZED, DataType::Type::INT8, DataType::Type::INT64},
-             {DataType::Type::INT64, DataType::Type::UINT64, DataType::Type::INT8, DataType::Type::INT16, DataType::Type::INT32},
-             {DataType::Type::INT64,
-              DataType::Type::INT32,
-              DataType::Type::INT16,
-              DataType::Type::INT8,
-              DataType::Type::UINT64,
-              DataType::Type::UINT32,
-              DataType::Type::UINT16,
-              DataType::Type::UINT8}}),
-        ::testing::ValuesIn<std::vector<DataType::Type>>(
-            {{DataType::Type::INT8},
-             {DataType::Type::VARSIZED},
-             {DataType::Type::VARSIZED, DataType::Type::INT8},
-             {DataType::Type::VARSIZED, DataType::Type::INT8, DataType::Type::INT64},
-             {DataType::Type::INT64,
-              DataType::Type::INT32,
-              DataType::Type::INT16,
-              DataType::Type::INT8,
-              DataType::Type::FLOAT32,
-              DataType::Type::UINT64,
-              DataType::Type::UINT32,
-              DataType::Type::UINT16,
-              DataType::Type::UINT8,
-              DataType::Type::FLOAT64}}),
-        ::testing::Values(ExecutionMode::COMPILER, ExecutionMode::INTERPRETER)),
+        ::testing::Range(0, noIterations), keyTypes, valTypes, ::testing::Values(ExecutionMode::COMPILER, ExecutionMode::INTERPRETER)),
     [](const testing::TestParamInfo<ChainedHashMapTest::ParamType>& info)
     {
         const auto iteration = std::get<0>(info.param);
@@ -179,4 +187,5 @@ INSTANTIATE_TEST_CASE_P(
         ss << magic_enum::enum_name(backend);
         return ss.str();
     });
+
 }


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
We reduce the no. chained hash map tests so that we go from 1175 total tests to 532 tests per default. We still let all chained hashmap tests run on the CI by enabling the cmake flag `ALL_HASHMAP_TESTS`.

## Verifying this change
This change is tested by running our CI tests
