### PR TITLE
Fix(#1345): Scope function arguments in SQL WHERE clause parsing

### DIFF
--- a/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
+++ b/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
@@ -910,15 +910,28 @@ void AntlrSQLQueryPlanCreator::exitFunctionCall(AntlrSQLParser::FunctionCallCont
                 auto constFunctionItem = ConstantValueLogicalFunction(*dataType, std::move(value));
                 helpers.top().functionBuilder.emplace_back(constFunctionItem);
             }
-            else if (auto logicalFunction = LogicalFunctionProvider::tryProvide(funcName, helpers.top().functionBuilder))
-            {
-                /// Remove exactly the functions used to create the 'logicalFunction' from the back of the function builder
-                helpers.top().functionBuilder.resize(helpers.top().functionBuilder.size() - logicalFunction.value().getChildren().size());
-                helpers.top().functionBuilder.push_back(*logicalFunction);
-            }
             else
             {
-                throw InvalidQuerySyntax("Unknown (aggregation) function: {}, resolved to token type: {}", funcName, tokenType);
+                const auto numArgs = context->argument.size();
+                if (numArgs > helpers.top().functionBuilder.size())
+                {
+                    throw InvalidQuerySyntax(
+                        "Function '{}' expects {} arguments but only {} are available",
+                        funcName,
+                        numArgs,
+                        helpers.top().functionBuilder.size());
+                }
+                auto argsBegin = helpers.top().functionBuilder.end() - static_cast<std::ptrdiff_t>(numArgs);
+                std::vector<LogicalFunction> funcArgs(argsBegin, helpers.top().functionBuilder.end());
+                if (auto logicalFunction = LogicalFunctionProvider::tryProvide(funcName, std::move(funcArgs)))
+                {
+                    helpers.top().functionBuilder.resize(helpers.top().functionBuilder.size() - numArgs);
+                    helpers.top().functionBuilder.push_back(*logicalFunction);
+                }
+                else
+                {
+                    throw InvalidQuerySyntax("Unknown (aggregation) function: {}, resolved to token type: {}", funcName, tokenType);
+                }
             }
     }
 

--- a/nes-systests/regression/ChainedFunctionsInWhere.test
+++ b/nes-systests/regression/ChainedFunctionsInWhere.test
@@ -1,0 +1,44 @@
+# description: Chained function calls in WHERE clause (regression for #1345)
+# groups: [regression, Selection]
+
+CREATE LOGICAL SOURCE stream(v1 INT64, v2 INT64, v3 FLOAT64);
+CREATE PHYSICAL SOURCE FOR stream TYPE File;
+ATTACH INLINE
+-5,10,-3.5
+0,0,0.0
+7,-2,4.2
+
+CREATE SINK sinkStream(out_v1 INT64, out_v2 INT64, out_v3 FLOAT64) TYPE File;
+
+# Multiple function calls in WHERE with AND
+SELECT v1 AS out_v1, v2 AS out_v2, v3 AS out_v3 FROM stream WHERE ABS(v1) > INT64(0) AND ABS(v2) > INT64(0) INTO sinkStream;
+----
+-5,10,-3.5
+7,-2,4.2
+
+# Multiple function calls in WHERE with OR
+SELECT v1 AS out_v1, v2 AS out_v2, v3 AS out_v3 FROM stream WHERE ABS(v1) > INT64(4) OR ABS(v3) > FLOAT64(4.0) INTO sinkStream;
+----
+-5,10,-3.5
+7,-2,4.2
+
+# Three chained function calls in WHERE
+SELECT v1 AS out_v1, v2 AS out_v2, v3 AS out_v3 FROM stream WHERE ABS(v1) > INT64(0) AND ABS(v2) > INT64(0) AND ABS(v3) > FLOAT64(0.0) INTO sinkStream;
+----
+-5,10,-3.5
+7,-2,4.2
+
+# Chained ABS calls in WHERE with multiple data types
+CREATE LOGICAL SOURCE stream2(i8 INT8, i16 INT16, i32 INT32, i64 INT64, u8 UINT8, u16 UINT16, u32 UINT32, u64 UINT64, f32 FLOAT32, f64 FLOAT64);
+CREATE PHYSICAL SOURCE FOR stream2 TYPE File;
+ATTACH INLINE
+-42,-129,-32769,-2147483649,42,256,65536,4294967296,23.2,-42.45
+
+CREATE SINK sinkStream2(i8 INT8, i16 INT16, i32 INT32, i64 INT64, u8 UINT8, u16 UINT16, u32 UINT32, u64 UINT64, f32 FLOAT32, f64 FLOAT64) TYPE File;
+
+SELECT ABS(i8) AS i8, ABS(i16) AS i16, ABS(i32) AS i32, ABS(i64) AS i64,
+       ABS(u8) AS u8, ABS(u16) AS u16, ABS(u32) AS u32, ABS(u64) AS u64,
+       ABS(f32) AS f32, ABS(f64) AS f64
+FROM stream2 WHERE ABS(i8) > INT8(0) AND ABS(f64) > FLOAT64(0) INTO sinkStream2;
+----
+42,129,32769,2147483649,42,256,65536,4294967296,23.2,42.45


### PR DESCRIPTION
## Summary
- Fixes chained function calls in SQL WHERE clauses (e.g., `WHERE ABS(v1) > 0 AND ABS(v2) > 0`) which previously failed because `exitFunctionCall` passed the entire `functionBuilder` vector to `LogicalFunctionProvider::tryProvide` instead of only the arguments belonging to the current function call
- Now uses the ANTLR-provided argument count (`context->argument.size()`) to extract only the relevant tail of the builder vector
- Adds regression systests for chained function calls with AND, OR, and triple-chaining in WHERE

## Test plan
- [x] `FunctionAbsolute.test` passes (existing + new chained-WHERE case)
- [x] `ChainedFunctionsInWhere.test` passes (3 new regression cases)
- [x] `SelectionEquivalence.test` passes (no regressions)
- [ ] CI full matrix

Closes #1345

🤖 Generated with [Claude Code](https://claude.com/claude-code)