### PR TITLE
Parse count star

### DIFF
--- a/nes-logical-operators/include/Operators/Windows/Aggregations/CountAggregationLogicalFunction.hpp
+++ b/nes-logical-operators/include/Operators/Windows/Aggregations/CountAggregationLogicalFunction.hpp
@@ -37,19 +37,20 @@ namespace NES
 class CountAggregationLogicalFunction
 {
 public:
-    explicit CountAggregationLogicalFunction(AggregationFieldAccess inputFunction);
+    explicit CountAggregationLogicalFunction(AggregationFieldAccess inputFunction, bool includeNullValues);
 
     [[nodiscard]] CountAggregationLogicalFunction withInferredType(const Schema<Field, Unordered>& schema) const;
     [[nodiscard]] std::string_view getName() const noexcept;
     [[nodiscard]] Reflected reflect() const;
     [[nodiscard]] static DataType getAggregateType();
     [[nodiscard]] AggregationFieldAccess getInputFunction() const;
-    [[nodiscard]] static bool shallIncludeNullValues() noexcept;
+    [[nodiscard]] bool shallIncludeNullValues() const noexcept;
     [[nodiscard]] std::string explain(ExplainVerbosity verbosity) const;
     [[nodiscard]] bool operator==(const CountAggregationLogicalFunction& other) const;
 
 private:
     AggregationFieldAccess inputFunction;
+    bool includeNullValues = false;
     static constexpr std::string_view NAME = "Count";
     static constexpr DataType::Type finalAggregateStampType = DataType::Type::UINT64;
 };

--- a/nes-logical-operators/registry/include/AggregationLogicalFunctionRegistry.hpp
+++ b/nes-logical-operators/registry/include/AggregationLogicalFunctionRegistry.hpp
@@ -30,6 +30,7 @@ using AggregationLogicalFunctionRegistryReturnType = WindowAggregationLogicalFun
 struct AggregationLogicalFunctionRegistryArguments
 {
     std::vector<AggregationFieldAccess> on;
+    bool includeNullValues;
 };
 
 class AggregationLogicalFunctionRegistry : public BaseRegistry<

--- a/nes-logical-operators/src/Operators/Windows/Aggregations/CountAggregationLogicalFunction.cpp
+++ b/nes-logical-operators/src/Operators/Windows/Aggregations/CountAggregationLogicalFunction.cpp
@@ -39,16 +39,15 @@
 
 namespace NES
 {
-CountAggregationLogicalFunction::CountAggregationLogicalFunction(AggregationFieldAccess inputFunction)
-    : inputFunction(std::move(inputFunction))
+/// COUNT(*) includes null values (counts all rows), COUNT(fieldName) does not
+CountAggregationLogicalFunction::CountAggregationLogicalFunction(AggregationFieldAccess inputFunction, const bool includeNullValues)
+    : inputFunction(std::move(inputFunction)), includeNullValues(includeNullValues)
 {
 }
 
-bool CountAggregationLogicalFunction::shallIncludeNullValues() noexcept
+bool CountAggregationLogicalFunction::shallIncludeNullValues() const noexcept
 {
-    /// For now, we hardcode it. As soon as TODO #699 is merged, we can specify here a difference
-    /// For example, COUNT(*) includes null whereas COUNT(fieldName) does not
-    return false;
+    return includeNullValues;
 }
 
 std::string_view CountAggregationLogicalFunction::getName() const noexcept
@@ -88,19 +87,39 @@ Reflected CountAggregationLogicalFunction::reflect() const
 
 CountAggregationLogicalFunction CountAggregationLogicalFunction::withInferredType(const Schema<Field, Unordered>& schema) const
 {
+    if (includeNullValues)
+    {
+        /// COUNT(*) does not refer to a specific field; use the first field of the schema as a placeholder
+        PRECONDITION(schema.size() >= 1, "Schema needs to have one field at least for CountAggregationLogicalFunction");
+        const auto& placeHolderField
+            = std::ranges::min_element(schema, {}, [](const auto& field) { return fmt::format("{}", field.getFullyQualifiedName()); });
+        auto newInputFunction = TypedLogicalFunction<FieldAccessLogicalFunction>{FieldAccessLogicalFunction{*placeHolderField}};
+        return CountAggregationLogicalFunction{newInputFunction, includeNullValues};
+    }
     auto newInputFunction = inferFieldAccess(inputFunction, schema);
-    return CountAggregationLogicalFunction{newInputFunction};
+    return CountAggregationLogicalFunction{newInputFunction, includeNullValues};
+}
+
+namespace detail
+{
+struct ReflectedCountAggregationLogicalFunction
+{
+    AggregationFieldAccess inputFunction;
+    bool includeNullValues;
+};
 }
 
 Reflected Reflector<CountAggregationLogicalFunction>::operator()(const CountAggregationLogicalFunction& function) const
 {
-    return reflect(function.getInputFunction());
+    return reflect(detail::ReflectedCountAggregationLogicalFunction{
+        .inputFunction = function.getInputFunction(), .includeNullValues = function.shallIncludeNullValues()});
 }
 
 CountAggregationLogicalFunction
 Unreflector<CountAggregationLogicalFunction>::operator()(const Reflected& reflected, const ReflectionContext& context) const
 {
-    return CountAggregationLogicalFunction{context.unreflect<AggregationFieldAccess>(reflected)};
+    auto [inputFunction, includeNullValues] = context.unreflect<detail::ReflectedCountAggregationLogicalFunction>(reflected);
+    return CountAggregationLogicalFunction{std::move(inputFunction), includeNullValues};
 }
 
 AggregationLogicalFunctionRegistryReturnType
@@ -110,12 +129,13 @@ AggregationLogicalFunctionGeneratedRegistrar::RegisterCountAggregationLogicalFun
     {
         throw CannotDeserialize("CountAggregationLogicalFunction requires exactly one field, but got {}", arguments.on.size());
     }
-    return CountAggregationLogicalFunction{arguments.on.at(0)};
+    return CountAggregationLogicalFunction{arguments.on.at(0), arguments.includeNullValues};
 }
 }
 
 size_t
 std::hash<NES::CountAggregationLogicalFunction>::operator()(const NES::CountAggregationLogicalFunction& aggregationFunction) const noexcept
 {
-    return folly::hash::hash_combine(aggregationFunction.getInputFunction(), aggregationFunction.getName());
+    return folly::hash::hash_combine(
+        aggregationFunction.getInputFunction(), aggregationFunction.getName(), aggregationFunction.shallIncludeNullValues());
 }

--- a/nes-sql-parser/AntlrSQL.g4
+++ b/nes-sql-parser/AntlrSQL.g4
@@ -355,7 +355,7 @@ predicate
 
 
 valueExpression
-    : (functionName | typeDefinition) '(' (argument+=expression (',' argument+=expression)*)? ')'                 #functionCall
+    : (functionName | typeDefinition) '(' (starArg=ASTERISK | argument+=expression (',' argument+=expression)*)? ')'                 #functionCall
     | op=(MINUS | PLUS | TILDE) valueExpression                                        #arithmeticUnary
     | left=valueExpression op=(ASTERISK | SLASH | PERCENT | DIV) right=valueExpression #arithmeticBinary
     | left=valueExpression op=(PLUS | MINUS | CONCAT_PIPE) right=valueExpression       #arithmeticBinary

--- a/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
+++ b/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
@@ -953,13 +953,24 @@ void AntlrSQLQueryPlanCreator::exitFunctionCall(AntlrSQLParser::FunctionCallCont
     auto isAggregation = false;
     switch (tokenType)
     {
-        case AntlrSQLLexer::COUNT:
-            ensureFieldAccessArgument();
+        case AntlrSQLLexer::COUNT: {
+            const auto includeNullValues = (context->starArg != nullptr);
+            if (includeNullValues)
+            {
+                /// COUNT(*) — no field argument needed; use a dummy * field
+                helpers.top().functionBuilder.emplace_back(UnboundFieldAccessLogicalFunction(Identifier::parse("*")));
+            }
+            else
+            {
+                ensureFieldAccessArgument();
+            }
             helpers.top().windowAggs.emplace_back(
-                CountAggregationLogicalFunction{helpers.top().functionBuilder.back().getAs<UnboundFieldAccessLogicalFunction>()},
+                CountAggregationLogicalFunction{
+                    helpers.top().functionBuilder.back().getAs<UnboundFieldAccessLogicalFunction>(), includeNullValues},
                 std::nullopt);
             isAggregation = true;
             break;
+        }
         case AntlrSQLLexer::AVG:
             ensureFieldAccessArgument();
             helpers.top().windowAggs.emplace_back(

--- a/nes-systests/operator/aggregation/WindowAggregationCount.test
+++ b/nes-systests/operator/aggregation/WindowAggregationCount.test
@@ -1,0 +1,93 @@
+# name: window/WindowAggregationCount.test
+# description: Test COUNT(*) vs COUNT(column_name) with null value handling
+# groups: [Aggregation, WindowOperators, NullHandling]
+
+
+CREATE LOGICAL SOURCE stream(value INT32, ts UINT64 NOT NULL, id INT32 NOT NULL);
+CREATE PHYSICAL SOURCE FOR stream TYPE File;
+ATTACH INLINE
+10,10,1
+30,20,2
+,60,1
+40,110,2
+50,160,1
+,210,2
+
+
+CREATE SINK sinkCountStar(start UINT64 NOT NULL, end UINT64 NOT NULL, rowCount UINT64 NOT NULL) TYPE File;
+CREATE SINK sinkCountBoth(start UINT64 NOT NULL, end UINT64 NOT NULL, rowCount UINT64 NOT NULL, valueCount UINT64 NOT NULL) TYPE File;
+CREATE SINK sinkCountStarKeyed(start UINT64 NOT NULL, end UINT64 NOT NULL, id INT32 NOT NULL, rowCount UINT64 NOT NULL) TYPE File;
+CREATE SINK sinkCountBothKeyed(start UINT64 NOT NULL, end UINT64 NOT NULL, id INT32 NOT NULL, rowCount UINT64 NOT NULL, valueCount UINT64 NOT NULL) TYPE File;
+
+
+# COUNT(*) counts all rows including those with null values - tumbling window
+SELECT start, end, COUNT(*) AS rowCount
+FROM stream WINDOW TUMBLING(ts, size 100 ms)
+INTO sinkCountStar;
+----
+0,100,3
+100,200,2
+200,300,1
+
+
+# COUNT(*) vs COUNT(column_name) - tumbling window
+# COUNT(*) includes rows with null value, COUNT(value) does not
+SELECT start, end, COUNT(*) AS rowCount, COUNT(value) AS valueCount
+FROM stream WINDOW TUMBLING(ts, size 100 ms)
+INTO sinkCountBoth;
+----
+0,100,3,2
+100,200,2,2
+200,300,1,0
+
+
+# COUNT(*) with keyed tumbling window
+SELECT start, end, id, COUNT(*) AS rowCount
+FROM stream GROUP BY (id) WINDOW TUMBLING(ts, size 100 ms)
+INTO sinkCountStarKeyed;
+----
+0,100,1,2
+0,100,2,1
+100,200,2,1
+100,200,1,1
+200,300,2,1
+
+
+# COUNT(*) vs COUNT(column_name) with keyed tumbling window
+SELECT start, end, id, COUNT(*) AS rowCount, COUNT(value) AS valueCount
+FROM stream GROUP BY (id) WINDOW TUMBLING(ts, size 100 ms)
+INTO sinkCountBothKeyed;
+----
+0,100,1,2,1
+0,100,2,1,1
+100,200,2,1,1
+100,200,1,1,1
+200,300,2,1,0
+
+
+# COUNT(*) vs COUNT(column_name) - sliding window
+SELECT start, end, COUNT(*) AS rowCount, COUNT(value) AS valueCount
+FROM stream WINDOW SLIDING(ts, size 100 ms, advance by 50 ms)
+INTO sinkCountBoth;
+----
+0,100,3,2
+50,150,2,1
+100,200,2,2
+150,250,2,1
+200,300,1,0
+
+
+# COUNT(*) vs COUNT(column_name) with keyed sliding window
+SELECT start, end, id, COUNT(*) AS rowCount, COUNT(value) AS valueCount
+FROM stream GROUP BY (id) WINDOW SLIDING(ts, size 100 ms, advance by 50 ms)
+INTO sinkCountBothKeyed;
+----
+0,100,1,2,1
+0,100,2,1,1
+50,150,1,1,0
+50,150,2,1,1
+100,200,2,1,1
+100,200,1,1,1
+150,250,1,1,1
+150,250,2,1,0
+200,300,2,1,0


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR solves bug #699 that did not allow to use `COUNT(*)` in our query api.

## Verifying this change
This change is tested by newly added SLT.

## Issue Closed by this pull request:

This PR closes #699 