### PR TITLE
Removed contradictory precoditions in VariableSizedData::isValid

### DIFF
--- a/nes-nautilus/src/Nautilus/DataTypes/VariableSizedData.cpp
+++ b/nes-nautilus/src/Nautilus/DataTypes/VariableSizedData.cpp
@@ -73,8 +73,6 @@ nautilus::val<bool> operator==(const nautilus::val<bool>& other, const VariableS
 
 nautilus::val<bool> VariableSizedData::isValid() const
 {
-    PRECONDITION(size > 0 && ptrToVarSized != nullptr, "VariableSizedData has a size of 0 but  a nullptr pointer to the data.");
-    PRECONDITION(size == 0 && ptrToVarSized == nullptr, "VariableSizedData has a size of 0 so there should be no pointer to the data.");
     return size > 0 && ptrToVarSized != nullptr;
 }
 

--- a/nes-systests/datatype/VariableSizedData.test
+++ b/nes-systests/datatype/VariableSizedData.test
@@ -37,3 +37,19 @@ SELECT * FROM streamWithText INTO sinkStreamWithText;
 2,3,test1,test1
 6,4,test1,test2
 8,5,test1,test2
+
+# Check ability to compare variable sized values to bools to test VariableSizedData::isValid()
+SELECT * FROM streamWithText WHERE text1 == BOOLEAN(1) INTO sinkStreamWithText;
+----
+1,1,test1,test1
+12,1,test1,test2
+4,1,test2,test2
+1,2,test1,test1
+11,2,test3,test2
+16,2,test1,test1
+1,3,test1,test2
+11,3,test3,test1
+3,3,test1,test2
+2,3,test1,test1
+6,4,test1,test2
+8,5,test1,test2


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This pull request removes two preconditions in `VariableSizedData::isValid()`, which could not be fulfilled both at the same time:
```c++
nautilus::val<bool> VariableSizedData::isValid() const
{
    PRECONDITION(size > 0 && ptrToVarSized != nullptr, "VariableSizedData has a size of 0 but  a nullptr pointer to the data.");
    PRECONDITION(size == 0 && ptrToVarSized == nullptr, "VariableSizedData has a size of 0 so there should be no pointer to the data.");
    return size > 0 && ptrToVarSized != nullptr;
}
```
Even if we combine both preconditions disjunctively into one, the precondition would still be violated during nautilus-tracing, as size and ptrToVarsized are nautilus-vals. Therefore, this pr removes it completely. It should be fine even without the preconditions, as we never read a varsized value further than its size.

## Verifying this change
Added a systest at `nes-systests/datatype/VariableSizedData.test` that compares varsized values to booleans, which utilizes isValid.

## What components does this pull request potentially affect?
- VariableSizedData nautilus-datatype


## Issue Closed by this pull request:

This PR closes #1440.
