### PR TITLE
feat(ConditionalFunction): add Conditional function plugin

### DIFF
--- a/nes-plugins/CMakeLists.txt
+++ b/nes-plugins/CMakeLists.txt
@@ -20,6 +20,7 @@ activate_optional_plugin("Sources/TCPSource" ON)
 activate_optional_plugin("Sources/GeneratorSource" ON)
 activate_optional_plugin("Sinks/VoidSink" ON)
 activate_optional_plugin("InputFormatters/JSONInputFormatter" ON)
+activate_optional_plugin("Functions/ConditionalFunction" ON)
 
 if (NES_ENABLES_TESTS)
   # ChecksumSink depends on Checksum.cpp from systest which is only added when tests are enabled.

--- a/nes-plugins/Functions/ConditionalFunction/CMakeLists.txt
+++ b/nes-plugins/Functions/ConditionalFunction/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(${PROJECT_SOURCE_DIR}/cmake/PluginRegistrationUtil.cmake)
+
+add_plugin(Conditional LogicalFunction nes-logical-operators ConditionalLogicalFunction.cpp)
+add_plugin(Conditional PhysicalFunction nes-physical-operators ConditionalPhysicalFunction.cpp)
+
+if (NES_ENABLES_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/nes-plugins/Functions/ConditionalFunction/ConditionalLogicalFunction.cpp
+++ b/nes-plugins/Functions/ConditionalFunction/ConditionalLogicalFunction.cpp
@@ -1,0 +1,167 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "ConditionalLogicalFunction.hpp"
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/Schema.hpp>
+#include <Functions/LogicalFunction.hpp>
+#include <Serialization/LogicalFunctionReflection.hpp>
+#include <Util/PlanRenderer.hpp>
+#include <Util/Reflection.hpp>
+#include <fmt/format.h>
+#include <ErrorHandling.hpp>
+#include <LogicalFunctionRegistry.hpp>
+
+namespace NES
+{
+ConditionalLogicalFunction::ConditionalLogicalFunction(std::vector<LogicalFunction> children)
+    : dataType(children.back().getDataType()), children(std::move(children))
+{
+}
+
+DataType ConditionalLogicalFunction::getDataType() const
+{
+    return dataType;
+}
+
+ConditionalLogicalFunction ConditionalLogicalFunction::withDataType(const DataType& dataType) const
+{
+    auto copy = *this;
+    copy.dataType = dataType;
+    return copy;
+}
+
+std::vector<LogicalFunction> ConditionalLogicalFunction::getChildren() const
+{
+    return children;
+}
+
+ConditionalLogicalFunction ConditionalLogicalFunction::withChildren(const std::vector<LogicalFunction>& children) const
+{
+    return ConditionalLogicalFunction(children);
+}
+
+std::string_view ConditionalLogicalFunction::getType() const
+{
+    return NAME;
+}
+
+bool ConditionalLogicalFunction::operator==(const ConditionalLogicalFunction& rhs) const
+{
+    return children == rhs.children;
+}
+
+std::string ConditionalLogicalFunction::explain(ExplainVerbosity verbosity) const
+{
+    std::string result = "CASE";
+    for (size_t i = 0; i + 1 < children.size(); i += 2)
+    {
+        result += fmt::format(" WHEN {} THEN {}", children.at(i).explain(verbosity), children.at(i + 1).explain(verbosity));
+    }
+    result += fmt::format(" ELSE {}", children.back().explain(verbosity));
+    return result;
+}
+
+LogicalFunction ConditionalLogicalFunction::withInferredDataType(const Schema& schema) const
+{
+    std::vector<LogicalFunction> inferredChildren;
+    inferredChildren.reserve(children.size());
+    for (const auto& child : children)
+    {
+        inferredChildren.push_back(child.withInferredDataType(schema));
+    }
+    /// Even indexes (0, 2, 4, ...) are conditions and must be BOOLEAN.
+    for (std::size_t i = 0; i + 1 < inferredChildren.size(); i += 2)
+    {
+        if (!inferredChildren.at(i).getDataType().isType(DataType::Type::BOOLEAN))
+        {
+            throw CannotInferSchema(
+                "ConditionalLogicalFunction: condition at index {} must be BOOLEAN, but was: {}", i, inferredChildren.at(i).getDataType());
+        }
+    }
+
+    /// Odd indexes (1, 3, 5, ...) are results and must have the same type as the default (last element).
+    const auto& resultType = inferredChildren.back().getDataType();
+    for (std::size_t i = 1; i + 1 < inferredChildren.size(); i += 2)
+    {
+        if (inferredChildren.at(i).getDataType() != resultType)
+        {
+            throw CannotInferSchema(
+                "ConditionalLogicalFunction: result at index {} has type {}, but expected {} (matching default)",
+                i,
+                inferredChildren.at(i).getDataType(),
+                resultType);
+        }
+    }
+
+    return withChildren(inferredChildren).withDataType(resultType);
+}
+
+Reflected Reflector<ConditionalLogicalFunction>::operator()(const ConditionalLogicalFunction& function) const
+{
+    detail::ReflectedConditionalLogicalFunction reflected;
+    reflected.children.reserve(function.children.size());
+    for (const auto& child : function.children)
+    {
+        reflected.children.push_back(std::make_optional(child));
+    }
+    return reflect(reflected);
+}
+
+ConditionalLogicalFunction Unreflector<ConditionalLogicalFunction>::operator()(const Reflected& reflected) const
+{
+    auto [childrenOpts] = unreflect<detail::ReflectedConditionalLogicalFunction>(reflected);
+    std::vector<LogicalFunction> children;
+    children.reserve(childrenOpts.size());
+    for (const auto& childOpt : childrenOpts)
+    {
+        if (!childOpt.has_value())
+        {
+            throw CannotDeserialize("ConditionalLogicalFunction child is missing");
+        }
+        children.push_back(childOpt.value());
+    }
+    if (children.size() < 3 || children.size() % 2 == 0)
+    {
+        throw CannotDeserialize("ConditionalLogicalFunction requires an odd number of children >= 3, but got {}", children.size());
+    }
+    return ConditionalLogicalFunction(std::move(children));
+}
+
+LogicalFunctionRegistryReturnType
+LogicalFunctionGeneratedRegistrar::RegisterConditionalLogicalFunction(LogicalFunctionRegistryArguments arguments)
+{
+    if (!arguments.reflected.isEmpty())
+    {
+        return unreflect<ConditionalLogicalFunction>(arguments.reflected);
+    }
+    /// Must have an odd number of children >= 3: at least one (condition, result) pair + default.
+    if (arguments.children.size() < 3 || arguments.children.size() % 2 == 0)
+    {
+        throw CannotDeserialize(
+            "ConditionalLogicalFunction requires an odd number of arguments >= 3 "
+            "(condition/result pairs + default), but got {}",
+            arguments.children.size());
+    }
+    return ConditionalLogicalFunction(std::move(arguments.children));
+}
+}

--- a/nes-plugins/Functions/ConditionalFunction/ConditionalLogicalFunction.hpp
+++ b/nes-plugins/Functions/ConditionalFunction/ConditionalLogicalFunction.hpp
@@ -1,0 +1,89 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/Schema.hpp>
+#include <Functions/LogicalFunction.hpp>
+#include <Util/Logger/Formatter.hpp>
+#include <Util/PlanRenderer.hpp>
+#include <Util/Reflection.hpp>
+
+namespace NES
+{
+
+/// @brief Represents a CASE WHEN expression. Children are stored as a flat list:
+/// [cond1, result1, cond2, result2, ..., condN, resultN, default]
+/// The list must have an odd number of elements >= 3.
+class ConditionalLogicalFunction final
+{
+public:
+    static constexpr std::string_view NAME = "Conditional";
+
+    explicit ConditionalLogicalFunction(std::vector<LogicalFunction> children);
+
+    [[nodiscard]] bool operator==(const ConditionalLogicalFunction& rhs) const;
+
+    [[nodiscard]] DataType getDataType() const;
+
+    [[nodiscard]] ConditionalLogicalFunction withDataType(const DataType& dataType) const;
+
+    [[nodiscard]] LogicalFunction withInferredDataType(const Schema& schema) const;
+
+    [[nodiscard]] std::vector<LogicalFunction> getChildren() const;
+
+    [[nodiscard]] ConditionalLogicalFunction withChildren(const std::vector<LogicalFunction>& children) const;
+
+    [[nodiscard]] std::string_view getType() const;
+
+    [[nodiscard]] std::string explain(ExplainVerbosity verbosity) const;
+
+private:
+    DataType dataType;
+    std::vector<LogicalFunction> children;
+
+    friend Reflector<ConditionalLogicalFunction>;
+};
+
+template <>
+struct Reflector<ConditionalLogicalFunction>
+{
+    Reflected operator()(const ConditionalLogicalFunction& function) const;
+};
+
+template <>
+struct Unreflector<ConditionalLogicalFunction>
+{
+    ConditionalLogicalFunction operator()(const Reflected& reflected) const;
+};
+
+static_assert(LogicalFunctionConcept<ConditionalLogicalFunction>);
+
+}
+
+namespace NES::detail
+{
+struct ReflectedConditionalLogicalFunction
+{
+    std::vector<std::optional<LogicalFunction>> children;
+};
+}
+
+FMT_OSTREAM(NES::ConditionalLogicalFunction);

--- a/nes-plugins/Functions/ConditionalFunction/ConditionalPhysicalFunction.cpp
+++ b/nes-plugins/Functions/ConditionalFunction/ConditionalPhysicalFunction.cpp
@@ -1,0 +1,79 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "ConditionalPhysicalFunction.hpp"
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include <DataTypes/DataType.hpp>
+#include <Functions/PhysicalFunction.hpp>
+#include <Nautilus/DataTypes/VarVal.hpp>
+#include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
+#include <ErrorHandling.hpp>
+#include <PhysicalFunctionRegistry.hpp>
+#include <static.hpp>
+
+namespace NES
+{
+ConditionalPhysicalFunction::ConditionalPhysicalFunction(std::vector<PhysicalFunction> inputFns) : elseFn(inputFns.back())
+{
+    inputFns.pop_back();
+
+    whenThenFns.reserve(inputFns.size() / 2);
+    for (size_t i = 0; i + 1 < inputFns.size(); i += 2)
+    {
+        whenThenFns.emplace_back(inputFns[i], inputFns[i + 1]);
+    }
+}
+
+VarVal ConditionalPhysicalFunction::execute(const Record& record, ArenaRef& arena) const
+{
+    for (nautilus::static_val<size_t> i = 0; i < whenThenFns.size(); ++i)
+    {
+        if (whenThenFns.at(i).first.execute(record, arena))
+        {
+            return whenThenFns.at(i).second.execute(record, arena);
+        }
+    }
+    return elseFn.execute(record, arena);
+}
+
+PhysicalFunctionRegistryReturnType
+PhysicalFunctionGeneratedRegistrar::RegisterConditionalPhysicalFunction(PhysicalFunctionRegistryArguments arguments)
+{
+    PRECONDITION(
+        arguments.childFunctions.size() >= 3,
+        "Conditional function must have at least 3 child functions: one condition, one return function, and one default function");
+    PRECONDITION(
+        arguments.childFunctions.size() % 2 == 1,
+        "Conditional function must have an odd number of child functions: an even number of WHEN/THEN pairs, and one default function");
+
+    const auto& inputTypes = arguments.inputTypes;
+    for (size_t i = 0; i + 1 < inputTypes.size() - 1; i += 2)
+    {
+        PRECONDITION(inputTypes[i].isType(DataType::Type::BOOLEAN), "All condition functions must have type BOOLEAN");
+    }
+
+    const auto& outputType = inputTypes.back();
+    for (size_t i = 1; i + 1 < inputTypes.size() - 1; i += 2)
+    {
+        PRECONDITION(inputTypes[i] == outputType, "All result functions must have the same type");
+    }
+
+    return ConditionalPhysicalFunction(std::move(arguments.childFunctions));
+}
+}

--- a/nes-plugins/Functions/ConditionalFunction/ConditionalPhysicalFunction.hpp
+++ b/nes-plugins/Functions/ConditionalFunction/ConditionalPhysicalFunction.hpp
@@ -1,0 +1,46 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include <Functions/PhysicalFunction.hpp>
+#include <Nautilus/DataTypes/VarVal.hpp>
+#include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
+
+namespace NES
+{
+/// @brief Executes a CASE WHEN expression at runtime.
+/// Evaluates conditions in order and returns the result of the first true condition,
+/// or the default if none match.
+///
+/// For a simpler example to use as reference, see ConcatPhysicalFunction.
+class ConditionalPhysicalFunction final
+{
+public:
+    explicit ConditionalPhysicalFunction(std::vector<PhysicalFunction> inputFns);
+
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
+
+private:
+    std::vector<std::pair<PhysicalFunction, PhysicalFunction>> whenThenFns;
+    PhysicalFunction elseFn;
+};
+
+static_assert(PhysicalFunctionConcept<ConditionalPhysicalFunction>);
+
+}

--- a/nes-plugins/Functions/ConditionalFunction/tests/CMakeLists.txt
+++ b/nes-plugins/Functions/ConditionalFunction/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_nes_test(conditional-logical-function-test ConditionalLogicalFunctionTest.cpp)
+target_link_libraries(conditional-logical-function-test nes-logical-operators nes-logical-operators-registry)
+target_include_directories(conditional-logical-function-test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+add_nes_test(conditional-physical-function-test ConditionalPhysicalFunctionTest.cpp)
+target_link_libraries(conditional-physical-function-test nes-data-types nes-physical-operators nes-memory-test-utils)
+target_include_directories(conditional-physical-function-test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/nes-plugins/Functions/ConditionalFunction/tests/ConditionalLogicalFunctionTest.cpp
+++ b/nes-plugins/Functions/ConditionalFunction/tests/ConditionalLogicalFunctionTest.cpp
@@ -1,0 +1,269 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/Schema.hpp>
+#include <Functions/ComparisonFunctions/GreaterLogicalFunction.hpp>
+#include <Functions/ComparisonFunctions/LessLogicalFunction.hpp>
+#include <Functions/ConstantValueLogicalFunction.hpp>
+#include <Functions/FieldAccessLogicalFunction.hpp>
+#include <Functions/LogicalFunction.hpp>
+#include <Serialization/LogicalFunctionReflection.hpp>
+#include <Util/PlanRenderer.hpp>
+#include <Util/Reflection.hpp>
+#include <BaseUnitTest.hpp>
+#include <ConditionalLogicalFunction.hpp>
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+
+/// A minimal conditional: one condition, one result, one default.
+TEST(ConditionalLogicalFunctionTest, InferDataTypeSimpleTwoWay)
+{
+    auto schema = Schema{}
+                      .addField("stream$a", DataType{DataType::Type::INT32})
+                      .addField("stream$b", DataType{DataType::Type::INT32})
+                      .addField("stream$flag", DataType{DataType::Type::BOOLEAN});
+
+    /// Conditional(flag, a, b) — picks between two fields
+    auto fn = LogicalFunction(ConditionalLogicalFunction({
+        FieldAccessLogicalFunction("flag"),
+        FieldAccessLogicalFunction("a"),
+        FieldAccessLogicalFunction("b"),
+    }));
+    auto inferred = fn.withInferredDataType(schema);
+    EXPECT_TRUE(inferred.getDataType().isType(DataType::Type::INT32));
+}
+
+/// Multi-branch conditional with three conditions.
+TEST(ConditionalLogicalFunctionTest, InferDataTypeMultiBranch)
+{
+    auto schema
+        = Schema{}.addField("stream$id", DataType{DataType::Type::INT32}).addField("stream$flag", DataType{DataType::Type::BOOLEAN});
+
+    auto fn = LogicalFunction(ConditionalLogicalFunction({
+        FieldAccessLogicalFunction("flag"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::VARSIZED}, "A"),
+        GreaterLogicalFunction(FieldAccessLogicalFunction("id"), ConstantValueLogicalFunction(DataType{DataType::Type::INT32}, "5")),
+        ConstantValueLogicalFunction(DataType{DataType::Type::VARSIZED}, "B"),
+        LessLogicalFunction(FieldAccessLogicalFunction("id"), ConstantValueLogicalFunction(DataType{DataType::Type::INT32}, "0")),
+        ConstantValueLogicalFunction(DataType{DataType::Type::VARSIZED}, "C"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::VARSIZED}, "D"),
+    }));
+    auto inferred = fn.withInferredDataType(schema);
+    EXPECT_TRUE(inferred.getDataType().isType(DataType::Type::VARSIZED));
+}
+
+/// Type inference infers the result type from the default (last child).
+TEST(ConditionalLogicalFunctionTest, InferDataTypeFromDefault)
+{
+    auto schema = Schema{}
+                      .addField("stream$temperature", DataType{DataType::Type::FLOAT32})
+                      .addField("stream$flag", DataType{DataType::Type::BOOLEAN});
+
+    /// Conditional(flag, temperature, 0.0) — mixes field access and constant
+    auto fn = LogicalFunction(ConditionalLogicalFunction({
+        FieldAccessLogicalFunction("flag"),
+        FieldAccessLogicalFunction("temperature"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::FLOAT32}, "0.0"),
+    }));
+    auto inferred = fn.withInferredDataType(schema);
+    EXPECT_TRUE(inferred.getDataType().isType(DataType::Type::FLOAT32));
+}
+
+/// Condition that is not BOOLEAN should fail validation.
+TEST(ConditionalLogicalFunctionTest, RejectsNonBooleanCondition)
+{
+    auto schema = Schema{}.addField("stream$id", DataType{DataType::Type::INT32});
+
+    /// Conditional(id, "yes", "no") — id is INT32, not BOOLEAN
+    auto fn = LogicalFunction(ConditionalLogicalFunction({
+        FieldAccessLogicalFunction("id"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::VARSIZED}, "yes"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::VARSIZED}, "no"),
+    }));
+    ASSERT_EXCEPTION_ERRORCODE(static_cast<void>(fn.withInferredDataType(schema)), ErrorCode::CannotInferSchema);
+}
+
+/// Non-BOOLEAN condition at a later index (not the first) should still fail validation.
+TEST(ConditionalLogicalFunctionTest, RejectsNonBooleanSecondCondition)
+{
+    auto schema
+        = Schema{}.addField("stream$flag", DataType{DataType::Type::BOOLEAN}).addField("stream$id", DataType{DataType::Type::INT32});
+
+    /// First condition is BOOLEAN, second "condition" is INT32
+    auto fn = LogicalFunction(ConditionalLogicalFunction({
+        FieldAccessLogicalFunction("flag"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::VARSIZED}, "A"),
+        FieldAccessLogicalFunction("id"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::VARSIZED}, "B"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::VARSIZED}, "C"),
+    }));
+    ASSERT_EXCEPTION_ERRORCODE(static_cast<void>(fn.withInferredDataType(schema)), ErrorCode::CannotInferSchema);
+}
+
+/// Result types that don't match the default should fail validation.
+TEST(ConditionalLogicalFunctionTest, RejectsMismatchedResultTypes)
+{
+    auto schema
+        = Schema{}.addField("stream$id", DataType{DataType::Type::INT32}).addField("stream$flag", DataType{DataType::Type::BOOLEAN});
+
+    /// Conditional(flag, id, "hello") — INT32 field vs VARSIZED default
+    auto fn = LogicalFunction(ConditionalLogicalFunction({
+        FieldAccessLogicalFunction("flag"),
+        FieldAccessLogicalFunction("id"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::VARSIZED}, "hello"),
+    }));
+    ASSERT_EXCEPTION_ERRORCODE(static_cast<void>(fn.withInferredDataType(schema)), ErrorCode::CannotInferSchema);
+}
+
+/// Deserialization rejects even number of children (missing default).
+TEST(ConditionalLogicalFunctionTest, RejectsEvenNumberOfChildren)
+{
+    auto fn = LogicalFunction(ConditionalLogicalFunction({
+        ConstantValueLogicalFunction(DataType{DataType::Type::BOOLEAN}, "true"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::VARSIZED}, "yes"),
+    }));
+    auto reflected = reflect(fn);
+    ASSERT_EXCEPTION_ERRORCODE(static_cast<void>(unreflect<LogicalFunction>(reflected)), ErrorCode::CannotDeserialize);
+}
+
+/// Deserialization rejects fewer than 3 children.
+TEST(ConditionalLogicalFunctionTest, RejectsTooFewChildren)
+{
+    auto fn = LogicalFunction(ConditionalLogicalFunction({
+        ConstantValueLogicalFunction(DataType{DataType::Type::VARSIZED}, "x"),
+    }));
+    auto reflected = reflect(fn);
+    ASSERT_EXCEPTION_ERRORCODE(static_cast<void>(unreflect<LogicalFunction>(reflected)), ErrorCode::CannotDeserialize);
+}
+
+/// Explain produces a readable CASE WHEN string with correct structure.
+TEST(ConditionalLogicalFunctionTest, Explain)
+{
+    auto fn = LogicalFunction(ConditionalLogicalFunction({
+        FieldAccessLogicalFunction("cond1"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::VARSIZED}, "r1"),
+        FieldAccessLogicalFunction("cond2"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::VARSIZED}, "r2"),
+        FieldAccessLogicalFunction("cond3"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::VARSIZED}, "r3"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::VARSIZED}, "fallback"),
+    }));
+    auto explanation = fn.explain(ExplainVerbosity::Short);
+    EXPECT_EQ(explanation, "CASE WHEN cond1 THEN r1 WHEN cond2 THEN r2 WHEN cond3 THEN r3 ELSE fallback");
+}
+
+/// Identical functions should compare equal.
+TEST(ConditionalLogicalFunctionTest, EqualityIdentical)
+{
+    auto lhs = ConditionalLogicalFunction({
+        FieldAccessLogicalFunction("flag"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::INT32}, "1"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::INT32}, "0"),
+    });
+    auto rhs = ConditionalLogicalFunction({
+        FieldAccessLogicalFunction("flag"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::INT32}, "1"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::INT32}, "0"),
+    });
+    EXPECT_TRUE(lhs == rhs);
+}
+
+/// Functions with different children should not compare equal.
+TEST(ConditionalLogicalFunctionTest, EqualityDifferent)
+{
+    auto lhs = ConditionalLogicalFunction({
+        FieldAccessLogicalFunction("flag"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::INT32}, "1"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::INT32}, "0"),
+    });
+    auto rhs = ConditionalLogicalFunction({
+        FieldAccessLogicalFunction("flag"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::INT32}, "2"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::INT32}, "0"),
+    });
+    EXPECT_FALSE(lhs == rhs);
+}
+
+/// Serialize then deserialize should produce an equal function.
+TEST(ConditionalLogicalFunctionTest, SerializeDeserializeRoundtrip)
+{
+    auto original = LogicalFunction(ConditionalLogicalFunction({
+        FieldAccessLogicalFunction("flag"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::VARSIZED}, "A"),
+        GreaterLogicalFunction(FieldAccessLogicalFunction("id"), ConstantValueLogicalFunction(DataType{DataType::Type::INT32}, "5")),
+        ConstantValueLogicalFunction(DataType{DataType::Type::VARSIZED}, "B"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::VARSIZED}, "C"),
+    }));
+
+    auto reflected = reflect(original);
+    auto deserialized = unreflect<LogicalFunction>(reflected);
+    EXPECT_TRUE(original == deserialized);
+}
+
+/// Serialize/deserialize roundtrip for a simple two-way conditional.
+TEST(ConditionalLogicalFunctionTest, SerializeDeserializeSimple)
+{
+    auto original = LogicalFunction(ConditionalLogicalFunction({
+        FieldAccessLogicalFunction("flag"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::INT32}, "1"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::INT32}, "0"),
+    }));
+
+    auto reflected = reflect(original);
+    auto deserialized = unreflect<LogicalFunction>(reflected);
+    EXPECT_TRUE(original == deserialized);
+}
+
+/// getChildren returns all children in order.
+TEST(ConditionalLogicalFunctionTest, GetChildrenReturnsAll)
+{
+    auto fn = ConditionalLogicalFunction({
+        FieldAccessLogicalFunction("flag"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::INT32}, "1"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::INT32}, "0"),
+    });
+    EXPECT_EQ(fn.getChildren().size(), 3U);
+}
+
+/// getType returns "Conditional".
+TEST(ConditionalLogicalFunctionTest, GetType)
+{
+    auto fn = ConditionalLogicalFunction({
+        FieldAccessLogicalFunction("flag"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::INT32}, "1"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::INT32}, "0"),
+    });
+    EXPECT_EQ(fn.getType(), "Conditional");
+}
+
+/// getDataType returns the type of the default (last) child.
+TEST(ConditionalLogicalFunctionTest, GetDataTypeMatchesDefault)
+{
+    auto fn = ConditionalLogicalFunction({
+        FieldAccessLogicalFunction("flag"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::INT32}, "1"),
+        ConstantValueLogicalFunction(DataType{DataType::Type::INT32}, "0"),
+    });
+    EXPECT_TRUE(fn.getDataType().isType(DataType::Type::INT32));
+}
+
+}

--- a/nes-plugins/Functions/ConditionalFunction/tests/ConditionalPhysicalFunctionTest.cpp
+++ b/nes-plugins/Functions/ConditionalFunction/tests/ConditionalPhysicalFunctionTest.cpp
@@ -1,0 +1,221 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <ConditionalPhysicalFunction.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <Functions/ConstantValuePhysicalFunction.hpp>
+#include <Functions/FieldAccessPhysicalFunction.hpp>
+#include <Functions/PhysicalFunction.hpp>
+#include <Nautilus/DataTypes/VarVal.hpp>
+#include <Nautilus/Interface/Record.hpp>
+#include <Runtime/BufferManager.hpp>
+#include <gtest/gtest.h>
+#include <Arena.hpp>
+#include <Engine.hpp>
+
+namespace NES
+{
+
+class ConditionalPhysicalFunctionTest : public testing::TestWithParam<bool>
+{
+public:
+    void SetUp() override
+    {
+        compilation = GetParam();
+        nautilus::engine::Options options;
+        options.setOption("engine.Compilation", compilation);
+        engine = std::make_unique<nautilus::engine::NautilusEngine>(options);
+        bm = BufferManager::create();
+    }
+
+    /// Executes any PhysicalFunction within the nautilus engine and returns the result cast to T.
+    template <typename T = int64_t>
+    T execute(const PhysicalFunction& fn)
+    {
+        Arena arena{bm};
+        auto function = engine->registerFunction(std::function(
+            [&]()
+            {
+                ArenaRef arenaRef(&arena);
+                const Record record{};
+                return fn.execute(record, arenaRef).cast<nautilus::val<T>>();
+            }));
+        return function();
+    }
+
+    /// Builds a ConditionalPhysicalFunction from raw PhysicalFunction inputs.
+    /// Layout: [cond1, then1, cond2, then2, ..., elseVal]
+    static PhysicalFunction conditional(std::vector<PhysicalFunction> fns) { return ConditionalPhysicalFunction(std::move(fns)); }
+
+    bool compilation{};
+    std::unique_ptr<nautilus::engine::NautilusEngine> engine;
+    std::shared_ptr<BufferManager> bm;
+};
+
+/// WHEN true THEN 42 ELSE 99 -> returns int64_t THEN value.
+TEST_P(ConditionalPhysicalFunctionTest, Int64ConditionTrue)
+{
+    auto fn = conditional({ConstantBooleanValueFunction(true), ConstantInt64ValueFunction(42), ConstantInt64ValueFunction(99)});
+    EXPECT_EQ(execute(fn), 42);
+}
+
+/// WHEN false THEN 3.14 ELSE 2.72 -> returns double ELSE value.
+TEST_P(ConditionalPhysicalFunctionTest, DoubleFallsToElse)
+{
+    auto fn = conditional({ConstantBooleanValueFunction(false), ConstantDoubleValueFunction(3.14), ConstantDoubleValueFunction(2.72)});
+    EXPECT_DOUBLE_EQ(execute<double>(fn), 2.72);
+}
+
+/// WHEN true THEN 1.5f ELSE 0.0f -> returns float THEN value.
+TEST_P(ConditionalPhysicalFunctionTest, FloatConditionTrue)
+{
+    auto fn = conditional({ConstantBooleanValueFunction(true), ConstantFloatValueFunction(1.5F), ConstantFloatValueFunction(0.0F)});
+    EXPECT_FLOAT_EQ(execute<float>(fn), 1.5F);
+}
+
+/// Multi-branch with int32_t: second condition matches.
+TEST_P(ConditionalPhysicalFunctionTest, Int32SecondBranchMatches)
+{
+    auto fn = conditional(
+        {ConstantBooleanValueFunction(false),
+         ConstantInt32ValueFunction(10),
+         ConstantBooleanValueFunction(true),
+         ConstantInt32ValueFunction(20),
+         ConstantInt32ValueFunction(30)});
+    EXPECT_EQ(execute<int32_t>(fn), 20);
+}
+
+/// Five branches, middle matches -> verifies short-circuit with many static_val iterations.
+TEST_P(ConditionalPhysicalFunctionTest, ManyBranchesMiddleMatches)
+{
+    auto fn = conditional(
+        {ConstantBooleanValueFunction(false),
+         ConstantInt64ValueFunction(100),
+         ConstantBooleanValueFunction(false),
+         ConstantInt64ValueFunction(200),
+         ConstantBooleanValueFunction(true),
+         ConstantInt64ValueFunction(300),
+         ConstantBooleanValueFunction(true),
+         ConstantInt64ValueFunction(400),
+         ConstantBooleanValueFunction(true),
+         ConstantInt64ValueFunction(500),
+         ConstantInt64ValueFunction(-1)});
+    EXPECT_EQ(execute(fn), 300);
+}
+
+/// The condition itself is a nested conditional that returns bool.
+/// condition = (WHEN true THEN true ELSE false), value -> THEN 42 ELSE 99
+TEST_P(ConditionalPhysicalFunctionTest, NestedCondition)
+{
+    auto nestedCond
+        = conditional({ConstantBooleanValueFunction(true), ConstantBooleanValueFunction(true), ConstantBooleanValueFunction(false)});
+
+    auto fn = conditional({std::move(nestedCond), ConstantInt64ValueFunction(42), ConstantInt64ValueFunction(99)});
+    EXPECT_EQ(execute(fn), 42);
+}
+
+/// The condition is a nested conditional that evaluates to false.
+/// condition = (WHEN false THEN true ELSE false) -> false, so returns ELSE.
+TEST_P(ConditionalPhysicalFunctionTest, NestedConditionEvaluatesToFalse)
+{
+    auto nestedCond
+        = conditional({ConstantBooleanValueFunction(false), ConstantBooleanValueFunction(true), ConstantBooleanValueFunction(false)});
+
+    auto fn = conditional({std::move(nestedCond), ConstantDoubleValueFunction(1.0), ConstantDoubleValueFunction(2.0)});
+    EXPECT_DOUBLE_EQ(execute<double>(fn), 2.0);
+}
+
+/// Both condition and result are nested conditionals.
+/// condition = (WHEN true THEN true ELSE false) -> true
+/// then = (WHEN false THEN 10 ELSE 20) -> 20
+/// else = 30
+TEST_P(ConditionalPhysicalFunctionTest, NestedConditionAndNestedResult)
+{
+    auto nestedCond
+        = conditional({ConstantBooleanValueFunction(true), ConstantBooleanValueFunction(true), ConstantBooleanValueFunction(false)});
+    auto nestedThen = conditional({ConstantBooleanValueFunction(false), ConstantInt64ValueFunction(10), ConstantInt64ValueFunction(20)});
+
+    auto fn = conditional({std::move(nestedCond), std::move(nestedThen), ConstantInt64ValueFunction(30)});
+    EXPECT_EQ(execute(fn), 20);
+}
+
+/// Deeply nested: condition is a conditional whose own condition is also a conditional.
+/// innerCond = (WHEN true THEN true ELSE false) -> true
+/// outerCond = (WHEN innerCond THEN false ELSE true) -> false
+/// top-level: WHEN outerCond THEN 1 ELSE 2 -> 2
+TEST_P(ConditionalPhysicalFunctionTest, DeeplyNestedCondition)
+{
+    auto innerCond
+        = conditional({ConstantBooleanValueFunction(true), ConstantBooleanValueFunction(true), ConstantBooleanValueFunction(false)});
+    auto outerCond = conditional({std::move(innerCond), ConstantBooleanValueFunction(false), ConstantBooleanValueFunction(true)});
+
+    auto fn = conditional({std::move(outerCond), ConstantInt64ValueFunction(1), ConstantInt64ValueFunction(2)});
+    EXPECT_EQ(execute(fn), 2);
+}
+
+/// Conditional with FieldAccessPhysicalFunction reading from an actual Record.
+/// WHEN flag THEN value ELSE 0 — with flag=true, value=42.
+TEST_P(ConditionalPhysicalFunctionTest, WithRecordFields)
+{
+    Arena arena{bm};
+    auto function = engine->registerFunction(std::function(
+        [&]()
+        {
+            ArenaRef arenaRef(&arena);
+            const Record record(std::unordered_map<Record::RecordFieldIdentifier, VarVal>{
+                {"flag", VarVal(true)},
+                {"value", VarVal(int64_t{42})},
+            });
+            auto fn
+                = conditional({FieldAccessPhysicalFunction("flag"), FieldAccessPhysicalFunction("value"), ConstantInt64ValueFunction(0)});
+            return fn.execute(record, arenaRef).cast<nautilus::val<int64_t>>();
+        }));
+    EXPECT_EQ(function(), 42);
+}
+
+/// Conditional with FieldAccessPhysicalFunction where condition is false, falls to else.
+/// WHEN flag THEN value ELSE -1 — with flag=false, value=42.
+TEST_P(ConditionalPhysicalFunctionTest, WithRecordFieldsFallsToElse)
+{
+    Arena arena{bm};
+    auto function = engine->registerFunction(std::function(
+        [&]()
+        {
+            ArenaRef arenaRef(&arena);
+            const Record record(std::unordered_map<Record::RecordFieldIdentifier, VarVal>{
+                {"flag", VarVal(false)},
+                {"value", VarVal(int64_t{42})},
+            });
+            auto fn
+                = conditional({FieldAccessPhysicalFunction("flag"), FieldAccessPhysicalFunction("value"), ConstantInt64ValueFunction(-1)});
+            return fn.execute(record, arenaRef).cast<nautilus::val<int64_t>>();
+        }));
+    EXPECT_EQ(function(), -1);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ConditionalPhysicalFunctionTest,
+    ConditionalPhysicalFunctionTest,
+    ::testing::Values(false, true),
+    [](const testing::TestParamInfo<bool>& info) { return info.param ? "Compiled" : "Interpreted"; });
+
+}

--- a/nes-systests/function/CaseWhen.test
+++ b/nes-systests/function/CaseWhen.test
@@ -1,0 +1,135 @@
+# name: function/CaseWhen.test
+# description: Tests for the CASE WHEN function
+# groups: [Function, FunctionCaseWhen]
+
+CREATE LOGICAL SOURCE intersection(intersection_id INT32, traffic_density FLOAT32, emergency_vehicle_detected BOOLEAN, pedestrian_waiting BOOLEAN);
+CREATE PHYSICAL SOURCE FOR intersection TYPE File;
+ATTACH INLINE
+1,0.5,true,false
+2,0.1,false,true
+3,0.9,false,false
+4,0.6,false,false
+5,0.3,false,false
+6,0.1,true,true
+7,0.9,false,true
+8,0.6,false,true
+9,0.3,false,true
+10,0.95,true,false
+
+CREATE SINK simple_signal(intersection.intersection_id INT32, signal VARSIZED) TYPE File;
+CREATE SINK traffic_light(intersection.intersection_id INT32, signal_command VARSIZED) TYPE File;
+
+# Minimal conditional: single condition with default (two-way branch)
+SELECT intersection_id,
+       Conditional(emergency_vehicle_detected, VARSIZED("STOP"),
+                   VARSIZED("GO"))
+       AS signal
+FROM intersection
+INTO simple_signal;
+----
+1,STOP
+2,GO
+3,GO
+4,GO
+5,GO
+6,STOP
+7,GO
+8,GO
+9,GO
+10,STOP
+
+# All five branches are taken: emergency, pedestrian+low density, high density, medium density, and default.
+# Rows 6-10 test priority ordering when multiple conditions could match:
+#   Row 6: emergency + pedestrian both true -> first branch (emergency) wins
+#   Row 7: pedestrian=true but density too high for branch 2, falls through to branch 3
+#   Row 8: pedestrian=true but density too high for branch 2, density not > 0.8, falls to branch 4
+#   Row 9: pedestrian=true but density not < 0.2, density not > 0.5, falls to default
+#   Row 10: emergency=true with high density -> branch 1 wins over branch 3
+SELECT intersection_id,
+       Conditional(emergency_vehicle_detected, VARSIZED("ALL_RED_EMERGENCY"),
+                   pedestrian_waiting AND traffic_density < FLOAT32(0.2), VARSIZED("PEDESTRIAN_WALK"),
+                   traffic_density > FLOAT32(0.8), VARSIZED("GREEN_EXTENDED"),
+                   traffic_density > FLOAT32(0.5), VARSIZED("GREEN_STANDARD"),
+                   VARSIZED("FLASHING_YELLOW"))
+       AS signal_command
+FROM intersection
+INTO traffic_light;
+----
+1,ALL_RED_EMERGENCY
+2,PEDESTRIAN_WALK
+3,GREEN_EXTENDED
+4,GREEN_STANDARD
+5,FLASHING_YELLOW
+6,ALL_RED_EMERGENCY
+7,GREEN_EXTENDED
+8,GREEN_STANDARD
+9,FLASHING_YELLOW
+10,ALL_RED_EMERGENCY
+
+CREATE SINK numeric_priority(intersection.intersection_id INT32, priority INT32) TYPE File;
+
+# Conditional returning INT32 values based on traffic density thresholds.
+# Row 1:  density=0.5  -> not > 0.8, not > 0.5 (not strictly), -> default 0
+# Row 2:  density=0.1  -> default 0
+# Row 3:  density=0.9  -> > 0.8 -> 3
+# Row 4:  density=0.6  -> > 0.5 -> 2
+# Row 5:  density=0.3  -> default 0
+# Row 6:  density=0.1  -> default 0
+# Row 7:  density=0.9  -> > 0.8 -> 3
+# Row 8:  density=0.6  -> > 0.5 -> 2
+# Row 9:  density=0.3  -> default 0
+# Row 10: density=0.95 -> > 0.8 -> 3
+SELECT intersection_id,
+       Conditional(traffic_density > FLOAT32(0.8), INT32(3),
+                   traffic_density > FLOAT32(0.5), INT32(2),
+                   INT32(0))
+       AS priority
+FROM intersection
+INTO numeric_priority;
+----
+1,0
+2,0
+3,3
+4,2
+5,0
+6,0
+7,3
+8,2
+9,0
+10,3
+
+CREATE SINK nested_signal(intersection.intersection_id INT32, action VARSIZED) TYPE File;
+
+# Nested conditional: the result of the outer conditional is itself a conditional.
+# Outer: if emergency -> inner conditional on density (high density -> EVACUATE, else YIELD)
+#        else -> inner conditional on pedestrian (waiting -> SLOW, else PROCEED)
+# Row 1:  emergency=true,  density=0.5  -> YIELD
+# Row 2:  emergency=false, pedestrian=true  -> SLOW
+# Row 3:  emergency=false, pedestrian=false -> PROCEED
+# Row 4:  emergency=false, pedestrian=false -> PROCEED
+# Row 5:  emergency=false, pedestrian=false -> PROCEED
+# Row 6:  emergency=true,  density=0.1  -> YIELD
+# Row 7:  emergency=false, pedestrian=true  -> SLOW
+# Row 8:  emergency=false, pedestrian=true  -> SLOW
+# Row 9:  emergency=false, pedestrian=true  -> SLOW
+# Row 10: emergency=true,  density=0.95 -> EVACUATE
+SELECT intersection_id,
+       Conditional(emergency_vehicle_detected,
+                   Conditional(traffic_density > FLOAT32(0.8), VARSIZED("EVACUATE"),
+                               VARSIZED("YIELD")),
+                   Conditional(pedestrian_waiting, VARSIZED("SLOW"),
+                               VARSIZED("PROCEED")))
+       AS action
+FROM intersection
+INTO nested_signal;
+----
+1,YIELD
+2,SLOW
+3,PROCEED
+4,PROCEED
+5,PROCEED
+6,YIELD
+7,SLOW
+8,SLOW
+9,SLOW
+10,EVACUATE


### PR DESCRIPTION
## Summary
- Adds a `ConditionalFunction` plugin implementing CASE WHEN expressions
- Logical layer validates conditions are BOOLEAN and result types are consistent
- Physical layer evaluates WHEN/THEN pairs in order with short-circuit to first match

## Test plan
- [x] Unit tests: `conditional-logical-function-test`, `conditional-physical-function-test`
- [x] System tests: `function/CaseWhen.test` (groups: Function, FunctionCaseWhen)

Resolves #1370 