### PR TITLE
fix(clang-tidy): Remove redundant member initializer in Schema::Field

### DIFF
--- a/nes-data-types/include/DataTypes/Schema.hpp
+++ b/nes-data-types/include/DataTypes/Schema.hpp
@@ -47,7 +47,7 @@ public:
         [[nodiscard]] std::string getUnqualifiedName() const;
 
         std::string name;
-        DataType dataType{};
+        DataType dataType;
     };
 
     /// TODO #764: move qualified field logic in central place and improve


### PR DESCRIPTION
## Summary
- Removes redundant `{}` initializer on `DataType dataType` member in `Schema::Field`
- `DataType` has an explicit default constructor, making the value-initialization redundant
- Fixes the `readability-redundant-member-init` error causing the nightly full clang-tidy CI to fail

## Test plan
- [x] Full build passes with `-G Ninja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DUSE_LOCAL_MLIR=ON`
- [x] `cmake --build build --target format` passes
- [ ] Nightly clang-tidy-full should pass with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)