### PR TITLE
Remove redundant UnregisterQuery RPC

### DIFF
--- a/grpc/SingleNodeWorkerRPCService.proto
+++ b/grpc/SingleNodeWorkerRPCService.proto
@@ -18,7 +18,6 @@ import "google/protobuf/empty.proto";
 
 service WorkerRPCService {
   rpc RegisterQuery (RegisterQueryRequest) returns (RegisterQueryReply) {}
-  rpc UnregisterQuery (UnregisterQueryRequest) returns (google.protobuf.Empty) {}
 
   rpc StartQuery (StartQueryRequest) returns (google.protobuf.Empty) {}
   rpc StopQuery (StopQueryRequest) returns (google.protobuf.Empty) {}
@@ -33,10 +32,6 @@ message RegisterQueryRequest {
 }
 
 message RegisterQueryReply {
-  uint64 queryId = 1;
-}
-
-message UnregisterQueryRequest {
   uint64 queryId = 1;
 }
 

--- a/nes-frontend/include/QueryManager/EmbeddedWorkerQuerySubmissionBackend.hpp
+++ b/nes-frontend/include/QueryManager/EmbeddedWorkerQuerySubmissionBackend.hpp
@@ -34,7 +34,6 @@ public:
     [[nodiscard]] std::expected<QueryId, Exception> registerQuery(LogicalPlan) override;
     std::expected<void, Exception> start(QueryId) override;
     std::expected<void, Exception> stop(QueryId) override;
-    std::expected<void, Exception> unregister(QueryId) override;
     [[nodiscard]] std::expected<LocalQueryStatus, Exception> status(QueryId) const override;
     [[nodiscard]] std::expected<WorkerStatus, Exception> workerStatus(std::chrono::system_clock::time_point after) const override;
 

--- a/nes-frontend/include/QueryManager/GRPCQuerySubmissionBackend.hpp
+++ b/nes-frontend/include/QueryManager/GRPCQuerySubmissionBackend.hpp
@@ -37,7 +37,6 @@ public:
     [[nodiscard]] std::expected<QueryId, Exception> registerQuery(LogicalPlan) override;
     std::expected<void, Exception> start(QueryId) override;
     std::expected<void, Exception> stop(QueryId) override;
-    std::expected<void, Exception> unregister(QueryId) override;
     [[nodiscard]] std::expected<LocalQueryStatus, Exception> status(QueryId) const override;
     [[nodiscard]] std::expected<WorkerStatus, Exception> workerStatus(std::chrono::system_clock::time_point after) const override;
 };

--- a/nes-frontend/include/QueryManager/QueryManager.hpp
+++ b/nes-frontend/include/QueryManager/QueryManager.hpp
@@ -45,7 +45,6 @@ public:
     [[nodiscard]] virtual std::expected<QueryId, Exception> registerQuery(LogicalPlan) = 0;
     virtual std::expected<void, Exception> start(QueryId) = 0;
     virtual std::expected<void, Exception> stop(QueryId) = 0;
-    virtual std::expected<void, Exception> unregister(QueryId) = 0;
     [[nodiscard]] virtual std::expected<LocalQueryStatus, Exception> status(QueryId) const = 0;
     [[nodiscard]] virtual std::expected<WorkerStatus, Exception> workerStatus(std::chrono::system_clock::time_point after) const = 0;
 };
@@ -67,7 +66,6 @@ public:
     /// Starts a pre-registered query. Start may potentially block waiting for the query state to change (even if it fails).
     std::expected<void, Exception> start(QueryId query);
     std::expected<void, Exception> stop(QueryId query);
-    std::expected<void, Exception> unregister(QueryId query);
     [[nodiscard]] std::expected<LocalQueryStatus, Exception> status(QueryId query) const;
     [[nodiscard]] std::vector<QueryId> queries() const;
     [[nodiscard]] std::expected<WorkerStatus, Exception> workerStatus(std::chrono::system_clock::time_point after) const;

--- a/nes-frontend/src/QueryManager/EmbeddedWorkerQuerySubmissionBackend.cpp
+++ b/nes-frontend/src/QueryManager/EmbeddedWorkerQuerySubmissionBackend.cpp
@@ -62,11 +62,6 @@ std::expected<void, Exception> EmbeddedWorkerQuerySubmissionBackend::stop(QueryI
     return worker.stopQuery(queryId, QueryTerminationType::Graceful);
 }
 
-std::expected<void, Exception> EmbeddedWorkerQuerySubmissionBackend::unregister(QueryId queryId)
-{
-    return worker.unregisterQuery(queryId);
-}
-
 std::expected<LocalQueryStatus, Exception> EmbeddedWorkerQuerySubmissionBackend::status(QueryId queryId) const
 {
     return worker.getQueryStatus(queryId);

--- a/nes-frontend/src/QueryManager/GRPCQuerySubmissionBackend.cpp
+++ b/nes-frontend/src/QueryManager/GRPCQuerySubmissionBackend.cpp
@@ -178,21 +178,4 @@ std::expected<void, Exception> GRPCQuerySubmissionBackend::stop(QueryId queryId)
         "Status: {}\nMessage: {}\nDetail: {}", magic_enum::enum_name(status.error_code()), status.error_message(), status.error_details())};
 }
 
-std::expected<void, Exception> GRPCQuerySubmissionBackend::unregister(QueryId queryId)
-{
-    grpc::ClientContext context;
-    UnregisterQueryRequest request;
-    google::protobuf::Empty response;
-    request.set_queryid(queryId.getRawValue());
-
-    const auto status = stub->UnregisterQuery(&context, request, &response);
-    if (status.ok())
-    {
-        NES_DEBUG("Unregister of query {} on node {} was successful.", queryId, workerConfig.grpc);
-        return {};
-    }
-
-    return std::unexpected{QueryUnregistrationFailed(
-        "Status: {}\nMessage: {}\nDetail: {}", magic_enum::enum_name(status.error_code()), status.error_message(), status.error_details())};
-}
 }

--- a/nes-frontend/src/QueryManager/QueryManager.cpp
+++ b/nes-frontend/src/QueryManager/QueryManager.cpp
@@ -172,6 +172,7 @@ std::expected<void, Exception> QueryManager::stop(QueryId queryId)
         auto result = backend->stop(queryId);
         if (result)
         {
+            state.queries.erase(queryId);
             NES_DEBUG("Stopping query {} was successful.", queryId);
             return {};
         }
@@ -180,32 +181,6 @@ std::expected<void, Exception> QueryManager::stop(QueryId queryId)
     catch (std::exception& e)
     {
         return std::unexpected{QueryStopFailed("Message from external exception: {} ", e.what())};
-    }
-}
-
-std::expected<void, Exception> QueryManager::unregister(QueryId queryId)
-{
-    auto queryResult = getQuery(queryId);
-    if (!queryResult.has_value())
-    {
-        return std::unexpected(queryResult.error());
-    }
-
-    try
-    {
-        auto result = backend->unregister(queryId);
-        if (result)
-        {
-            auto erased = state.queries.erase(queryId);
-            INVARIANT(erased == 1, "Should not unregister query that has not been registered");
-            NES_DEBUG("Unregister of query {} was successful.", queryId);
-            return {};
-        }
-        return std::unexpected{result.error()};
-    }
-    catch (std::exception& e)
-    {
-        return std::unexpected{QueryUnregistrationFailed("Message from external exception: {} ", e.what())};
     }
 }
 

--- a/nes-frontend/src/Statements/StatementHandler.cpp
+++ b/nes-frontend/src/Statements/StatementHandler.cpp
@@ -198,12 +198,9 @@ QueryStatementHandler::QueryStatementHandler(
 
 std::expected<DropQueryStatementResult, Exception> QueryStatementHandler::operator()(const DropQueryStatement& statement)
 {
-    auto stopResult = queryManager->stop(statement.id)
-                          .and_then([&statement, this] { return queryManager->unregister(statement.id); })
-                          .transform_error([](auto error) { return QueryStopFailed("Could not stop query: {}", error.what()); })
-                          .transform([&statement] { return DropQueryStatementResult{statement.id}; });
-
-    return stopResult;
+    return queryManager->stop(statement.id)
+        .transform_error([](auto error) { return QueryStopFailed("Could not stop query: {}", error.what()); })
+        .transform([&statement] { return DropQueryStatementResult{statement.id}; });
 }
 
 std::expected<ExplainQueryStatementResult, Exception> QueryStatementHandler::operator()(const ExplainQueryStatement& statement)

--- a/nes-runtime/include/Runtime/NodeEngine.hpp
+++ b/nes-runtime/include/Runtime/NodeEngine.hpp
@@ -30,7 +30,7 @@ class QueryTracker;
 
 /// @brief this class represents the interface and entrance point into the
 /// query processing part of NES. It provides basic functionality
-/// such as registering, unregistering, starting, and stopping.
+/// such as registering, starting, and stopping.
 class NodeEngine
 {
     friend class NodeEngineBuilder;
@@ -49,7 +49,6 @@ public:
         std::unique_ptr<SourceProvider> sourceProvider);
 
     void registerCompiledQueryPlan(QueryId queryId, std::unique_ptr<CompiledQueryPlan> compiledQueryPlan);
-    void unregisterQuery(QueryId queryId);
     void startQuery(QueryId queryId);
     /// Termination will happen asynchronously, thus the query might very well be running for an indeterminate time after this method has
     /// been called.

--- a/nes-runtime/src/Runtime/NodeEngine.cpp
+++ b/nes-runtime/src/Runtime/NodeEngine.cpp
@@ -116,13 +116,6 @@ void NodeEngine::startQuery(QueryId queryId)
     }
 }
 
-void NodeEngine::unregisterQuery(QueryId queryId)
-{
-    PRECONDITION(queryId != INVALID_QUERY_ID, "QueryId must be not invalid!");
-    NES_INFO("Unregister {}", queryId);
-    queryEngine->stop(queryId);
-}
-
 void NodeEngine::stopQuery(QueryId queryId, QueryTerminationType)
 {
     PRECONDITION(queryId != INVALID_QUERY_ID, "QueryId must be not invalid!");

--- a/nes-single-node-worker/include/GrpcService.hpp
+++ b/nes-single-node-worker/include/GrpcService.hpp
@@ -29,8 +29,6 @@ class GRPCServer final : public WorkerRPCService::Service
 public:
     grpc::Status RegisterQuery(grpc::ServerContext*, const RegisterQueryRequest*, RegisterQueryReply*) override;
 
-    grpc::Status UnregisterQuery(grpc::ServerContext*, const UnregisterQueryRequest*, google::protobuf::Empty*) override;
-
     grpc::Status StartQuery(grpc::ServerContext*, const StartQueryRequest*, google::protobuf::Empty*) override;
 
     grpc::Status StopQuery(grpc::ServerContext*, const StopQueryRequest*, google::protobuf::Empty*) override;

--- a/nes-single-node-worker/include/SingleNodeWorker.hpp
+++ b/nes-single-node-worker/include/SingleNodeWorker.hpp
@@ -73,10 +73,6 @@ public:
     /// @param terminationType dictates what happens with in in-flight data
     std::expected<void, Exception> stopQuery(QueryId queryId, QueryTerminationType terminationType) noexcept;
 
-    /// Unregisters a stopped Query.
-    /// @param queryId identifies the registered stopped query
-    std::expected<void, Exception> unregisterQuery(QueryId queryId) noexcept;
-
     /// Complete history of query status changes.
     [[nodiscard]] std::optional<QueryLog::Log> getQueryLog(QueryId queryId) const;
     /// Summary structure for query.

--- a/nes-single-node-worker/src/GrpcService.cpp
+++ b/nes-single-node-worker/src/GrpcService.cpp
@@ -85,25 +85,6 @@ grpc::Status GRPCServer::RegisterQuery(grpc::ServerContext* context, const Regis
     return {grpc::INTERNAL, "unknown exception"};
 }
 
-grpc::Status GRPCServer::UnregisterQuery(grpc::ServerContext* context, const UnregisterQueryRequest* request, google::protobuf::Empty*)
-{
-    const auto queryId = QueryId(request->queryid());
-    CPPTRACE_TRY
-    {
-        getValueOrThrow(delegate.unregisterQuery(queryId));
-        return grpc::Status::OK;
-    }
-    CPPTRACE_CATCH(const Exception& e)
-    {
-        return handleError(e, context);
-    }
-    CPPTRACE_CATCH_ALT(const std::exception& e)
-    {
-        return handleError(e, context);
-    }
-    return {grpc::INTERNAL, "unknown exception"};
-}
-
 grpc::Status GRPCServer::StartQuery(grpc::ServerContext* context, const StartQueryRequest* request, google::protobuf::Empty*)
 {
     const auto queryId = QueryId(request->queryid());

--- a/nes-single-node-worker/src/SingleNodeWorker.cpp
+++ b/nes-single-node-worker/src/SingleNodeWorker.cpp
@@ -139,21 +139,6 @@ std::expected<void, Exception> SingleNodeWorker::stopQuery(QueryId queryId, Quer
     std::unreachable();
 }
 
-std::expected<void, Exception> SingleNodeWorker::unregisterQuery(QueryId queryId) noexcept
-{
-    CPPTRACE_TRY
-    {
-        PRECONDITION(queryId != INVALID_QUERY_ID, "QueryId must be not invalid!");
-        nodeEngine->unregisterQuery(queryId);
-        return {};
-    }
-    CPPTRACE_CATCH(...)
-    {
-        return std::unexpected(wrapExternalException());
-    }
-    std::unreachable();
-}
-
 std::expected<LocalQueryStatus, Exception> SingleNodeWorker::getQueryStatus(QueryId queryId) const noexcept
 {
     CPPTRACE_TRY

--- a/nes-systests/systest/include/QuerySubmitter.hpp
+++ b/nes-systests/systest/include/QuerySubmitter.hpp
@@ -31,7 +31,6 @@ public:
     std::expected<QueryId, Exception> registerQuery(const LogicalPlan& plan);
     void startQuery(QueryId query);
     void stopQuery(QueryId query);
-    void unregisterQuery(QueryId query);
     LocalQueryStatus waitForQueryTermination(QueryId query);
 
     /// Blocks until atleast one query has finished (or potentially failed)

--- a/nes-systests/systest/src/QuerySubmitter.cpp
+++ b/nes-systests/systest/src/QuerySubmitter.cpp
@@ -68,14 +68,6 @@ void QuerySubmitter::stopQuery(const QueryId query)
     }
 }
 
-void QuerySubmitter::unregisterQuery(const QueryId query)
-{
-    if (auto unregistered = queryManager->unregister(query); !unregistered.has_value())
-    {
-        throw std::move(unregistered.error());
-    }
-}
-
 LocalQueryStatus QuerySubmitter::waitForQueryTermination(const QueryId query)
 {
     while (true)

--- a/nes-systests/systest/tests/SystestRunnerTest.cpp
+++ b/nes-systests/systest/tests/SystestRunnerTest.cpp
@@ -109,7 +109,6 @@ public:
     MOCK_METHOD((std::expected<QueryId, Exception>), registerQuery, (LogicalPlan), (override));
     MOCK_METHOD((std::expected<void, Exception>), start, (QueryId), (override));
     MOCK_METHOD((std::expected<void, Exception>), stop, (QueryId), (override));
-    MOCK_METHOD((std::expected<void, Exception>), unregister, (QueryId), (override));
     MOCK_METHOD((std::expected<LocalQueryStatus, Exception>), status, (QueryId), (const, override));
     MOCK_METHOD((std::expected<WorkerStatus, Exception>), workerStatus, (std::chrono::system_clock::time_point), (const, override));
 };


### PR DESCRIPTION
## Summary

- Remove the `UnregisterQuery` RPC which was semantically redundant with `StopQuery` — both called `queryEngine->stop()` at the `NodeEngine` level
- Fold the `state.queries.erase()` bookkeeping from `QueryManager::unregister()` into `QueryManager::stop()`
- Simplify `DROP QUERY` to just call `stop()` instead of chaining `stop().and_then(unregister())`
- Remove all related server/client implementations, proto definitions, and test mocks (17 files, -122 lines)

Closes #1458
