### PR TITLE
Fix(#1440): fix contradictory preconditions in VariableSizedData::isValid

### DIFF
--- a/nes-nautilus/src/Nautilus/DataTypes/VariableSizedData.cpp
+++ b/nes-nautilus/src/Nautilus/DataTypes/VariableSizedData.cpp
@@ -73,8 +73,8 @@ nautilus::val<bool> operator==(const nautilus::val<bool>& other, const VariableS
 
 nautilus::val<bool> VariableSizedData::isValid() const
 {
-    PRECONDITION(size > 0 && ptrToVarSized != nullptr, "VariableSizedData has a size of 0 but  a nullptr pointer to the data.");
-    PRECONDITION(size == 0 && ptrToVarSized == nullptr, "VariableSizedData has a size of 0 so there should be no pointer to the data.");
+    PRECONDITION(size == 0 || ptrToVarSized != nullptr, "VariableSizedData has a size > 0 but a nullptr pointer to the data.");
+    PRECONDITION(size != 0 || ptrToVarSized == nullptr, "VariableSizedData has a size of 0 so there should be no pointer to the data.");
     return size > 0 && ptrToVarSized != nullptr;
 }
 


### PR DESCRIPTION
## Summary
- Fixed two `PRECONDITION` checks in `VariableSizedData::isValid()` that used `&&` (logical AND), making them mutually exclusive and impossible to both satisfy
- Changed to `||` (logical OR) so each precondition correctly validates its invariant: if size > 0 then pointer must be non-null, and if size == 0 then pointer must be null
- Also fixed the error message on the first precondition to accurately describe the failure condition

Closes #1440

## Test plan
- [ ] Verify existing `VariableSizedDataTest` unit tests pass
- [ ] Build in Debug mode (where PRECONDITION macros are active) and confirm no assertion failures in normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)