### PR TITLE
Fix(#1043): suppress ANTLR error messages printed to stdout

### DIFF
--- a/nes-sql-parser/src/StatementBinder.cpp
+++ b/nes-sql-parser/src/StatementBinder.cpp
@@ -466,7 +466,10 @@ StatementBinder::parseAndBind(const std::string_view statementString) const
         AntlrSQLLexer lexer(&input);
         antlr4::CommonTokenStream tokens(&lexer);
         AntlrSQLParser parser(&tokens);
-        /// Enable that antlr throws exeptions on parsing errors
+        /// Remove default error listeners that print to stdout/stderr
+        lexer.removeErrorListeners();
+        parser.removeErrorListeners();
+        /// Enable that antlr throws exceptions on parsing errors
         parser.setErrorHandler(std::make_shared<antlr4::BailErrorStrategy>());
         AntlrSQLParser::MultipleStatementsContext* tree = parser.multipleStatements();
         if (tree == nullptr)


### PR DESCRIPTION
## Summary
- Remove default ANTLR `ConsoleErrorListener` from both lexer and parser in `StatementBinder::parseAndBind` by calling `removeErrorListeners()` before parsing
- This prevents ANTLR from printing error messages to stdout/stderr when parsing invalid input, eliminating duplicate error output in the REPL
- The same pattern was already correctly applied in `AntlrSQLQueryParser.cpp` but was missing in `StatementBinder.cpp`

Closes #1043

## Test plan
- [ ] Parse an invalid SQL statement via the REPL and verify that no ANTLR error messages appear on stdout/stderr
- [ ] Verify that invalid SQL still produces a proper exception/error response
- [ ] Run existing `statement-binder-test` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)