### PR TITLE
Fix(#1458): remove redundant UnregisterQuery RPC

### DIFF
--- a/grpc/SingleNodeWorkerRPCService.proto
+++ b/grpc/SingleNodeWorkerRPCService.proto
@@ -18,7 +18,6 @@ import "google/protobuf/empty.proto";
 
 service WorkerRPCService {
   rpc RegisterQuery (RegisterQueryRequest) returns (RegisterQueryReply) {}
-  rpc UnregisterQuery (UnregisterQueryRequest) returns (google.protobuf.Empty) {}
 
   rpc StartQuery (StartQueryRequest) returns (google.protobuf.Empty) {}
   rpc StopQuery (StopQueryRequest) returns (google.protobuf.Empty) {}
@@ -33,10 +32,6 @@ message RegisterQueryRequest {
 }
 
 message RegisterQueryReply {
-  uint64 queryId = 1;
-}
-
-message UnregisterQueryRequest {
   uint64 queryId = 1;
 }
 

--- a/nes-common/include/ExceptionDefinitions.inc
+++ b/nes-common/include/ExceptionDefinitions.inc
@@ -87,7 +87,6 @@ EXCEPTION(QueryNotFound, 5000, "query is not registered")
 EXCEPTION(QueryRegistrationFailed, 5001, "query registration call failed")
 EXCEPTION(QueryStartFailed, 5002, "query start call failed")
 EXCEPTION(QueryStopFailed, 5003, "query stop call failed")
-EXCEPTION(QueryUnregistrationFailed, 5004, "query unregistration call failed")
 EXCEPTION(QueryStatusFailed, 5005, "query status call failed")
 
 /// 9XXX Internal errors (e.g. bugs)

--- a/nes-frontend/include/QueryManager/EmbeddedWorkerQuerySubmissionBackend.hpp
+++ b/nes-frontend/include/QueryManager/EmbeddedWorkerQuerySubmissionBackend.hpp
@@ -34,7 +34,6 @@ public:
     [[nodiscard]] std::expected<QueryId, Exception> registerQuery(LogicalPlan) override;
     std::expected<void, Exception> start(QueryId) override;
     std::expected<void, Exception> stop(QueryId) override;
-    std::expected<void, Exception> unregister(QueryId) override;
     [[nodiscard]] std::expected<LocalQueryStatus, Exception> status(QueryId) const override;
     [[nodiscard]] std::expected<WorkerStatus, Exception> workerStatus(std::chrono::system_clock::time_point after) const override;
 

--- a/nes-frontend/include/QueryManager/GRPCQuerySubmissionBackend.hpp
+++ b/nes-frontend/include/QueryManager/GRPCQuerySubmissionBackend.hpp
@@ -37,7 +37,6 @@ public:
     [[nodiscard]] std::expected<QueryId, Exception> registerQuery(LogicalPlan) override;
     std::expected<void, Exception> start(QueryId) override;
     std::expected<void, Exception> stop(QueryId) override;
-    std::expected<void, Exception> unregister(QueryId) override;
     [[nodiscard]] std::expected<LocalQueryStatus, Exception> status(QueryId) const override;
     [[nodiscard]] std::expected<WorkerStatus, Exception> workerStatus(std::chrono::system_clock::time_point after) const override;
 };

--- a/nes-frontend/include/QueryManager/QueryManager.hpp
+++ b/nes-frontend/include/QueryManager/QueryManager.hpp
@@ -45,7 +45,6 @@ public:
     [[nodiscard]] virtual std::expected<QueryId, Exception> registerQuery(LogicalPlan) = 0;
     virtual std::expected<void, Exception> start(QueryId) = 0;
     virtual std::expected<void, Exception> stop(QueryId) = 0;
-    virtual std::expected<void, Exception> unregister(QueryId) = 0;
     [[nodiscard]] virtual std::expected<LocalQueryStatus, Exception> status(QueryId) const = 0;
     [[nodiscard]] virtual std::expected<WorkerStatus, Exception> workerStatus(std::chrono::system_clock::time_point after) const = 0;
 };
@@ -67,7 +66,6 @@ public:
     /// Starts a pre-registered query. Start may potentially block waiting for the query state to change (even if it fails).
     std::expected<void, Exception> start(QueryId query);
     std::expected<void, Exception> stop(QueryId query);
-    std::expected<void, Exception> unregister(QueryId query);
     [[nodiscard]] std::expected<LocalQueryStatus, Exception> status(QueryId query) const;
     [[nodiscard]] std::vector<QueryId> queries() const;
     [[nodiscard]] std::expected<WorkerStatus, Exception> workerStatus(std::chrono::system_clock::time_point after) const;

--- a/nes-frontend/src/QueryManager/EmbeddedWorkerQuerySubmissionBackend.cpp
+++ b/nes-frontend/src/QueryManager/EmbeddedWorkerQuerySubmissionBackend.cpp
@@ -62,11 +62,6 @@ std::expected<void, Exception> EmbeddedWorkerQuerySubmissionBackend::stop(QueryI
     return worker.stopQuery(queryId, QueryTerminationType::Graceful);
 }
 
-std::expected<void, Exception> EmbeddedWorkerQuerySubmissionBackend::unregister(QueryId queryId)
-{
-    return worker.unregisterQuery(queryId);
-}
-
 std::expected<LocalQueryStatus, Exception> EmbeddedWorkerQuerySubmissionBackend::status(QueryId queryId) const
 {
     return worker.getQueryStatus(queryId);

--- a/nes-frontend/src/QueryManager/GRPCQuerySubmissionBackend.cpp
+++ b/nes-frontend/src/QueryManager/GRPCQuerySubmissionBackend.cpp
@@ -178,21 +178,4 @@ std::expected<void, Exception> GRPCQuerySubmissionBackend::stop(QueryId queryId)
         "Status: {}\nMessage: {}\nDetail: {}", magic_enum::enum_name(status.error_code()), status.error_message(), status.error_details())};
 }
 
-std::expected<void, Exception> GRPCQuerySubmissionBackend::unregister(QueryId queryId)
-{
-    grpc::ClientContext context;
-    UnregisterQueryRequest request;
-    google::protobuf::Empty response;
-    request.set_queryid(queryId.getRawValue());
-
-    const auto status = stub->UnregisterQuery(&context, request, &response);
-    if (status.ok())
-    {
-        NES_DEBUG("Unregister of query {} on node {} was successful.", queryId, workerConfig.grpc);
-        return {};
-    }
-
-    return std::unexpected{QueryUnregistrationFailed(
-        "Status: {}\nMessage: {}\nDetail: {}", magic_enum::enum_name(status.error_code()), status.error_message(), status.error_details())};
-}
 }

--- a/nes-frontend/src/QueryManager/QueryManager.cpp
+++ b/nes-frontend/src/QueryManager/QueryManager.cpp
@@ -172,6 +172,8 @@ std::expected<void, Exception> QueryManager::stop(QueryId queryId)
         auto result = backend->stop(queryId);
         if (result)
         {
+            auto erased = state.queries.erase(queryId);
+            INVARIANT(erased == 1, "Should not stop query that has not been registered");
             NES_DEBUG("Stopping query {} was successful.", queryId);
             return {};
         }
@@ -180,32 +182,6 @@ std::expected<void, Exception> QueryManager::stop(QueryId queryId)
     catch (std::exception& e)
     {
         return std::unexpected{QueryStopFailed("Message from external exception: {} ", e.what())};
-    }
-}
-
-std::expected<void, Exception> QueryManager::unregister(QueryId queryId)
-{
-    auto queryResult = getQuery(queryId);
-    if (!queryResult.has_value())
-    {
-        return std::unexpected(queryResult.error());
-    }
-
-    try
-    {
-        auto result = backend->unregister(queryId);
-        if (result)
-        {
-            auto erased = state.queries.erase(queryId);
-            INVARIANT(erased == 1, "Should not unregister query that has not been registered");
-            NES_DEBUG("Unregister of query {} was successful.", queryId);
-            return {};
-        }
-        return std::unexpected{result.error()};
-    }
-    catch (std::exception& e)
-    {
-        return std::unexpected{QueryUnregistrationFailed("Message from external exception: {} ", e.what())};
     }
 }
 

--- a/nes-frontend/src/Statements/StatementHandler.cpp
+++ b/nes-frontend/src/Statements/StatementHandler.cpp
@@ -193,12 +193,9 @@ QueryStatementHandler::QueryStatementHandler(SharedPtr<QueryManager> queryManage
 
 std::expected<DropQueryStatementResult, Exception> QueryStatementHandler::operator()(const DropQueryStatement& statement)
 {
-    auto stopResult = queryManager->stop(statement.id)
-                          .and_then([&statement, this] { return queryManager->unregister(statement.id); })
-                          .transform_error([](auto error) { return QueryStopFailed("Could not stop query: {}", error.what()); })
-                          .transform([&statement] { return DropQueryStatementResult{statement.id}; });
-
-    return stopResult;
+    return queryManager->stop(statement.id)
+        .transform_error([](auto error) { return QueryStopFailed("Could not stop query: {}", error.what()); })
+        .transform([&statement] { return DropQueryStatementResult{statement.id}; });
 }
 
 std::expected<ExplainQueryStatementResult, Exception> QueryStatementHandler::operator()(const ExplainQueryStatement& statement)

--- a/nes-runtime/include/Runtime/NodeEngine.hpp
+++ b/nes-runtime/include/Runtime/NodeEngine.hpp
@@ -49,7 +49,6 @@ public:
         std::unique_ptr<SourceProvider> sourceProvider);
 
     void registerCompiledQueryPlan(QueryId queryId, std::unique_ptr<CompiledQueryPlan> compiledQueryPlan);
-    void unregisterQuery(QueryId queryId);
     void startQuery(QueryId queryId);
     /// Termination will happen asynchronously, thus the query might very well be running for an indeterminate time after this method has
     /// been called.

--- a/nes-runtime/src/Runtime/NodeEngine.cpp
+++ b/nes-runtime/src/Runtime/NodeEngine.cpp
@@ -116,13 +116,6 @@ void NodeEngine::startQuery(QueryId queryId)
     }
 }
 
-void NodeEngine::unregisterQuery(QueryId queryId)
-{
-    PRECONDITION(queryId != INVALID_QUERY_ID, "QueryId must be not invalid!");
-    NES_INFO("Unregister {}", queryId);
-    queryEngine->stop(queryId);
-}
-
 void NodeEngine::stopQuery(QueryId queryId, QueryTerminationType)
 {
     PRECONDITION(queryId != INVALID_QUERY_ID, "QueryId must be not invalid!");

--- a/nes-single-node-worker/include/GrpcService.hpp
+++ b/nes-single-node-worker/include/GrpcService.hpp
@@ -29,8 +29,6 @@ class GRPCServer final : public WorkerRPCService::Service
 public:
     grpc::Status RegisterQuery(grpc::ServerContext*, const RegisterQueryRequest*, RegisterQueryReply*) override;
 
-    grpc::Status UnregisterQuery(grpc::ServerContext*, const UnregisterQueryRequest*, google::protobuf::Empty*) override;
-
     grpc::Status StartQuery(grpc::ServerContext*, const StartQueryRequest*, google::protobuf::Empty*) override;
 
     grpc::Status StopQuery(grpc::ServerContext*, const StopQueryRequest*, google::protobuf::Empty*) override;

--- a/nes-single-node-worker/include/SingleNodeWorker.hpp
+++ b/nes-single-node-worker/include/SingleNodeWorker.hpp
@@ -75,10 +75,6 @@ public:
     /// @param terminationType dictates what happens with in in-flight data
     std::expected<void, Exception> stopQuery(QueryId queryId, QueryTerminationType terminationType) noexcept;
 
-    /// Unregisters a stopped Query.
-    /// @param queryId identifies the registered stopped query
-    std::expected<void, Exception> unregisterQuery(QueryId queryId) noexcept;
-
     /// Complete history of query status changes.
     [[nodiscard]] std::optional<QueryLog::Log> getQueryLog(QueryId queryId) const;
     /// Summary structure for query.

--- a/nes-single-node-worker/src/GrpcService.cpp
+++ b/nes-single-node-worker/src/GrpcService.cpp
@@ -85,25 +85,6 @@ grpc::Status GRPCServer::RegisterQuery(grpc::ServerContext* context, const Regis
     return {grpc::INTERNAL, "unknown exception"};
 }
 
-grpc::Status GRPCServer::UnregisterQuery(grpc::ServerContext* context, const UnregisterQueryRequest* request, google::protobuf::Empty*)
-{
-    const auto queryId = QueryId(request->queryid());
-    CPPTRACE_TRY
-    {
-        getValueOrThrow(delegate.unregisterQuery(queryId));
-        return grpc::Status::OK;
-    }
-    CPPTRACE_CATCH(const Exception& e)
-    {
-        return handleError(e, context);
-    }
-    CPPTRACE_CATCH_ALT(const std::exception& e)
-    {
-        return handleError(e, context);
-    }
-    return {grpc::INTERNAL, "unknown exception"};
-}
-
 grpc::Status GRPCServer::StartQuery(grpc::ServerContext* context, const StartQueryRequest* request, google::protobuf::Empty*)
 {
     const auto queryId = QueryId(request->queryid());

--- a/nes-single-node-worker/src/SingleNodeWorker.cpp
+++ b/nes-single-node-worker/src/SingleNodeWorker.cpp
@@ -143,21 +143,6 @@ std::expected<void, Exception> SingleNodeWorker::stopQuery(QueryId queryId, Quer
     std::unreachable();
 }
 
-std::expected<void, Exception> SingleNodeWorker::unregisterQuery(QueryId queryId) noexcept
-{
-    CPPTRACE_TRY
-    {
-        PRECONDITION(queryId != INVALID_QUERY_ID, "QueryId must be not invalid!");
-        nodeEngine->unregisterQuery(queryId);
-        return {};
-    }
-    CPPTRACE_CATCH(...)
-    {
-        return std::unexpected(wrapExternalException());
-    }
-    std::unreachable();
-}
-
 std::expected<LocalQueryStatus, Exception> SingleNodeWorker::getQueryStatus(QueryId queryId) const noexcept
 {
     CPPTRACE_TRY

--- a/nes-systests/systest/include/QuerySubmitter.hpp
+++ b/nes-systests/systest/include/QuerySubmitter.hpp
@@ -31,7 +31,6 @@ public:
     std::expected<QueryId, Exception> registerQuery(const LogicalPlan& plan);
     void startQuery(QueryId query);
     void stopQuery(QueryId query);
-    void unregisterQuery(QueryId query);
     LocalQueryStatus waitForQueryTermination(QueryId query);
 
     /// Blocks until atleast one query has finished (or potentially failed)

--- a/nes-systests/systest/src/QuerySubmitter.cpp
+++ b/nes-systests/systest/src/QuerySubmitter.cpp
@@ -68,14 +68,6 @@ void QuerySubmitter::stopQuery(const QueryId query)
     }
 }
 
-void QuerySubmitter::unregisterQuery(const QueryId query)
-{
-    if (auto unregistered = queryManager->unregister(query); !unregistered.has_value())
-    {
-        throw std::move(unregistered.error());
-    }
-}
-
 LocalQueryStatus QuerySubmitter::waitForQueryTermination(const QueryId query)
 {
     while (true)

--- a/nes-systests/systest/tests/SystestRunnerTest.cpp
+++ b/nes-systests/systest/tests/SystestRunnerTest.cpp
@@ -108,7 +108,6 @@ public:
     MOCK_METHOD((std::expected<QueryId, Exception>), registerQuery, (LogicalPlan), (override));
     MOCK_METHOD((std::expected<void, Exception>), start, (QueryId), (override));
     MOCK_METHOD((std::expected<void, Exception>), stop, (QueryId), (override));
-    MOCK_METHOD((std::expected<void, Exception>), unregister, (QueryId), (override));
     MOCK_METHOD((std::expected<LocalQueryStatus, Exception>), status, (QueryId), (const, override));
     MOCK_METHOD((std::expected<WorkerStatus, Exception>), workerStatus, (std::chrono::system_clock::time_point), (const, override));
 };


### PR DESCRIPTION
## Summary
- Removed `UnregisterQuery` RPC from `SingleNodeWorkerRPCService.proto` and the `UnregisterQueryRequest` message
- Removed server-side implementation from `GRPCServer` and `SingleNodeWorker::unregisterQuery`
- Removed `NodeEngine::unregisterQuery` (which was just a duplicate call to `queryEngine->stop()`)
- Removed client-side implementation from `GRPCQuerySubmissionBackend::unregister` and `EmbeddedWorkerQuerySubmissionBackend::unregister`
- Removed `QuerySubmissionBackend::unregister` from the virtual interface and `QueryManager::unregister`
- Folded `state.queries.erase()` bookkeeping (previously in `QueryManager::unregister`) into `QueryManager::stop`
- Simplified `DROP QUERY` in `StatementHandler` to just call `stop()` instead of `stop()` then `unregister()`
- Removed unused `QueryUnregistrationFailed` exception definition
- Cleaned up systest `QuerySubmitter::unregisterQuery` and mock in `SystestRunnerTest`

Closes #1458

## Test plan
- [x] Full build succeeds in Docker (371/371 targets, zero errors)
- [ ] CI smoke tests pass
- [ ] Existing systests pass (DROP QUERY now just calls stop, which handles cleanup)
- [ ] No remaining references to UnregisterQuery/unregisterQuery/unregister in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)