### PR TITLE
Fix(#1108): remove incorrect noexcept qualifiers from Statement logic

### DIFF
--- a/nes-frontend/include/Statements/StatementHandler.hpp
+++ b/nes-frontend/include/Statements/StatementHandler.hpp
@@ -135,14 +135,14 @@ class StatementHandler
 public:
     template <typename Statement>
     requires(std::invocable<HandlerImpl, const Statement&>)
-    [[nodiscard]] auto apply(const Statement& statement) const noexcept -> decltype(std::declval<HandlerImpl>()(statement))
+    [[nodiscard]] auto apply(const Statement& statement) const -> decltype(std::declval<HandlerImpl>()(statement))
     {
         return static_cast<HandlerImpl*>(this)->operator()(statement);
     }
 
     template <typename Statement>
     requires(std::invocable<HandlerImpl, const Statement&>)
-    auto apply(const Statement& statement) noexcept -> decltype(std::declval<HandlerImpl>()(statement))
+    auto apply(const Statement& statement) -> decltype(std::declval<HandlerImpl>()(statement))
     {
         return static_cast<HandlerImpl*>(this)->operator()(statement);
     }

--- a/nes-sql-parser/include/SQLQueryParser/StatementBinder.hpp
+++ b/nes-sql-parser/include/SQLQueryParser/StatementBinder.hpp
@@ -182,7 +182,7 @@ class StatementBinder
 public:
     explicit StatementBinder(
         const std::shared_ptr<const SourceCatalog>& sourceCatalog,
-        const std::function<LogicalPlan(AntlrSQLParser::QueryContext*)>& queryPlanBinder) noexcept;
+        const std::function<LogicalPlan(AntlrSQLParser::QueryContext*)>& queryPlanBinder);
 
     StatementBinder(const StatementBinder& other) = delete;
     StatementBinder& operator=(const StatementBinder& other) = delete;
@@ -192,10 +192,10 @@ public:
     /// If the destructor was implicitly defaulted, it would call the destructor of the unique ptr, which would require the definition of Impl.
     /// Deferring the destructor default to the implementation, where also the definition of Impl is, solves this problem.
     ~StatementBinder();
-    [[nodiscard]] std::expected<Statement, Exception> bind(AntlrSQLParser::StatementContext* statementAST) const noexcept;
+    [[nodiscard]] std::expected<Statement, Exception> bind(AntlrSQLParser::StatementContext* statementAST) const;
     [[nodiscard]] std::expected<std::vector<std::expected<Statement, Exception>>, Exception>
-    parseAndBind(std::string_view statementString) const noexcept;
-    [[nodiscard]] std::expected<Statement, Exception> parseAndBindSingle(std::string_view statementStrings) const noexcept;
+    parseAndBind(std::string_view statementString) const;
+    [[nodiscard]] std::expected<Statement, Exception> parseAndBindSingle(std::string_view statementStrings) const;
 };
 }
 
@@ -206,7 +206,7 @@ struct formatter<std::unordered_map<std::string, std::string>>
 {
     [[nodiscard]] static constexpr auto parse(const format_parse_context& ctx) noexcept -> decltype(ctx.begin()) { return ctx.begin(); }
 
-    static constexpr auto format(const std::unordered_map<std::string, std::string>& mapToFormat, format_context& ctx) noexcept
+    static constexpr auto format(const std::unordered_map<std::string, std::string>& mapToFormat, format_context& ctx)
         -> decltype(ctx.out())
     {
         auto out = ctx.out();

--- a/nes-sql-parser/src/StatementBinder.cpp
+++ b/nes-sql-parser/src/StatementBinder.cpp
@@ -421,7 +421,7 @@ public:
 
 StatementBinder::StatementBinder(
     const std::shared_ptr<const SourceCatalog>& sourceCatalog,
-    const std::function<LogicalPlan(AntlrSQLParser::QueryContext*)>& queryPlanBinder) noexcept
+    const std::function<LogicalPlan(AntlrSQLParser::QueryContext*)>& queryPlanBinder)
     : impl(std::make_unique<Impl>(sourceCatalog, queryPlanBinder))
 {
 }
@@ -442,13 +442,13 @@ StatementBinder& StatementBinder::operator=(StatementBinder&& other) noexcept
 
 StatementBinder::~StatementBinder() = default;
 
-std::expected<Statement, Exception> StatementBinder::bind(AntlrSQLParser::StatementContext* statementAST) const noexcept
+std::expected<Statement, Exception> StatementBinder::bind(AntlrSQLParser::StatementContext* statementAST) const
 {
     return impl->bind(statementAST);
 }
 
 std::expected<std::vector<std::expected<Statement, Exception>>, Exception>
-StatementBinder::parseAndBind(const std::string_view statementString) const noexcept
+StatementBinder::parseAndBind(const std::string_view statementString) const
 {
     try
     {
@@ -474,7 +474,7 @@ StatementBinder::parseAndBind(const std::string_view statementString) const noex
     }
 }
 
-std::expected<Statement, Exception> StatementBinder::parseAndBindSingle(std::string_view statementStrings) const noexcept
+std::expected<Statement, Exception> StatementBinder::parseAndBindSingle(std::string_view statementStrings) const
 {
     auto allParsed = parseAndBind(statementStrings);
     if (allParsed.has_value())


### PR DESCRIPTION
## Summary
- Removed incorrect `noexcept` qualifiers from `StatementBinder` constructor, `bind()`, `parseAndBind()`, and `parseAndBindSingle()` methods (both header and source), as these functions can throw due to memory allocations and internal exception handling
- Removed `noexcept` from `fmt::formatter<std::unordered_map<std::string, std::string>>::format()` since `format_to` can allocate
- Removed `noexcept` from `StatementHandler::apply()` (both const and non-const overloads), as the delegated `operator()` calls can throw
- Kept `noexcept` on move constructor, move assignment operator, and `fmt::formatter::parse()` where it is genuinely safe

Closes #1108

## Test plan
- [x] Verified `nes-sql-parser` target builds successfully with the changes
- [ ] CI should confirm no regressions across the full test matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)