### PR TITLE
fix(Unpooled Buffers): Fixed wrong buffer size after a load

### DIFF
--- a/nes-memory/UnpooledChunksManager.cpp
+++ b/nes-memory/UnpooledChunksManager.cpp
@@ -186,7 +186,7 @@ UnpooledChunksManager::getUnpooledBuffer(const size_t neededSize, size_t alignme
 
     if (leakedMemSegment->controlBlock->prepare(bufferRecycler))
     {
-        return TupleBuffer(leakedMemSegment->controlBlock.get(), leakedMemSegment->ptr, neededSize);
+        return TupleBuffer{leakedMemSegment->controlBlock.get(), leakedMemSegment->ptr, leakedMemSegment->size};
     }
     throw InvalidRefCountForBuffer("[BufferManager] got buffer with invalid reference counter");
 }

--- a/nes-memory/tests/CMakeLists.txt
+++ b/nes-memory/tests/CMakeLists.txt
@@ -19,3 +19,6 @@ target_link_libraries(unpooled-buffer-test nes-memory nes-memory-test-utils)
 
 add_nes_test(tuple-buffer-memory-access-tests TupleBufferMemoryAccessTest.cpp)
 target_link_libraries(tuple-buffer-memory-access-tests nes-memory)
+
+add_nes_test(child-buffer-tests ChildBufferTests.cpp)
+target_link_libraries(child-buffer-tests nes-memory)

--- a/nes-memory/tests/ChildBufferTests.cpp
+++ b/nes-memory/tests/ChildBufferTests.cpp
@@ -1,0 +1,105 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+
+#include <cstddef>
+#include <cstdint>
+#include <ctime>
+#include <random>
+
+#include <Runtime/BufferManager.hpp>
+#include <Runtime/TupleBuffer.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <gtest/gtest.h>
+
+/// Testing if the buffer size stays the same during a store --> load with small, odd sizes
+TEST(ChildBufferTests, StoreAndLoadChildBufferOddSizes)
+{
+    constexpr std::array<size_t, 6> oddSizes = {1, 3, 7, 13, 63, 127};
+
+    auto bufferManager = NES::BufferManager::create(1000);
+    auto baseBuffer = bufferManager->getBufferBlocking();
+
+    for (size_t i = 0; i < std::size(oddSizes); ++i)
+    {
+        auto buffer = bufferManager->getUnpooledBuffer(oddSizes[i]);
+        ASSERT_TRUE(buffer.has_value()) << "Failed to allocate unpooled buffer of size " << oddSizes[i];
+
+        const auto bufferSizeBeforeStore = buffer.value().getBufferSize();
+        const auto bufferIndex = baseBuffer.storeChildBuffer(buffer.value());
+        EXPECT_EQ(bufferIndex.getRawIndex(), i);
+        EXPECT_EQ(baseBuffer.getNumberOfChildBuffers(), i + 1);
+
+        auto loadedBuffer = baseBuffer.loadChildBuffer(bufferIndex);
+        EXPECT_EQ(loadedBuffer.getBufferSize(), bufferSizeBeforeStore);
+    }
+}
+
+/// Testing if the buffer size stays the same during a store --> load with power-of-2 sizes
+TEST(ChildBufferTests, StoreAndLoadChildBufferPowerOfTwoSizes)
+{
+    constexpr std::array<size_t, 13> powerOfTwoSizes = {8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768};
+
+    auto bufferManager = NES::BufferManager::create(1000);
+    auto baseBuffer = bufferManager->getBufferBlocking();
+
+    for (size_t i = 0; i < std::size(powerOfTwoSizes); ++i)
+    {
+        auto buffer = bufferManager->getUnpooledBuffer(powerOfTwoSizes[i]);
+        ASSERT_TRUE(buffer.has_value()) << "Failed to allocate unpooled buffer of size " << powerOfTwoSizes[i];
+
+        const auto bufferSizeBeforeStore = buffer.value().getBufferSize();
+        const auto bufferIndex = baseBuffer.storeChildBuffer(buffer.value());
+        EXPECT_EQ(bufferIndex.getRawIndex(), i);
+        EXPECT_EQ(baseBuffer.getNumberOfChildBuffers(), i + 1);
+
+        auto loadedBuffer = baseBuffer.loadChildBuffer(bufferIndex);
+        EXPECT_EQ(loadedBuffer.getBufferSize(), bufferSizeBeforeStore);
+    }
+}
+
+/// Testing if the buffer size stays the same during a store --> load with random sizes
+TEST(ChildBufferTests, StoreAndLoadChildBufferRandomSizes)
+{
+    constexpr size_t minSize = 10;
+    constexpr size_t maxSize = 1024;
+    constexpr size_t minNumberOfRandomSizes = 100;
+    constexpr size_t maxNumberOfRandomSizes = 1'000;
+
+    /// Getting a "random" seed and logging the seed to be able to rerun the test with the same random values
+    const auto seed = static_cast<unsigned>(std::time(nullptr));
+    NES_INFO("ChildBufferTests seed: {}", seed);
+    std::mt19937 gen{seed};
+    std::uniform_int_distribution<size_t> sizeDist{minSize, maxSize};
+    std::uniform_int_distribution<size_t> countDist{minNumberOfRandomSizes, maxNumberOfRandomSizes};
+    const size_t numberOfRandomSizes = countDist(gen);
+
+    auto bufferManager = NES::BufferManager::create(1000);
+    auto baseBuffer = bufferManager->getBufferBlocking();
+
+    for (size_t i = 0; i < numberOfRandomSizes; ++i)
+    {
+        const size_t randomSize = sizeDist(gen);
+        auto buffer = bufferManager->getUnpooledBuffer(randomSize);
+        ASSERT_TRUE(buffer.has_value()) << "Failed to allocate unpooled buffer of size " << randomSize;
+
+        const auto bufferSizeBeforeStore = buffer.value().getBufferSize();
+        const auto bufferIndex = baseBuffer.storeChildBuffer(buffer.value());
+        EXPECT_EQ(bufferIndex.getRawIndex(), i);
+        EXPECT_EQ(baseBuffer.getNumberOfChildBuffers(), i + 1);
+
+        auto loadedBuffer = baseBuffer.loadChildBuffer(bufferIndex);
+        EXPECT_EQ(loadedBuffer.getBufferSize(), bufferSizeBeforeStore);
+    }
+}

--- a/nes-memory/tests/UnpooledBufferTests.cpp
+++ b/nes-memory/tests/UnpooledBufferTests.cpp
@@ -74,10 +74,6 @@ void runAllocations(
     /// Running all allocations concurrently for #numberOfThreads
     std::vector<std::thread> threads;
     const auto chunkSize = numberOfThreads / numberOfRandomAllocationSizes;
-    for (auto& allocation : randomAllocations)
-    {
-        allocation.buffer = bufferManager->getUnpooledBuffer(allocation.neededSize);
-    }
     for (size_t i = 0; i < numberOfThreads; ++i)
     {
         size_t start = i * chunkSize;
@@ -106,7 +102,7 @@ void runAllocations(
     for (const auto& allocation : randomAllocations)
     {
         ASSERT_TRUE(allocation.buffer.has_value());
-        ASSERT_EQ(allocation.buffer.value().getBufferSize(), allocation.neededSize);
+        ASSERT_GE(allocation.buffer.value().getBufferSize(), allocation.neededSize);
     }
 }
 


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR fixes a bug that would return the wrong buffer size after a load. The main culprit was that we align the buffer size but return the `neededSize`.


## Verifying this change
This change is tested by the newly added test.