### PR TITLE
Add bloom filter implementation into NLJ, tests, and benchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ option(NES_ENABLES_TESTS "Enable tests" ON)
 option(NES_ENABLE_PRECOMPILED_HEADERS "Enable precompiled headers (might improve compilation time)" OFF)
 option(NES_ENABLE_EXPERIMENTAL_EXECUTION_MLIR "Enables the MLIR backend." ON)
 option(NES_LOG_WITH_STACKTRACE "Log exceptions with stacktrace" ON)
-option(ENABLE_LARGE_TESTS "Runs testcases with larger input data" OFF)
+option(ENABLE_LARGE_TESTS "Runs testcases with larger input data" ON)
 option(NES_DEBUG_TUPLE_BUFFER_LEAKS "Heavyweight instrumentation for Tuplebuffer debugging" OFF)
 
 
@@ -62,6 +62,13 @@ set(CMAKE_THREAD_LIBS_INIT "-lpthread")
 include(cmake/HostIdentification.cmake)
 include(cmake/Sanitizers.cmake)
 include(cmake/ImportDependencies.cmake)
+
+# Default to Release mode for optimal performance in benchmarks
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+    message(STATUS "CMAKE_BUILD_TYPE not specified, defaulting to Release for BloomFilter benchmarks")
+endif()
+
 project(NES LANGUAGES C CXX)
 set(VCPKG_POLICY_ALLOW_RESTRICTED_HEADERS enabled)
 message(STATUS "Going to use ${CMAKE_CXX_COMPILER}")

--- a/nes-nautilus/include/Nautilus/Interface/Hash/BloomFilter.hpp
+++ b/nes-nautilus/include/Nautilus/Interface/Hash/BloomFilter.hpp
@@ -1,0 +1,75 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace NES::Nautilus::Interface {
+
+/**
+ * @brief Simple Bloom filter for 64-bit keys.
+ *
+ * Core properties:
+ *  - No false negatives (if an inserted key is queried, mightContain() never returns false).
+ *  - False positives are possible and controlled via configuration.
+ */
+class BloomFilter {
+  public:
+    using KeyType = std::uint64_t;
+
+    /**
+     * @brief Construct a Bloom filter with an expected number of entries and target false positive rate.
+     *
+     * @param expectedEntries Estimated number of keys that will be inserted.
+     * @param falsePositiveRate Target false positive probability in (0,1),
+     *                          for example 0.01 for 1%.
+     */
+    BloomFilter(std::size_t expectedEntries, double falsePositiveRate);
+
+    /**
+     * @brief Insert a key into the filter.
+     */
+    void add(KeyType key);
+
+    /**
+     * @brief Query if a key might be in the set.
+     *
+     * @return true  If the key might be contained (false positive possible).
+     * @return false If the key is definitely not contained.
+     */
+    [[nodiscard]] bool mightContain(KeyType key) const;
+
+    /**
+     * @brief Reset all bits in the filter.
+     */
+    void clear();
+
+    [[nodiscard]] std::size_t sizeInBits() const { return bitCount; }
+    [[nodiscard]] std::size_t hashFunctionCount() const { return hashCount; }
+
+  private:
+    std::size_t bitCount;                 ///< m = number of bits in the filter
+    std::size_t hashCount;                ///< k = number of hash functions
+    std::vector<std::uint64_t> bits;      ///< bit array packed into 64-bit words
+
+    void setBit(std::size_t bitIndex);
+    [[nodiscard]] bool getBit(std::size_t bitIndex) const;
+
+    /// Compute base hashes for key (used for double hashing).
+    void computeBaseHashes(KeyType key, std::uint64_t& h1, std::uint64_t& h2) const;
+};
+
+} // namespace NES::Nautilus::Interface

--- a/nes-nautilus/include/Nautilus/Interface/Hash/BloomFilterRef.hpp
+++ b/nes-nautilus/include/Nautilus/Interface/Hash/BloomFilterRef.hpp
@@ -1,0 +1,70 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <Nautilus/Interface/Hash/BloomFilter.hpp>
+#include <function.hpp>
+#include <val.hpp>
+
+namespace NES::Nautilus::Interface
+{
+
+/// Proxy function to call BloomFilter::mightContain from Nautilus JIT code.
+/// Acts as a bridge between JIT-compiled code and the host-side BloomFilter.
+inline bool mightContainProxy(const BloomFilter* filter, uint64_t value)
+{
+    if (filter == nullptr)
+    {
+        return true; // No filter = check everything
+    }
+    return filter->mightContain(value);
+}
+
+/**
+ * @brief Nautilus-native wrapper for BloomFilter that can be used in JIT-compiled code.
+ *
+ * This is the Nautilus equivalent of BloomFilter, similar to how PagedVectorRef wraps PagedVector.
+ * It allows BloomFilter operations to be called from within Nautilus-compiled code 
+ */
+class BloomFilterRef
+{
+public:
+    /**
+     * @brief Construct a BloomFilterRef from a Nautilus val<pointer>.
+     * @param filter Nautilus val wrapping the host-side BloomFilter pointer
+     */
+    explicit BloomFilterRef(const nautilus::val<const BloomFilter*>& filter) : filterPtr(filter)
+    {
+    }
+
+    /**
+     * @brief Check if a value might be in the BloomFilter.
+     *
+     * This method can be called from Nautilus JIT-compiled code.
+     * It uses the invoke mechanism to call back to the host-side BloomFilter.
+     *
+     * @param value The value to check (Nautilus val type for JIT compatibility)
+     * @return nautilus::val<bool> - true if value might be present, false if definitely not present
+     */
+    [[nodiscard]] nautilus::val<bool> mightContain(nautilus::val<uint64_t> value) const
+    {
+        return nautilus::invoke(mightContainProxy, filterPtr, value);
+    }
+
+private:
+    nautilus::val<const BloomFilter*> filterPtr;
+};
+
+} // namespace NES::Nautilus::Interface

--- a/nes-nautilus/include/Nautilus/Interface/PagedVector/PagedVectorRef.hpp
+++ b/nes-nautilus/include/Nautilus/Interface/PagedVector/PagedVectorRef.hpp
@@ -53,6 +53,9 @@ public:
     [[nodiscard]] PagedVectorRefIter end(const std::vector<Record::RecordFieldIdentifier>& projections) const;
     nautilus::val<bool> operator==(const PagedVectorRef& other) const;
     [[nodiscard]] nautilus::val<uint64_t> getNumberOfTuples() const;
+    
+    /// Get the underlying PagedVector pointer for use in invoke() calls
+    [[nodiscard]] nautilus::val<PagedVector*> getPagedVectorPtr() const { return pagedVectorRef; }
 
 private:
     nautilus::val<PagedVector*> pagedVectorRef;

--- a/nes-nautilus/src/Nautilus/Interface/Hash/BloomFilter.cpp
+++ b/nes-nautilus/src/Nautilus/Interface/Hash/BloomFilter.cpp
@@ -1,0 +1,139 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+#include <Nautilus/Interface/Hash/BloomFilter.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+// Forward declaration of existing Murmur-style hash from MurMur3HashFunction.cpp
+namespace NES {
+std::uint64_t hashBytes(void* data, std::uint64_t length);
+}
+
+namespace NES::Nautilus::Interface {
+
+namespace {
+
+// small helper for ceil-division
+inline std::size_t divRoundUp(std::size_t x, std::size_t y) {
+    return (x + y - 1) / y;
+}
+
+} // namespace
+
+BloomFilter::BloomFilter(std::size_t expectedEntries, double falsePositiveRate)
+    : bitCount(0)
+    , hashCount(0) {
+
+    // Basic sanity checks and defaults
+    if (expectedEntries == 0) {
+        expectedEntries = 1;
+    }
+    if (falsePositiveRate <= 0.0 || falsePositiveRate >= 1.0) {
+        // default to 1% if user passes an invalid value
+        falsePositiveRate = 0.01;
+    }
+
+    // Standard Bloom filter formulas:
+    //
+    //   m = -n * ln(p) / (ln(2)^2)
+    //   k = (m / n) * ln(2)
+    //
+    const double ln2 = std::log(2.0);
+    const double mDouble =
+        -static_cast<double>(expectedEntries) * std::log(falsePositiveRate) / (ln2 * ln2);
+
+    bitCount = static_cast<std::size_t>(std::ceil(mDouble));
+    if (bitCount == 0) {
+        bitCount = 1;
+    }
+
+    const double kDouble = (bitCount / static_cast<double>(expectedEntries)) * ln2;
+    hashCount = static_cast<std::size_t>(std::max(1.0, std::round(kDouble)));
+
+    const std::size_t wordCount = divRoundUp(bitCount, static_cast<std::size_t>(64));
+    bits.assign(wordCount, 0);
+}
+
+void BloomFilter::clear() {
+    std::fill(bits.begin(), bits.end(), 0);
+}
+
+void BloomFilter::setBit(std::size_t bitIndex) {
+    const std::size_t wordIndex = bitIndex / 64;
+    const std::size_t offset    = bitIndex % 64;
+    bits[wordIndex] |= (std::uint64_t(1) << offset);
+}
+
+bool BloomFilter::getBit(std::size_t bitIndex) const {
+    const std::size_t wordIndex = bitIndex / 64;
+    const std::size_t offset    = bitIndex % 64;
+    return (bits[wordIndex] >> offset) & std::uint64_t(1);
+}
+
+void BloomFilter::computeBaseHashes(KeyType key,
+                                    std::uint64_t& h1,
+                                    std::uint64_t& h2) const {
+    // Use existing Murmur-style hash for the bytes of the key.
+    // hashBytes takes a non-const void* pointer.
+    auto mutableKey = key;
+    h1 = ::NES::hashBytes(static_cast<void*>(&mutableKey), static_cast<std::uint64_t>(sizeof(KeyType)));
+
+    // Derive a second hash value from h1 (mixing function similar to robin-hood hashing).
+    h2 = h1;
+    h2 ^= (h2 >> 33);
+    h2 *= 0xff51afd7ed558ccdULL;
+    h2 ^= (h2 >> 33);
+    h2 *= 0xc4ceb9fe1a85ec53ULL;
+    h2 ^= (h2 >> 33);
+
+    // Avoid h2 == 0 to prevent all combined hashes becoming identical.
+    if (h2 == 0) {
+        h2 = 0x9e3779b97f4a7c15ULL; // arbitrary odd constant
+    }
+}
+
+void BloomFilter::add(KeyType key) {
+    std::uint64_t h1 = 0;
+    std::uint64_t h2 = 0;
+    computeBaseHashes(key, h1, h2);
+
+    for (std::size_t i = 0; i < hashCount; ++i) {
+        const std::uint64_t combined = h1 + i * h2;
+        const std::size_t bitIndex =
+            static_cast<std::size_t>(combined % static_cast<std::uint64_t>(bitCount));
+        setBit(bitIndex);
+    }
+}
+
+bool BloomFilter::mightContain(KeyType key) const {
+    std::uint64_t h1 = 0;
+    std::uint64_t h2 = 0;
+    computeBaseHashes(key, h1, h2);
+
+    for (std::size_t i = 0; i < hashCount; ++i) {
+        const std::uint64_t combined = h1 + i * h2;
+        const std::size_t bitIndex =
+            static_cast<std::size_t>(combined % static_cast<std::uint64_t>(bitCount));
+        if (!getBit(bitIndex)) {
+            // one bit is 0 -> key definitely not present (FILTERED)
+            return false;
+        }
+    }
+    // all bits are 1 -> key might be present (PASSED - could be false positive)
+    return true;
+}
+
+} // namespace NES::Nautilus::Interface

--- a/nes-nautilus/src/Nautilus/Interface/Hash/CMakeLists.txt
+++ b/nes-nautilus/src/Nautilus/Interface/Hash/CMakeLists.txt
@@ -13,4 +13,5 @@
 add_source_files(nes-nautilus
         HashFunction.cpp
         MurMur3HashFunction.cpp
+        BloomFilter.cpp
         )

--- a/nes-nautilus/tests/CMakeLists.txt
+++ b/nes-nautilus/tests/CMakeLists.txt
@@ -27,3 +27,6 @@ target_link_libraries(chained-hashmap-unit-tests nes-nautilus-test-util)
 
 add_nes_unit_test(chained-hashmap-unit-tests-custom-value "UnitTests/ChainedHashMapCustomValueTest.cpp")
 target_link_libraries(chained-hashmap-unit-tests-custom-value nes-nautilus-test-util)
+
+add_nes_unit_test(bloom-filter-unit-tests "UnitTests/BloomFilterTest.cpp")
+target_link_libraries(bloom-filter-unit-tests nes-nautilus-test-util)

--- a/nes-nautilus/tests/UnitTests/BloomFilterTest.cpp
+++ b/nes-nautilus/tests/UnitTests/BloomFilterTest.cpp
@@ -1,0 +1,172 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <cstddef>
+#include <cstdint>
+#include <Nautilus/Interface/Hash/BloomFilter.hpp>
+#include <Util/Logger/LogLevel.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <Util/Logger/impl/NesLogger.hpp>
+#include <gtest/gtest.h>
+#include <BaseUnitTest.hpp>
+
+namespace NES::Nautilus::Interface
+{
+
+class BloomFilterTest : public Testing::BaseUnitTest
+{
+public:
+    static void SetUpTestCase()
+    {
+        Logger::setupLogging("BloomFilterTest.log", LogLevel::LOG_DEBUG);
+        NES_INFO("Setup BloomFilterTest class.");
+    }
+
+    static void TearDownTestCase() { NES_INFO("Tear down BloomFilterTest class."); }
+};
+
+TEST_F(BloomFilterTest, noFalseNegatives)
+{
+    constexpr std::size_t numKeys = 1000;
+    constexpr double fpRate = 0.01;
+
+    BloomFilter filter(numKeys, fpRate);
+
+    for (std::uint64_t key = 0; key < numKeys; ++key)
+    {
+        filter.add(key);
+    }
+
+    for (std::uint64_t key = 0; key < numKeys; ++key)
+    {
+        ASSERT_TRUE(filter.mightContain(key)) << "False negative for key " << key;
+    }
+}
+
+TEST_F(BloomFilterTest, clearResetsFilter)
+{
+    constexpr std::size_t numKeys = 100;
+    constexpr double fpRate = 0.01;
+
+    BloomFilter filter(numKeys, fpRate);
+
+    for (std::uint64_t key = 0; key < numKeys; ++key)
+    {
+        filter.add(key);
+    }
+
+    for (std::uint64_t key = 0; key < numKeys; ++key)
+    {
+        ASSERT_TRUE(filter.mightContain(key)) << "Key " << key << " should be present before clear";
+    }
+
+    filter.clear();
+
+    for (std::uint64_t key = 0; key < numKeys; ++key)
+    {
+        ASSERT_FALSE(filter.mightContain(key)) << "Key " << key << " should not be present after clear";
+    }
+}
+
+TEST_F(BloomFilterTest, falsePositiveRateSanity)
+{
+    constexpr std::size_t numInserted = 1000;
+    constexpr std::size_t numQueries = 10000;
+    constexpr double configuredFpRate = 0.01;
+    constexpr double maxAcceptableFpRate = 0.05;
+
+    BloomFilter filter(numInserted, configuredFpRate);
+
+    for (std::uint64_t key = 0; key < numInserted; ++key)
+    {
+        filter.add(key);
+    }
+
+    std::size_t falsePositives = 0;
+    constexpr std::uint64_t queryOffset = 1000000;
+
+    for (std::uint64_t i = 0; i < numQueries; ++i)
+    {
+        std::uint64_t key = queryOffset + i;
+        if (filter.mightContain(key))
+        {
+            ++falsePositives;
+        }
+    }
+
+    const double actualFpRate = static_cast<double>(falsePositives) / static_cast<double>(numQueries);
+
+    ASSERT_LE(actualFpRate, maxAcceptableFpRate)
+        << "False positive rate " << actualFpRate << " exceeds threshold " << maxAcceptableFpRate;
+
+    NES_INFO("False positive rate: {} (configured: {})", actualFpRate, configuredFpRate);
+}
+
+TEST_F(BloomFilterTest, edgeCaseZeroExpectedEntries)
+{
+    BloomFilter filter(0, 0.01);
+
+    ASSERT_GT(filter.sizeInBits(), 0) << "Filter should have non-zero size even with 0 expected entries";
+    ASSERT_GT(filter.hashFunctionCount(), 0) << "Filter should have at least one hash function";
+
+    filter.add(42);
+    ASSERT_TRUE(filter.mightContain(42));
+}
+
+TEST_F(BloomFilterTest, edgeCaseInvalidFalsePositiveRate)
+{
+    BloomFilter filter1(100, -0.5);
+    ASSERT_GT(filter1.sizeInBits(), 0) << "Filter should handle negative FP rate";
+
+    BloomFilter filter2(100, 0.0);
+    ASSERT_GT(filter2.sizeInBits(), 0) << "Filter should handle zero FP rate";
+
+    BloomFilter filter3(100, 1.0);
+    ASSERT_GT(filter3.sizeInBits(), 0) << "Filter should handle FP rate = 1.0";
+
+    BloomFilter filter4(100, 1.5);
+    ASSERT_GT(filter4.sizeInBits(), 0) << "Filter should handle FP rate > 1.0";
+}
+
+TEST_F(BloomFilterTest, sameKeyMultipleInserts)
+{
+    constexpr std::size_t numKeys = 100;
+    constexpr double fpRate = 0.01;
+
+    BloomFilter filter(numKeys, fpRate);
+
+    constexpr std::uint64_t key = 42;
+
+    filter.add(key);
+    filter.add(key);
+    filter.add(key);
+
+    ASSERT_TRUE(filter.mightContain(key)) << "Key should still be present after multiple inserts";
+}
+
+TEST_F(BloomFilterTest, gettersReturnReasonableValues)
+{
+    constexpr std::size_t numKeys = 1000;
+    constexpr double fpRate = 0.01;
+
+    BloomFilter filter(numKeys, fpRate);
+
+    ASSERT_GT(filter.sizeInBits(), 0) << "Bit count should be positive";
+    ASSERT_GT(filter.hashFunctionCount(), 0) << "Hash function count should be positive";
+
+    NES_INFO("For {} entries with FP rate {}: m={} bits, k={} hashes",
+             numKeys, fpRate, filter.sizeInBits(), filter.hashFunctionCount());
+}
+
+} // namespace NES::Nautilus::Interface

--- a/nes-physical-operators/CMakeLists.txt
+++ b/nes-physical-operators/CMakeLists.txt
@@ -27,3 +27,7 @@ target_include_directories(nes-physical-operators PUBLIC
 create_registries_for_component(PhysicalFunction AggregationPhysicalFunction)
 
 add_tests_if_enabled(tests)
+
+if (CMAKE_BUILD_TYPE STREQUAL "Benchmark")
+        add_subdirectory(benchmarks)
+endif ()

--- a/nes-physical-operators/include/Join/NestedLoopJoin/NLJBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/NestedLoopJoin/NLJBuildPhysicalOperator.hpp
@@ -36,8 +36,14 @@ public:
         OperatorHandlerId operatorHandlerId,
         JoinBuildSideType joinBuildSide,
         std::unique_ptr<TimeFunction> timeFunction,
-        std::shared_ptr<TupleBufferRef> bufferRef);
+        std::shared_ptr<TupleBufferRef> bufferRef,
+        const std::vector<std::string>& joinKeyFieldNames,
+        bool bloomFilterEnabled);
 
     void execute(ExecutionContext& executionCtx, Record& record) const override;
+
+private:
+    std::vector<std::string> joinKeyFieldNames;
+    bool bloomFilterEnabled;
 };
 }

--- a/nes-physical-operators/include/Join/NestedLoopJoin/NLJOperatorHandler.hpp
+++ b/nes-physical-operators/include/Join/NestedLoopJoin/NLJOperatorHandler.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -26,6 +27,15 @@
 
 namespace NES
 {
+/// BloomFilter metrics for monitoring join performance
+struct BloomFilterMetrics
+{
+    std::atomic<uint64_t> bloomChecksTotal{0};
+    std::atomic<uint64_t> bloomMisses{0};
+    std::atomic<uint64_t> bloomHits{0};
+    std::atomic<uint64_t> bloomFalsePositives{0};
+};
+
 /// This task models the information for a join window trigger
 struct EmittedNLJWindowTrigger
 {
@@ -45,10 +55,13 @@ public:
     NLJOperatorHandler(
         const std::vector<OriginId>& inputOrigins,
         OriginId outputOriginId,
-        std::unique_ptr<WindowSlicesStoreInterface> sliceAndWindowStore);
+        std::unique_ptr<WindowSlicesStoreInterface> sliceAndWindowStore,
+        bool bloomFilterEnabled = true);
 
     [[nodiscard]] std::function<std::vector<std::shared_ptr<Slice>>(SliceStart, SliceEnd)>
     getCreateNewSlicesFunction(const CreateNewSlicesArguments&) const override;
+    
+    [[nodiscard]] BloomFilterMetrics* getBloomFilterMetrics() const { return const_cast<BloomFilterMetrics*>(&bloomFilterMetrics); }
 
 private:
     void emitSlicesToProbe(
@@ -57,5 +70,8 @@ private:
         const WindowInfo& windowInfo,
         const SequenceData& sequenceData,
         PipelineExecutionContext* pipelineCtx) override;
+
+    bool bloomFilterEnabled;
+    BloomFilterMetrics bloomFilterMetrics;
 };
 }

--- a/nes-physical-operators/include/Join/NestedLoopJoin/NLJProbePhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/NestedLoopJoin/NLJProbePhysicalOperator.hpp
@@ -18,9 +18,12 @@
 #include <memory>
 #include <vector>
 #include <Functions/PhysicalFunction.hpp>
+#include <Join/NestedLoopJoin/NLJOperatorHandler.hpp>
 #include <Join/StreamJoinProbePhysicalOperator.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
+#include <Nautilus/Interface/Hash/BloomFilter.hpp>
+#include <Nautilus/Interface/Hash/BloomFilterRef.hpp>
 #include <Nautilus/Interface/PagedVector/PagedVectorRef.hpp>
 #include <Nautilus/Interface/Record.hpp>
 #include <Nautilus/Interface/RecordBuffer.hpp>
@@ -41,8 +44,8 @@ public:
         const JoinSchema& joinSchema,
         std::shared_ptr<TupleBufferRef> leftMemoryProvider,
         std::shared_ptr<TupleBufferRef> rightMemoryProvider,
-        std::vector<Record::RecordFieldIdentifier> leftKeyFieldNames,
-        std::vector<Record::RecordFieldIdentifier> rightKeyFieldNames);
+        const std::vector<std::string>& leftKeyFieldNames,
+        const std::vector<std::string>& rightKeyFieldNames);
 
     void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
 
@@ -52,14 +55,13 @@ protected:
         const PagedVectorRef& innerPagedVector,
         TupleBufferRef& outerMemoryProvider,
         TupleBufferRef& innerMemoryProvider,
-        const std::vector<Record::RecordFieldIdentifier>& outerKeyFieldNames,
-        const std::vector<Record::RecordFieldIdentifier>& innerKeyFieldNames,
         ExecutionContext& executionCtx,
         const nautilus::val<Timestamp>& windowStart,
-        const nautilus::val<Timestamp>& windowEnd) const;
+        const nautilus::val<Timestamp>& windowEnd,
+        const nautilus::val<const Nautilus::Interface::BloomFilter*>& innerBloomFilterPtr) const;
     std::shared_ptr<TupleBufferRef> leftMemoryProvider;
     std::shared_ptr<TupleBufferRef> rightMemoryProvider;
-    std::vector<Record::RecordFieldIdentifier> leftKeyFieldNames;
-    std::vector<Record::RecordFieldIdentifier> rightKeyFieldNames;
+    std::vector<std::string> leftKeyFieldNames;
+    std::vector<std::string> rightKeyFieldNames;
 };
 }

--- a/nes-physical-operators/include/Join/NestedLoopJoin/NLJSlice.hpp
+++ b/nes-physical-operators/include/Join/NestedLoopJoin/NLJSlice.hpp
@@ -19,6 +19,8 @@
 #include <vector>
 #include <Identifiers/Identifiers.hpp>
 #include <Join/StreamJoinUtil.hpp>
+#include <Nautilus/Interface/Hash/BloomFilter.hpp>
+#include <Nautilus/Interface/Hash/BloomFilterRef.hpp>
 #include <Nautilus/Interface/PagedVector/PagedVector.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <SliceStore/Slice.hpp>
@@ -26,11 +28,16 @@
 namespace NES
 {
 
+struct BloomFilterMetrics;
+
 /// This class represents a single slice for the NestedLoopJoin. It stores all tuples for the left and right stream.
 class NLJSlice final : public Slice
 {
 public:
-    NLJSlice(SliceStart sliceStart, SliceEnd sliceEnd, uint64_t numberOfWorkerThreads);
+    NLJSlice(SliceStart sliceStart, SliceEnd sliceEnd, uint64_t numberOfWorkerThreads, BloomFilterMetrics* metrics = nullptr);
+
+    /// Set join key field names for BloomFilter hashing (called before combinePagedVectors)
+    void setJoinKeyFieldNames(const std::vector<std::string>& leftKeyFields, const std::vector<std::string>& rightKeyFields);
 
     /// Returns the number of tuples in this slice on either side.
     [[nodiscard]] uint64_t getNumberOfTuplesLeft() const;
@@ -42,11 +49,46 @@ public:
     [[nodiscard]] PagedVector* getPagedVectorRef(WorkerThreadId workerThreadId, JoinBuildSideType joinBuildSide) const;
 
     /// Moves all tuples in this slice to the PagedVector at 0th index on both sides.
-    void combinePagedVectors();
+    /// Also creates BloomFilters for both sides to optimize join probing (if enabled).
+    void combinePagedVectors(bool bloomFilterEnabled = true);
+
+    /// Returns the BloomFilter for the specified join side (may be null if not built)
+    [[nodiscard]] Nautilus::Interface::BloomFilter* getBloomFilter(JoinBuildSideType joinBuildSide) const;
+
+    /// Returns a Nautilus-native BloomFilterRef for use in JIT-compiled code.
+    [[nodiscard]] Nautilus::Interface::BloomFilterRef getBloomFilterRef(JoinBuildSideType joinBuildSide) const;
+
+    /// This method is called from the BUILD phase for each inserted record
+    void addToBloomFilter(uint64_t hash, JoinBuildSideType buildSide);
+
+    // TODO: Future optimization - currently unused but prepared for hash reuse
+    // in PROBE phase to avoid redundant hash computations
+    /// Stores precomputed join-key hashes per side for later probe optimization.
+    void storeJoinKeyHash(uint64_t hash, JoinBuildSideType buildSide);
+
+    /// Expose stored hashes for subsequent integration steps.
+    [[nodiscard]] const std::vector<uint64_t>& getLeftJoinKeyHashes() const;
+    [[nodiscard]] const std::vector<uint64_t>& getRightJoinKeyHashes() const;
 
 private:
     std::vector<std::unique_ptr<PagedVector>> leftPagedVectors;
     std::vector<std::unique_ptr<PagedVector>> rightPagedVectors;
     std::mutex combinePagedVectorsMutex;
+
+    /// Join key field names for BloomFilter hashing
+    std::vector<std::string> leftJoinKeyFields;
+    std::vector<std::string> rightJoinKeyFields;
+
+    /// Stored precomputed join-key hashes gathered during BUILD phase.
+    std::vector<uint64_t> leftJoinKeyHashes;
+    std::vector<uint64_t> rightJoinKeyHashes;
+
+    /// BloomFilters for left and right side (created during combinePagedVectors)
+    std::unique_ptr<Nautilus::Interface::BloomFilter> leftBloomFilter;
+    std::unique_ptr<Nautilus::Interface::BloomFilter> rightBloomFilter;
+
+    
+    /// Metrics tracking pointer (optional, may be null)
+    BloomFilterMetrics* bloomFilterMetrics;
 };
 }

--- a/nes-physical-operators/src/Join/NestedLoopJoin/NLJBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/NestedLoopJoin/NLJBuildPhysicalOperator.cpp
@@ -20,6 +20,8 @@
 #include <Join/StreamJoinBuildPhysicalOperator.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
+#include <Nautilus/Interface/Hash/HashFunction.hpp>
+#include <Nautilus/Interface/Hash/MurMur3HashFunction.hpp>
 #include <Nautilus/Interface/PagedVector/PagedVectorRef.hpp>
 #include <Nautilus/Interface/Record.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
@@ -46,12 +48,22 @@ SliceEnd getNLJSliceEndProxy(const NLJSlice* nljSlice)
     return nljSlice->getSliceEnd();
 }
 
+void addJoinKeyHashToSliceProxy(NLJSlice* nljSlice, const uint64_t hash, const JoinBuildSideType joinBuildSide)
+{
+    PRECONDITION(nljSlice != nullptr, "nlj slice pointer should not be null!");
+    nljSlice->addToBloomFilter(hash, joinBuildSide);
+}
+
 NLJBuildPhysicalOperator::NLJBuildPhysicalOperator(
     const OperatorHandlerId operatorHandlerId,
     const JoinBuildSideType joinBuildSide,
     std::unique_ptr<TimeFunction> timeFunction,
-    std::shared_ptr<TupleBufferRef> bufferRef)
-    : StreamJoinBuildPhysicalOperator(operatorHandlerId, joinBuildSide, std::move(timeFunction), std::move(bufferRef))
+    std::shared_ptr<TupleBufferRef> bufferRef,
+    const std::vector<std::string>& joinKeyFieldNames,
+    const bool bloomFilterEnabled)
+    : StreamJoinBuildPhysicalOperator(operatorHandlerId, joinBuildSide, std::move(timeFunction), std::move(bufferRef)),
+      joinKeyFieldNames(joinKeyFieldNames),
+      bloomFilterEnabled(bloomFilterEnabled)
 {
 }
 
@@ -87,5 +99,25 @@ void NLJBuildPhysicalOperator::execute(ExecutionContext& executionCtx, Record& r
     /// Write record to the pagedVector
     const PagedVectorRef pagedVectorRef(nljPagedVectorMemRef, bufferRef);
     pagedVectorRef.writeRecord(record, executionCtx.pipelineMemoryProvider.bufferProvider);
+
+    /// Compute join-key hash for BloomFilter integration and store it in the slice.
+    /// Only create BloomFilter if enabled to avoid unnecessary overhead.
+    if (bloomFilterEnabled && !joinKeyFieldNames.empty())
+    {
+        std::vector<VarVal> joinKeyValues;
+        joinKeyValues.reserve(joinKeyFieldNames.size());
+
+        for (const auto& joinKeyFieldName : joinKeyFieldNames)
+        {
+            PRECONDITION(record.hasField(joinKeyFieldName), "Join key field should be present in record");
+            joinKeyValues.push_back(record.read(joinKeyFieldName));
+        }
+
+        MurMur3HashFunction murMur3HashFunction;
+        const HashFunction& hashFunction = murMur3HashFunction;
+        const auto joinKeyHash = hashFunction.calculate(joinKeyValues);
+
+        invoke(addJoinKeyHashToSliceProxy, sliceReference, joinKeyHash, nautilus::val<JoinBuildSideType>(joinBuildSide));
+    }
 }
 }

--- a/nes-physical-operators/src/Join/NestedLoopJoin/NLJOperatorHandler.cpp
+++ b/nes-physical-operators/src/Join/NestedLoopJoin/NLJOperatorHandler.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstring>
 #include <functional>
 #include <memory>
 #include <utility>
@@ -38,8 +39,10 @@ namespace NES
 NLJOperatorHandler::NLJOperatorHandler(
     const std::vector<OriginId>& inputOrigins,
     const OriginId outputOriginId,
-    std::unique_ptr<WindowSlicesStoreInterface> sliceAndWindowStore)
-    : StreamJoinOperatorHandler(inputOrigins, outputOriginId, std::move(sliceAndWindowStore))
+    std::unique_ptr<WindowSlicesStoreInterface> sliceAndWindowStore,
+    bool bloomFilterEnabled)
+    : StreamJoinOperatorHandler(inputOrigins, outputOriginId, std::move(sliceAndWindowStore)),
+      bloomFilterEnabled(bloomFilterEnabled)
 {
 }
 
@@ -50,11 +53,12 @@ NLJOperatorHandler::getCreateNewSlicesFunction(const CreateNewSlicesArguments&) 
         numberOfWorkerThreads > 0, "Number of worker threads not set for window based operator. Was setWorkerThreads() being called?");
     return std::function(
         [numberOfWorkerThreads = numberOfWorkerThreads,
-         outputOriginId = outputOriginId](SliceStart sliceStart, SliceEnd sliceEnd) -> std::vector<std::shared_ptr<Slice>>
+         outputOriginId = outputOriginId,
+         metricsPtr = const_cast<BloomFilterMetrics*>(&bloomFilterMetrics)](SliceStart sliceStart, SliceEnd sliceEnd) -> std::vector<std::shared_ptr<Slice>>
         {
             NES_TRACE(
                 "Creating new NLJ slice for sliceStart {} and sliceEnd {} for output origin {}", sliceStart, sliceEnd, outputOriginId);
-            return {std::make_shared<NLJSlice>(sliceStart, sliceEnd, numberOfWorkerThreads)};
+            return {std::make_shared<NLJSlice>(sliceStart, sliceEnd, numberOfWorkerThreads, metricsPtr)};
         });
 }
 
@@ -68,8 +72,9 @@ void NLJOperatorHandler::emitSlicesToProbe(
     auto& nljSliceLeft = dynamic_cast<NLJSlice&>(sliceLeft);
     auto& nljSliceRight = dynamic_cast<NLJSlice&>(sliceRight);
 
-    nljSliceLeft.combinePagedVectors();
-    nljSliceRight.combinePagedVectors();
+    nljSliceLeft.combinePagedVectors(bloomFilterEnabled);
+    nljSliceRight.combinePagedVectors(bloomFilterEnabled);
+
     const auto totalNumberOfTuples = nljSliceLeft.getNumberOfTuplesLeft() + nljSliceRight.getNumberOfTuplesRight();
 
     auto tupleBuffer = pipelineCtx->getBufferManager()->getBufferBlocking();

--- a/nes-physical-operators/src/Join/NestedLoopJoin/NLJProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/NestedLoopJoin/NLJProbePhysicalOperator.cpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <utility>
 #include <vector>
+#include <iostream>
 #include <Functions/PhysicalFunction.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Join/NestedLoopJoin/NLJOperatorHandler.hpp>
@@ -25,6 +26,9 @@
 #include <Join/StreamJoinProbePhysicalOperator.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Nautilus/Interface/BufferRef/TupleBufferRef.hpp>
+#include <Nautilus/Interface/Hash/BloomFilterRef.hpp>
+#include <Nautilus/Interface/Hash/HashFunction.hpp>
+#include <Nautilus/Interface/Hash/MurMur3HashFunction.hpp>
 #include <Nautilus/Interface/NESStrongTypeRef.hpp>
 #include <Nautilus/Interface/PagedVector/PagedVectorRef.hpp>
 #include <Nautilus/Interface/Record.hpp>
@@ -70,11 +74,11 @@ Timestamp getNLJWindowEndProxy(const EmittedNLJWindowTrigger* nljWindowTriggerTa
     return nljWindowTriggerTask->windowInfo.windowEnd;
 }
 
-SliceEnd getNLJSliceEndProxy(const EmittedNLJWindowTrigger* nljWindowTriggerTask, const JoinBuildSideType joinBuildSide)
+SliceEnd getNLJSliceEndProxy(const EmittedNLJWindowTrigger* nljWindowTriggerTask, const JoinBuildSideType joinBuildSideType)
 {
     PRECONDITION(nljWindowTriggerTask != nullptr, "nljWindowTriggerTask should not be null");
 
-    switch (joinBuildSide)
+    switch (joinBuildSideType)
     {
         case JoinBuildSideType::Left:
             return nljWindowTriggerTask->leftSliceEnd;
@@ -82,6 +86,13 @@ SliceEnd getNLJSliceEndProxy(const EmittedNLJWindowTrigger* nljWindowTriggerTask
             return nljWindowTriggerTask->rightSliceEnd;
     }
     std::unreachable();
+}
+
+// Proxy to get BloomFilter pointer from a slice 
+const Nautilus::Interface::BloomFilter* getBloomFilterProxy(const NLJSlice* slice, JoinBuildSideType joinBuildSide)
+{
+    PRECONDITION(slice != nullptr, "slice should not be null");
+    return slice->getBloomFilter(joinBuildSide);
 }
 }
 
@@ -92,13 +103,13 @@ NLJProbePhysicalOperator::NLJProbePhysicalOperator(
     const JoinSchema& joinSchema,
     std::shared_ptr<TupleBufferRef> leftMemoryProvider,
     std::shared_ptr<TupleBufferRef> rightMemoryProvider,
-    std::vector<Record::RecordFieldIdentifier> leftKeyFieldNames,
-    std::vector<Record::RecordFieldIdentifier> rightKeyFieldNames)
+    const std::vector<std::string>& leftKeyFieldNames,
+    const std::vector<std::string>& rightKeyFieldNames)
     : StreamJoinProbePhysicalOperator(operatorHandlerId, std::move(joinFunction), WindowMetaData(std::move(windowMetaData)), joinSchema)
     , leftMemoryProvider(std::move(leftMemoryProvider))
     , rightMemoryProvider(std::move(rightMemoryProvider))
-    , leftKeyFieldNames(std::move(leftKeyFieldNames))
-    , rightKeyFieldNames(std::move(rightKeyFieldNames))
+    , leftKeyFieldNames(leftKeyFieldNames)
+    , rightKeyFieldNames(rightKeyFieldNames)
 {
 }
 
@@ -107,23 +118,49 @@ void NLJProbePhysicalOperator::performNLJ(
     const PagedVectorRef& innerPagedVector,
     TupleBufferRef& outerMemoryProvider,
     TupleBufferRef& innerMemoryProvider,
-    const std::vector<Record::RecordFieldIdentifier>& outerKeyFieldNames,
-    const std::vector<Record::RecordFieldIdentifier>& innerKeyFieldNames,
     ExecutionContext& executionCtx,
     const nautilus::val<Timestamp>& windowStart,
-    const nautilus::val<Timestamp>& windowEnd) const
+    const nautilus::val<Timestamp>& windowEnd,
+    const nautilus::val<const Nautilus::Interface::BloomFilter*>& innerBloomFilterPtr) const
 {
     const auto outerFields = outerMemoryProvider.getAllFieldNames();
     const auto innerFields = innerMemoryProvider.getAllFieldNames();
 
+    // Determine which key field names to use for outer tuples
+    // Check if outer side is left or right by comparing memory provider addresses
+    const auto& outerKeyFieldNames = (&outerMemoryProvider == leftMemoryProvider.get()) ? leftKeyFieldNames : rightKeyFieldNames;
+    
     nautilus::val<uint64_t> outerItemPos(0);
-    for (auto outerIt = outerPagedVector.begin(outerKeyFieldNames); outerIt != outerPagedVector.end(outerKeyFieldNames); ++outerIt)
+    for (auto outerIt = outerPagedVector.begin(outerFields); outerIt != outerPagedVector.end(outerFields); ++outerIt)
     {
+        // Compute hash of outer tuple's join-key fields
+        std::vector<VarVal> outerJoinKeyValues;
+        for (const auto& joinKeyFieldName : outerKeyFieldNames)
+        {
+            PRECONDITION((*outerIt).hasField(joinKeyFieldName), "Join key field should be present in outer record");
+            outerJoinKeyValues.push_back((*outerIt).read(joinKeyFieldName));
+        }
+        
+        MurMur3HashFunction murMur3HashFunction;
+        const HashFunction& hashFunction = murMur3HashFunction;
+        const auto outerJoinKeyHash = hashFunction.calculate(outerJoinKeyValues);
+        
+        // BloomFilter check: skip this outer tuple if inner BloomFilter says it's definitely not present
+        const Nautilus::Interface::BloomFilterRef innerBloomFilter(innerBloomFilterPtr);
+        if (!innerBloomFilter.mightContain(outerJoinKeyHash))
+        {
+            // BloomFilter says this outer tuple's join-key is definitely NOT in the inner side
+            // Skip the entire inner loop for this outer tuple
+            ++outerItemPos;
+            continue;
+        }
+        
+        // This outer tuple MIGHT match (BloomFilter says "maybe"),check inner tuples
         nautilus::val<uint64_t> innerItemPos(0);
-        for (auto innerIt = innerPagedVector.begin(innerKeyFieldNames); innerIt != innerPagedVector.end(innerKeyFieldNames); ++innerIt)
+        for (auto innerIt = innerPagedVector.begin(innerFields); innerIt != innerPagedVector.end(innerFields); ++innerIt)
         {
             const auto joinedKeyFields
-                = createJoinedRecord(*outerIt, *innerIt, windowStart, windowEnd, outerKeyFieldNames, innerKeyFieldNames);
+                = createJoinedRecord(*outerIt, *innerIt, windowStart, windowEnd, outerFields, innerFields);
             if (joinFunction.execute(joinedKeyFields, executionCtx.pipelineMemoryProvider.arena))
             {
                 auto outerRecord = outerPagedVector.readRecord(outerItemPos, outerFields);
@@ -190,32 +227,37 @@ void NLJProbePhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer
     const auto numberOfTuplesLeft = leftPagedVector.getNumberOfTuples();
     const auto numberOfTuplesRight = rightPagedVector.getNumberOfTuples();
 
-    /// Outer loop should have more no. tuples
+    /// Outer loop should have fewer tuples for better performance
+    /// Get BloomFilter from inner side to filter outer tuples
     if (numberOfTuplesLeft < numberOfTuplesRight)
     {
+        // Left is outer, right is inner - use right's BloomFilter to filter left tuples
+        auto rightBloomFilterPtr = invoke(getBloomFilterProxy, sliceRefRight, nautilus::val<JoinBuildSideType>(JoinBuildSideType::Right));
+        
         performNLJ(
             leftPagedVector,
             rightPagedVector,
             *leftMemoryProvider,
             *rightMemoryProvider,
-            leftKeyFieldNames,
-            rightKeyFieldNames,
             executionCtx,
             windowStart,
-            windowEnd);
+            windowEnd,
+            rightBloomFilterPtr);
     }
     else
     {
+        // Right is outer, left is inner - use left's BloomFilter to filter right tuples
+        auto leftBloomFilterPtr = invoke(getBloomFilterProxy, sliceRefLeft, nautilus::val<JoinBuildSideType>(JoinBuildSideType::Left));
+        
         performNLJ(
             rightPagedVector,
             leftPagedVector,
             *rightMemoryProvider,
             *leftMemoryProvider,
-            rightKeyFieldNames,
-            leftKeyFieldNames,
             executionCtx,
             windowStart,
-            windowEnd);
+            windowEnd,
+            leftBloomFilterPtr);
     }
 }
 

--- a/nes-physical-operators/src/Join/NestedLoopJoin/NLJSlice.cpp
+++ b/nes-physical-operators/src/Join/NestedLoopJoin/NLJSlice.cpp
@@ -13,21 +13,27 @@
 */
 
 #include <Join/NestedLoopJoin/NLJSlice.hpp>
+#include <fstream>
 
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <mutex>
 #include <numeric>
 #include <utility>
 #include <Identifiers/Identifiers.hpp>
+#include <Join/NestedLoopJoin/NLJOperatorHandler.hpp>
 #include <Join/StreamJoinUtil.hpp>
+#include <Nautilus/Interface/Hash/BloomFilter.hpp>
 #include <Nautilus/Interface/PagedVector/PagedVector.hpp>
 #include <SliceStore/Slice.hpp>
+#include <Util/Logger/Logger.hpp>
 
 namespace NES
 {
 
-NLJSlice::NLJSlice(const SliceStart sliceStart, const SliceEnd sliceEnd, const uint64_t numberOfWorkerThreads) : Slice(sliceStart, sliceEnd)
+NLJSlice::NLJSlice(const SliceStart sliceStart, const SliceEnd sliceEnd, const uint64_t numberOfWorkerThreads, BloomFilterMetrics* metrics) 
+    : Slice(sliceStart, sliceEnd), bloomFilterMetrics(metrics)
 {
     for (uint64_t i = 0; i < numberOfWorkerThreads; ++i)
     {
@@ -38,6 +44,13 @@ NLJSlice::NLJSlice(const SliceStart sliceStart, const SliceEnd sliceEnd, const u
     {
         rightPagedVectors.emplace_back(std::make_unique<PagedVector>());
     }
+}
+
+void NLJSlice::setJoinKeyFieldNames(const std::vector<std::string>& leftKeyFields,
+                                    const std::vector<std::string>& rightKeyFields)
+{
+    leftJoinKeyFields = leftKeyFields;
+    rightJoinKeyFields = rightKeyFields;
 }
 
 uint64_t NLJSlice::getNumberOfTuplesLeft() const
@@ -82,7 +95,7 @@ PagedVector* NLJSlice::getPagedVectorRef(const WorkerThreadId workerThreadId, co
     std::unreachable();
 }
 
-void NLJSlice::combinePagedVectors()
+void NLJSlice::combinePagedVectors(const bool bloomFilterEnabled)
 {
     /// Due to the out-of-order nature of our execution engine, it might happen that we call this code here from multiple worker threads.
     /// For example, if different worker threads are emitting the same slice for different windows.
@@ -109,5 +122,91 @@ void NLJSlice::combinePagedVectors()
         }
         rightPagedVectors.erase(rightPagedVectors.begin() + 1, rightPagedVectors.end());
     }
+    
+    if (bloomFilterEnabled)
+    {
+        
+        // Track BloomFilter creation in metrics (BUILD phase tracking)
+        if (bloomFilterMetrics && (leftBloomFilter || rightBloomFilter)) {
+            NES_INFO("BloomFilter BUILD: leftBF={} bits, rightBF={} bits, slice=[{}, {}]",
+                     leftBloomFilter ? leftBloomFilter->sizeInBits() : 0,
+                     rightBloomFilter ? rightBloomFilter->sizeInBits() : 0,
+                     sliceStart, sliceEnd);
+        }
+    }
 }
+
+
+Nautilus::Interface::BloomFilter* NLJSlice::getBloomFilter(const JoinBuildSideType joinBuildSide) const
+{
+    switch (joinBuildSide)
+    {
+        case JoinBuildSideType::Left:
+            return leftBloomFilter.get();
+        case JoinBuildSideType::Right:
+            return rightBloomFilter.get();
+    }
+    std::unreachable();
 }
+
+Nautilus::Interface::BloomFilterRef NLJSlice::getBloomFilterRef(const JoinBuildSideType joinBuildSide) const
+{
+    return Nautilus::Interface::BloomFilterRef(getBloomFilter(joinBuildSide));
+}
+
+void NLJSlice::storeJoinKeyHash(const uint64_t hash, const JoinBuildSideType buildSide)
+{
+    const std::scoped_lock lock(combinePagedVectorsMutex);
+
+    switch (buildSide)
+    {
+        case JoinBuildSideType::Left:
+            leftJoinKeyHashes.push_back(hash);
+            break;
+        case JoinBuildSideType::Right:
+            rightJoinKeyHashes.push_back(hash);
+            break;
+    }
+}
+
+const std::vector<uint64_t>& NLJSlice::getLeftJoinKeyHashes() const
+{
+    return leftJoinKeyHashes;
+}
+
+const std::vector<uint64_t>& NLJSlice::getRightJoinKeyHashes() const
+{
+    return rightJoinKeyHashes;
+}
+
+void NLJSlice::addToBloomFilter(const uint64_t hash, const JoinBuildSideType buildSide)
+{
+    // Initialize BloomFilters on first use (lazy initialization during BUILD phase)
+    constexpr double falsePositiveRate = 0.01;
+    const std::scoped_lock lock(combinePagedVectorsMutex);
+    
+    switch (buildSide)
+    {
+        case JoinBuildSideType::Left:
+            leftJoinKeyHashes.push_back(hash);
+            if (!leftBloomFilter)
+            {
+                // TODO: Improve for dynamic sizing: currently we start with a reasonable default size, but in the future we could use the number of inserted hashes to resize the BloomFilter dynamically during BUILD phase
+                // Estimate: start with reasonable size, will hold 100K elements
+                leftBloomFilter = std::make_unique<Nautilus::Interface::BloomFilter>(100000, falsePositiveRate);
+            }
+            leftBloomFilter->add(hash);
+            break;
+            
+        case JoinBuildSideType::Right:
+            rightJoinKeyHashes.push_back(hash);
+            if (!rightBloomFilter)
+            {
+                rightBloomFilter = std::make_unique<Nautilus::Interface::BloomFilter>(100000, falsePositiveRate);
+            }
+            rightBloomFilter->add(hash);
+            break;
+    }
+}
+
+} // namespace NES

--- a/nes-physical-operators/tests/CMakeLists.txt
+++ b/nes-physical-operators/tests/CMakeLists.txt
@@ -18,3 +18,14 @@ endfunction()
 
 add_nes_physical_operator_test(EmitPhysicalOperatorTest EmitPhysicalOperatorTest.cpp)
 add_nes_physical_operator_test(SliceAssignerTest SliceAssignerTest.cpp)
+
+# BloomFilter minimal categories: integration, correctness, performance
+add_nes_physical_operator_test(BloomFilterNLJTest Join/BloomFilterNLJTest.cpp)
+target_link_libraries(BloomFilterNLJTest nes-nautilus-test-util)
+add_nes_physical_operator_test(BloomFilterE2ETest Join/BloomFilterE2ETest.cpp)
+add_nes_physical_operator_test(NLJBloomFilterMetricsTest Join/NLJBloomFilterMetricsTest.cpp)
+
+# Performance
+add_nes_physical_operator_test(NLJBloomFilterPerformanceTest Join/NLJBloomFilterPerformanceTest.cpp)
+target_link_libraries(NLJBloomFilterPerformanceTest nes-nautilus-test-util)
+

--- a/nes-physical-operators/tests/Join/BloomFilterE2ETest.cpp
+++ b/nes-physical-operators/tests/Join/BloomFilterE2ETest.cpp
@@ -1,0 +1,113 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <gtest/gtest.h>
+#include <Join/NestedLoopJoin/NLJSlice.hpp>
+#include <Nautilus/Interface/Hash/BloomFilter.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <Util/Logger/LogLevel.hpp>
+#include <chrono>
+#include <iostream>
+#include <random>
+
+namespace NES
+{
+
+class BloomFilterE2ETest : public testing::Test
+{
+public:
+    static void SetUpTestSuite()
+    {
+        Logger::setupLogging("BloomFilterE2ETest.log", LogLevel::LOG_DEBUG);
+        NES_INFO("Setup BloomFilterE2ETest class.");
+    }
+
+    static void TearDownTestSuite()
+    {
+        NES_INFO("Tear down BloomFilterE2ETest class.");
+    }
+
+
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+    }
+};
+
+/**
+ * CORRECTNESS TEST: verify BloomFilter filtering preserves join correctness.
+ */
+TEST_F(BloomFilterE2ETest, CorrectnessValidation)
+{
+    const uint64_t totalItems = 1000;
+    const uint64_t matchingItems = 50;
+
+    std::cout << "\nCorrectness Validation " << std::endl;
+
+    // Build BloomFilter with items 0-49
+    constexpr double falsePositiveRate = 0.01;
+    Nautilus::Interface::BloomFilter filter(matchingItems, falsePositiveRate);
+
+    for (uint64_t i = 0; i < matchingItems; ++i)
+    {
+        filter.add(i);
+    }
+
+    // Get filtered positions
+    std::vector<uint64_t> filtered;
+    for (uint64_t i = 0; i < totalItems; ++i)
+    {
+        if (filter.mightContain(i))
+        {
+            filtered.push_back(i);
+        }
+    }
+
+    // Verify all matching items are included (no false negatives)
+    for (uint64_t i = 0; i < matchingItems; ++i)
+    {
+        EXPECT_TRUE(std::find(filtered.begin(), filtered.end(), i) != filtered.end())
+            << "Matching item " << i << " should be in filtered set (no false negatives allowed)";
+    }
+
+    // Count false positives
+    uint64_t falsePositives = 0;
+    for (uint64_t pos : filtered)
+    {
+        if (pos >= matchingItems)
+        {
+            falsePositives++;
+        }
+    }
+
+    const double measuredFPR = static_cast<double>(falsePositives) / (totalItems - matchingItems);
+    
+    std::cout << "Matching items: " << matchingItems << std::endl;
+    std::cout << "Filtered set size: " << filtered.size() << std::endl;
+    std::cout << "False positives: " << falsePositives << std::endl;
+    std::cout << "Measured FPR: " << (measuredFPR * 100) << "%" << std::endl;
+
+    EXPECT_LE(measuredFPR, 0.03) 
+        << "False positive rate should be close to configured 1% (allowing 3% due to randomness)";
+    EXPECT_EQ(filtered.size() - matchingItems, falsePositives)
+        << "Filtered set should contain exactly matching items + false positives";
+
+    std::cout << "Correctness verified: No false negatives, acceptable false positive rate" << std::endl;
+}
+
+} // namespace NES

--- a/nes-physical-operators/tests/Join/BloomFilterNLJTest.cpp
+++ b/nes-physical-operators/tests/Join/BloomFilterNLJTest.cpp
@@ -1,0 +1,111 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <gtest/gtest.h>
+#include <Join/NestedLoopJoin/NLJSlice.hpp>
+#include <Join/StreamJoinUtil.hpp>
+#include <Nautilus/Interface/Hash/BloomFilter.hpp>
+#include <Time/Timestamp.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <Util/Logger/LogLevel.hpp>
+#include <NautilusTestUtils.hpp>
+#include <PagedVectorTestUtils.hpp>
+
+namespace NES
+{
+
+class BloomFilterNLJTest : public testing::Test, public TestUtils::NautilusTestUtils
+{
+public:
+    static void SetUpTestSuite()
+    {
+        Logger::setupLogging("BloomFilterNLJTest.log", LogLevel::LOG_DEBUG);
+        NES_INFO("Setup BloomFilterNLJTest class.");
+    }
+
+    static void TearDownTestSuite()
+    {
+        NES_INFO("Tear down BloomFilterNLJTest class.");
+    }
+
+
+protected:
+    void SetUp() override 
+    {
+        bufferManager = BufferManager::create();
+        schema = Schema{}.addField("id", DataType::Type::UINT64);
+        
+        // Setup NautilusEngine for PagedVector operations
+        nautilus::engine::Options options;
+        options.setOption("engine.Compilation", false); // Use interpreter for faster tests
+        nautilusEngine = std::make_unique<nautilus::engine::NautilusEngine>(options);
+    }
+    
+    void TearDown() override 
+    {
+        bufferManager.reset();
+        nautilusEngine.reset();
+    }
+    
+    std::shared_ptr<BufferManager> bufferManager;
+    Schema schema;
+    std::unique_ptr<nautilus::engine::NautilusEngine> nautilusEngine;
+};
+
+/**
+ * @brief Integration TEST: Verify BUILD phase creates accessible BloomFilter references
+ *
+ * Minimal integration coverage for NLJ + BloomFilter:
+ * - create NLJSlice
+ * - store tuples on both sides
+ * - run combinePagedVectors()
+ * - fetch BloomFilterRef for both build sides
+ */
+TEST_F(BloomFilterNLJTest, BuildPhase_BloomFilterRefAccess)
+{
+    std::cout << "\nBUILD Phase Test: BloomFilterRef Access" << std::endl;
+    
+    NLJSlice slice(Timestamp(0), Timestamp(100), 1);
+    
+    // Add tuples to both sides
+    const uint64_t tupleCount = 30;
+    auto records = createMonotonicallyIncreasingValues(
+        schema, MemoryLayoutType::ROW_LAYOUT, tupleCount, *bufferManager);
+    
+    PagedVector* leftPagedVector = slice.getPagedVectorRefLeft(WorkerThreadId(0));
+    PagedVector* rightPagedVector = slice.getPagedVectorRefRight(WorkerThreadId(0));
+    
+    constexpr auto pageSize = 4096;
+    const auto projections = schema.getFieldNames();
+    
+    TestUtils::runStoreTest(*leftPagedVector, schema, MemoryLayoutType::ROW_LAYOUT, 
+                            pageSize, projections, records, *nautilusEngine, *bufferManager);
+    TestUtils::runStoreTest(*rightPagedVector, schema, MemoryLayoutType::ROW_LAYOUT,
+                            pageSize, projections, records, *nautilusEngine, *bufferManager);
+    
+    slice.combinePagedVectors();
+    
+    // Get BloomFilterRef, this is what performNLJ() use
+    Nautilus::Interface::BloomFilterRef leftRef = slice.getBloomFilterRef(JoinBuildSideType::Left);
+    Nautilus::Interface::BloomFilterRef rightRef = slice.getBloomFilterRef(JoinBuildSideType::Right);
+    
+    std::cout << "BloomFilterRef for LEFT obtained" << std::endl;
+    std::cout << "BloomFilterRef for RIGHT obtained" << std::endl;
+    std::cout << "Ready for use in performNLJ() JIT-compiled code\n" << std::endl;
+    
+    // We cannot evaluate BloomFilterRef.mightContain() directly here because it expects
+    // Nautilus val<uint64_t>. Accessing both refs without errors validates integration wiring.
+}
+
+} // namespace NES

--- a/nes-physical-operators/tests/Join/BloomFilterSelectivityTest.cpp
+++ b/nes-physical-operators/tests/Join/BloomFilterSelectivityTest.cpp
@@ -1,0 +1,240 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Nautilus/Interface/Hash/BloomFilter.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <gtest/gtest.h>
+#include <BaseUnitTest.hpp>
+#include <chrono>
+#include <random>
+#include <vector>
+#include <algorithm>
+#include <cmath>
+
+namespace NES
+{
+
+/**
+ * @brief Test BloomFilter performance with different join selectivity rates
+ * Selectivity shows how many outer tuples can actually match inner tuples.
+ * - Sparse 1%: Few matching tuples : BloomFilter is helpful
+ * - Medium 10%: Some matches : BloomFilter still helpful
+ * - Dense 50%: Many matches : BloomFilter less helpful
+ */
+class BloomFilterSelectivityTest : public Testing::BaseUnitTest
+{
+public:
+    static void SetUpTestCase()
+    {
+        Logger::setupLogging("BloomFilterSelectivityTest.log", LogLevel::LOG_INFO);
+    }
+
+    static void TearDownTestCase() { }
+};
+
+TEST_F(BloomFilterSelectivityTest, SelectivityImpactWithRandomIDs)
+{
+    // Test: Messe BloomFilter-Speedup bei verschiedenen Join-Selectivity Raten
+    // Nutze RANDOM IDs
+    // Kleinere Datenmengen für schnelle Test-Ausführung / kann erhöht werden
+
+    constexpr uint64_t innerTupleCount = 50000;   
+    constexpr uint64_t outerTupleCount = 50000;   
+    constexpr double fpRate = 0.01; 
+    constexpr size_t repetitions = 1;
+
+    const double selectivities[] = {0.01, 0.10, 0.50};
+    const char* selectivityNames[] = {"Sparse (1%)", "Medium (10%)", "Dense (50%)"};
+
+    NES_INFO("BloomFilter Selectivity Impact Test");
+    NES_INFO("Inner tuples: {}", innerTupleCount);
+    NES_INFO("Outer tuples: {}", outerTupleCount);
+    NES_INFO("FP Rate: {}%", fpRate * 100.0);
+    NES_INFO("Testing different join selectivity rates with RANDOM IDs");
+    NES_INFO("");
+
+    for (size_t s = 0; s < 3; ++s)
+    {
+        double selectivity = selectivities[s];
+        const char* name = selectivityNames[s];
+
+        NES_INFO(" Scenario: {} ", name);
+
+        // Generate random IDs for inner side
+        std::mt19937 rng(42);
+        std::uniform_int_distribution<uint64_t> idDist(0, UINT64_MAX);
+
+        std::vector<uint64_t> innerIDs;
+        innerIDs.reserve(innerTupleCount);
+        for (uint64_t i = 0; i < innerTupleCount; ++i)
+        {
+            innerIDs.push_back(idDist(rng));
+        }
+
+        // Generate outer IDs: some match inner (selectivity %), rest are random misses
+        std::vector<uint64_t> outerIDs;
+        outerIDs.reserve(outerTupleCount);
+        uint64_t matchingOuterTuples = static_cast<uint64_t>(outerTupleCount * selectivity);
+
+        for (uint64_t i = 0; i < outerTupleCount; ++i)
+        {
+
+            if (i < matchingOuterTuples)
+            {
+                // This outer tuple should match (random from inner)
+                uint64_t innerIdx = idDist(rng) % innerTupleCount;
+                outerIDs.push_back(innerIDs[innerIdx]);
+            }
+            else
+
+            {
+                // This outer tuple should NOT match (random ID)
+                outerIDs.push_back(idDist(rng));
+            }
+        }
+
+        // Shuffle outer IDs to mix matching and non-matching
+        std::shuffle(outerIDs.begin(), outerIDs.end(), rng);
+
+        // WITHOUT BloomFilter
+        auto baselineTest = [&]() {
+            uint64_t joinResults = 0;
+            for (uint64_t outerID : outerIDs)
+            {
+                for (uint64_t innerID : innerIDs)
+                {
+                    if (outerID == innerID)
+                    {
+                        joinResults++;
+                    }
+                }
+            }
+            return joinResults;
+        };
+
+        // WITH BloomFilter
+        struct ProbeStats
+        {
+            uint64_t joinResults;
+            uint64_t candidateOuterTuples;
+        };
+
+        auto bloomFilterTest = [&]() {
+            Nautilus::Interface::BloomFilter bloomFilter(innerTupleCount, fpRate);
+
+            // Build phase: add all inner IDs to BloomFilter
+            for (uint64_t innerID : innerIDs)
+            {
+                bloomFilter.add(innerID);
+            }
+
+            // Probe phase: filter outer IDs
+            uint64_t joinResults = 0;
+            uint64_t candidateOuterTuples = 0;
+
+            for (uint64_t outerID : outerIDs)
+            {
+                // Early filtering: if BloomFilter says "no", skip inner loop entirely
+                if (!bloomFilter.mightContain(outerID))
+                {
+                    continue;
+                }
+
+                ++candidateOuterTuples;
+
+                // Only check inner tuples for possibly matching outer IDs
+                for (uint64_t innerID : innerIDs)
+                {
+                    if (outerID == innerID)
+                    {
+                        joinResults++;
+                        break;
+                    }
+                }
+            }
+
+            return ProbeStats{joinResults, candidateOuterTuples};
+        };
+
+        // Verify correctness
+        uint64_t baselineResult = baselineTest();
+        ProbeStats bloomResult = bloomFilterTest();
+        ASSERT_EQ(baselineResult, bloomResult.joinResults)
+            << "Join results should be identical with and without BloomFilter";
+
+        // Measure performance
+        auto baselineTotalNanos = std::chrono::nanoseconds(0);
+        auto bloomTotalNanos = std::chrono::nanoseconds(0);
+
+        volatile uint64_t timingGuard = 0;
+        for (size_t rep = 0; rep < repetitions; ++rep)
+        {
+            auto start = std::chrono::high_resolution_clock::now();
+            timingGuard += baselineTest();
+            auto end = std::chrono::high_resolution_clock::now();
+            baselineTotalNanos += std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+
+            start = std::chrono::high_resolution_clock::now();
+            timingGuard += bloomFilterTest().joinResults;
+            end = std::chrono::high_resolution_clock::now();
+            bloomTotalNanos += std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+        }
+
+        ASSERT_GT(timingGuard, 0U);
+
+        double baselineAvgMs = static_cast<double>(baselineTotalNanos.count()) / 1'000'000.0 / repetitions;
+        double bloomAvgMs = static_cast<double>(bloomTotalNanos.count()) / 1'000'000.0 / repetitions;
+        double speedup = baselineAvgMs / bloomAvgMs;
+        const uint64_t baselineComparisons = outerTupleCount * innerTupleCount;
+        const uint64_t bloomComparisons = bloomResult.candidateOuterTuples * innerTupleCount;
+        const double outerPruning = 100.0 * static_cast<double>(outerTupleCount - bloomResult.candidateOuterTuples)
+            / static_cast<double>(outerTupleCount);
+
+        NES_INFO("Baseline (NO BloomFilter): {:.2f} ms", baselineAvgMs);
+        NES_INFO("WITH BloomFilter: {:.2f} ms", bloomAvgMs);
+        NES_INFO("Speedup: {:.2f}x", speedup);
+        NES_INFO("Candidate outer tuples: {} / {}", bloomResult.candidateOuterTuples, outerTupleCount);
+        NES_INFO("Comparisons: {} -> {}", baselineComparisons, bloomComparisons);
+        NES_INFO("Outer pruning: {:.2f}%", outerPruning);
+        NES_INFO("Join matches: {}", baselineResult);
+        NES_INFO("Expected matches: ~{}", matchingOuterTuples);
+        NES_INFO("");
+
+        // Assertions based on deterministic work reduction (robust across machines)
+        ASSERT_LT(bloomComparisons, baselineComparisons)
+            << "BloomFilter should reduce probe-loop comparisons";
+        ASSERT_LT(bloomResult.candidateOuterTuples, outerTupleCount)
+            << "BloomFilter should prune at least some outer tuples";
+
+        // Different selectivity scenarios should have different pruning behavior
+        if (selectivity == 0.01)
+        {
+            ASSERT_GT(outerPruning, 90.0) << "Sparse joins should prune most outer tuples (>90%)";
+        }
+        else if (selectivity == 0.10)
+        {
+            ASSERT_GT(outerPruning, 70.0) << "Medium joins should prune strongly (>70%)";
+        }
+        else if (selectivity == 0.50)
+        {
+            ASSERT_GT(outerPruning, 30.0) << "Dense joins should still prune a meaningful share (>30%)";
+        }
+    }
+
+    NES_INFO("Summary");
+    NES_INFO("BloomFilter effectiveness scales with selectivity");
+    NES_INFO("");
+}
+
+} // namespace NES

--- a/nes-physical-operators/tests/Join/NLJBloomFilterMetricsTest.cpp
+++ b/nes-physical-operators/tests/Join/NLJBloomFilterMetricsTest.cpp
@@ -1,0 +1,150 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <cstdint>
+#include <Join/NestedLoopJoin/NLJOperatorHandler.hpp>
+#include <Nautilus/Interface/Hash/BloomFilter.hpp>
+#include <Util/Logger/LogLevel.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <Util/Logger/impl/NesLogger.hpp>
+#include <gtest/gtest.h>
+#include <BaseUnitTest.hpp>
+
+namespace NES
+{
+
+/// Minimal test that exercises BloomFilter metrics on synthetic NLJ-like data.
+/// We create two BloomFilters (representing left and right join sides) populated
+/// with different key spaces, then replay the exact host-side metrics counting
+/// logic used in NLJOperatorHandler::emitSlicesToProbe to produce the NES_INFO output.
+class NLJBloomFilterMetricsTest : public Testing::BaseUnitTest
+{
+public:
+    static void SetUpTestSuite()
+    {
+        Logger::setupLogging("NLJBloomFilterMetricsTest.log", LogLevel::LOG_DEBUG);
+        NES_INFO("Setup NLJBloomFilterMetricsTest class.");
+    }
+
+    void SetUp() override { BaseUnitTest::SetUp(); }
+};
+
+TEST_F(NLJBloomFilterMetricsTest, syntheticMetricsOutput)
+{
+    /// --- 1. Create BloomFilters mimicking two join sides ---
+    /// Left side: 20 tuples with keys 0..19
+    /// Right side: 30 tuples with keys 10..39
+    /// Overlap: keys 10..19 (10 keys)
+    /// Non-overlapping left keys: 0..9 (10 keys, should be misses)
+    constexpr uint64_t leftTupleCount = 20;
+    constexpr uint64_t rightTupleCount = 30;
+
+    Nautilus::Interface::BloomFilter rightBloomFilter(rightTupleCount, 0.01);
+    Nautilus::Interface::BloomFilter leftBloomFilter(leftTupleCount, 0.01);
+
+    // Populate right BloomFilter with keys 10..39
+    for (uint64_t i = 10; i < 10 + rightTupleCount; ++i)
+    {
+        rightBloomFilter.add(i);
+    }
+    // Populate left BloomFilter with keys 0..19
+    for (uint64_t i = 0; i < leftTupleCount; ++i)
+    {
+        leftBloomFilter.add(i);
+    }
+
+    /// --- 2. Replay the exact metrics counting logic from NLJOperatorHandler::emitSlicesToProbe ---
+    BloomFilterMetrics bloomFilterMetrics; /// same struct used in NLJOperatorHandler
+
+    uint64_t localChecks = 0;
+    uint64_t localMisses = 0;
+    const char* outerSide = nullptr;
+
+    // left (20) < right (30), so left is outer
+    if (leftTupleCount < rightTupleCount)
+    {
+        outerSide = "left";
+        localChecks = leftTupleCount;
+        // Check each left key against right BloomFilter
+        for (uint64_t i = 0; i < leftTupleCount; ++i)
+        {
+            if (!rightBloomFilter.mightContain(i))
+            {
+                localMisses++;
+            }
+        }
+    }
+    else
+    {
+        outerSide = "right";
+        localChecks = rightTupleCount;
+        for (uint64_t i = 0; i < rightTupleCount; ++i)
+        {
+            if (!leftBloomFilter.mightContain(i))
+            {
+                localMisses++;
+            }
+        }
+    }
+
+    const uint64_t localHits = localChecks - localMisses;
+
+    // Accumulate into thread-safe counters
+    bloomFilterMetrics.bloomChecksTotal.fetch_add(localChecks, std::memory_order_relaxed);
+    bloomFilterMetrics.bloomMisses.fetch_add(localMisses, std::memory_order_relaxed);
+    bloomFilterMetrics.bloomHits.fetch_add(localHits, std::memory_order_relaxed);
+
+    // Simulate false positives: in a real NLJ probe, if bloom says HIT but inner loop finds 0 matches,
+    // that's a false positive. For this synthetic test, assume 2 of the hits were false positives.
+    constexpr uint64_t simulatedFP = 2;
+    bloomFilterMetrics.bloomFalsePositives.fetch_add(simulatedFP, std::memory_order_relaxed);
+
+    /// --- 3. Print the EXACT same NES_INFO lines as NLJOperatorHandler::emitSlicesToProbe ---
+
+    // Per-invocation log
+    if (localMisses > 0 && localChecks > 0)
+    {
+        const double skipRateLocal = (static_cast<double>(localMisses) / localChecks) * 100.0;
+        const uint64_t potentialInnerLoopsSaved =
+            localMisses * (localChecks == leftTupleCount ? rightTupleCount : leftTupleCount);
+        NES_INFO("BloomFilter Analysis: Filtered {} out of {} {} tuples ({:.2f}%) - "
+                 "Potentially saved ~{} inner loop iterations",
+                 localMisses, localChecks, outerSide, skipRateLocal, potentialInnerLoopsSaved);
+    }
+
+    // Cumulative metrics report
+    const uint64_t cumChecks = bloomFilterMetrics.bloomChecksTotal.load(std::memory_order_relaxed);
+    const uint64_t cumMisses = bloomFilterMetrics.bloomMisses.load(std::memory_order_relaxed);
+    const uint64_t cumHits = bloomFilterMetrics.bloomHits.load(std::memory_order_relaxed);
+    const uint64_t cumFP = bloomFilterMetrics.bloomFalsePositives.load(std::memory_order_relaxed);
+    const double skipRate = cumChecks > 0 ? (static_cast<double>(cumMisses) / cumChecks) * 100.0 : 0.0;
+    const double fpRateContext = cumHits > 0 ? (static_cast<double>(cumFP) / cumHits) * 100.0 : 0.0;
+
+    NES_INFO("BloomFilter Metrics [cumulative]: bloom_checks_total={} bloom_misses={} bloom_hits={} "
+             "bloom_false_positives={} skip_rate={:.2f}% fp_rate_context={:.2f}%",
+             cumChecks, cumMisses, cumHits, cumFP, skipRate, fpRateContext);
+
+    /// --- 4. Basic assertions ---
+    // Left keys 0..9 are NOT in right BloomFilter (keys 10..39), so those 10 should be misses.
+    // Left keys 10..19 ARE in right BloomFilter, so those 10 are hits.
+    // (Bloom filters may have false positives but never false negatives, so misses <= 10)
+    EXPECT_GE(localMisses, 0u);
+    EXPECT_LE(localMisses, 10u); // at most 10 definite misses (keys 0..9)
+    EXPECT_EQ(cumChecks, leftTupleCount); // left is outer (20 < 30)
+    EXPECT_EQ(cumChecks, cumMisses + cumHits);
+    EXPECT_EQ(cumFP, simulatedFP);
+
+    NES_INFO("NLJBloomFilterMetricsTest::syntheticMetricsOutput completed successfully");
+}
+}

--- a/nes-physical-operators/tests/Join/NLJBloomFilterPerformanceTest.cpp
+++ b/nes-physical-operators/tests/Join/NLJBloomFilterPerformanceTest.cpp
@@ -1,0 +1,183 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Nautilus/Interface/Hash/BloomFilter.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <Util/Logger/LogLevel.hpp>
+#include <gtest/gtest.h>
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <tuple>
+
+using BloomFilter = NES::Nautilus::Interface::BloomFilter;
+
+namespace {
+
+class NLJBloomFilterPerformanceTestSuite : public testing::Test
+{
+public:
+    static void SetUpTestSuite()
+    {
+        NES::Logger::setupLogging("NLJBloomFilterPerformanceTest.log", NES::LogLevel::LOG_DEBUG);
+        NES_INFO("Setup NLJBloomFilterPerformanceTest class.");
+    }
+
+    static void TearDownTestSuite()
+    {
+        NES_INFO("Tear down NLJBloomFilterPerformanceTest class.");
+    }
+};
+
+struct Scenario
+{
+    const char* name;
+    uint64_t outerTuples;
+    uint64_t innerTuples;
+    uint64_t overlapTuples;
+};
+
+struct ProbeResult
+{
+    uint64_t matchCount;
+    uint64_t probedOuterTuples;
+};
+
+[[nodiscard]] ProbeResult runProbeWithoutBloomFilter(const Scenario& scenario)
+{
+    const uint64_t firstOverlappingOuterPos = scenario.outerTuples - scenario.overlapTuples;
+    uint64_t matchCount = 0;
+    for (uint64_t outerPos = 0; outerPos < scenario.outerTuples; ++outerPos)
+    {
+        for (uint64_t innerPos = 0; innerPos < scenario.innerTuples; ++innerPos)
+        {
+            if (outerPos >= firstOverlappingOuterPos && innerPos == outerPos - firstOverlappingOuterPos)
+            {
+                ++matchCount;
+            }
+        }
+    }
+    return {.matchCount = matchCount, .probedOuterTuples = scenario.outerTuples};
+}
+
+[[nodiscard]] ProbeResult runProbeWithBloomFilter(const Scenario& scenario)
+{
+    const uint64_t firstOverlappingOuterPos = scenario.outerTuples - scenario.overlapTuples;
+    BloomFilter bloomFilter(scenario.overlapTuples, 0.01);
+    for (uint64_t innerPos = 0; innerPos < scenario.overlapTuples; ++innerPos)
+    {
+        bloomFilter.add(firstOverlappingOuterPos + innerPos);
+    }
+
+    uint64_t matchCount = 0;
+    uint64_t probedOuterTuples = 0;
+    for (uint64_t outerPos = 0; outerPos < scenario.outerTuples; ++outerPos)
+    {
+        if (!bloomFilter.mightContain(outerPos))
+        {
+            continue;
+        }
+
+        ++probedOuterTuples;
+        for (uint64_t innerPos = 0; innerPos < scenario.innerTuples; ++innerPos)
+        {
+            if (outerPos >= firstOverlappingOuterPos && innerPos == outerPos - firstOverlappingOuterPos)
+            {
+                ++matchCount;
+            }
+        }
+    }
+    return {.matchCount = matchCount, .probedOuterTuples = probedOuterTuples};
+}
+
+template<typename Fn>
+[[nodiscard]] std::chrono::nanoseconds measureNanos(Fn&& fn, const size_t repetitions)
+{
+    std::chrono::nanoseconds total{0};
+    for (size_t i = 0; i < repetitions; ++i)
+    {
+        const auto start = std::chrono::steady_clock::now();
+        fn();
+        total += std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - start);
+    }
+    return total;
+}
+
+} // namespace
+
+TEST_F(NLJBloomFilterPerformanceTestSuite, ProbeLoopWorkReductionAndTiming)
+{
+    constexpr size_t repetitions = 8;
+    volatile uint64_t timingSink = 0;
+    const std::array<Scenario, 3> scenarios{{
+        {.name = "Sparse", .outerTuples = 100'000, .innerTuples = 50'000, .overlapTuples = 1'000},
+        {.name = "Medium", .outerTuples = 100'000, .innerTuples = 75'000, .overlapTuples = 10'000},
+        {.name = "Dense", .outerTuples = 100'000, .innerTuples = 90'000, .overlapTuples = 50'000},
+    }};
+
+    std::cout << "\nNLJ BloomFilter Performance Test\n";
+    std::cout << "repetitions=" << repetitions << "\n";
+
+    for (const auto& scenario : scenarios)
+    {
+        const auto baselineResult = runProbeWithoutBloomFilter(scenario);
+        const auto bloomResult = runProbeWithBloomFilter(scenario);
+
+        ASSERT_EQ(baselineResult.matchCount, scenario.overlapTuples);
+        ASSERT_EQ(bloomResult.matchCount, scenario.overlapTuples);
+        ASSERT_LT(bloomResult.probedOuterTuples, baselineResult.probedOuterTuples);
+
+        const auto baselineTime = measureNanos(
+            [&]() { timingSink += runProbeWithoutBloomFilter(scenario).matchCount; }, repetitions);
+        const auto bloomTime = measureNanos(
+            [&]() { timingSink += runProbeWithBloomFilter(scenario).matchCount; }, repetitions);
+
+        const double averageBaselineMs = static_cast<double>(baselineTime.count()) / 1'000'000.0 / repetitions;
+        const double averageBloomMs = static_cast<double>(bloomTime.count()) / 1'000'000.0 / repetitions;
+        const double speedup = averageBaselineMs / averageBloomMs;
+        const double outerPruning = 100.0
+            * static_cast<double>(baselineResult.probedOuterTuples - bloomResult.probedOuterTuples)
+            / static_cast<double>(baselineResult.probedOuterTuples);
+        const uint64_t baselineComparisons = baselineResult.probedOuterTuples * scenario.innerTuples;
+        const uint64_t bloomComparisons = bloomResult.probedOuterTuples * scenario.innerTuples;
+
+        std::cout << "scenario=" << scenario.name
+                  << " outer=" << scenario.outerTuples
+                  << " inner=" << scenario.innerTuples
+                  << " overlap=" << scenario.overlapTuples
+                  << " avg_no_bloom_ms=" << averageBaselineMs
+                  << " avg_with_bloom_ms=" << averageBloomMs
+                  << " speedup=" << speedup << "x"
+                  << " comparisons=" << baselineComparisons << "->" << bloomComparisons
+                  << " outer_pruning=" << outerPruning << "%\n";
+
+        EXPECT_LT(bloomComparisons, baselineComparisons);
+        EXPECT_GT(outerPruning, 0.0);
+
+        if (std::string_view(scenario.name) == "Sparse")
+        {
+            EXPECT_GT(outerPruning, 90.0);
+        }
+        else if (std::string_view(scenario.name) == "Medium")
+        {
+            EXPECT_GT(outerPruning, 70.0);
+        }
+        else if (std::string_view(scenario.name) == "Dense")
+        {
+            EXPECT_GT(outerPruning, 30.0);
+        }
+    }
+    EXPECT_GT(timingSink, 0U);
+}

--- a/nes-query-optimizer/include/QueryExecutionConfiguration.hpp
+++ b/nes-query-optimizer/include/QueryExecutionConfiguration.hpp
@@ -22,6 +22,7 @@
 #include <Configurations/BaseOption.hpp>
 #include <Configurations/Enums/EnumOption.hpp>
 #include <Configurations/ScalarOption.hpp>
+#include <Configurations/Validation/BooleanValidation.hpp>
 #include <Configurations/Validation/FloatValidation.hpp>
 #include <Configurations/Validation/NumberValidation.hpp>
 #include <Util/ExecutionMode.hpp>
@@ -83,6 +84,11 @@ public:
            StreamJoinStrategy::OPTIMIZER_CHOOSES,
            "Join Strategy"
            "[NESTED_LOOP_JOIN|HASH_JOIN|OPTIMIZER_CHOOSES]."};
+    BoolOption nljBloomFilterEnabled
+        = {"nlj_bloomfilter_enabled",
+           "true",
+           "Enable BloomFilter optimization for nested loop join probe.",
+           {std::make_shared<BooleanValidation>()}};
 
 private:
     std::vector<BaseOption*> getOptions() override
@@ -94,7 +100,8 @@ private:
             &joinStrategy,
             &numberOfRecordsPerKey,
             &maxNumberOfBuckets,
-            &operatorBufferSize};
+            &operatorBufferSize,
+            &nljBloomFilterEnabled};
     }
 };
 

--- a/nes-query-optimizer/src/RewriteRules/LowerToPhysical/LowerToPhysicalNLJoin.cpp
+++ b/nes-query-optimizer/src/RewriteRules/LowerToPhysical/LowerToPhysicalNLJoin.cpp
@@ -107,11 +107,18 @@ RewriteRuleResultSubgraph LowerToPhysicalNLJoin::apply(LogicalOperator logicalOp
 
     auto [timeStampFieldLeft, timeStampFieldRight] = TimestampField::getTimestampLeftAndRight(*join, windowType);
 
+    // Extract join key field names for both sides - needed for BloomFilter hashing
+    auto leftJoinKeyFieldNames = getJoinFieldNames(leftInputSchema, logicalJoinFunction);
+    auto rightJoinKeyFieldNames = getJoinFieldNames(rightInputSchema, logicalJoinFunction);
+
+    // Read BloomFilter enabled flag from configuration
+    const bool bloomFilterEnabled = conf.nljBloomFilterEnabled.getValue();
+
     auto leftBuildOperator
-        = NLJBuildPhysicalOperator(handlerId, JoinBuildSideType::Left, timeStampFieldLeft.toTimeFunction(), leftBufferRef);
+        = NLJBuildPhysicalOperator(handlerId, JoinBuildSideType::Left, timeStampFieldLeft.toTimeFunction(), leftBufferRef, leftJoinKeyFieldNames, bloomFilterEnabled);
 
     auto rightBuildOperator
-        = NLJBuildPhysicalOperator(handlerId, JoinBuildSideType::Right, timeStampFieldRight.toTimeFunction(), rightBufferRef);
+        = NLJBuildPhysicalOperator(handlerId, JoinBuildSideType::Right, timeStampFieldRight.toTimeFunction(), rightBufferRef, rightJoinKeyFieldNames, bloomFilterEnabled);
 
     auto joinSchema = JoinSchema(leftInputSchema, rightInputSchema, outputSchema);
     auto probeOperator = NLJProbePhysicalOperator(
@@ -121,12 +128,17 @@ RewriteRuleResultSubgraph LowerToPhysicalNLJoin::apply(LogicalOperator logicalOp
         joinSchema,
         leftBufferRef,
         rightBufferRef,
-        getJoinFieldNames(leftInputSchema, logicalJoinFunction),
-        getJoinFieldNames(rightInputSchema, logicalJoinFunction));
+        leftJoinKeyFieldNames,
+        rightJoinKeyFieldNames);
 
     auto sliceAndWindowStore
         = std::make_unique<DefaultTimeBasedSliceStore>(windowType->getSize().getTime(), windowType->getSlide().getTime());
-    auto handler = std::make_shared<NLJOperatorHandler>(inputOriginIds, outputOriginId, std::move(sliceAndWindowStore));
+    
+    auto handler = std::make_shared<NLJOperatorHandler>(
+        inputOriginIds, 
+        outputOriginId, 
+        std::move(sliceAndWindowStore),
+        bloomFilterEnabled);
 
     auto leftBuildWrapper = std::make_shared<PhysicalOperatorWrapper>(
         std::move(leftBuildOperator),

--- a/nes-systests/benchmark_BF/BloomFilterNLJNoOverlap_Benchmark.test
+++ b/nes-systests/benchmark_BF/BloomFilterNLJNoOverlap_Benchmark.test
@@ -1,0 +1,38 @@
+# name: join/BloomFilterNLJNoOverlap_Benchmark.test
+# description: Benchmark NLJ with BloomFilter when there is no overlap (expect empty result)
+# groups: [Join, Benchmark, large]
+
+GlobalConfiguration worker.default_query_execution.join_strategy: [NESTED_LOOP_JOIN]
+
+# Outer stream: 1,000 tuples (ids 0..999)
+CREATE LOGICAL SOURCE outer_stream(id UINT64, payload UINT64, ts UINT64);
+CREATE PHYSICAL SOURCE FOR outer_stream TYPE Generator SET(
+       'ALL' as `SOURCE`.STOP_GENERATOR_WHEN_SEQUENCE_FINISHES,
+       1 AS `SOURCE`.SEED,
+       'FIXED' AS `SOURCE`.GENERATOR_RATE_TYPE,
+       'emit_rate 100000' AS `SOURCE`.GENERATOR_RATE_CONFIG,
+       'SEQUENCE UINT64 0 1000 1, SEQUENCE UINT64 0 1000 1, SEQUENCE UINT64 0 1000 1'
+       AS `SOURCE`.GENERATOR_SCHEMA
+);
+
+# Inner stream: 1,000 tuples (ids 5000..5999) => NO OVERLAP
+CREATE LOGICAL SOURCE inner_stream(id2 UINT64, payload2 UINT64, ts UINT64);
+CREATE PHYSICAL SOURCE FOR inner_stream TYPE Generator SET(
+       'ALL' as `SOURCE`.STOP_GENERATOR_WHEN_SEQUENCE_FINISHES,
+       1 AS `SOURCE`.SEED,
+       'FIXED' AS `SOURCE`.GENERATOR_RATE_TYPE,
+       'emit_rate 100000' AS `SOURCE`.GENERATOR_RATE_CONFIG,
+       'SEQUENCE UINT64 5000 6000 1, SEQUENCE UINT64 0 1000 1, SEQUENCE UINT64 0 1000 1'
+       AS `SOURCE`.GENERATOR_SCHEMA
+);
+
+CREATE SINK noOverlapSink(outer_streaminner_stream.start UINT64, outer_streaminner_stream.end UINT64, outer_streaminner_stream.match_count UINT64) TYPE File;
+
+# No matches expected; system outputs no rows for empty join
+SELECT start, end, COUNT(id) AS match_count
+FROM (SELECT * FROM outer_stream)
+INNER JOIN (SELECT * FROM inner_stream)
+ON id = id2
+WINDOW TUMBLING (ts, size 1000000 ms)
+INTO noOverlapSink;
+----

--- a/nes-systests/benchmark_BF/BloomFilterNLJPerf_LowSelectivity.test
+++ b/nes-systests/benchmark_BF/BloomFilterNLJPerf_LowSelectivity.test
@@ -1,0 +1,39 @@
+# name: join/BloomFilterNLJPerf_LowSelectivity.test
+# description: Large-scale low-selectivity (1%) NLJ performance test with BloomFilter enabled
+# groups: [Join, Benchmark, large]
+
+GlobalConfiguration worker.default_query_execution.join_strategy: [NESTED_LOOP_JOIN]
+
+# Outer stream: 10,000 tuples (ids 0..9999)
+CREATE LOGICAL SOURCE outer_stream(id UINT64, payload UINT64, ts UINT64);
+CREATE PHYSICAL SOURCE FOR outer_stream TYPE Generator SET(
+       'ALL' as `SOURCE`.STOP_GENERATOR_WHEN_SEQUENCE_FINISHES,
+       1 AS `SOURCE`.SEED,
+       'FIXED' AS `SOURCE`.GENERATOR_RATE_TYPE,
+       'emit_rate 100000' AS `SOURCE`.GENERATOR_RATE_CONFIG,
+       'SEQUENCE UINT64 0 10000 1, SEQUENCE UINT64 0 10000 1, SEQUENCE UINT64 0 10000 1'
+       AS `SOURCE`.GENERATOR_SCHEMA
+);
+
+# Inner stream: 1,000,000 tuples (ids 0..999999) => overlap = 10,000 (1% selectivity)
+CREATE LOGICAL SOURCE inner_stream(id2 UINT64, payload2 UINT64, ts UINT64);
+CREATE PHYSICAL SOURCE FOR inner_stream TYPE Generator SET(
+       'ALL' as `SOURCE`.STOP_GENERATOR_WHEN_SEQUENCE_FINISHES,
+       1 AS `SOURCE`.SEED,
+       'FIXED' AS `SOURCE`.GENERATOR_RATE_TYPE,
+       'emit_rate 100000' AS `SOURCE`.GENERATOR_RATE_CONFIG,
+       'SEQUENCE UINT64 0 1000000 1, SEQUENCE UINT64 0 1000000 1, SEQUENCE UINT64 0 1000000 1'
+       AS `SOURCE`.GENERATOR_SCHEMA
+);
+
+CREATE SINK joinPerfSink(outer_streaminner_stream.start UINT64, outer_streaminner_stream.end UINT64, outer_streaminner_stream.match_count UINT64) TYPE File;
+
+# Single large tumbling window to keep one output row
+SELECT start, end, COUNT(id) AS match_count
+FROM (SELECT * FROM outer_stream)
+INNER JOIN (SELECT * FROM inner_stream)
+ON id = id2
+WINDOW TUMBLING (ts, size 1000000 ms)
+INTO joinPerfSink;
+----
+0 1000000 10000

--- a/nes-systests/benchmark_BF/BloomFilterNLJPerf_LowSelectivity_NoBF.test
+++ b/nes-systests/benchmark_BF/BloomFilterNLJPerf_LowSelectivity_NoBF.test
@@ -1,0 +1,40 @@
+# name: join/BloomFilterNLJPerf_LowSelectivity_NoBF.test
+# description: Large-scale low-selectivity (1%) NLJ performance test with BloomFilter disabled
+# groups: [Join, Benchmark, large]
+
+GlobalConfiguration worker.default_query_execution.join_strategy: [NESTED_LOOP_JOIN]
+GlobalConfiguration worker.default_query_execution.nlj_bloomfilter_enabled: [false]
+
+# Outer stream: 10,000 tuples (ids 0..9999)
+CREATE LOGICAL SOURCE outer_stream(id UINT64, payload UINT64, ts UINT64);
+CREATE PHYSICAL SOURCE FOR outer_stream TYPE Generator SET(
+       'ALL' as `SOURCE`.STOP_GENERATOR_WHEN_SEQUENCE_FINISHES,
+       1 AS `SOURCE`.SEED,
+       'FIXED' AS `SOURCE`.GENERATOR_RATE_TYPE,
+       'emit_rate 100000' AS `SOURCE`.GENERATOR_RATE_CONFIG,
+       'SEQUENCE UINT64 0 10000 1, SEQUENCE UINT64 0 10000 1, SEQUENCE UINT64 0 10000 1'
+       AS `SOURCE`.GENERATOR_SCHEMA
+);
+
+# Inner stream: 1,000,000 tuples (ids 0..999999) => overlap = 10,000 (1% selectivity)
+CREATE LOGICAL SOURCE inner_stream(id2 UINT64, payload2 UINT64, ts UINT64);
+CREATE PHYSICAL SOURCE FOR inner_stream TYPE Generator SET(
+       'ALL' as `SOURCE`.STOP_GENERATOR_WHEN_SEQUENCE_FINISHES,
+       1 AS `SOURCE`.SEED,
+       'FIXED' AS `SOURCE`.GENERATOR_RATE_TYPE,
+       'emit_rate 100000' AS `SOURCE`.GENERATOR_RATE_CONFIG,
+       'SEQUENCE UINT64 0 1000000 1, SEQUENCE UINT64 0 1000000 1, SEQUENCE UINT64 0 1000000 1'
+       AS `SOURCE`.GENERATOR_SCHEMA
+);
+
+CREATE SINK joinPerfSink(outer_streaminner_stream.start UINT64, outer_streaminner_stream.end UINT64, outer_streaminner_stream.match_count UINT64) TYPE File;
+
+# Single large tumbling window to keep one output row
+SELECT start, end, COUNT(id) AS match_count
+FROM (SELECT * FROM outer_stream)
+INNER JOIN (SELECT * FROM inner_stream)
+ON id = id2
+WINDOW TUMBLING (ts, size 1000000 ms)
+INTO joinPerfSink;
+----
+0 1000000 10000

--- a/nes-systests/benchmark_BF/BloomFilterNLJPerf_TrueLowSelectivity.test
+++ b/nes-systests/benchmark_BF/BloomFilterNLJPerf_TrueLowSelectivity.test
@@ -1,0 +1,42 @@
+# name: BloomFilterNLJPerf_TrueLowSelectivity
+# description: True low-selectivity (20%) NLJ performance test - BloomFilter filters 80% of outer tuples
+# groups: [Join, Benchmark, large]
+
+GlobalConfiguration worker.default_query_execution.join_strategy: [NESTED_LOOP_JOIN]
+
+# Outer stream: 50,000 tuples (ids 0..49999)
+CREATE LOGICAL SOURCE outer_stream(id UINT64, payload UINT64, ts UINT64);
+CREATE PHYSICAL SOURCE FOR outer_stream TYPE Generator SET(
+       'ALL' as `SOURCE`.STOP_GENERATOR_WHEN_SEQUENCE_FINISHES,
+       1 AS `SOURCE`.SEED,
+       'FIXED' AS `SOURCE`.GENERATOR_RATE_TYPE,
+       'emit_rate 100000' AS `SOURCE`.GENERATOR_RATE_CONFIG,
+       'SEQUENCE UINT64 0 50000 1, SEQUENCE UINT64 0 50000 1, SEQUENCE UINT64 0 50000 1'
+       AS `SOURCE`.GENERATOR_SCHEMA
+);
+
+# Inner stream: 100,000 tuples (ids 40000..139999)
+# Overlap: ids 40000..49999 (10,000 tuples = 20% of outer)
+# BloomFilter filters: ids 0..39999 (40,000 tuples = 80% of outer) ✅
+CREATE LOGICAL SOURCE inner_stream(id2 UINT64, payload2 UINT64, ts UINT64);
+CREATE PHYSICAL SOURCE FOR inner_stream TYPE Generator SET(
+       'ALL' as `SOURCE`.STOP_GENERATOR_WHEN_SEQUENCE_FINISHES,
+       1 AS `SOURCE`.SEED,
+       'FIXED' AS `SOURCE`.GENERATOR_RATE_TYPE,
+       'emit_rate 100000' AS `SOURCE`.GENERATOR_RATE_CONFIG,
+       'SEQUENCE UINT64 40000 140000 1, SEQUENCE UINT64 0 100000 1, SEQUENCE UINT64 0 100000 1'
+       AS `SOURCE`.GENERATOR_SCHEMA
+);
+
+CREATE SINK joinPerfSink(outer_streaminner_stream.start UINT64, outer_streaminner_stream.end UINT64, outer_streaminner_stream.match_count UINT64) TYPE File;
+
+# Single large tumbling window to keep one output row
+SELECT start, end, COUNT(id) AS match_count
+FROM (SELECT * FROM outer_stream)
+INNER JOIN (SELECT * FROM inner_stream)
+ON id = id2
+WINDOW TUMBLING (ts, size 1000000 ms)
+INTO joinPerfSink;
+----
+0 1000000 10000
+

--- a/nes-systests/benchmark_BF/BloomFilterNLJPerf_TrueLowSelectivity_NoBF.test
+++ b/nes-systests/benchmark_BF/BloomFilterNLJPerf_TrueLowSelectivity_NoBF.test
@@ -1,0 +1,42 @@
+# name: BloomFilterNLJPerf_TrueLowSelectivity_NoBF
+# description: True low-selectivity (20%) NLJ performance test WITHOUT BloomFilter (baseline comparison)
+# groups: [Join, Benchmark, large]
+
+GlobalConfiguration worker.default_query_execution.join_strategy: [NESTED_LOOP_JOIN]
+
+# Outer stream: 50,000 tuples (ids 0..49999)
+CREATE LOGICAL SOURCE outer_stream(id UINT64, payload UINT64, ts UINT64);
+CREATE PHYSICAL SOURCE FOR outer_stream TYPE Generator SET(
+       'ALL' as `SOURCE`.STOP_GENERATOR_WHEN_SEQUENCE_FINISHES,
+       1 AS `SOURCE`.SEED,
+       'FIXED' AS `SOURCE`.GENERATOR_RATE_TYPE,
+       'emit_rate 100000' AS `SOURCE`.GENERATOR_RATE_CONFIG,
+       'SEQUENCE UINT64 0 50000 1, SEQUENCE UINT64 0 50000 1, SEQUENCE UINT64 0 50000 1'
+       AS `SOURCE`.GENERATOR_SCHEMA
+);
+
+# Inner stream: 100,000 tuples (ids 40000..139999)
+# Overlap: ids 40000..49999 (10,000 tuples = 20% of outer)
+# WITHOUT BloomFilter: all 50K outer tuples check all 100K inner tuples
+CREATE LOGICAL SOURCE inner_stream(id2 UINT64, payload2 UINT64, ts UINT64);
+CREATE PHYSICAL SOURCE FOR inner_stream TYPE Generator SET(
+       'ALL' as `SOURCE`.STOP_GENERATOR_WHEN_SEQUENCE_FINISHES,
+       1 AS `SOURCE`.SEED,
+       'FIXED' AS `SOURCE`.GENERATOR_RATE_TYPE,
+       'emit_rate 100000' AS `SOURCE`.GENERATOR_RATE_CONFIG,
+       'SEQUENCE UINT64 40000 140000 1, SEQUENCE UINT64 0 100000 1, SEQUENCE UINT64 0 100000 1'
+       AS `SOURCE`.GENERATOR_SCHEMA
+);
+
+CREATE SINK joinPerfSink(outer_streaminner_stream.start UINT64, outer_streaminner_stream.end UINT64, outer_streaminner_stream.match_count UINT64) TYPE File;
+
+# Single large tumbling window to keep one output row
+SELECT start, end, COUNT(id) AS match_count
+FROM (SELECT * FROM outer_stream)
+INNER JOIN (SELECT * FROM inner_stream)
+ON id = id2
+WINDOW TUMBLING (ts, size 1000000 ms)
+INTO joinPerfSink;
+----
+0 1000000 10000
+

--- a/nes-systests/benchmark_BF/Nexmark.test
+++ b/nes-systests/benchmark_BF/Nexmark.test
@@ -1,0 +1,60 @@
+# name: milestone/Nexmark.test
+# description: Nexmark benchmark taken from https://github.com/nexmark/nexmark/tree/master/nexmark-flink/src/main/resources/queries
+# groups: [milestone, benchmark, large, Aggregation, Join]
+
+# Source definitions
+CREATE LOGICAL SOURCE bid(timestamp UINT64, auctionId INT32, bidder INT32, datetime INT64, price FLOAT64);
+CREATE PHYSICAL SOURCE FOR bid TYPE File;
+ATTACH FILE large/nexmark/bid_653M.csv
+CREATE LOGICAL SOURCE auction(timestamp UINT64, id INT32, initialbid INT32, reserve INT32, expires INT64, seller INT32, category INT32);
+CREATE PHYSICAL SOURCE FOR auction TYPE File;
+ATTACH FILE large/nexmark/auction_modified_74M.csv
+
+CREATE SINK q1CheckSum(price FLOAT64)  TYPE Checksum;
+CREATE SINK q2CheckSum(bid.timestamp UINT64, bid.auctionId INT32, bid.bidder INT32, bid.datetime INT64, bid.price FLOAT64)  TYPE Checksum;
+CREATE SINK q5Checksum(bidbid.start UINT64, bidbid.end UINT64, bid.auctionId INT32, bid.num UINT64, bid.max_tmp UINT64)  TYPE Checksum;
+CREATE SINK q8VariantChecksum(bidauction.start UINT64, bidauction.end UINT64, bid_timestamp UINT64, bid.auctionId INT32, bid.bidder INT32, bid.datetime INT64, bid.price FLOAT64, auction_timestamp UINT64, auction.id INT32, auction.initialbid INT32, auction.reserve INT32, auction.expires INT64, auction.seller INT32, auction.category INT32)  TYPE Checksum;
+
+# Query 0
+SELECT * FROM bid INTO q2CheckSum;
+----
+18106394 33146443404
+
+# Query 1
+SELECT price * FLOAT64(89) / FLOAT64(100) AS price FROM bid INTO q1CheckSum;
+----
+18106394 5431093917
+
+# Query 2
+SELECT * FROM bid WHERE auctionId % INT32(123) = INT32(0) INTO q2CheckSum;
+----
+146516 268224796
+
+# Query 5
+SELECT start, end, auctionId, num, max_tmp
+FROM (SELECT auctionId, COUNT(auctionId) AS num, start, end
+      FROM bid
+      GROUP BY auctionId
+      WINDOW SLIDING(timestamp, SIZE 10 SEC, ADVANCE BY 2 SEC))
+INNER JOIN (SELECT MAX(num_ids) AS max_tmp, start, end
+              FROM
+                    (SELECT auctionId, COUNT(auctionId) AS num_ids, start
+                     FROM bid
+                     GROUP BY auctionId
+                     WINDOW SLIDING(timestamp, SIZE 10 SEC, ADVANCE BY 2 SEC))
+              WINDOW TUMBLING(start, SIZE 2 SEC))
+ON num == max_tmp
+WINDOW TUMBLING(start, SIZE 2 SEC)
+INTO q5Checksum;
+----
+243784, 390918029
+
+
+# Query 8 Variant (We are not using the actual Q8 but a variant, as we have swapped the Person stream with the Bid stream)
+SELECT start, end, bid_timestamp, auctionId, bidder, datetime, price, auction_timestamp, id, initialbid, reserve, expires, seller, category
+    FROM (SELECT *, timestamp as bid_timestamp FROM bid)
+INNER JOIN
+    (SELECT *, timestamp as auction_timestamp FROM auction)
+ON auctionId = id WINDOW TUMBLING (timestamp, size 10 sec) INTO q8VariantChecksum;
+----
+9149189 44872388544

--- a/nes-systests/benchmark_BF/Nexmark_multiple_GB_of_Bids.test
+++ b/nes-systests/benchmark_BF/Nexmark_multiple_GB_of_Bids.test
@@ -1,0 +1,84 @@
+# name: milestone/Nexmark_multiple_GB_of_Bids.test
+# description: Nexmark benchmark taken from https://github.com/nexmark/nexmark/tree/master/nexmark-flink/src/main/resources/queries
+# We have used https://github.com/risingwavelabs/nexmark-rs to generate the source csv files
+# groups: [milestone, benchmark, large, Aggregation, Join]
+
+# Source definition. We have removed some columns that are not needed in our queries
+CREATE LOGICAL SOURCE bid(timestamp UINT64, auctionId INT32, bidder INT32, price FLOAT64);
+CREATE PHYSICAL SOURCE FOR bid TYPE File;
+ATTACH FILE large/nexmark/bid_6GB.csv
+
+CREATE LOGICAL SOURCE auction(timestamp UINT64, id INT32, initialbid INT32, reserve INT32, expires UINT64, seller INT32, category INT32);
+CREATE PHYSICAL SOURCE FOR auction TYPE File;
+ATTACH FILE large/nexmark/auction_707MB.csv
+
+CREATE LOGICAL SOURCE person(id INT32, name VARSIZED, email_address VARSIZED, credit_card VARSIZED, city VARSIZED, state VARSIZED, timestamp UINT64, extra VARSIZED);
+CREATE PHYSICAL SOURCE FOR person TYPE File;
+ATTACH FILE large/nexmark/person_840MB.csv
+
+CREATE SINK bidCheckSum(bid.timestamp UINT64, bid.auctionId INT32, bid.bidder INT32, bid.price FLOAT64)  TYPE Checksum;
+CREATE SINK q1CheckSum(bid.timestamp UINT64, bid.auctionId INT32, bid.bidder INT32, price FLOAT64)  TYPE Checksum;
+CREATE SINK q2CheckSum(bid.auctionId INT32, bid.price FLOAT64)  TYPE Checksum;
+CREATE SINK q5Checksum(bidbid.start UINT64, bidbid.end UINT64, bid.auctionId INT32, bid.num UINT64, bid.max_tmp UINT64)  TYPE Checksum;
+CREATE SINK q8CheckSum(personauction.start UINT64, personauction.end UINT64, person.id INT32, person.name VARSIZED)  TYPE Checksum;
+CREATE SINK q8VariantCheckSum(bidauction.start UINT64, bidauction.end UINT64, bid.timestamp UINT64, bid.auctionId INT32, bid.bidder INT32, bid.price FLOAT64, bid.timestamp UINT64, auction.id INT32, auction.initialbid INT32, auction.reserve INT32, auction.expires UINT64, auction.seller INT32, auction.category INT32)  TYPE Checksum;
+
+
+# Query 0
+SELECT * FROM bid INTO bidCheckSum;
+----
+183991721 353216217968
+
+# Query 1
+SELECT timestamp, auctionId, bidder, price * FLOAT64(908) / FLOAT64(1000) AS price FROM bid INTO q1CheckSum;
+----
+183991721 370730288260
+
+# Query 2
+SELECT auctionId, price FROM bid WHERE auctionId % INT32(123) = INT32(0) INTO q2CheckSum;
+----
+1511777 1211558031
+
+# Query 5
+SELECT start, end, auctionId, num, max_tmp
+FROM (SELECT auctionId, COUNT(auctionId) AS num, start, end
+      FROM bid
+      GROUP BY auctionId
+      WINDOW SLIDING(timestamp, SIZE 10 SEC, ADVANCE BY 2 SEC))
+INNER JOIN (SELECT MAX(num_ids) AS max_tmp, start, end
+              FROM
+                    (SELECT auctionId, COUNT(auctionId) AS num_ids, start
+                     FROM bid
+                     GROUP BY auctionId
+                     WINDOW SLIDING(timestamp, SIZE 10 SEC, ADVANCE BY 2 SEC))
+              WINDOW TUMBLING(start, SIZE 2 SEC))
+ON num == max_tmp
+WINDOW TUMBLING(start, SIZE 2 SEC)
+INTO q5Checksum;
+----
+10589 23372488
+
+
+# Query 8
+# Until PR #755 is not merged, we need to do another subquery to project the required fields
+SELECT start, end, id, name
+FROM (
+        SELECT *
+            FROM (SELECT * FROM person)
+        INNER JOIN
+            (SELECT * FROM auction)
+        ON id = seller WINDOW TUMBLING (timestamp, size 10 sec)
+    )
+INTO q8CheckSum;
+----
+10999751 33652579169
+
+
+# Query 8 Variant (We are not using the actual Q8 but a variant, as we have swapped the Person stream with the Bid stream)
+SELECT start, end, timestamp, auctionId, bidder, price, timestamp, id, initialbid, reserve, expires, seller, category
+    FROM (SELECT * FROM bid)
+INNER JOIN
+    (SELECT * FROM auction)
+ON auctionId = id WINDOW TUMBLING (timestamp, size 10 sec) INTO q8VariantCheckSum;
+----
+182197843 1176742157900

--- a/nes-systests/systest/CMakeLists.txt
+++ b/nes-systests/systest/CMakeLists.txt
@@ -102,6 +102,50 @@ if (ENABLE_LARGE_TESTS)
     ExternalData_Add_Test(TEST_DATA_LARGE
             NAME systest_large_${joinStrategy}
             COMMAND systest -n 6 --workingDir=${CMAKE_CURRENT_BINARY_DIR}/large_scale_${joinStrategy} --data ${EXPANDED_TEST_DATA_PATH} -t ${CMAKE_CURRENT_SOURCE_DIR}/../benchmark/Nexmark.test:05 -- --worker.default_query_execution.execution_mode=COMPILER --worker.query_engine.number_of_worker_threads=4 --worker.number_of_buffers_in_global_buffer_manager=2000000 --worker.default_query_execution.join_strategy=${joinStrategy})
+
+    # BloomFilter-specific benchmarks with Nexmark JOIN queries
+    # Performance test with BloomFilter ENABLED on NLJ
+    ExternalData_Add_Test(test-data
+            NAME systest_large_benchmark_BF_NLJ_WithBF
+            COMMAND systest -b --workingDir=${CMAKE_CURRENT_BINARY_DIR}/large_scale_benchmark_bf_nlj_with --data ${EXPANDED_TEST_DATA_PATH} -t ${CMAKE_CURRENT_SOURCE_DIR}/../benchmark_BF/Nexmark.test:05 -- --worker.default_query_execution.execution_mode=COMPILER --worker.query_engine.number_of_worker_threads=2 --worker.number_of_buffers_in_global_buffer_manager=200000 --worker.default_query_execution.join_strategy=NESTED_LOOP_JOIN --worker.default_query_execution.nlj_bloomfilter_enabled=true)
+
+    # Performance test with BloomFilter DISABLED on NLJ (for comparison)
+    ExternalData_Add_Test(test-data
+            NAME systest_large_benchmark_BF_NLJ_WithoutBF
+            COMMAND systest -b --workingDir=${CMAKE_CURRENT_BINARY_DIR}/large_scale_benchmark_bf_nlj_without --data ${EXPANDED_TEST_DATA_PATH} -t ${CMAKE_CURRENT_SOURCE_DIR}/../benchmark_BF/Nexmark.test:05 -- --worker.default_query_execution.execution_mode=COMPILER --worker.query_engine.number_of_worker_threads=2 --worker.number_of_buffers_in_global_buffer_manager=200000 --worker.default_query_execution.join_strategy=NESTED_LOOP_JOIN --worker.default_query_execution.nlj_bloomfilter_enabled=false)
+
+    # Large-scale BloomFilter benchmarks with Nexmark multiple GB dataset
+    # WITH BloomFilter ENABLED
+    ExternalData_Add_Test(test-data
+            NAME systest_large_benchmark_BF_Large_WithBF
+            COMMAND systest -b --workingDir=${CMAKE_CURRENT_BINARY_DIR}/large_scale_benchmark_bf_large_with --data ${EXPANDED_TEST_DATA_PATH} -t ${CMAKE_CURRENT_SOURCE_DIR}/../benchmark_BF/Nexmark_multiple_GB_of_Bids.test:05 -- --worker.default_query_execution.execution_mode=COMPILER --worker.query_engine.number_of_worker_threads=2 --worker.number_of_buffers_in_global_buffer_manager=200000 --worker.default_query_execution.join_strategy=NESTED_LOOP_JOIN --worker.default_query_execution.nlj_bloomfilter_enabled=true)
+
+    # WITHOUT BloomFilter (for comparison)
+    ExternalData_Add_Test(test-data
+            NAME systest_large_benchmark_BF_Large_WithoutBF
+            COMMAND systest -b --workingDir=${CMAKE_CURRENT_BINARY_DIR}/large_scale_benchmark_bf_large_without --data ${EXPANDED_TEST_DATA_PATH} -t ${CMAKE_CURRENT_SOURCE_DIR}/../benchmark_BF/Nexmark_multiple_GB_of_Bids.test:05 -- --worker.default_query_execution.execution_mode=COMPILER --worker.query_engine.number_of_worker_threads=2 --worker.number_of_buffers_in_global_buffer_manager=200000 --worker.default_query_execution.join_strategy=NESTED_LOOP_JOIN --worker.default_query_execution.nlj_bloomfilter_enabled=false)
+
+    # BloomFilter join benchmarks from benchmark_BF tests
+    ExternalData_Add_Test(test-data
+            NAME systest_large_benchmark_BF_LowSelectivity_WithBF
+            COMMAND systest -b --workingDir=${CMAKE_CURRENT_BINARY_DIR}/large_scale_benchmark_bf_lowselect_with --data ${EXPANDED_TEST_DATA_PATH} -t ${CMAKE_CURRENT_SOURCE_DIR}/../benchmark_BF/BloomFilterNLJPerf_LowSelectivity.test -- --worker.default_query_execution.execution_mode=COMPILER --worker.query_engine.number_of_worker_threads=2 --worker.number_of_buffers_in_global_buffer_manager=200000 --worker.default_query_execution.join_strategy=NESTED_LOOP_JOIN --worker.default_query_execution.nlj_bloomfilter_enabled=true)
+
+    ExternalData_Add_Test(test-data
+            NAME systest_large_benchmark_BF_LowSelectivity_WithoutBF
+            COMMAND systest -b --workingDir=${CMAKE_CURRENT_BINARY_DIR}/large_scale_benchmark_bf_lowselect_without --data ${EXPANDED_TEST_DATA_PATH} -t ${CMAKE_CURRENT_SOURCE_DIR}/../benchmark_BF/BloomFilterNLJPerf_LowSelectivity_NoBF.test -- --worker.default_query_execution.execution_mode=COMPILER --worker.query_engine.number_of_worker_threads=2 --worker.number_of_buffers_in_global_buffer_manager=200000 --worker.default_query_execution.join_strategy=NESTED_LOOP_JOIN --worker.default_query_execution.nlj_bloomfilter_enabled=false)
+
+    # True low-selectivity benchmarks with non-overlapping ID ranges
+    ExternalData_Add_Test(test-data
+            NAME systest_large_benchmark_BF_TrueLowSelectivity_WithBF
+            COMMAND systest -b --workingDir=${CMAKE_CURRENT_BINARY_DIR}/large_scale_benchmark_bf_truelowselect_with --data ${EXPANDED_TEST_DATA_PATH} -t ${CMAKE_CURRENT_SOURCE_DIR}/../benchmark_BF/BloomFilterNLJPerf_TrueLowSelectivity.test -- --worker.default_query_execution.execution_mode=COMPILER --worker.query_engine.number_of_worker_threads=2 --worker.number_of_buffers_in_global_buffer_manager=200000 --worker.default_query_execution.join_strategy=NESTED_LOOP_JOIN --worker.default_query_execution.nlj_bloomfilter_enabled=true)
+
+    ExternalData_Add_Test(test-data
+            NAME systest_large_benchmark_BF_TrueLowSelectivity_WithoutBF
+            COMMAND systest -b --workingDir=${CMAKE_CURRENT_BINARY_DIR}/large_scale_benchmark_bf_truelowselect_without --data ${EXPANDED_TEST_DATA_PATH} -t ${CMAKE_CURRENT_SOURCE_DIR}/../benchmark_BF/BloomFilterNLJPerf_TrueLowSelectivity_NoBF.test -- --worker.default_query_execution.execution_mode=COMPILER --worker.query_engine.number_of_worker_threads=2 --worker.number_of_buffers_in_global_buffer_manager=200000 --worker.default_query_execution.join_strategy=NESTED_LOOP_JOIN --worker.default_query_execution.nlj_bloomfilter_enabled=false)
+
+    ExternalData_Add_Test(test-data
+            NAME systest_large_benchmark_BF_NoOverlap
+            COMMAND systest -b --workingDir=${CMAKE_CURRENT_BINARY_DIR}/large_scale_benchmark_bf_nooverlap --data ${EXPANDED_TEST_DATA_PATH} -t ${CMAKE_CURRENT_SOURCE_DIR}/../benchmark_BF/BloomFilterNLJNoOverlap_Benchmark.test -- --worker.default_query_execution.execution_mode=COMPILER --worker.query_engine.number_of_worker_threads=2 --worker.number_of_buffers_in_global_buffer_manager=200000 --worker.default_query_execution.join_strategy=NESTED_LOOP_JOIN --worker.default_query_execution.nlj_bloomfilter_enabled=true)
 endif ()
 
 


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This pull request adds a BloomFilter and its integration into the nested loop join. The change list is as follows:
- New BloomFilter file with clear(), add() and mightcontain() functions.
- Integration into the NLJ with changed files 'NLJBuild/OperatorHandles/Probe/Slice', to reduce lookups
- Integrated an enableBloomFilterFlag for Testing with and without a BloomFilter to see performance gain.


## Verifying this change
This change is tested by
- *Added integration tests for creating the BloomFilter in the NLJ context*
- Creating a folder Benchmark_BF for BloomFilter Benchmark tests, which contain already existing Nexmark "Join" Tests and synthetic tests.
- *Added test that measures the BloomFilters performance (UNIT test)*
- *Added metrics test with blommCheckTotal/bloomMisses/bloomHits/bloomFalsePositives*