### PR TITLE
Fix(#1397): add CI cron job for Docker cleanup

### DIFF
--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -1,0 +1,16 @@
+name: Docker Cleanup
+
+on:
+  schedule:
+    - cron: '0 3 * * 0' # Every Sunday at 3:00 AM UTC
+  workflow_dispatch:
+
+jobs:
+  docker-cleanup:
+    strategy:
+      matrix:
+        arch: [ x64, arm64 ]
+    runs-on: [ self-hosted, linux, Build, "${{ matrix.arch }}" ]
+    steps:
+      - name: Prune all unused Docker data
+        run: docker system prune -af --volumes


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that runs `docker system prune -af --volumes` weekly (Sundays at 3:00 AM UTC) on all self-hosted CI runners (x64 and arm64)
- Includes `workflow_dispatch` trigger for manual runs
- Prevents disk space exhaustion from accumulated Docker images, containers, and volumes

Closes #1397

## Test plan
- [ ] Verify the workflow appears in the Actions tab after merge
- [ ] Trigger manually via `workflow_dispatch` to confirm it runs on both x64 and arm64 runners
- [ ] Confirm `docker system prune -af --volumes` executes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)