### PR TITLE
Fix(#1002): allow duplicate field names in systest schema matching

### DIFF
--- a/nes-systests/regression/DuplicateFieldNamesInResult.test
+++ b/nes-systests/regression/DuplicateFieldNamesInResult.test
@@ -1,0 +1,31 @@
+# description: Regression test for #1002 — systest result matching must handle duplicate field names
+# groups: [regression]
+
+# This test verifies that the systest result checker correctly matches schemas
+# where the output contains duplicate field names (e.g., from a join where both
+# sides contribute a field with the same name).
+
+CREATE LOGICAL SOURCE left_stream(id UINT64 NOT NULL, value UINT64 NOT NULL, timestamp UINT64 NOT NULL);
+CREATE PHYSICAL SOURCE FOR left_stream TYPE File;
+ATTACH INLINE
+1,100,1
+2,200,1
+
+CREATE LOGICAL SOURCE right_stream(id UINT64 NOT NULL, value UINT64 NOT NULL, timestamp UINT64 NOT NULL);
+CREATE PHYSICAL SOURCE FOR right_stream TYPE File;
+ATTACH INLINE
+1,10,1
+2,20,1
+
+# Join produces duplicate field names: left_stream.value and right_stream.value both map to "value" in the output.
+CREATE SINK joinSink(left_stream.value UINT64 NOT NULL, right_stream.value UINT64 NOT NULL) TYPE File;
+
+SELECT left_stream.value, right_stream.value
+FROM left_stream
+INNER JOIN right_stream
+ON left_stream.id = right_stream.id
+WINDOW TUMBLING(timestamp, SIZE 1 SEC)
+INTO joinSink;
+----
+100,10
+200,20

--- a/nes-systests/regression/DuplicateFieldNamesInResult.test
+++ b/nes-systests/regression/DuplicateFieldNamesInResult.test
@@ -2,30 +2,18 @@
 # groups: [regression]
 
 # This test verifies that the systest result checker correctly matches schemas
-# where the output contains duplicate field names (e.g., from a join where both
-# sides contribute a field with the same name).
+# where the output contains duplicate field names (e.g., selecting the same field twice).
 
-CREATE LOGICAL SOURCE left_stream(id UINT64 NOT NULL, value UINT64 NOT NULL, timestamp UINT64 NOT NULL);
-CREATE PHYSICAL SOURCE FOR left_stream TYPE File;
+CREATE LOGICAL SOURCE stream(id UINT64 NOT NULL, value UINT64 NOT NULL, timestamp UINT64 NOT NULL);
+CREATE PHYSICAL SOURCE FOR stream TYPE File;
 ATTACH INLINE
-1,100,1
-2,200,1
+1,100,1000
+2,200,2000
 
-CREATE LOGICAL SOURCE right_stream(id UINT64 NOT NULL, value UINT64 NOT NULL, timestamp UINT64 NOT NULL);
-CREATE PHYSICAL SOURCE FOR right_stream TYPE File;
-ATTACH INLINE
-1,10,1
-2,20,1
+# Selecting the same field twice produces duplicate field names in the output.
+CREATE SINK dupSink(stream.id UINT64 NOT NULL, stream.id UINT64 NOT NULL) TYPE File;
 
-# Join produces duplicate field names: left_stream.value and right_stream.value both map to "value" in the output.
-CREATE SINK joinSink(left_stream.value UINT64 NOT NULL, right_stream.value UINT64 NOT NULL) TYPE File;
-
-SELECT left_stream.value, right_stream.value
-FROM left_stream
-INNER JOIN right_stream
-ON left_stream.id = right_stream.id
-WINDOW TUMBLING(timestamp, SIZE 1 SEC)
-INTO joinSink;
+SELECT id, id FROM stream INTO dupSink;
 ----
-100,10
-200,20
+1,1
+2,2

--- a/nes-systests/systest/src/SystestResultCheck.cpp
+++ b/nes-systests/systest/src/SystestResultCheck.cpp
@@ -436,10 +436,22 @@ ExpectedToActualFieldMap compareSchemas(const ExpectedResultSchema& expectedResu
     std::unordered_set<size_t> matchedActualResultFields;
     for (const auto& [expectedFieldIdx, expectedField] : expectedResultSchema.getRawValue() | NES::views::enumerate)
     {
-        if (const auto& matchingFieldIt = std::ranges::find(actualResultSchema.getRawValue(), expectedField);
-            matchingFieldIt != actualResultSchema.getRawValue().end())
+        /// Find a matching actual field that has not already been matched. This handles duplicate field names
+        /// by matching each expected field to a distinct actual field in order.
+        const auto& actualFields = actualResultSchema.getRawValue().getFields();
+        auto matchingFieldIt = actualFields.end();
+        for (auto it = actualFields.begin(); it != actualFields.end(); ++it)
         {
-            auto offset = std::ranges::distance(actualResultSchema.getRawValue().begin(), matchingFieldIt);
+            const auto idx = static_cast<size_t>(std::distance(actualFields.begin(), it));
+            if (*it == expectedField and not matchedActualResultFields.contains(idx))
+            {
+                matchingFieldIt = it;
+                break;
+            }
+        }
+        if (matchingFieldIt != actualFields.end())
+        {
+            auto offset = static_cast<size_t>(std::distance(actualFields.begin(), matchingFieldIt));
             expectedToActualFieldMap.expectedToActualFieldMap.emplace_back(expectedField.dataType, offset);
             matchedActualResultFields.emplace(offset);
             expectedToActualFieldMap.expectedResultsFieldSortIdx.emplace_back(expectedFieldIdx);


### PR DESCRIPTION
## Summary
- Fixes the systest schema comparison to correctly handle duplicate field names (e.g., `SELECT id, id FROM stream`)
- The root cause was that `std::ranges::find` always matched the first occurrence of a field, so the second duplicate field was never matched and reported as "unexpected field in actual result schema"
- The fix tracks already-matched actual field indices and skips them when searching for subsequent matches

Closes #1002

## Test plan
- [ ] Run existing systest suite to verify no regressions
- [ ] Create a test with duplicate fields (`SELECT id, id FROM stream INTO sink`) and verify it passes without schema mismatch errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)