### PR TITLE
Fix(#1376): add predicate pushdown optimization phase

### DIFF
--- a/nes-query-optimizer/private/Phases/PredicatePushdown.hpp
+++ b/nes-query-optimizer/private/Phases/PredicatePushdown.hpp
@@ -1,0 +1,47 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <string>
+#include <unordered_set>
+#include <Functions/LogicalFunction.hpp>
+#include <Operators/LogicalOperator.hpp>
+#include <Plans/LogicalPlan.hpp>
+
+namespace NES
+{
+
+/// Pushes Selection (filter) operators closer to data sources in the logical plan.
+/// This reduces the volume of data flowing through the pipeline by filtering early.
+///
+/// Currently supported pushdown rules:
+/// - Selection past Projection: if the selection's predicate only references fields available in the projection's input
+/// - Selection past Join: if the selection's predicate only references fields from one side of the join
+class PredicatePushdown
+{
+public:
+    LogicalPlan apply(const LogicalPlan& queryPlan);
+
+private:
+    LogicalOperator apply(const LogicalOperator& logicalOperator);
+
+    /// Collects all field names referenced by FieldAccessLogicalFunction nodes in a logical function tree
+    static std::unordered_set<std::string> collectReferencedFields(const LogicalFunction& function);
+
+    /// Checks if all referenced fields belong to a given schema
+    static bool allFieldsBelongToSchema(const std::unordered_set<std::string>& fields, const Schema& schema);
+};
+
+}

--- a/nes-query-optimizer/src/Phases/CMakeLists.txt
+++ b/nes-query-optimizer/src/Phases/CMakeLists.txt
@@ -12,4 +12,5 @@
 
 add_source_files(nes-query-optimizer
         DecideJoinTypes.cpp
-        DecideMemoryLayout.cpp)
+        DecideMemoryLayout.cpp
+        PredicatePushdown.cpp)

--- a/nes-query-optimizer/src/Phases/PredicatePushdown.cpp
+++ b/nes-query-optimizer/src/Phases/PredicatePushdown.cpp
@@ -1,0 +1,147 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+#include <Phases/PredicatePushdown.hpp>
+
+#include <ranges>
+#include <unordered_set>
+#include <vector>
+
+#include <Functions/FieldAccessLogicalFunction.hpp>
+#include <Functions/LogicalFunction.hpp>
+#include <Iterators/BFSIterator.hpp>
+#include <Operators/LogicalOperator.hpp>
+#include <Operators/ProjectionLogicalOperator.hpp>
+#include <Operators/SelectionLogicalOperator.hpp>
+#include <Operators/Windows/JoinLogicalOperator.hpp>
+#include <Plans/LogicalPlan.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+
+std::unordered_set<std::string> PredicatePushdown::collectReferencedFields(const LogicalFunction& function)
+{
+    std::unordered_set<std::string> fields;
+    for (const auto& node : BFSRange<LogicalFunction>(function))
+    {
+        if (const auto fieldAccess = node.tryGetAs<FieldAccessLogicalFunction>())
+        {
+            fields.insert(fieldAccess.value()->getFieldName());
+        }
+    }
+    return fields;
+}
+
+bool PredicatePushdown::allFieldsBelongToSchema(const std::unordered_set<std::string>& fields, const Schema& schema)
+{
+    return std::ranges::all_of(fields, [&schema](const std::string& fieldName) { return schema.getFieldByName(fieldName).has_value(); });
+}
+
+LogicalPlan PredicatePushdown::apply(const LogicalPlan& queryPlan)
+{
+    PRECONDITION(queryPlan.getRootOperators().size() == 1, "Only single root operators are supported for now");
+    PRECONDITION(not queryPlan.getRootOperators().empty(), "Query must have a sink root operator");
+    return LogicalPlan{queryPlan.getQueryId(), {apply(queryPlan.getRootOperators()[0])}};
+}
+
+LogicalOperator PredicatePushdown::apply(const LogicalOperator& logicalOperator)
+{
+    /// First, recursively apply to all children
+    const auto children = logicalOperator.getChildren()
+        | std::views::transform([this](const LogicalOperator& child) { return apply(child); }) | std::ranges::to<std::vector>();
+    auto current = logicalOperator.withChildren(children);
+
+    /// Check if the current operator is a Selection
+    const auto selectionOp = current.tryGetAs<SelectionLogicalOperator>();
+    if (not selectionOp.has_value())
+    {
+        return current;
+    }
+
+    const auto& predicate = selectionOp.value()->getPredicate();
+    const auto referencedFields = collectReferencedFields(predicate);
+
+    /// The selection should have exactly one child
+    const auto currentChildren = current.getChildren();
+    if (currentChildren.size() != 1)
+    {
+        return current;
+    }
+    const auto& child = currentChildren[0];
+
+    /// Rule 1: Push Selection past Projection
+    /// A selection can be pushed below a projection if all fields referenced by the predicate
+    /// are available in the projection's input (i.e., they exist in the schema before the projection).
+    if (const auto projectionOp = child.tryGetAs<ProjectionLogicalOperator>())
+    {
+        /// Check that the predicate's fields exist in the projection's input schema
+        const auto projInputSchemas = projectionOp.value()->getInputSchemas();
+        if (not projInputSchemas.empty() and allFieldsBelongToSchema(referencedFields, projInputSchemas[0]))
+        {
+            NES_DEBUG("PredicatePushdown: pushing selection below projection (operator {})", child.getId());
+            /// Swap: projection becomes the parent, selection moves below it
+            /// New tree: Projection -> Selection -> Projection's children
+            const auto projChildren = child.getChildren();
+            auto newSelection = current.withChildren(projChildren);
+            /// Re-apply pushdown on the newly positioned selection in case it can be pushed further
+            newSelection = apply(newSelection);
+            return child.withChildren({newSelection});
+        }
+        return current;
+    }
+
+    /// Rule 2: Push Selection past Join
+    /// If the selection's predicate only references fields from one side of the join,
+    /// push the selection to that side.
+    if (const auto joinOp = child.tryGetAs<JoinLogicalOperator>())
+    {
+        const auto leftSchema = joinOp.value()->getLeftSchema();
+        const auto rightSchema = joinOp.value()->getRightSchema();
+        const auto joinChildren = child.getChildren();
+
+        if (joinChildren.size() != 2)
+        {
+            return current;
+        }
+
+        const auto allLeft = allFieldsBelongToSchema(referencedFields, leftSchema);
+        const auto allRight = allFieldsBelongToSchema(referencedFields, rightSchema);
+
+        if (allLeft and not allRight)
+        {
+            NES_DEBUG("PredicatePushdown: pushing selection to left side of join (operator {})", child.getId());
+            /// Push selection to the left child of the join
+            auto newLeftChild = current.withChildren({joinChildren[0]});
+            /// Re-apply pushdown on the newly positioned selection
+            newLeftChild = apply(newLeftChild);
+            return child.withChildren({newLeftChild, joinChildren[1]});
+        }
+        if (allRight and not allLeft)
+        {
+            NES_DEBUG("PredicatePushdown: pushing selection to right side of join (operator {})", child.getId());
+            /// Push selection to the right child of the join
+            auto newRightChild = current.withChildren({joinChildren[1]});
+            /// Re-apply pushdown on the newly positioned selection
+            newRightChild = apply(newRightChild);
+            return child.withChildren({joinChildren[0], newRightChild});
+        }
+        /// If the predicate references fields from both sides, we cannot push it down
+        return current;
+    }
+
+    return current;
+}
+
+}

--- a/nes-query-optimizer/src/QueryOptimizer.cpp
+++ b/nes-query-optimizer/src/QueryOptimizer.cpp
@@ -16,6 +16,7 @@
 
 #include <Phases/DecideJoinTypes.hpp>
 #include <Phases/DecideMemoryLayout.hpp>
+#include <Phases/PredicatePushdown.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <OptimizedPlan.hpp>
 #include <QueryOptimizerConfiguration.hpp>
@@ -31,10 +32,13 @@ OptimizedPlan QueryOptimizer::optimize(const LogicalPlan& plan) const
 OptimizedPlan QueryOptimizer::optimize(const LogicalPlan& plan, const QueryOptimizerConfiguration& defaultQueryOptimization)
 {
     /// In the future, we will have a real rule matching engine / rule driver for our optimizer.
-    /// For now, we just decide the join type (if one exists in the query), set the memory layout type and lower to physical operators in a pure function.
+    /// For now, we apply predicate pushdown, decide the join type (if one exists in the query),
+    /// set the memory layout type and lower to physical operators in a pure function.
+    PredicatePushdown predicatePushdown;
     DecideJoinTypes joinTypeDecider(defaultQueryOptimization.joinStrategy);
     DecideMemoryLayout memoryLayoutDecider;
-    auto optimizedPlan = joinTypeDecider.apply(plan);
+    auto pushdownPlan = predicatePushdown.apply(plan);
+    auto optimizedPlan = joinTypeDecider.apply(pushdownPlan);
     return OptimizedPlan{memoryLayoutDecider.apply(optimizedPlan)};
 }
 

--- a/nes-query-optimizer/tests/CMakeLists.txt
+++ b/nes-query-optimizer/tests/CMakeLists.txt
@@ -19,3 +19,4 @@ endfunction()
 
 add_nes_optimizer_test(DecideJoinTypesTest UnitTests/DecideJoinTypesTest.cpp)
 add_nes_optimizer_test(DecideMemoryLayoutTest UnitTests/DecideMemoryLayoutTest.cpp)
+add_nes_optimizer_test(PredicatePushdownTest UnitTests/PredicatePushdownTest.cpp)

--- a/nes-query-optimizer/tests/UnitTests/PredicatePushdownTest.cpp
+++ b/nes-query-optimizer/tests/UnitTests/PredicatePushdownTest.cpp
@@ -1,0 +1,237 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <Util/Logger/LogLevel.hpp>
+#include <Util/Logger/impl/NesLogger.hpp>
+#include <gtest/gtest.h>
+#include <BaseUnitTest.hpp>
+
+#include <Phases/PredicatePushdown.hpp>
+
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/DataTypeProvider.hpp>
+#include <DataTypes/Schema.hpp>
+#include <Functions/BooleanFunctions/EqualsLogicalFunction.hpp>
+#include <Functions/ComparisonFunctions/GreaterLogicalFunction.hpp>
+#include <Functions/FieldAccessLogicalFunction.hpp>
+#include <Iterators/BFSIterator.hpp>
+#include <Operators/LogicalOperator.hpp>
+#include <Operators/ProjectionLogicalOperator.hpp>
+#include <Operators/SelectionLogicalOperator.hpp>
+#include <Operators/Windows/JoinLogicalOperator.hpp>
+#include <Plans/LogicalPlan.hpp>
+#include <Plans/LogicalPlanBuilder.hpp>
+#include <WindowTypes/Measures/TimeCharacteristic.hpp>
+#include <WindowTypes/Measures/TimeMeasure.hpp>
+#include <WindowTypes/Types/TumblingWindow.hpp>
+#include <WindowTypes/Types/WindowType.hpp>
+
+namespace NES
+{
+namespace
+{
+
+class PredicatePushdownTest : public Testing::BaseUnitTest
+{
+public:
+    static void SetUpTestSuite() { Logger::setupLogging("PredicatePushdownTest.log", LogLevel::LOG_DEBUG); }
+
+    static constexpr uint64_t TUMBLING_WINDOW_SIZE_MS = 1000;
+
+    static LogicalPlan createSourcePlan(const std::string& sourceType, const Schema& schema)
+    {
+        return LogicalPlanBuilder::createLogicalPlan(sourceType, schema, {}, {});
+    }
+
+    static Schema createSchema(const std::string& prefix)
+    {
+        Schema schema;
+        schema.addField(prefix + ".id", DataTypeProvider::provideDataType(DataType::Type::UINT64));
+        schema.addField(prefix + ".value", DataTypeProvider::provideDataType(DataType::Type::UINT64));
+        schema.addField(prefix + ".ts", DataTypeProvider::provideDataType(DataType::Type::UINT64));
+        return schema;
+    }
+
+    static std::shared_ptr<Windowing::WindowType> createTumblingWindow()
+    {
+        return std::make_shared<Windowing::TumblingWindow>(
+            Windowing::TimeCharacteristic::createIngestionTime(), Windowing::TimeMeasure(TUMBLING_WINDOW_SIZE_MS));
+    }
+};
+
+/// A plan without any Selection should remain unchanged.
+TEST_F(PredicatePushdownTest, PlanWithoutSelectionIsUnchanged)
+{
+    auto schema = createSchema("src");
+    auto plan = createSourcePlan("TEST", schema);
+    plan = LogicalPlanBuilder::addSink("test_sink", plan);
+
+    PredicatePushdown phase;
+    auto result = phase.apply(plan);
+
+    /// The plan should have the same structure
+    ASSERT_EQ(result.getRootOperators().size(), 1);
+    auto root = result.getRootOperators()[0];
+    EXPECT_EQ(root.getName(), "Sink");
+}
+
+/// Selection above Projection: selection should be pushed below the projection.
+/// Plan: Sink -> Selection -> Projection -> Source
+/// Expected: Sink -> Projection -> Selection -> Source
+TEST_F(PredicatePushdownTest, SelectionPushedBelowProjection)
+{
+    auto schema = createSchema("src");
+    auto plan = createSourcePlan("TEST", schema);
+
+    /// Add a projection that keeps all fields
+    std::vector<ProjectionLogicalOperator::Projection> projections;
+    projections.emplace_back(std::nullopt, LogicalFunction{FieldAccessLogicalFunction("src.id")});
+    projections.emplace_back(std::nullopt, LogicalFunction{FieldAccessLogicalFunction("src.value")});
+    plan = LogicalPlanBuilder::addProjection(projections, false, plan);
+
+    /// Add a selection that filters on src.id (which is available before the projection)
+    auto selectionFn = LogicalFunction{GreaterLogicalFunction(
+        LogicalFunction{FieldAccessLogicalFunction("src.id")}, LogicalFunction{FieldAccessLogicalFunction("src.id")})};
+    plan = LogicalPlanBuilder::addSelection(selectionFn, plan);
+    plan = LogicalPlanBuilder::addSink("test_sink", plan);
+
+    PredicatePushdown phase;
+    auto result = phase.apply(plan);
+
+    /// Verify the structure: Sink -> Projection -> Selection -> Source
+    auto root = result.getRootOperators()[0];
+    EXPECT_EQ(root.getName(), "Sink");
+
+    auto sinkChildren = root.getChildren();
+    ASSERT_EQ(sinkChildren.size(), 1);
+    EXPECT_EQ(sinkChildren[0].getName(), "Projection") << "Expected Projection as first child of Sink after pushdown";
+
+    auto projChildren = sinkChildren[0].getChildren();
+    ASSERT_EQ(projChildren.size(), 1);
+    EXPECT_EQ(projChildren[0].getName(), "Selection") << "Expected Selection as child of Projection after pushdown";
+}
+
+/// Selection above Join referencing only left side fields: push selection to left child.
+/// Plan: Sink -> Selection(left.id > left.id) -> Join -> (Left, Right)
+/// Expected: Sink -> Join -> (Selection(left.id > left.id) -> Left, Right)
+TEST_F(PredicatePushdownTest, SelectionPushedToLeftSideOfJoin)
+{
+    auto leftSchema = createSchema("left");
+    auto rightSchema = createSchema("right");
+    auto leftPlan = createSourcePlan("TEST", leftSchema);
+    auto rightPlan = createSourcePlan("TEST", rightSchema);
+
+    auto joinFunction = LogicalFunction{EqualsLogicalFunction(
+        LogicalFunction{FieldAccessLogicalFunction("left.id")}, LogicalFunction{FieldAccessLogicalFunction("right.id")})};
+
+    auto plan
+        = LogicalPlanBuilder::addJoin(leftPlan, rightPlan, joinFunction, createTumblingWindow(), JoinLogicalOperator::JoinType::INNER_JOIN);
+
+    /// Add a selection that references only left-side fields
+    auto selectionFn = LogicalFunction{GreaterLogicalFunction(
+        LogicalFunction{FieldAccessLogicalFunction("left.id")}, LogicalFunction{FieldAccessLogicalFunction("left.id")})};
+    plan = LogicalPlanBuilder::addSelection(selectionFn, plan);
+    plan = LogicalPlanBuilder::addSink("test_sink", plan);
+
+    PredicatePushdown phase;
+    auto result = phase.apply(plan);
+
+    /// Verify: Sink -> Join -> (Selection -> Left, Right)
+    auto root = result.getRootOperators()[0];
+    EXPECT_EQ(root.getName(), "Sink");
+
+    auto sinkChildren = root.getChildren();
+    ASSERT_EQ(sinkChildren.size(), 1);
+    EXPECT_EQ(sinkChildren[0].getName(), "Join") << "Expected Join directly under Sink after pushdown";
+
+    auto joinChildren = sinkChildren[0].getChildren();
+    ASSERT_EQ(joinChildren.size(), 2);
+    EXPECT_EQ(joinChildren[0].getName(), "Selection") << "Expected Selection pushed to left side of Join";
+}
+
+/// Selection above Join referencing only right side fields: push selection to right child.
+TEST_F(PredicatePushdownTest, SelectionPushedToRightSideOfJoin)
+{
+    auto leftSchema = createSchema("left");
+    auto rightSchema = createSchema("right");
+    auto leftPlan = createSourcePlan("TEST", leftSchema);
+    auto rightPlan = createSourcePlan("TEST", rightSchema);
+
+    auto joinFunction = LogicalFunction{EqualsLogicalFunction(
+        LogicalFunction{FieldAccessLogicalFunction("left.id")}, LogicalFunction{FieldAccessLogicalFunction("right.id")})};
+
+    auto plan
+        = LogicalPlanBuilder::addJoin(leftPlan, rightPlan, joinFunction, createTumblingWindow(), JoinLogicalOperator::JoinType::INNER_JOIN);
+
+    /// Add a selection that references only right-side fields
+    auto selectionFn = LogicalFunction{GreaterLogicalFunction(
+        LogicalFunction{FieldAccessLogicalFunction("right.value")}, LogicalFunction{FieldAccessLogicalFunction("right.value")})};
+    plan = LogicalPlanBuilder::addSelection(selectionFn, plan);
+    plan = LogicalPlanBuilder::addSink("test_sink", plan);
+
+    PredicatePushdown phase;
+    auto result = phase.apply(plan);
+
+    /// Verify: Sink -> Join -> (Left, Selection -> Right)
+    auto root = result.getRootOperators()[0];
+    auto sinkChildren = root.getChildren();
+    ASSERT_EQ(sinkChildren.size(), 1);
+    EXPECT_EQ(sinkChildren[0].getName(), "Join");
+
+    auto joinChildren = sinkChildren[0].getChildren();
+    ASSERT_EQ(joinChildren.size(), 2);
+    EXPECT_NE(joinChildren[0].getName(), "Selection") << "Selection should not be on the left side";
+    EXPECT_EQ(joinChildren[1].getName(), "Selection") << "Expected Selection pushed to right side of Join";
+}
+
+/// Selection above Join referencing both sides: selection should NOT be pushed down.
+TEST_F(PredicatePushdownTest, SelectionReferencingBothSidesStaysAboveJoin)
+{
+    auto leftSchema = createSchema("left");
+    auto rightSchema = createSchema("right");
+    auto leftPlan = createSourcePlan("TEST", leftSchema);
+    auto rightPlan = createSourcePlan("TEST", rightSchema);
+
+    auto joinFunction = LogicalFunction{EqualsLogicalFunction(
+        LogicalFunction{FieldAccessLogicalFunction("left.id")}, LogicalFunction{FieldAccessLogicalFunction("right.id")})};
+
+    auto plan
+        = LogicalPlanBuilder::addJoin(leftPlan, rightPlan, joinFunction, createTumblingWindow(), JoinLogicalOperator::JoinType::INNER_JOIN);
+
+    /// Add a selection that references fields from both sides
+    auto selectionFn = LogicalFunction{EqualsLogicalFunction(
+        LogicalFunction{FieldAccessLogicalFunction("left.value")}, LogicalFunction{FieldAccessLogicalFunction("right.value")})};
+    plan = LogicalPlanBuilder::addSelection(selectionFn, plan);
+    plan = LogicalPlanBuilder::addSink("test_sink", plan);
+
+    PredicatePushdown phase;
+    auto result = phase.apply(plan);
+
+    /// Verify: Sink -> Selection -> Join (unchanged)
+    auto root = result.getRootOperators()[0];
+    auto sinkChildren = root.getChildren();
+    ASSERT_EQ(sinkChildren.size(), 1);
+    EXPECT_EQ(sinkChildren[0].getName(), "Selection") << "Selection referencing both sides should stay above Join";
+
+    auto selectionChildren = sinkChildren[0].getChildren();
+    ASSERT_EQ(selectionChildren.size(), 1);
+    EXPECT_EQ(selectionChildren[0].getName(), "Join");
+}
+
+}
+}


### PR DESCRIPTION
## Summary
- Adds a `PredicatePushdown` optimization phase to the query optimizer that pushes `Selection` (filter) operators closer to data sources
- Supports pushing selections below `Projection` operators (when predicate fields exist in input schema) and past `Join` operators (when predicate references only one side)
- Registered as the first phase in `QueryOptimizer::optimize()`, running before `DecideJoinTypes` and `DecideMemoryLayout`

Closes #1376

**Note:** This is the first of several planned optimization phases (predicate pushdown). Projection pruning and join reordering are planned as follow-up work.

## Test plan
- [ ] `PredicatePushdownTest::PlanWithoutSelectionIsUnchanged` — verifies plans without selections pass through unmodified
- [ ] `PredicatePushdownTest::SelectionPushedBelowProjection` — verifies selection is swapped below projection
- [ ] `PredicatePushdownTest::SelectionPushedToLeftSideOfJoin` — verifies selection pushed to left join child when predicate references only left fields
- [ ] `PredicatePushdownTest::SelectionPushedToRightSideOfJoin` — verifies selection pushed to right join child
- [ ] `PredicatePushdownTest::SelectionReferencingBothSidesStaysAboveJoin` — verifies selection stays above join when it references both sides

🤖 Generated with [Claude Code](https://claude.com/claude-code)