### PR TITLE
feat(SIMDJSON): supports access to nested data

### DIFF
--- a/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONInputFormatIndexer.hpp
+++ b/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONInputFormatIndexer.hpp
@@ -62,6 +62,13 @@ struct ConfigParametersSIMDJSON
         = DescriptorConfig::createConfigParameterContainerMap(InputFormatterDescriptor::parameterMap, TUPLE_DELIMITER);
 };
 
+/// Parses JSON-encoded tuples (one JSON object per tuple delimiter, '\n' by default) using
+/// SIMDJSON's ondemand parser. Nested JSON objects are accessed by encoding the path in the
+/// (quoted) schema field name with '/' as separator, e.g. "MILK/CYCLES/LEFT" reads
+/// {"MILK": {"CYCLES": {"LEFT": ...}}}. Unquoted identifiers are uppercased, so JSON keys must be
+/// uppercase to match; use quoted identifiers for case-sensitive keys. For nullable fields, a
+/// missing field, a missing parent object, or an explicit JSON null all map to NULL; for NOT NULL
+/// fields, a missing field/parent raises FieldNotFound. JSON arrays are not supported.
 class SIMDJSONInputFormatIndexer final : public InputFormatIndexer
 {
     /// Passkey idiom (to enforce checks before calling the constructor)
@@ -80,11 +87,11 @@ public:
     explicit SIMDJSONInputFormatIndexer(
         Private,
         const char tupleDelimiter,
-        std::vector<Identifier> fieldNamesInJson,
+        std::vector<std::string> jsonPointersToFields,
         std::vector<Record::RecordFieldIdentifier> fieldNamesOutput,
         std::vector<DataType> fieldDataTypes)
         : tupleDelimiter(tupleDelimiter)
-        , fieldNamesInJson(std::move(fieldNamesInJson))
+        , jsonPointersToFields(std::move(jsonPointersToFields))
         , fieldNamesOutput(std::move(fieldNamesOutput))
         , fieldDataTypes(std::move(fieldDataTypes))
         , nullValues({})
@@ -95,21 +102,23 @@ public:
     static std::unique_ptr<SIMDJSONInputFormatIndexer> create(const InputFormatterDescriptor& config, const TupleBufferRef& tupleBufferRef)
     {
         /// JSON keys are unqualified — take the trailing identifier of each (possibly source-qualified) name.
-        std::vector<Identifier> fieldNamesInJson;
+        /// Precompute each field's JSON Pointer (RFC 6901) once: prepend '/' and escape literal '~' as
+        /// '~0'. A '/' in a (quoted) field name deliberately stays unescaped — it separates nesting levels.
+        std::vector<std::string> jsonPointersToFields;
         for (const auto& fieldName : tupleBufferRef.getAllFieldNames())
         {
-            fieldNamesInJson.emplace_back(*std::ranges::rbegin(fieldName));
+            jsonPointersToFields.emplace_back("/" + replaceAll(std::ranges::rbegin(fieldName)->asCanonicalString(), "~", "~0"));
         }
 
         auto fieldNamesOutput = tupleBufferRef.getAllFieldNames();
         auto fieldDataTypes = tupleBufferRef.getAllDataTypes();
-        PRECONDITION(fieldNamesInJson.size() == fieldDataTypes.size(), "No. fields must be equal to no. data types");
+        PRECONDITION(jsonPointersToFields.size() == fieldDataTypes.size(), "No. fields must be equal to no. data types");
         PRECONDITION(fieldNamesOutput.size() == fieldDataTypes.size(), "No. fields must be equal to no. data types");
 
         return std::make_unique<SIMDJSONInputFormatIndexer>(
             Private{},
             config.getFromConfig(ConfigParametersSIMDJSON::TUPLE_DELIMITER),
-            std::move(fieldNamesInJson),
+            std::move(jsonPointersToFields),
             std::move(fieldNamesOutput),
             std::move(fieldDataTypes));
     }
@@ -130,7 +139,10 @@ public:
 
     [[nodiscard]] const Record::RecordFieldIdentifier& getFieldNameAt(uint64_t fieldIndex) const { return fieldNamesOutput[fieldIndex]; }
 
-    [[nodiscard]] const Identifier& getFieldNameInJsonAt(uint64_t fieldIndex) const { return fieldNamesInJson[fieldIndex]; }
+    [[nodiscard]] std::string_view getJsonPointerAt(const nautilus::static_val<uint64_t>& fieldIndex) const
+    {
+        return jsonPointersToFields[fieldIndex];
+    }
 
     [[nodiscard]] const DataType& getFieldDataTypeAt(uint64_t fieldIndex) const { return fieldDataTypes[fieldIndex]; }
 
@@ -145,7 +157,7 @@ protected:
 
 private:
     char tupleDelimiter;
-    std::vector<Identifier> fieldNamesInJson;
+    std::vector<std::string> jsonPointersToFields;
     std::vector<Record::RecordFieldIdentifier> fieldNamesOutput;
     std::vector<DataType> fieldDataTypes;
     std::vector<std::string> nullValues;

--- a/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONParsingUtil.hpp
+++ b/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONParsingUtil.hpp
@@ -27,7 +27,6 @@
 #include <DataTypes/DataTypesUtil.hpp>
 #include <DataTypes/VarVal.hpp>
 #include <DataTypes/VariableSizedData.hpp>
-#include <Identifiers/Identifier.hpp>
 #include <Identifiers/QualifiedIdentifier.hpp>
 #include <Interface/Record.hpp>
 #include <magic_enum/magic_enum.hpp>
@@ -70,37 +69,30 @@ requires(
 ParseResultFixed<T>*
 parseJsonFixedSizeIntoVarValProxy(FieldIndex fieldIndex, RawBufferIndex* rawBufferIndex, const InputFormatIndexer* indexer);
 
-inline simdjson::simdjson_result<simdjson::ondemand::value> accessSIMDJsonFieldOrThrow(
-    simdjson::simdjson_result<simdjson::ondemand::document_reference>& simdJsonReference, const std::string_view fieldName)
+/// Navigates to the field's value via simdjson's JSON Pointer API (the pointer is precomputed in
+/// SIMDJSONInputFormatIndexer). at_pointer rewinds the document, which resets the parser's internal
+/// string buffer; string values extracted earlier in the same tuple would dangle, which is why
+/// parseJsonVarSizedProxy copies var-sized values out (see SIMDJSONRawBufferIndex::storeVarSizedValue).
+/// For nullable fields, a missing field, a missing parent object, or an explicit JSON null all map to
+/// NULL (nullopt). For non-nullable fields, a missing field/parent throws FieldNotFound.
+template <bool Nullable>
+std::optional<simdjson::simdjson_result<simdjson::ondemand::value>>
+navigateToField(simdjson::simdjson_result<simdjson::ondemand::document_reference>& doc, const std::string_view jsonPointer)
 {
-    const auto simdJsonResult = simdJsonReference[fieldName];
-    if (not simdJsonResult.has_value())
+    auto simdJsonResult = doc.at_pointer(jsonPointer);
+    if constexpr (Nullable)
+    {
+        if (not simdJsonResult.has_value() or simdJsonResult.is_null())
+        {
+            return std::nullopt;
+        }
+    }
+    else if (not simdJsonResult.has_value())
     {
         throw FieldNotFound(
-            "SimdJson has not found the fieldName {} with error: {}", fieldName, magic_enum::enum_name(simdJsonResult.error()));
+            "SimdJson has not found the field at {} with error: {}", jsonPointer, magic_enum::enum_name(simdJsonResult.error()));
     }
     return simdJsonResult;
-}
-
-inline bool checkIsNullJsonProxy(
-    const FieldIndex fieldIndex, const SIMDJSONRawBufferIndex* simdJsonRawBufferIndex, const SIMDJSONInputFormatIndexer* simdIndexer)
-{
-    const auto fieldNameStr = simdIndexer->getFieldNameInJsonAt(fieldIndex).asCanonicalString();
-    const std::string_view fieldName = fieldNameStr;
-    auto currentDoc = *simdJsonRawBufferIndex->getDocStreamIterator();
-
-    /// First, we check if the key is not in the doc. If this is the case, we can return true, as this counts as null
-    if (not currentDoc[fieldName].has_value())
-    {
-        return true;
-    }
-
-    /// Second, we need to check if the key is equal to one of the null values
-    if (accessSIMDJsonFieldOrThrow(currentDoc, fieldName).is_null())
-    {
-        return true;
-    }
-    return false;
 }
 
 VarVal parseJsonVarSized(
@@ -201,31 +193,26 @@ parseJsonFixedSizeIntoVarValProxy(const FieldIndex fieldIndex, RawBufferIndex* r
     thread_local static ParseResultFixed<T> result;
     result.isNull = false;
 
-    /// Checking if the field is null but only if the field is nullable
-    if constexpr (Nullable)
-    {
-        if (checkIsNullJsonProxy(fieldIndex, simdJsonRawBufferIndex, simdIndexer))
-        {
-            result.isNull = true;
-            result.value = T{0};
-            return &result;
-        }
-    }
-
-    const auto fieldNameStr = simdIndexer->getFieldNameInJsonAt(fieldIndex).asCanonicalString();
-    const std::string_view fieldName = fieldNameStr;
+    const auto jsonPointer = simdIndexer->getJsonPointerAt(fieldIndex);
     auto currentDoc = *simdJsonRawBufferIndex->getDocStreamIterator();
-    auto simdJsonResult = accessSIMDJsonFieldOrThrow(currentDoc, fieldName);
+    auto navigated = navigateToField<Nullable>(currentDoc, jsonPointer);
+    if (not navigated.has_value())
+    {
+        result.isNull = true;
+        result.value = T{0};
+        return &result;
+    }
+    auto& simdJsonResult = navigated.value();
     /// Order is important, since signed_integral<char> is true and unsigned_integral<bool> is true
     if constexpr (std::same_as<T, bool>)
     {
-        const auto parsedValue = parseSIMDJsonValueOrThrow<T, Nullable>(simdJsonResult.get_bool(), simdJsonResult, "bool", fieldName);
+        const auto parsedValue = parseSIMDJsonValueOrThrow<T, Nullable>(simdJsonResult.get_bool(), simdJsonResult, "bool", jsonPointer);
         return returnNullValueOrParsed(parsedValue, result);
     }
     else if constexpr (std::same_as<T, char>)
     {
         const auto parsedValue
-            = parseSIMDJsonValueOrThrow<std::string_view, Nullable>(simdJsonResult.get_string(), simdJsonResult, "char", fieldName);
+            = parseSIMDJsonValueOrThrow<std::string_view, Nullable>(simdJsonResult.get_string(), simdJsonResult, "char", jsonPointer);
         if (not parsedValue.has_value())
         {
             result.isNull = true;
@@ -239,24 +226,24 @@ parseJsonFixedSizeIntoVarValProxy(const FieldIndex fieldIndex, RawBufferIndex* r
     else if constexpr (std::signed_integral<T>)
     {
         const auto parsedValue
-            = parseSIMDJsonValueOrThrow<int64_t, Nullable>(simdJsonResult.get_int64(), simdJsonResult, "integer", fieldName);
+            = parseSIMDJsonValueOrThrow<int64_t, Nullable>(simdJsonResult.get_int64(), simdJsonResult, "integer", jsonPointer);
         return returnNullValueOrParsed(parsedValue, result);
     }
     else if constexpr (std::unsigned_integral<T>)
     {
         const auto parsedValue
-            = parseSIMDJsonValueOrThrow<uint64_t, Nullable>(simdJsonResult.get_uint64(), simdJsonResult, "unsigned", fieldName);
+            = parseSIMDJsonValueOrThrow<uint64_t, Nullable>(simdJsonResult.get_uint64(), simdJsonResult, "unsigned", jsonPointer);
         return returnNullValueOrParsed(parsedValue, result);
     }
     else if constexpr (std::is_same_v<T, double>)
     {
-        const auto parsedValue = parseSIMDJsonValueOrThrow<T, Nullable>(simdJsonResult.get_double(), simdJsonResult, "double", fieldName);
+        const auto parsedValue = parseSIMDJsonValueOrThrow<T, Nullable>(simdJsonResult.get_double(), simdJsonResult, "double", jsonPointer);
         return returnNullValueOrParsed(parsedValue, result);
     }
     else if constexpr (std::is_same_v<T, float>)
     {
         const auto parsedValue
-            = parseSIMDJsonValueOrThrow<double, Nullable>(simdJsonResult.get_double(), simdJsonResult, "float", fieldName);
+            = parseSIMDJsonValueOrThrow<double, Nullable>(simdJsonResult.get_double(), simdJsonResult, "float", jsonPointer);
         return returnNullValueOrParsed(parsedValue, result);
     }
     else
@@ -285,24 +272,26 @@ ParsedResultVariableSized* parseJsonVarSizedProxy(FieldIndex fieldIndex, RawBuff
     /// the size of the var sized and the pointer to it
     thread_local ParsedResultVariableSized result{};
 
-    /// Checking if the field is null but only if the field is nullable
-    if constexpr (Nullable)
-    {
-        if (checkIsNullJsonProxy(fieldIndex, simdJsonRawBufferIndex, simdIndexer))
-        {
-            constexpr auto sizeOfValue = 0;
-            result = ParsedResultVariableSized{.varSizedPointer = nullptr, .size = sizeOfValue, .isNull = true};
-            return &result;
-        }
-    }
+    const auto jsonPointer = simdIndexer->getJsonPointerAt(fieldIndex);
     auto currentDoc = *simdJsonRawBufferIndex->getDocStreamIterator();
-    const auto fieldNameStr = simdIndexer->getFieldNameInJsonAt(fieldIndex).asCanonicalString();
-    const std::string_view fieldName = fieldNameStr;
+    auto navigated = navigateToField<Nullable>(currentDoc, jsonPointer);
+    if (not navigated.has_value())
+    {
+        result = ParsedResultVariableSized{.varSizedPointer = nullptr, .size = 0, .isNull = true};
+        return &result;
+    }
+    const auto parsedValue
+        = parseSIMDJsonValueOrThrow<std::string_view, Nullable>(navigated->get_string(), *navigated, "string", jsonPointer);
+    if (not parsedValue.has_value())
+    {
+        result = ParsedResultVariableSized{.varSizedPointer = nullptr, .size = 0, .isNull = true};
+        return &result;
+    }
 
-    /// Get the value from the document and convert it to a span of bytes
-    const std::string_view value = accessSIMDJsonFieldOrThrow(currentDoc, fieldName);
-
-    result = ParsedResultVariableSized{.varSizedPointer = value.data(), .size = value.size(), .isNull = false};
+    /// at_pointer for a later field of this tuple rewinds the parser and reuses its string buffer,
+    /// so copy the value to keep it valid until the tuple has been emitted.
+    const std::string& stored = simdJsonRawBufferIndex->storeVarSizedValue(parsedValue.value());
+    result = ParsedResultVariableSized{.varSizedPointer = stored.data(), .size = stored.size(), .isNull = false};
     return &result;
 }
 

--- a/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONRawBufferIndex.cpp
+++ b/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONRawBufferIndex.cpp
@@ -194,6 +194,7 @@ std::pair<bool, FieldIndex> SIMDJSONRawBufferIndex::indexJSON(const std::string_
 std::pair<bool, FieldIndex> SIMDJSONRawBufferIndex::indexJSON(const std::string_view jsonSV, size_t batchSize)
 {
     const simdjson::padded_string_view paddedJSONSV{jsonSV.data(), jsonSV.size(), jsonSV.size() + simdjson::SIMDJSON_PADDING};
+    this->varSizedValues.clear();
     this->parser = std::make_shared<simdjson::ondemand::parser>();
     this->parser->threaded = false;
     if (jsonSV.size() > batchSize)

--- a/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONRawBufferIndex.hpp
+++ b/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONRawBufferIndex.hpp
@@ -16,8 +16,10 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <memory>
 #include <optional>
+#include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
@@ -72,6 +74,11 @@ public:
 
     [[nodiscard]] simdjson::ondemand::document_stream::iterator getDocStreamIterator() const { return docStreamIterator; }
 
+    /// Copies a var-sized value out of simdjson's string buffer: at_pointer for a later field of the
+    /// same tuple rewinds the parser and overwrites that buffer. A deque never relocates stored
+    /// strings; cleared per raw buffer in indexJSON, so growth is bounded by the batch size.
+    const std::string& storeVarSizedValue(const std::string_view value) { return varSizedValues.emplace_back(value); }
+
 private:
     bool isAtLastTuple{false};
     FieldIndex offsetOfFirstTuple{};
@@ -79,6 +86,7 @@ private:
     std::shared_ptr<simdjson::ondemand::parser> parser;
     std::shared_ptr<simdjson::ondemand::document_stream> docStream;
     simdjson::ondemand::document_stream::iterator docStreamIterator;
+    std::deque<std::string> varSizedValues;
 };
 
 }

--- a/nes-systests/formatter/JSON/NestedJSON.test
+++ b/nes-systests/formatter/JSON/NestedJSON.test
@@ -1,0 +1,137 @@
+# name: NestedJSON.test
+# description: tests support for nested json
+# groups: [Formatter, JSON]
+
+CREATE LOGICAL SOURCE NestedJSON("key" UINT64, "value" UINT64, "EXTRA_KEY/NAME" VARSIZED);
+CREATE PHYSICAL SOURCE FOR NestedJSON TYPE File SET('JSON' AS INPUT_FORMATTER."TYPE");
+ATTACH INLINE
+{"key":1, "value":2, "EXTRA_KEY": {"NAME": "max"}}
+
+
+CREATE LOGICAL SOURCE NestedJSON2("machineId" UINT32, "milk/cycles/left" FLOAT64, "milk/cycles/right" FLOAT64, "milk/totalTime" FLOAT64, "water/totalQuantity" FLOAT64);
+CREATE PHYSICAL SOURCE FOR NestedJSON2 TYPE File SET('JSON' AS INPUT_FORMATTER."TYPE");
+ATTACH INLINE
+{"machineId":101,"milk":{"cycles":{"left":0,"right":0},"totalTime":0.0},"water":{"totalQuantity":0.0}}
+
+SELECT "key", "value", "EXTRA_KEY/NAME" FROM NestedJSON INTO File();
+----
+1,2,max
+
+CREATE LOGICAL SOURCE CoffeeJSON("absoluteCounter" UINT64, "airPumpTime" FLOAT64, "beans/frontOrRightQuantity" FLOAT64, "milk/cycles/left" UINT64);
+CREATE PHYSICAL SOURCE FOR CoffeeJSON TYPE File SET('JSON' AS INPUT_FORMATTER."TYPE");
+ATTACH INLINE
+{"absoluteCounter": 0, "airPumpTime": 0.1, "beans": {"adjustment": 0, "frontOrRightQuantity": 0.1, "powderChuteQuantity": 0.1, "quantityHopper1": 0.1, "quantityHopper2": 0.1, "quantityHopper3": 0.1, "quantityHopper4": 0.1, "rearOrLeftQuantity": 0.1, "totalQuantity": 0.1}, "brewCycles": {"left": 0, "right": 0}, "cleaningCounter": 0, "heatingTimeCoffeeBoiler": {"left": 0.1, "right": 0.1}, "hotWaterTime": 0.1, "lastReset": "2021-12-14T15:05:03", "machineId": 0, "machineTimestamp": "2021-12-14T15:05:03", "milk": {"cycles": {"left": 0, "right": 0}, "steamTime": {"left": 0.1, "right": 0.1}, "totalTime": 0.1}, "powder": {"time": 0, "totalQuantityLeft": 0, "totalQuantityRight": 0}, "rinseOrCleanCycles": {"left": 0, "right": 0}, "serverTimestamp": "2022-01-27T08:36:23Z", "steam": {"heatingTimeSteamBoilers": [0.1], "steamTime": {"left": 0.1, "right": 0.1}}, "water": {"cleaningQuantity": 0.1, "productsQuantity": 0.1, "purgeQuantity": 0.1, "rinseQuantity": 0.1, "totalQuantity": 0.1}}
+
+SELECT "absoluteCounter", "airPumpTime", "beans/frontOrRightQuantity", "milk/cycles/left" FROM CoffeeJSON INTO File();
+----
+0,0.1,0.1,0
+
+
+SELECT "machineId", "milk/cycles/left", "milk/cycles/right", "milk/totalTime", "water/totalQuantity" FROM NestedJSON2 INTO File();
+----
+101,0,0,0.0,0.0
+
+## Multiple VARSIZED fields from same and different nested parents.
+CREATE LOGICAL SOURCE MultiVarsized("id" UINT64 NOT NULL, "user/name" VARSIZED NOT NULL, "user/email" VARSIZED NOT NULL, "meta/tag" VARSIZED NOT NULL);
+CREATE PHYSICAL SOURCE FOR MultiVarsized TYPE File SET('JSON' AS INPUT_FORMATTER."TYPE");
+ATTACH INLINE
+{"id": 1, "user": {"name": "alice", "email": "alice@test.com"}, "meta": {"tag": "admin"}}
+{"id": 2, "user": {"name": "bob", "email": "bob@test.com"}, "meta": {"tag": "user"}}
+
+SELECT "id", "user/name", "user/email", "meta/tag" FROM MultiVarsized INTO File();
+----
+1,alice,alice@test.com,admin
+2,bob,bob@test.com,user
+
+## Schema field order is the reverse of JSON key order.
+CREATE LOGICAL SOURCE ReversedOrder("c/val" VARSIZED NOT NULL, "b/val" VARSIZED NOT NULL, "a/val" VARSIZED NOT NULL);
+CREATE PHYSICAL SOURCE FOR ReversedOrder TYPE File SET('JSON' AS INPUT_FORMATTER."TYPE");
+ATTACH INLINE
+{"a": {"val": "first"}, "b": {"val": "middle"}, "c": {"val": "last"}}
+
+SELECT "c/val", "b/val", "a/val" FROM ReversedOrder INTO File();
+----
+last,middle,first
+
+## Multiple siblings under the same deeply nested parent.
+CREATE LOGICAL SOURCE DeepSiblings("root/a/x" UINT64 NOT NULL, "root/a/y" UINT64 NOT NULL, "root/b/x" UINT64 NOT NULL, "root/b/y" UINT64 NOT NULL);
+CREATE PHYSICAL SOURCE FOR DeepSiblings TYPE File SET('JSON' AS INPUT_FORMATTER."TYPE");
+ATTACH INLINE
+{"root": {"a": {"x": 10, "y": 20}, "b": {"x": 30, "y": 40}}}
+
+SELECT "root/a/x", "root/a/y", "root/b/x", "root/b/y" FROM DeepSiblings INTO File();
+----
+10,20,30,40
+
+## Multiple VARSIZED fields from sibling nested parents, multiple tuples.
+CREATE LOGICAL SOURCE VarsizedSiblings("source/name" VARSIZED NOT NULL, "source/location" VARSIZED NOT NULL, "target/name" VARSIZED NOT NULL, "target/location" VARSIZED NOT NULL);
+CREATE PHYSICAL SOURCE FOR VarsizedSiblings TYPE File SET('JSON' AS INPUT_FORMATTER."TYPE");
+ATTACH INLINE
+{"source": {"name": "sensor-1", "location": "room-a"}, "target": {"name": "actuator-1", "location": "room-b"}}
+{"source": {"name": "sensor-2", "location": "room-c"}, "target": {"name": "actuator-2", "location": "room-d"}}
+
+SELECT "source/name", "source/location", "target/name", "target/location" FROM VarsizedSiblings INTO File();
+----
+sensor-1,room-a,actuator-1,room-b
+sensor-2,room-c,actuator-2,room-d
+
+## Nullable nested fields: explicit null, missing child key, missing parent object.
+CREATE LOGICAL SOURCE NestedNullable("id" UINT64 NOT NULL, "info/city" VARSIZED, "info/zip" UINT32);
+CREATE PHYSICAL SOURCE FOR NestedNullable TYPE File SET('JSON' AS INPUT_FORMATTER."TYPE");
+ATTACH INLINE
+{"id": 1, "info": {"city": "berlin", "zip": 10115}}
+{"id": 2, "info": {"city": null, "zip": 20095}}
+{"id": 3, "info": {"zip": 30159}}
+{"id": 4}
+
+SELECT "id", "info/city", "info/zip" FROM NestedNullable INTO File();
+----
+1,berlin,10115
+2,NULL,20095
+3,NULL,30159
+4,NULL,NULL
+
+## Missing nested child key with NOT NULL field.
+## Must produce an error, not silently return a default value.
+CREATE LOGICAL SOURCE NestedMissing("id" UINT64 NOT NULL, "info/missing" VARSIZED NOT NULL);
+CREATE PHYSICAL SOURCE FOR NestedMissing TYPE File SET('JSON' AS INPUT_FORMATTER."TYPE");
+ATTACH INLINE
+{"id": 1, "info": {"city": "berlin"}}
+
+SELECT "id", "info/missing" FROM NestedMissing INTO File();
+----
+ERROR 2004
+
+## Missing parent object with NOT NULL nested field.
+CREATE LOGICAL SOURCE MissingParent("id" UINT64 NOT NULL, "info/city" VARSIZED NOT NULL);
+CREATE PHYSICAL SOURCE FOR MissingParent TYPE File SET('JSON' AS INPUT_FORMATTER."TYPE");
+ATTACH INLINE
+{"id": 1}
+
+SELECT "id", "info/city" FROM MissingParent INTO File();
+----
+ERROR 2004
+
+## Multiple tuples with varying string lengths across records.
+CREATE LOGICAL SOURCE VaryingLengths("a/x" VARSIZED NOT NULL, "b/y" VARSIZED NOT NULL);
+CREATE PHYSICAL SOURCE FOR VaryingLengths TYPE File SET('JSON' AS INPUT_FORMATTER."TYPE");
+ATTACH INLINE
+{"a": {"x": "short"}, "b": {"y": "a-very-long-string-value"}}
+{"a": {"x": "another-long-string-here"}, "b": {"y": "s"}}
+{"a": {"x": "mid"}, "b": {"y": "mid"}}
+
+SELECT "a/x", "b/y" FROM VaryingLengths INTO File();
+----
+short,a-very-long-string-value
+another-long-string-here,s
+mid,mid
+
+## Deeply nested VARSIZED: 3 levels deep, multiple string fields at mixed depths.
+CREATE LOGICAL SOURCE DeepVarsized("org/team/lead" VARSIZED NOT NULL, "org/team/project" VARSIZED NOT NULL, "org/location" VARSIZED NOT NULL);
+CREATE PHYSICAL SOURCE FOR DeepVarsized TYPE File SET('JSON' AS INPUT_FORMATTER."TYPE");
+ATTACH INLINE
+{"org": {"team": {"lead": "carol", "project": "nebula"}, "location": "berlin"}}
+
+SELECT "org/team/lead", "org/team/project", "org/location" FROM DeepVarsized INTO File();
+----
+carol,nebula,berlin


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR adds support for accessing nested JSON fields in the SIMDJSON input formatter. Previously, only flat (top-level) JSON fields could be parsed. Now, nested fields can be accessed using `$` as a path separator in schema field names (e.g., `milk$cycles$left` maps to `{"milk": {"cycles": {"left": ...}}}`).

Key changes:
- Added `navigateToField()` which splits a JSON Pointer path into segments and navigates step by step using `find_field_unordered` (preserving the parser's internal string buffer so VARSIZED string_views remain valid)
- Field names in `SIMDJSONMetaData` are now converted from `$`-separated to `/`-separated JSON Pointer paths
- Refactored null checking (`checkIsNullJsonProxy`) to work on already-navigated `simdjson_result<value>` instead of re-navigating from the document root
- Refactored fixed-size and var-sized proxy functions to navigate once and reuse the result for both null checks and value extraction

## Verifying this change
This change is tested by the newly added system test `NestedJSON.test`, which covers:
- Simple one-level nesting with mixed types (UINT64, VARSIZED)
- Deep nesting (e.g., `milk$cycles$left`)
- Large JSON documents with many nested fields (coffee machine schema)
- Multiple VARSIZED fields from same and different nested parents
- Schema field order reversed from JSON key order
- Multiple siblings under deeply nested parents
- Nullable nested fields (explicit null, missing child key, missing parent)