### PR TITLE
Removed duplicated NULL check in JSONOutputFormatter

### DIFF
--- a/nes-output-formatters/src/CSVOutputFormatter.cpp
+++ b/nes-output-formatters/src/CSVOutputFormatter.cpp
@@ -111,12 +111,27 @@ void writeValue(
             currentRemainingSize -= amountWritten;
             break;
         }
-        default: {
+        case DataType::Type::INT8:
+        case DataType::Type::INT16:
+        case DataType::Type::INT32:
+        case DataType::Type::INT64:
+        case DataType::Type::UINT8:
+        case DataType::Type::UINT16:
+        case DataType::Type::UINT32:
+        case DataType::Type::UINT64:
+        case DataType::Type::FLOAT32:
+        case DataType::Type::FLOAT64:
+        case DataType::Type::BOOLEAN:
+        case DataType::Type::CHAR: {
             /// Convert the VarVal to a string and write it into the address.
             const nautilus::val<uint64_t> amountWritten
                 = formatAndWriteVal(value, fieldType, fieldPointer, currentRemainingSize, recordBuffer, bufferProvider);
             written += amountWritten;
             currentRemainingSize -= amountWritten;
+            break;
+        }
+        case DataType::Type::UNDEFINED: {
+            throw UnknownDataType("CSV-OutputFormatting for type UNDEFINED is not supported.");
         }
     }
 }

--- a/nes-plugins/OutputFormatters/JSONOutputFormatter/JSONOutputFormatter.cpp
+++ b/nes-plugins/OutputFormatters/JSONOutputFormatter/JSONOutputFormatter.cpp
@@ -154,11 +154,24 @@ void writeValue(
             currentRemainingSize -= amountWritten;
             break;
         }
-        default: {
+        case DataType::Type::INT8:
+        case DataType::Type::INT16:
+        case DataType::Type::INT32:
+        case DataType::Type::INT64:
+        case DataType::Type::UINT8:
+        case DataType::Type::UINT16:
+        case DataType::Type::UINT32:
+        case DataType::Type::UINT64:
+        case DataType::Type::FLOAT32:
+        case DataType::Type::FLOAT64: {
             const nautilus::val<uint64_t> amountWritten
                 = formatAndWriteVal(value, fieldType, fieldPointer + written, currentRemainingSize, recordBuffer, bufferProvider);
             written += amountWritten;
             currentRemainingSize -= amountWritten;
+            break;
+        }
+        case DataType::Type::UNDEFINED: {
+            throw UnknownDataType("JSON-OutputFormatting for type UNDEFINED is not supported.");
         }
     }
 }
@@ -248,5 +261,4 @@ OutputFormatterRegistryReturnType OutputFormatterGeneratedRegistrar::RegisterJSO
 {
     return std::make_unique<JSONOutputFormatter>(std::move(args.fieldNames));
 }
-
 }


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
The JSONOutputFormatter currently checks for NULL values twice. This PR removes the duplicated NULL check.

## Verifying this change
This change is tested by
- Existing tests

## What components does this pull request potentially affect?
- JSONOutputFormatter plugin

## Issue Closed by this pull request:

This PR closes #1502 
