### PR TITLE
Remove unused RequestQueryLog RPC

### DIFF
--- a/grpc/SingleNodeWorkerRPCService.proto
+++ b/grpc/SingleNodeWorkerRPCService.proto
@@ -23,7 +23,6 @@ service WorkerRPCService {
   rpc StopQuery (StopQueryRequest) returns (google.protobuf.Empty) {}
 
   rpc RequestQueryStatus (QueryStatusRequest) returns (QueryStatusReply) {}
-  rpc RequestQueryLog (QueryLogRequest) returns (QueryLogReply) {}
   rpc RequestStatus (WorkerStatusRequest) returns (WorkerStatusResponse) {}
 }
 
@@ -75,20 +74,6 @@ message QueryStatusReply {
     uint64 queryId = 1;
     QueryState state = 2;
     QueryMetrics metrics = 3;
-}
-
-message QueryLogRequest {
-    uint64 queryId = 1;
-}
-
-message QueryLogEntry {
-    QueryState state = 1;
-    uint64 unixTimeInMs = 2;
-    optional Error error = 3;
-}
-
-message QueryLogReply {
-    repeated QueryLogEntry entries = 1;
 }
 
 message WorkerStatusRequest {

--- a/nes-single-node-worker/include/GrpcService.hpp
+++ b/nes-single-node-worker/include/GrpcService.hpp
@@ -35,8 +35,6 @@ public:
 
     grpc::Status RequestQueryStatus(grpc::ServerContext*, const QueryStatusRequest*, QueryStatusReply*) override;
 
-    grpc::Status RequestQueryLog(grpc::ServerContext* context, const QueryLogRequest* request, QueryLogReply* response) override;
-
     grpc::Status RequestStatus(grpc::ServerContext* context, const WorkerStatusRequest* request, WorkerStatusResponse* response) override;
 
     explicit GRPCServer(SingleNodeWorker&& delegate) : delegate(std::move(delegate)) { }

--- a/nes-single-node-worker/include/SingleNodeWorker.hpp
+++ b/nes-single-node-worker/include/SingleNodeWorker.hpp
@@ -73,8 +73,6 @@ public:
     /// @param terminationType dictates what happens with in in-flight data
     std::expected<void, Exception> stopQuery(QueryId queryId, QueryTerminationType terminationType) noexcept;
 
-    /// Complete history of query status changes.
-    [[nodiscard]] std::optional<QueryLog::Log> getQueryLog(QueryId queryId) const;
     /// Summary structure for query.
     [[nodiscard]] std::expected<LocalQueryStatus, Exception> getQueryStatus(QueryId queryId) const noexcept;
     [[nodiscard]] WorkerStatus getWorkerStatus(std::chrono::system_clock::time_point after) const;

--- a/nes-single-node-worker/src/GrpcService.cpp
+++ b/nes-single-node-worker/src/GrpcService.cpp
@@ -176,48 +176,6 @@ grpc::Status GRPCServer::RequestQueryStatus(grpc::ServerContext* context, const 
     return {grpc::INTERNAL, "unknown exception"};
 }
 
-grpc::Status GRPCServer::RequestQueryLog(grpc::ServerContext* context, const QueryLogRequest* request, QueryLogReply* reply)
-{
-    CPPTRACE_TRY
-    {
-        auto queryId = QueryId(request->queryid());
-        auto log = delegate.getQueryLog(queryId);
-        if (log.has_value())
-        {
-            for (const auto& entry : *log)
-            {
-                QueryLogEntry logEntry;
-                logEntry.set_state(static_cast<::QueryState>(entry.state));
-                logEntry.set_unixtimeinms(
-                    std::chrono::duration_cast<std::chrono::milliseconds>(entry.timestamp.time_since_epoch()).count());
-                if (entry.exception.has_value())
-                {
-                    Error error;
-                    error.set_message(entry.exception.value().what());
-                    error.set_stacktrace(entry.exception.value().trace().to_string());
-                    error.set_code(entry.exception.value().code());
-                    error.set_location(
-                        std::string(entry.exception.value().where()->filename) + ":"
-                        + std::to_string(entry.exception.value().where()->line.value_or(0)));
-                    logEntry.mutable_error()->CopyFrom(error);
-                }
-                reply->add_entries()->CopyFrom(logEntry);
-            }
-            return grpc::Status::OK;
-        }
-        return {grpc::NOT_FOUND, "Query does not exist"};
-    }
-    CPPTRACE_CATCH(const Exception& e)
-    {
-        return handleError(e, context);
-    }
-    CPPTRACE_CATCH_ALT(const std::exception& e)
-    {
-        return handleError(e, context);
-    }
-    return {grpc::INTERNAL, "unknown exception"};
-}
-
 grpc::Status GRPCServer::RequestStatus(grpc::ServerContext* context, const WorkerStatusRequest* request, WorkerStatusResponse* response)
 {
     CPPTRACE_TRY

--- a/nes-single-node-worker/src/SingleNodeWorker.cpp
+++ b/nes-single-node-worker/src/SingleNodeWorker.cpp
@@ -208,9 +208,4 @@ WorkerStatus SingleNodeWorker::getWorkerStatus(std::chrono::system_clock::time_p
     return status;
 }
 
-std::optional<QueryLog::Log> SingleNodeWorker::getQueryLog(QueryId queryId) const
-{
-    return nodeEngine->getQueryLog()->getLogForQuery(queryId);
-}
-
 }


### PR DESCRIPTION
## Summary
- Remove the `RequestQueryLog` RPC from `WorkerRPCService` proto and all related server-side implementation
- This RPC was never called by any client (C++ frontend or coordinator)
- The underlying `QueryLog` class in `nes-runtime` is retained as it is still used internally

Closes #1510

## Test plan
- [x] Existing tests pass (no client ever called this RPC, so no test breakage expected)
- [x] Build succeeds with the proto change