### PR TITLE
refactor(Query Engine): seperate query compilation from query setup 

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -401,13 +401,14 @@
                 fi
 
                 # shellcheck disable=SC2016
-                exec ./.nix/nix-run.sh bash -lc '
+                exec ./.nix/nix-run.sh bash -c '
                   set -euo pipefail
                   base_ref="$1"
                   jobs="$2"
 
                   echo "nes-clang-tidy: configuring build/"
-                  ./.nix/nix-cmake.sh -GNinja -B build -DUSE_SANITIZER=none -DCMAKE_BUILD_TYPE=Debug -DNES_LOG_LEVEL=DEBUG
+                  rm -rf build
+                  ./.nix/nix-cmake.sh -GNinja -B build -DUSE_SANITIZER=none -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DNES_LOG_LEVEL=DEBUG
 
                   echo "nes-clang-tidy: building generated headers"
                   ./.nix/nix-cmake.sh --build build -j -- -k 0

--- a/nes-executable/include/ExecutablePipelineStage.hpp
+++ b/nes-executable/include/ExecutablePipelineStage.hpp
@@ -27,7 +27,12 @@ class ExecutablePipelineStage
 {
 public:
     virtual ~ExecutablePipelineStage() = default;
+
     /// Prepares the ExecutablePipelineStage for future execution.
+    /// `prepare` may throw to indicate an error.
+    virtual void prepare(PipelineExecutionContext&) { }
+
+    /// Starts the ExecutablePipelineStage after `prepare` completed.
     /// `start` may throw to indicate an error.
     virtual void start(PipelineExecutionContext& pipelineExecutionContext) = 0;
 
@@ -36,7 +41,7 @@ public:
     virtual void execute(const TupleBuffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext) = 0;
 
     /// Stops the ExecutablePipelineStage allowing it to flush left over state.
-    /// `stop` should never be called on a pipeline that has not previously been `started`.
+    /// `stop` should never be called on a pipeline that has not previously been `prepared`.
     /// `stop` is not guaranteed to be called, thus the destructor should take care of cleanup.
     /// `stop` may throw to indicate an error.
     virtual void stop(PipelineExecutionContext& pipelineExecutionContext) = 0;

--- a/nes-executable/include/ExecutablePipelineStage.hpp
+++ b/nes-executable/include/ExecutablePipelineStage.hpp
@@ -28,11 +28,11 @@ class ExecutablePipelineStage
 public:
     virtual ~ExecutablePipelineStage() = default;
 
-    /// Prepares the ExecutablePipelineStage for future execution.
-    /// `prepare` may throw to indicate an error.
-    virtual void prepare(PipelineExecutionContext&) { }
+    /// Compiles the ExecutablePipelineStage for future execution.
+    /// `compile` may throw to indicate an error.
+    virtual void compile(PipelineExecutionContext&) { }
 
-    /// Starts the ExecutablePipelineStage after `prepare` completed.
+    /// Starts the ExecutablePipelineStage after `compile` completed.
     /// `start` may throw to indicate an error.
     virtual void start(PipelineExecutionContext& pipelineExecutionContext) = 0;
 
@@ -41,7 +41,7 @@ public:
     virtual void execute(const TupleBuffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext) = 0;
 
     /// Stops the ExecutablePipelineStage allowing it to flush left over state.
-    /// `stop` should never be called on a pipeline that has not previously been `prepared`.
+    /// `stop` should never be called on a pipeline that has not previously been `compiled`.
     /// `stop` is not guaranteed to be called, thus the destructor should take care of cleanup.
     /// `stop` may throw to indicate an error.
     virtual void stop(PipelineExecutionContext& pipelineExecutionContext) = 0;

--- a/nes-executable/include/ExecutablePipelineStage.hpp
+++ b/nes-executable/include/ExecutablePipelineStage.hpp
@@ -29,10 +29,12 @@ public:
     virtual ~ExecutablePipelineStage() = default;
 
     /// Compiles the ExecutablePipelineStage for future execution.
+    /// The expected lifecycle is `compile` -> `start` -> `execute*` -> `stop`.
     /// `compile` may throw to indicate an error.
     virtual void compile(PipelineExecutionContext&) { }
 
     /// Starts the ExecutablePipelineStage after `compile` completed.
+    /// QueryEngine and the test task queues call `start` only after `compile` returned successfully.
     /// `start` may throw to indicate an error.
     virtual void start(PipelineExecutionContext& pipelineExecutionContext) = 0;
 
@@ -41,7 +43,7 @@ public:
     virtual void execute(const TupleBuffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext) = 0;
 
     /// Stops the ExecutablePipelineStage allowing it to flush left over state.
-    /// `stop` should never be called on a pipeline that has not previously been `compiled`.
+    /// QueryEngine only stops pipelines that have previously been `started`.
     /// `stop` is not guaranteed to be called, thus the destructor should take care of cleanup.
     /// `stop` may throw to indicate an error.
     virtual void stop(PipelineExecutionContext& pipelineExecutionContext) = 0;

--- a/nes-executable/tests/TestUtils/TestTaskQueue.cpp
+++ b/nes-executable/tests/TestUtils/TestTaskQueue.cpp
@@ -132,7 +132,7 @@ void SingleThreadedTestTaskQueue::enqueueTasks(std::vector<TestPipelineTask> pip
 
 void SingleThreadedTestTaskQueue::runTasks()
 {
-    tasks.front().task.eps->prepare(*tasks.front().pipelineExecutionContext);
+    tasks.front().task.eps->compile(*tasks.front().pipelineExecutionContext);
     tasks.front().task.eps->start(*tasks.front().pipelineExecutionContext);
     while (not tasks.empty())
     {
@@ -162,7 +162,7 @@ MultiThreadedTestTaskQueue::MultiThreadedTestTaskQueue(
     /// Store a pointer to the executable pipeline stage to call 'stop()' after completion
     this->eps = testTasks.front().eps;
     auto pec = TestPipelineExecutionContext(this->bufferProvider, WorkerThreadId(0), PipelineId(0), this->resultBuffers);
-    this->eps->prepare(pec);
+    this->eps->compile(pec);
     this->eps->start(pec);
 
     /// Fill the task queue with test tasks

--- a/nes-executable/tests/TestUtils/TestTaskQueue.cpp
+++ b/nes-executable/tests/TestUtils/TestTaskQueue.cpp
@@ -132,6 +132,7 @@ void SingleThreadedTestTaskQueue::enqueueTasks(std::vector<TestPipelineTask> pip
 
 void SingleThreadedTestTaskQueue::runTasks()
 {
+    tasks.front().task.eps->prepare(*tasks.front().pipelineExecutionContext);
     tasks.front().task.eps->start(*tasks.front().pipelineExecutionContext);
     while (not tasks.empty())
     {
@@ -160,8 +161,8 @@ MultiThreadedTestTaskQueue::MultiThreadedTestTaskQueue(
     PRECONDITION(not testTasks.empty(), "Test tasks must not be empty.");
     /// Store a pointer to the executable pipeline stage to call 'stop()' after completion
     this->eps = testTasks.front().eps;
-    /// Start/Compile the executable pipeline stage
     auto pec = TestPipelineExecutionContext(this->bufferProvider, WorkerThreadId(0), PipelineId(0), this->resultBuffers);
+    this->eps->prepare(pec);
     this->eps->start(pec);
 
     /// Fill the task queue with test tasks

--- a/nes-physical-operators/include/Aggregation/AggregationBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Aggregation/AggregationBuildPhysicalOperator.hpp
@@ -59,10 +59,15 @@ public:
     void execute(ExecutionContext& ctx, Record& record) const override;
 
 private:
+    struct CleanupState
+    {
+        std::once_flag once;
+        std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec> cleanupStateNautilusFunction;
+    };
+
     std::vector<std::shared_ptr<AggregationPhysicalFunction>> aggregationPhysicalFunctions;
     HashMapOptions hashMapOptions;
-    mutable std::once_flag cleanupStateNautilusFunctionOnce;
-    mutable std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec> cleanupStateNautilusFunction;
+    std::unique_ptr<CleanupState> cleanupState;
 };
 
 }

--- a/nes-physical-operators/include/Aggregation/AggregationBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Aggregation/AggregationBuildPhysicalOperator.hpp
@@ -19,7 +19,6 @@
 #include <vector>
 #include <Aggregation/AggregationOperatorHandler.hpp>
 #include <Aggregation/Function/AggregationPhysicalFunction.hpp>
-#include <HashMapSlice.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Nautilus/Interface/HashMap/HashMap.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
@@ -27,6 +26,7 @@
 #include <Watermark/TimeFunction.hpp>
 #include <CompilationContext.hpp>
 #include <HashMapOptions.hpp>
+#include <HashMapSlice.hpp>
 #include <WindowBuildPhysicalOperator.hpp>
 
 namespace NES

--- a/nes-physical-operators/include/Aggregation/AggregationBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Aggregation/AggregationBuildPhysicalOperator.hpp
@@ -19,6 +19,7 @@
 #include <vector>
 #include <Aggregation/AggregationOperatorHandler.hpp>
 #include <Aggregation/Function/AggregationPhysicalFunction.hpp>
+#include <HashMapSlice.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Nautilus/Interface/HashMap/HashMap.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
@@ -51,13 +52,15 @@ public:
         std::unique_ptr<TimeFunction> timeFunction,
         std::vector<std::shared_ptr<AggregationPhysicalFunction>> aggregationFunctions,
         HashMapOptions hashMapOptions);
-    void setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const override;
+    AggregationBuildPhysicalOperator(const AggregationBuildPhysicalOperator& other);
+    void compile(CompilationContext& compilationContext) const override;
+    void setup(ExecutionContext& executionCtx) const override;
     void execute(ExecutionContext& ctx, Record& record) const override;
 
 private:
-    /// The aggregation function is a shared_ptr, because it is used in the aggregation build and in the getSliceCleanupFunction()
     std::vector<std::shared_ptr<AggregationPhysicalFunction>> aggregationPhysicalFunctions;
     HashMapOptions hashMapOptions;
+    mutable std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec> cleanupStateNautilusFunction;
 };
 
 }

--- a/nes-physical-operators/include/Aggregation/AggregationBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Aggregation/AggregationBuildPhysicalOperator.hpp
@@ -16,6 +16,7 @@
 
 
 #include <memory>
+#include <mutex>
 #include <vector>
 #include <Aggregation/AggregationOperatorHandler.hpp>
 #include <Aggregation/Function/AggregationPhysicalFunction.hpp>
@@ -60,6 +61,7 @@ public:
 private:
     std::vector<std::shared_ptr<AggregationPhysicalFunction>> aggregationPhysicalFunctions;
     HashMapOptions hashMapOptions;
+    mutable std::once_flag cleanupStateNautilusFunctionOnce;
     mutable std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec> cleanupStateNautilusFunction;
 };
 

--- a/nes-physical-operators/include/Aggregation/AggregationBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Aggregation/AggregationBuildPhysicalOperator.hpp
@@ -16,7 +16,6 @@
 
 
 #include <memory>
-#include <mutex>
 #include <vector>
 #include <Aggregation/AggregationOperatorHandler.hpp>
 #include <Aggregation/Function/AggregationPhysicalFunction.hpp>
@@ -55,19 +54,11 @@ public:
         HashMapOptions hashMapOptions);
     AggregationBuildPhysicalOperator(const AggregationBuildPhysicalOperator& other);
     void compile(CompilationContext& compilationContext) const override;
-    void setup(ExecutionContext& executionCtx) const override;
     void execute(ExecutionContext& ctx, Record& record) const override;
 
 private:
-    struct CleanupState
-    {
-        std::once_flag once;
-        std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec> cleanupStateNautilusFunction;
-    };
-
     std::vector<std::shared_ptr<AggregationPhysicalFunction>> aggregationPhysicalFunctions;
     HashMapOptions hashMapOptions;
-    std::unique_ptr<CleanupState> cleanupState;
 };
 
 }

--- a/nes-physical-operators/include/Aggregation/AggregationOperatorHandler.hpp
+++ b/nes-physical-operators/include/Aggregation/AggregationOperatorHandler.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 #include <algorithm>
+#include <atomic>
 #include <bit>
 #include <cstdint>
 #include <functional>

--- a/nes-physical-operators/include/Aggregation/AggregationOperatorHandler.hpp
+++ b/nes-physical-operators/include/Aggregation/AggregationOperatorHandler.hpp
@@ -66,10 +66,12 @@ public:
     [[nodiscard]] std::function<std::vector<std::shared_ptr<Slice>>(SliceStart, SliceEnd)>
     getCreateNewSlicesFunction(const CreateNewSlicesArguments& newSlicesArguments) const override;
 
-    /// Is required to not perform the setup again and resolving a race condition to the cleanup state function
-    std::atomic<bool> setupAlreadyCalled;
-    /// shared_ptr as multiple slices need access to it
+    bool trySetCleanupStateNautilusFunction(std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec> cleanupStateNautilusFunction);
+
     std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec> cleanupStateNautilusFunction;
+
+private:
+    std::atomic<bool> cleanupStateNautilusFunctionInstalled;
 
 protected:
     void triggerSlices(

--- a/nes-physical-operators/include/EmitPhysicalOperator.hpp
+++ b/nes-physical-operators/include/EmitPhysicalOperator.hpp
@@ -22,7 +22,6 @@
 #include <Nautilus/Interface/RecordBuffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <nautilus/val.hpp>
-#include <CompilationContext.hpp>
 #include <ExecutionContext.hpp>
 #include <PhysicalOperator.hpp>
 
@@ -36,7 +35,7 @@ class EmitPhysicalOperator final : public PhysicalOperatorConcept
 public:
     explicit EmitPhysicalOperator(OperatorHandlerId operatorHandlerId, std::shared_ptr<TupleBufferRef> bufferRef);
 
-    void setup(ExecutionContext&, CompilationContext&) const override { /*noop*/ }
+    void setup(ExecutionContext&) const override { /*noop*/ }
 
     void terminate(ExecutionContext&) const override { /*noop*/ }
 

--- a/nes-physical-operators/include/Join/HashJoin/HJBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJBuildPhysicalOperator.hpp
@@ -15,6 +15,7 @@
 #pragma once
 #include <memory>
 #include <Identifiers/Identifiers.hpp>
+#include <HashMapSlice.hpp>
 #include <Join/HashJoin/HJOperatorHandler.hpp>
 #include <Join/StreamJoinBuildPhysicalOperator.hpp>
 #include <Join/StreamJoinUtil.hpp>
@@ -56,11 +57,14 @@ public:
         std::unique_ptr<TimeFunction> timeFunction,
         const std::shared_ptr<TupleBufferRef>& bufferRef,
         HashMapOptions hashMapOptions);
-    void setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const override;
+    HJBuildPhysicalOperator(const HJBuildPhysicalOperator& other);
+    void compile(CompilationContext& compilationContext) const override;
+    void setup(ExecutionContext& executionCtx) const override;
     void execute(ExecutionContext& ctx, Record& record) const override;
 
 private:
     HashMapOptions hashMapOptions;
+    mutable std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec> cleanupStateNautilusFunction;
 };
 
 }

--- a/nes-physical-operators/include/Join/HashJoin/HJBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJBuildPhysicalOperator.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 #include <memory>
+#include <mutex>
 #include <Identifiers/Identifiers.hpp>
 #include <Join/HashJoin/HJOperatorHandler.hpp>
 #include <Join/StreamJoinBuildPhysicalOperator.hpp>
@@ -64,6 +65,7 @@ public:
 
 private:
     HashMapOptions hashMapOptions;
+    mutable std::once_flag cleanupStateNautilusFunctionOnce;
     mutable std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec> cleanupStateNautilusFunction;
 };
 

--- a/nes-physical-operators/include/Join/HashJoin/HJBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJBuildPhysicalOperator.hpp
@@ -64,9 +64,14 @@ public:
     void execute(ExecutionContext& ctx, Record& record) const override;
 
 private:
+    struct CleanupState
+    {
+        std::once_flag once;
+        std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec> cleanupStateNautilusFunction;
+    };
+
     HashMapOptions hashMapOptions;
-    mutable std::once_flag cleanupStateNautilusFunctionOnce;
-    mutable std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec> cleanupStateNautilusFunction;
+    std::unique_ptr<CleanupState> cleanupState;
 };
 
 }

--- a/nes-physical-operators/include/Join/HashJoin/HJBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJBuildPhysicalOperator.hpp
@@ -15,7 +15,6 @@
 #pragma once
 #include <memory>
 #include <Identifiers/Identifiers.hpp>
-#include <HashMapSlice.hpp>
 #include <Join/HashJoin/HJOperatorHandler.hpp>
 #include <Join/StreamJoinBuildPhysicalOperator.hpp>
 #include <Join/StreamJoinUtil.hpp>
@@ -28,6 +27,7 @@
 #include <CompilationContext.hpp>
 #include <ExecutionContext.hpp>
 #include <HashMapOptions.hpp>
+#include <HashMapSlice.hpp>
 
 namespace NES
 {

--- a/nes-physical-operators/include/Join/HashJoin/HJBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJBuildPhysicalOperator.hpp
@@ -14,7 +14,6 @@
 
 #pragma once
 #include <memory>
-#include <mutex>
 #include <Identifiers/Identifiers.hpp>
 #include <Join/HashJoin/HJOperatorHandler.hpp>
 #include <Join/StreamJoinBuildPhysicalOperator.hpp>
@@ -60,18 +59,10 @@ public:
         HashMapOptions hashMapOptions);
     HJBuildPhysicalOperator(const HJBuildPhysicalOperator& other);
     void compile(CompilationContext& compilationContext) const override;
-    void setup(ExecutionContext& executionCtx) const override;
     void execute(ExecutionContext& ctx, Record& record) const override;
 
 private:
-    struct CleanupState
-    {
-        std::once_flag once;
-        std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec> cleanupStateNautilusFunction;
-    };
-
     HashMapOptions hashMapOptions;
-    std::unique_ptr<CleanupState> cleanupState;
 };
 
 }

--- a/nes-physical-operators/include/Join/HashJoin/HJOperatorHandler.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJOperatorHandler.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 #include <algorithm>
+#include <atomic>
 #include <bit>
 #include <cstdint>
 #include <functional>

--- a/nes-physical-operators/include/Join/HashJoin/HJOperatorHandler.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJOperatorHandler.hpp
@@ -71,16 +71,13 @@ public:
     [[nodiscard]] std::function<std::vector<std::shared_ptr<Slice>>(SliceStart, SliceEnd)>
     getCreateNewSlicesFunction(const CreateNewSlicesArguments& newSlicesArguments) const override;
 
-    bool wasSetupCalled(const JoinBuildSideType& buildSide);
-    void setNautilusCleanupExec(
+    bool trySetNautilusCleanupExec(
         std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec> nautilusCleanupExec, const JoinBuildSideType& buildSide);
     [[nodiscard]] std::vector<std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec>> getNautilusCleanupExec() const;
 
 private:
-    /// Is required to not perform the setup again and resolving a race condition to the cleanup state function
-    std::atomic<bool> setupAlreadyCalledLeft;
-    std::atomic<bool> setupAlreadyCalledRight;
-    /// shared_ptr as multiple slices need access to it
+    std::atomic<bool> leftCleanupStateNautilusFunctionInstalled;
+    std::atomic<bool> rightCleanupStateNautilusFunctionInstalled;
     std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec> leftCleanupStateNautilusFunction;
     std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec> rightCleanupStateNautilusFunction;
 

--- a/nes-physical-operators/include/PhysicalOperator.hpp
+++ b/nes-physical-operators/include/PhysicalOperator.hpp
@@ -59,8 +59,10 @@ struct PhysicalOperatorConcept
     [[nodiscard]] virtual std::optional<struct PhysicalOperator> getChild() const = 0;
     virtual void setChild(struct PhysicalOperator child) = 0;
 
+    virtual void compile(CompilationContext& compilationContext) const;
+
     /// This is called once before the operator starts processing records.
-    virtual void setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const;
+    virtual void setup(ExecutionContext& executionCtx) const;
 
     /// Opens the operator for processing records.
     /// This is called before each batch of records is processed.
@@ -81,8 +83,9 @@ struct PhysicalOperatorConcept
     const OperatorId id = INVALID_OPERATOR_ID;
 
 protected:
+    void compileChild(CompilationContext& compilationContext) const;
     /// Helper classes to propagate to the child
-    void setupChild(ExecutionContext& executionCtx, CompilationContext& compilationContext) const;
+    void setupChild(ExecutionContext& executionCtx) const;
     void openChild(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
     void closeChild(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
     void executeChild(ExecutionContext& executionCtx, Record& record) const;
@@ -118,7 +121,8 @@ struct PhysicalOperator
     [[nodiscard]] std::optional<PhysicalOperator> getChild() const;
     [[nodiscard]] PhysicalOperator withChild(PhysicalOperator child) const;
 
-    void setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const;
+    void compile(CompilationContext& compilationContext) const;
+    void setup(ExecutionContext& executionCtx) const;
     void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
     void close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
     void terminate(ExecutionContext& executionCtx) const;
@@ -186,10 +190,9 @@ private:
 
         void setChild(PhysicalOperator child) override { data.setChild(child); }
 
-        void setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const override
-        {
-            data.setup(executionCtx, compilationContext);
-        }
+        void compile(CompilationContext& compilationContext) const override { data.compile(compilationContext); }
+
+        void setup(ExecutionContext& executionCtx) const override { data.setup(executionCtx); }
 
         void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override { data.open(executionCtx, recordBuffer); }
 

--- a/nes-physical-operators/include/WindowBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/WindowBuildPhysicalOperator.hpp
@@ -19,7 +19,6 @@
 #include <optional>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Watermark/TimeFunction.hpp>
-#include <CompilationContext.hpp>
 #include <OperatorState.hpp>
 #include <PhysicalOperator.hpp>
 #include <val.hpp>
@@ -50,7 +49,7 @@ public:
     /// This setup function can be called in a multithreaded environment. Meaning that if
     /// multiple pipelines with the same operator (e.g. JoinBuild) have access to the same operator handler, this will lead to race conditions.
     /// Therefore, any setup to the operator handler should happen in the WindowProbePhysicalOperator.
-    void setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const override;
+    void setup(ExecutionContext& executionCtx) const override;
 
     /// Initializes the time function, e.g., method that extracts the timestamp from a record
     void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;

--- a/nes-physical-operators/include/WindowProbePhysicalOperator.hpp
+++ b/nes-physical-operators/include/WindowProbePhysicalOperator.hpp
@@ -18,7 +18,6 @@
 #include <Nautilus/Interface/RecordBuffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Windowing/WindowMetaData.hpp>
-#include <CompilationContext.hpp>
 #include <PhysicalOperator.hpp>
 
 namespace NES
@@ -34,7 +33,7 @@ public:
     /// The setup method is called for each pipeline during the query initialization procedure. Meaning that if
     /// multiple pipelines with the same operator (e.g. JoinBuild) have access to the same operator handler, this will lead to race conditions.
     /// Therefore, any setup to the operator handler should ONLY happen in the WindowProbePhysicalOperator.
-    void setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const override;
+    void setup(ExecutionContext& executionCtx) const override;
 
     /// Checks the current watermark and then deletes all slices and windows that are not valid anymore
     void close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;

--- a/nes-physical-operators/src/Aggregation/AggregationBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Aggregation/AggregationBuildPhysicalOperator.cpp
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <ranges>
 #include <utility>
 #include <vector>
@@ -83,34 +84,35 @@ void AggregationBuildPhysicalOperator::compile(CompilationContext& compilationCo
 {
     compileChild(compilationContext);
 
-    if (cleanupStateNautilusFunction)
-    {
-        return;
-    }
-
-    cleanupStateNautilusFunction
-        = std::make_shared<CreateNewHashMapSliceArgs::NautilusCleanupExec>(compilationContext.registerFunction(std::function(
-            [copyOfHashMapOptions = hashMapOptions,
-             copyOfAggregationFunctions = aggregationPhysicalFunctions](const nautilus::val<HashMap*>& hashMap)
-            {
-                const ChainedHashMapRef hashMapRef(
-                    hashMap,
-                    copyOfHashMapOptions.fieldKeys,
-                    copyOfHashMapOptions.fieldValues,
-                    copyOfHashMapOptions.entriesPerPage,
-                    copyOfHashMapOptions.entrySize);
-                for (const auto entry : hashMapRef)
-                {
-                    const ChainedHashMapRef::ChainedEntryRef entryRefReset(
-                        entry, hashMap, copyOfHashMapOptions.fieldKeys, copyOfHashMapOptions.fieldValues);
-                    auto state = static_cast<nautilus::val<AggregationState*>>(entryRefReset.getValueMemArea());
-                    for (const auto& aggFunction : nautilus::static_iterable(copyOfAggregationFunctions))
+    std::call_once(
+        cleanupStateNautilusFunctionOnce,
+        [this, &compilationContext]
+        {
+            cleanupStateNautilusFunction
+                = std::make_shared<CreateNewHashMapSliceArgs::NautilusCleanupExec>(compilationContext.registerFunction(std::function(
+                    [copyOfHashMapOptions = hashMapOptions,
+                     copyOfAggregationFunctions = aggregationPhysicalFunctions](nautilus::val<HashMap*> hashMap)
                     {
-                        aggFunction->cleanup(state);
-                        state = state + aggFunction->getSizeOfStateInBytes();
-                    }
-                }
-            })));
+                        auto currentHashMap = hashMap;
+                        const ChainedHashMapRef hashMapRef(
+                            currentHashMap,
+                            copyOfHashMapOptions.fieldKeys,
+                            copyOfHashMapOptions.fieldValues,
+                            copyOfHashMapOptions.entriesPerPage,
+                            copyOfHashMapOptions.entrySize);
+                        for (const auto entry : hashMapRef)
+                        {
+                            const ChainedHashMapRef::ChainedEntryRef entryRefReset(
+                                entry, currentHashMap, copyOfHashMapOptions.fieldKeys, copyOfHashMapOptions.fieldValues);
+                            auto state = static_cast<nautilus::val<AggregationState*>>(entryRefReset.getValueMemArea());
+                            for (const auto& aggFunction : nautilus::static_iterable(copyOfAggregationFunctions))
+                            {
+                                aggFunction->cleanup(state);
+                                state = state + aggFunction->getSizeOfStateInBytes();
+                            }
+                        }
+                    })));
+        });
 }
 
 void AggregationBuildPhysicalOperator::setup(ExecutionContext& executionCtx) const

--- a/nes-physical-operators/src/Aggregation/AggregationBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Aggregation/AggregationBuildPhysicalOperator.cpp
@@ -85,17 +85,16 @@ void AggregationBuildPhysicalOperator::compile(CompilationContext& compilationCo
     compileChild(compilationContext);
 
     std::call_once(
-        cleanupStateNautilusFunctionOnce,
+        cleanupState->once,
         [this, &compilationContext]
         {
-            cleanupStateNautilusFunction
+            cleanupState->cleanupStateNautilusFunction
                 = std::make_shared<CreateNewHashMapSliceArgs::NautilusCleanupExec>(compilationContext.registerFunction(std::function(
                     [copyOfHashMapOptions = hashMapOptions,
                      copyOfAggregationFunctions = aggregationPhysicalFunctions](nautilus::val<HashMap*> hashMap)
                     {
-                        auto currentHashMap = hashMap;
                         const ChainedHashMapRef hashMapRef(
-                            currentHashMap,
+                            hashMap,
                             copyOfHashMapOptions.fieldKeys,
                             copyOfHashMapOptions.fieldValues,
                             copyOfHashMapOptions.entriesPerPage,
@@ -103,7 +102,7 @@ void AggregationBuildPhysicalOperator::compile(CompilationContext& compilationCo
                         for (const auto entry : hashMapRef)
                         {
                             const ChainedHashMapRef::ChainedEntryRef entryRefReset(
-                                entry, currentHashMap, copyOfHashMapOptions.fieldKeys, copyOfHashMapOptions.fieldValues);
+                                entry, hashMap, copyOfHashMapOptions.fieldKeys, copyOfHashMapOptions.fieldValues);
                             auto state = static_cast<nautilus::val<AggregationState*>>(entryRefReset.getValueMemArea());
                             for (const auto& aggFunction : nautilus::static_iterable(copyOfAggregationFunctions))
                             {
@@ -119,12 +118,13 @@ void AggregationBuildPhysicalOperator::setup(ExecutionContext& executionCtx) con
 {
     WindowBuildPhysicalOperator::setup(executionCtx);
 
-    PRECONDITION(cleanupStateNautilusFunction != nullptr, "Expected compiled cleanup function for aggregation build operator");
+    PRECONDITION(
+        cleanupState->cleanupStateNautilusFunction != nullptr, "Expected compiled cleanup function for aggregation build operator");
 
     auto* const operatorHandler = dynamic_cast<AggregationOperatorHandler*>(
         nautilus::details::RawValueResolver<OperatorHandler*>::getRawValue(executionCtx.getGlobalOperatorHandler(operatorHandlerId)));
     PRECONDITION(operatorHandler != nullptr, "Expected AggregationOperatorHandler for {}", operatorHandlerId);
-    operatorHandler->trySetCleanupStateNautilusFunction(cleanupStateNautilusFunction);
+    operatorHandler->trySetCleanupStateNautilusFunction(cleanupState->cleanupStateNautilusFunction);
 }
 
 void AggregationBuildPhysicalOperator::execute(ExecutionContext& ctx, Record& record) const
@@ -185,7 +185,7 @@ AggregationBuildPhysicalOperator::AggregationBuildPhysicalOperator(
     : WindowBuildPhysicalOperator(operatorHandlerId, std::move(timeFunction))
     , aggregationPhysicalFunctions(std::move(aggregationFunctions))
     , hashMapOptions(std::move(hashMapOptions))
-    , cleanupStateNautilusFunction(nullptr)
+    , cleanupState(std::make_unique<CleanupState>())
 {
 }
 
@@ -193,7 +193,7 @@ AggregationBuildPhysicalOperator::AggregationBuildPhysicalOperator(const Aggrega
     : WindowBuildPhysicalOperator(other)
     , aggregationPhysicalFunctions(other.aggregationPhysicalFunctions)
     , hashMapOptions(other.hashMapOptions)
-    , cleanupStateNautilusFunction(nullptr)
+    , cleanupState(std::make_unique<CleanupState>())
 {
 }
 

--- a/nes-physical-operators/src/Aggregation/AggregationBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Aggregation/AggregationBuildPhysicalOperator.cpp
@@ -77,46 +77,49 @@ HashMap* getAggHashMapProxy(
     return aggregationSlice->getHashMapPtrOrCreate(workerThreadId);
 }
 
-void AggregationBuildPhysicalOperator::setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const
+void AggregationBuildPhysicalOperator::compile(CompilationContext& compilationContext) const
 {
-    WindowBuildPhysicalOperator::setup(executionCtx, compilationContext);
+    compileChild(compilationContext);
 
-    /// Creating the cleanup function for the slice of current stream
-    /// As the setup function does not get traced, we do not need to have any nautilus::invoke calls to jump to the C++ runtime
-    /// We are not allowed to use const or const references for the lambda function params, as nautilus does not support this in the registerFunction method.
-    /// ReSharper disable once CppPassValueParameterByConstReference
-    /// NOLINTBEGIN(performance-unnecessary-value-param)
-    auto* const operatorHandler = dynamic_cast<AggregationOperatorHandler*>(
-        nautilus::details::RawValueResolver<OperatorHandler*>::getRawValue(executionCtx.getGlobalOperatorHandler(operatorHandlerId)));
-    if (bool expectedValue = false; operatorHandler->setupAlreadyCalled.compare_exchange_strong(expectedValue, true))
+    if (cleanupStateNautilusFunction)
     {
-        operatorHandler->cleanupStateNautilusFunction
-            = std::make_shared<CreateNewHashMapSliceArgs::NautilusCleanupExec>(compilationContext.registerFunction(std::function(
-                [copyOfHashMapOptions = hashMapOptions,
-                 copyOfAggregationFunctions = aggregationPhysicalFunctions](nautilus::val<HashMap*> hashMap)
-                {
-                    const ChainedHashMapRef hashMapRef(
-                        hashMap,
-                        copyOfHashMapOptions.fieldKeys,
-                        copyOfHashMapOptions.fieldValues,
-                        copyOfHashMapOptions.entriesPerPage,
-                        copyOfHashMapOptions.entrySize);
-                    for (const auto entry : hashMapRef)
-                    {
-                        const ChainedHashMapRef::ChainedEntryRef entryRefReset(
-                            entry, hashMap, copyOfHashMapOptions.fieldKeys, copyOfHashMapOptions.fieldValues);
-                        auto state = static_cast<nautilus::val<AggregationState*>>(entryRefReset.getValueMemArea());
-                        for (const auto& aggFunction : nautilus::static_iterable(copyOfAggregationFunctions))
-                        {
-                            aggFunction->cleanup(state);
-                            state = state + aggFunction->getSizeOfStateInBytes();
-                        }
-                    }
-                })));
+        return;
     }
 
+    cleanupStateNautilusFunction = std::make_shared<CreateNewHashMapSliceArgs::NautilusCleanupExec>(compilationContext.registerFunction(
+        std::function(
+            [copyOfHashMapOptions = hashMapOptions, copyOfAggregationFunctions = aggregationPhysicalFunctions](nautilus::val<HashMap*> hashMap)
+            {
+                const ChainedHashMapRef hashMapRef(
+                    hashMap,
+                    copyOfHashMapOptions.fieldKeys,
+                    copyOfHashMapOptions.fieldValues,
+                    copyOfHashMapOptions.entriesPerPage,
+                    copyOfHashMapOptions.entrySize);
+                for (const auto entry : hashMapRef)
+                {
+                    const ChainedHashMapRef::ChainedEntryRef entryRefReset(
+                        entry, hashMap, copyOfHashMapOptions.fieldKeys, copyOfHashMapOptions.fieldValues);
+                    auto state = static_cast<nautilus::val<AggregationState*>>(entryRefReset.getValueMemArea());
+                    for (const auto& aggFunction : nautilus::static_iterable(copyOfAggregationFunctions))
+                    {
+                        aggFunction->cleanup(state);
+                        state = state + aggFunction->getSizeOfStateInBytes();
+                    }
+                }
+            })));
+}
 
-    /// NOLINTEND(performance-unnecessary-value-param)
+void AggregationBuildPhysicalOperator::setup(ExecutionContext& executionCtx) const
+{
+    WindowBuildPhysicalOperator::setup(executionCtx);
+
+    PRECONDITION(cleanupStateNautilusFunction != nullptr, "Expected compiled cleanup function for aggregation build operator");
+
+    auto* const operatorHandler = dynamic_cast<AggregationOperatorHandler*>(
+        nautilus::details::RawValueResolver<OperatorHandler*>::getRawValue(executionCtx.getGlobalOperatorHandler(operatorHandlerId)));
+    PRECONDITION(operatorHandler != nullptr, "Expected AggregationOperatorHandler for {}", operatorHandlerId);
+    operatorHandler->trySetCleanupStateNautilusFunction(cleanupStateNautilusFunction);
 }
 
 void AggregationBuildPhysicalOperator::execute(ExecutionContext& ctx, Record& record) const
@@ -177,6 +180,15 @@ AggregationBuildPhysicalOperator::AggregationBuildPhysicalOperator(
     : WindowBuildPhysicalOperator(operatorHandlerId, std::move(timeFunction))
     , aggregationPhysicalFunctions(std::move(aggregationFunctions))
     , hashMapOptions(std::move(hashMapOptions))
+    , cleanupStateNautilusFunction(nullptr)
+{
+}
+
+AggregationBuildPhysicalOperator::AggregationBuildPhysicalOperator(const AggregationBuildPhysicalOperator& other)
+    : WindowBuildPhysicalOperator(other)
+    , aggregationPhysicalFunctions(other.aggregationPhysicalFunctions)
+    , hashMapOptions(other.hashMapOptions)
+    , cleanupStateNautilusFunction(nullptr)
 {
 }
 

--- a/nes-physical-operators/src/Aggregation/AggregationBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Aggregation/AggregationBuildPhysicalOperator.cpp
@@ -86,9 +86,10 @@ void AggregationBuildPhysicalOperator::compile(CompilationContext& compilationCo
         return;
     }
 
-    cleanupStateNautilusFunction = std::make_shared<CreateNewHashMapSliceArgs::NautilusCleanupExec>(compilationContext.registerFunction(
-        std::function(
-            [copyOfHashMapOptions = hashMapOptions, copyOfAggregationFunctions = aggregationPhysicalFunctions](nautilus::val<HashMap*> hashMap)
+    cleanupStateNautilusFunction
+        = std::make_shared<CreateNewHashMapSliceArgs::NautilusCleanupExec>(compilationContext.registerFunction(std::function(
+            [copyOfHashMapOptions = hashMapOptions,
+             copyOfAggregationFunctions = aggregationPhysicalFunctions](nautilus::val<HashMap*> hashMap)
             {
                 const ChainedHashMapRef hashMapRef(
                     hashMap,

--- a/nes-physical-operators/src/Aggregation/AggregationBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Aggregation/AggregationBuildPhysicalOperator.cpp
@@ -26,6 +26,7 @@
 #include <Nautilus/Interface/HashMap/ChainedHashMap/ChainedHashMapRef.hpp>
 #include <Nautilus/Interface/HashMap/HashMap.hpp>
 #include <Nautilus/Interface/Record.hpp>
+#include <Runtime/Execution/OperatorHandler.hpp>
 #include <SliceStore/Slice.hpp>
 #include <Time/Timestamp.hpp>
 #include <CompilationContext.hpp>
@@ -36,6 +37,7 @@
 #include <function.hpp>
 #include <options.hpp>
 #include <static.hpp>
+#include <val_details.hpp>
 #include <val_ptr.hpp>
 
 namespace NES
@@ -89,7 +91,7 @@ void AggregationBuildPhysicalOperator::compile(CompilationContext& compilationCo
     cleanupStateNautilusFunction
         = std::make_shared<CreateNewHashMapSliceArgs::NautilusCleanupExec>(compilationContext.registerFunction(std::function(
             [copyOfHashMapOptions = hashMapOptions,
-             copyOfAggregationFunctions = aggregationPhysicalFunctions](nautilus::val<HashMap*> hashMap)
+             copyOfAggregationFunctions = aggregationPhysicalFunctions](const nautilus::val<HashMap*>& hashMap)
             {
                 const ChainedHashMapRef hashMapRef(
                     hashMap,

--- a/nes-physical-operators/src/Aggregation/AggregationBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Aggregation/AggregationBuildPhysicalOperator.cpp
@@ -16,7 +16,6 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
-#include <mutex>
 #include <ranges>
 #include <utility>
 #include <vector>
@@ -84,47 +83,31 @@ void AggregationBuildPhysicalOperator::compile(CompilationContext& compilationCo
 {
     compileChild(compilationContext);
 
-    std::call_once(
-        cleanupState->once,
-        [this, &compilationContext]
-        {
-            cleanupState->cleanupStateNautilusFunction
-                = std::make_shared<CreateNewHashMapSliceArgs::NautilusCleanupExec>(compilationContext.registerFunction(std::function(
-                    [copyOfHashMapOptions = hashMapOptions,
-                     copyOfAggregationFunctions = aggregationPhysicalFunctions](nautilus::val<HashMap*> hashMap)
-                    {
-                        const ChainedHashMapRef hashMapRef(
-                            hashMap,
-                            copyOfHashMapOptions.fieldKeys,
-                            copyOfHashMapOptions.fieldValues,
-                            copyOfHashMapOptions.entriesPerPage,
-                            copyOfHashMapOptions.entrySize);
-                        for (const auto entry : hashMapRef)
-                        {
-                            const ChainedHashMapRef::ChainedEntryRef entryRefReset(
-                                entry, hashMap, copyOfHashMapOptions.fieldKeys, copyOfHashMapOptions.fieldValues);
-                            auto state = static_cast<nautilus::val<AggregationState*>>(entryRefReset.getValueMemArea());
-                            for (const auto& aggFunction : nautilus::static_iterable(copyOfAggregationFunctions))
-                            {
-                                aggFunction->cleanup(state);
-                                state = state + aggFunction->getSizeOfStateInBytes();
-                            }
-                        }
-                    })));
-        });
-}
-
-void AggregationBuildPhysicalOperator::setup(ExecutionContext& executionCtx) const
-{
-    WindowBuildPhysicalOperator::setup(executionCtx);
-
-    PRECONDITION(
-        cleanupState->cleanupStateNautilusFunction != nullptr, "Expected compiled cleanup function for aggregation build operator");
-
-    auto* const operatorHandler = dynamic_cast<AggregationOperatorHandler*>(
-        nautilus::details::RawValueResolver<OperatorHandler*>::getRawValue(executionCtx.getGlobalOperatorHandler(operatorHandlerId)));
+    auto* const operatorHandler = dynamic_cast<AggregationOperatorHandler*>(compilationContext.getGlobalOperatorHandler(operatorHandlerId));
     PRECONDITION(operatorHandler != nullptr, "Expected AggregationOperatorHandler for {}", operatorHandlerId);
-    operatorHandler->trySetCleanupStateNautilusFunction(cleanupState->cleanupStateNautilusFunction);
+    operatorHandler->trySetCleanupStateNautilusFunction(
+        std::make_shared<CreateNewHashMapSliceArgs::NautilusCleanupExec>(compilationContext.registerFunction(std::function(
+            [copyOfHashMapOptions = hashMapOptions,
+             copyOfAggregationFunctions = aggregationPhysicalFunctions](nautilus::val<HashMap*> hashMap)
+            {
+                const ChainedHashMapRef hashMapRef(
+                    hashMap,
+                    copyOfHashMapOptions.fieldKeys,
+                    copyOfHashMapOptions.fieldValues,
+                    copyOfHashMapOptions.entriesPerPage,
+                    copyOfHashMapOptions.entrySize);
+                for (const auto entry : hashMapRef)
+                {
+                    const ChainedHashMapRef::ChainedEntryRef entryRefReset(
+                        entry, hashMap, copyOfHashMapOptions.fieldKeys, copyOfHashMapOptions.fieldValues);
+                    auto state = static_cast<nautilus::val<AggregationState*>>(entryRefReset.getValueMemArea());
+                    for (const auto& aggFunction : nautilus::static_iterable(copyOfAggregationFunctions))
+                    {
+                        aggFunction->cleanup(state);
+                        state = state + aggFunction->getSizeOfStateInBytes();
+                    }
+                }
+            }))));
 }
 
 void AggregationBuildPhysicalOperator::execute(ExecutionContext& ctx, Record& record) const
@@ -185,7 +168,6 @@ AggregationBuildPhysicalOperator::AggregationBuildPhysicalOperator(
     : WindowBuildPhysicalOperator(operatorHandlerId, std::move(timeFunction))
     , aggregationPhysicalFunctions(std::move(aggregationFunctions))
     , hashMapOptions(std::move(hashMapOptions))
-    , cleanupState(std::make_unique<CleanupState>())
 {
 }
 
@@ -193,7 +175,6 @@ AggregationBuildPhysicalOperator::AggregationBuildPhysicalOperator(const Aggrega
     : WindowBuildPhysicalOperator(other)
     , aggregationPhysicalFunctions(other.aggregationPhysicalFunctions)
     , hashMapOptions(other.hashMapOptions)
-    , cleanupState(std::make_unique<CleanupState>())
 {
 }
 

--- a/nes-physical-operators/src/Aggregation/AggregationOperatorHandler.cpp
+++ b/nes-physical-operators/src/Aggregation/AggregationOperatorHandler.cpp
@@ -33,6 +33,7 @@
 #include <SliceStore/WindowSlicesStoreInterface.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <ErrorHandling.hpp>
+#include <HashMapSlice.hpp>
 #include <PipelineExecutionContext.hpp>
 #include <WindowBasedOperatorHandler.hpp>
 

--- a/nes-physical-operators/src/Aggregation/AggregationOperatorHandler.cpp
+++ b/nes-physical-operators/src/Aggregation/AggregationOperatorHandler.cpp
@@ -45,10 +45,22 @@ AggregationOperatorHandler::AggregationOperatorHandler(
     std::unique_ptr<WindowSlicesStoreInterface> sliceAndWindowStore,
     const uint64_t maxNumberOfBuckets)
     : WindowBasedOperatorHandler(inputOrigins, outputOriginId, std::move(sliceAndWindowStore))
-    , setupAlreadyCalled(false)
+    , cleanupStateNautilusFunctionInstalled(false)
     , rollingAverageNumberOfKeys(RollingAverage<uint64_t>{100})
     , maxNumberOfBuckets(maxNumberOfBuckets)
 {
+}
+
+bool AggregationOperatorHandler::trySetCleanupStateNautilusFunction(
+    std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec> cleanupStateNautilusFunction)
+{
+    bool expectedValue = false;
+    if (!cleanupStateNautilusFunctionInstalled.compare_exchange_strong(expectedValue, true))
+    {
+        return false;
+    }
+    this->cleanupStateNautilusFunction = std::move(cleanupStateNautilusFunction);
+    return true;
 }
 
 std::function<std::vector<std::shared_ptr<Slice>>(SliceStart, SliceEnd)>

--- a/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
@@ -74,50 +74,50 @@ HashMap* getHashJoinHashMapProxy(
     return hjSlice->getHashMapPtrOrCreate(workerThreadId, buildSide);
 }
 
-void HJBuildPhysicalOperator::setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const
+void HJBuildPhysicalOperator::compile(CompilationContext& compilationContext) const
 {
-    StreamJoinBuildPhysicalOperator::setup(executionCtx, compilationContext);
+    compileChild(compilationContext);
 
-    /// Creating the cleanup function for the slice of current stream
-    /// As the setup function does not get traced, we do not need to have any nautilus::invoke calls to jump to the C++ runtime
-    /// We are not allowed to use const or const references for the lambda function params, as nautilus does not support this in the registerFunction method.
-    /// ReSharper disable once CppPassValueParameterByConstReference
-    /// NOLINTBEGIN(performance-unnecessary-value-param)
-    auto* const operatorHandler = dynamic_cast<HJOperatorHandler*>(
-        nautilus::details::RawValueResolver<OperatorHandler*>::getRawValue(executionCtx.getGlobalOperatorHandler(operatorHandlerId)));
-    if (operatorHandler->wasSetupCalled(joinBuildSide))
+    if (cleanupStateNautilusFunction)
     {
         return;
     }
 
-    const auto cleanupStateNautilusFunction
-        = std::make_shared<CreateNewHashMapSliceArgs::NautilusCleanupExec>(compilationContext.registerFunction(std::function(
-            [copyOfHashMapOptions = hashMapOptions](nautilus::val<HashMap*> hashMap)
+    cleanupStateNautilusFunction = std::make_shared<CreateNewHashMapSliceArgs::NautilusCleanupExec>(compilationContext.registerFunction(
+        std::function([copyOfHashMapOptions = hashMapOptions](nautilus::val<HashMap*> hashMap)
+        {
+            const ChainedHashMapRef hashMapRef{
+                hashMap,
+                copyOfHashMapOptions.fieldKeys,
+                copyOfHashMapOptions.fieldValues,
+                copyOfHashMapOptions.entriesPerPage,
+                copyOfHashMapOptions.entrySize};
+            for (const auto entry : hashMapRef)
             {
-                const ChainedHashMapRef hashMapRef{
-                    hashMap,
-                    copyOfHashMapOptions.fieldKeys,
-                    copyOfHashMapOptions.fieldValues,
-                    copyOfHashMapOptions.entriesPerPage,
-                    copyOfHashMapOptions.entrySize};
-                for (const auto entry : hashMapRef)
-                {
-                    const ChainedHashMapRef::ChainedEntryRef entryRefReset{
-                        entry, hashMap, copyOfHashMapOptions.fieldKeys, copyOfHashMapOptions.fieldValues};
-                    const auto state = entryRefReset.getValueMemArea();
-                    nautilus::invoke(
-                        +[](int8_t* pagedVectorMemArea) -> void
-                        {
-                            /// Calls the destructor of the PagedVector
-                            /// NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-                            auto* pagedVector = reinterpret_cast<PagedVector*>(pagedVectorMemArea);
-                            pagedVector->~PagedVector();
-                        },
-                        state);
-                }
-            })));
-    /// NOLINTEND(performance-unnecessary-value-param)
-    operatorHandler->setNautilusCleanupExec(cleanupStateNautilusFunction, joinBuildSide);
+                const ChainedHashMapRef::ChainedEntryRef entryRefReset{
+                    entry, hashMap, copyOfHashMapOptions.fieldKeys, copyOfHashMapOptions.fieldValues};
+                const auto state = entryRefReset.getValueMemArea();
+                nautilus::invoke(
+                    +[](int8_t* pagedVectorMemArea) -> void
+                    {
+                        auto* pagedVector = reinterpret_cast<PagedVector*>(pagedVectorMemArea);
+                        pagedVector->~PagedVector();
+                    },
+                    state);
+            }
+        })));
+}
+
+void HJBuildPhysicalOperator::setup(ExecutionContext& executionCtx) const
+{
+    StreamJoinBuildPhysicalOperator::setup(executionCtx);
+
+    PRECONDITION(cleanupStateNautilusFunction != nullptr, "Expected compiled cleanup function for hash join build operator");
+
+    auto* const operatorHandler = dynamic_cast<HJOperatorHandler*>(
+        nautilus::details::RawValueResolver<OperatorHandler*>::getRawValue(executionCtx.getGlobalOperatorHandler(operatorHandlerId)));
+    PRECONDITION(operatorHandler != nullptr, "Expected HJOperatorHandler for {}", operatorHandlerId);
+    operatorHandler->trySetNautilusCleanupExec(cleanupStateNautilusFunction, joinBuildSide);
 }
 
 void HJBuildPhysicalOperator::execute(ExecutionContext& ctx, Record& record) const
@@ -191,6 +191,14 @@ HJBuildPhysicalOperator::HJBuildPhysicalOperator(
     HashMapOptions hashMapOptions)
     : StreamJoinBuildPhysicalOperator(operatorHandlerId, joinBuildSide, std::move(timeFunction), bufferRef)
     , hashMapOptions(std::move(hashMapOptions))
+    , cleanupStateNautilusFunction(nullptr)
+{
+}
+
+HJBuildPhysicalOperator::HJBuildPhysicalOperator(const HJBuildPhysicalOperator& other)
+    : StreamJoinBuildPhysicalOperator(other)
+    , hashMapOptions(other.hashMapOptions)
+    , cleanupStateNautilusFunction(nullptr)
 {
 }
 

--- a/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <utility>
 #include <Identifiers/Identifiers.hpp>
 #include <Join/HashJoin/HJOperatorHandler.hpp>
@@ -79,35 +80,35 @@ void HJBuildPhysicalOperator::compile(CompilationContext& compilationContext) co
 {
     compileChild(compilationContext);
 
-    if (cleanupStateNautilusFunction)
-    {
-        return;
-    }
-
-    cleanupStateNautilusFunction
-        = std::make_shared<CreateNewHashMapSliceArgs::NautilusCleanupExec>(compilationContext.registerFunction(std::function(
-            [copyOfHashMapOptions = hashMapOptions](nautilus::val<HashMap*> hashMap)
-            {
-                const ChainedHashMapRef hashMapRef{
-                    hashMap,
-                    copyOfHashMapOptions.fieldKeys,
-                    copyOfHashMapOptions.fieldValues,
-                    copyOfHashMapOptions.entriesPerPage,
-                    copyOfHashMapOptions.entrySize};
-                for (const auto entry : hashMapRef)
-                {
-                    const ChainedHashMapRef::ChainedEntryRef entryRefReset{
-                        entry, hashMap, copyOfHashMapOptions.fieldKeys, copyOfHashMapOptions.fieldValues};
-                    const auto state = entryRefReset.getValueMemArea();
-                    nautilus::invoke(
-                        +[](int8_t* pagedVectorMemArea) -> void
+    std::call_once(
+        cleanupStateNautilusFunctionOnce,
+        [this, &compilationContext]
+        {
+            cleanupStateNautilusFunction
+                = std::make_shared<CreateNewHashMapSliceArgs::NautilusCleanupExec>(compilationContext.registerFunction(std::function(
+                    [copyOfHashMapOptions = hashMapOptions](nautilus::val<HashMap*> hashMap)
+                    {
+                        const ChainedHashMapRef hashMapRef{
+                            hashMap,
+                            copyOfHashMapOptions.fieldKeys,
+                            copyOfHashMapOptions.fieldValues,
+                            copyOfHashMapOptions.entriesPerPage,
+                            copyOfHashMapOptions.entrySize};
+                        for (const auto entry : hashMapRef)
                         {
-                            auto* pagedVector = reinterpret_cast<PagedVector*>(pagedVectorMemArea);
-                            pagedVector->~PagedVector();
-                        },
-                        state);
-                }
-            })));
+                            const ChainedHashMapRef::ChainedEntryRef entryRefReset{
+                                entry, hashMap, copyOfHashMapOptions.fieldKeys, copyOfHashMapOptions.fieldValues};
+                            const auto state = entryRefReset.getValueMemArea();
+                            nautilus::invoke(
+                                +[](int8_t* pagedVectorMemArea) -> void
+                                {
+                                    auto* pagedVector = reinterpret_cast<PagedVector*>(pagedVectorMemArea);
+                                    pagedVector->~PagedVector();
+                                },
+                                state);
+                        }
+                    })));
+        });
 }
 
 void HJBuildPhysicalOperator::setup(ExecutionContext& executionCtx) const

--- a/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
@@ -81,10 +81,10 @@ void HJBuildPhysicalOperator::compile(CompilationContext& compilationContext) co
     compileChild(compilationContext);
 
     std::call_once(
-        cleanupStateNautilusFunctionOnce,
+        cleanupState->once,
         [this, &compilationContext]
         {
-            cleanupStateNautilusFunction
+            cleanupState->cleanupStateNautilusFunction
                 = std::make_shared<CreateNewHashMapSliceArgs::NautilusCleanupExec>(compilationContext.registerFunction(std::function(
                     [copyOfHashMapOptions = hashMapOptions](nautilus::val<HashMap*> hashMap)
                     {
@@ -115,12 +115,12 @@ void HJBuildPhysicalOperator::setup(ExecutionContext& executionCtx) const
 {
     StreamJoinBuildPhysicalOperator::setup(executionCtx);
 
-    PRECONDITION(cleanupStateNautilusFunction != nullptr, "Expected compiled cleanup function for hash join build operator");
+    PRECONDITION(cleanupState->cleanupStateNautilusFunction != nullptr, "Expected compiled cleanup function for hash join build operator");
 
     auto* const operatorHandler = dynamic_cast<HJOperatorHandler*>(
         nautilus::details::RawValueResolver<OperatorHandler*>::getRawValue(executionCtx.getGlobalOperatorHandler(operatorHandlerId)));
     PRECONDITION(operatorHandler != nullptr, "Expected HJOperatorHandler for {}", operatorHandlerId);
-    operatorHandler->trySetNautilusCleanupExec(cleanupStateNautilusFunction, joinBuildSide);
+    operatorHandler->trySetNautilusCleanupExec(cleanupState->cleanupStateNautilusFunction, joinBuildSide);
 }
 
 void HJBuildPhysicalOperator::execute(ExecutionContext& ctx, Record& record) const
@@ -194,12 +194,12 @@ HJBuildPhysicalOperator::HJBuildPhysicalOperator(
     HashMapOptions hashMapOptions)
     : StreamJoinBuildPhysicalOperator(operatorHandlerId, joinBuildSide, std::move(timeFunction), bufferRef)
     , hashMapOptions(std::move(hashMapOptions))
-    , cleanupStateNautilusFunction(nullptr)
+    , cleanupState(std::make_unique<CleanupState>())
 {
 }
 
 HJBuildPhysicalOperator::HJBuildPhysicalOperator(const HJBuildPhysicalOperator& other)
-    : StreamJoinBuildPhysicalOperator(other), hashMapOptions(other.hashMapOptions), cleanupStateNautilusFunction(nullptr)
+    : StreamJoinBuildPhysicalOperator(other), hashMapOptions(other.hashMapOptions), cleanupState(std::make_unique<CleanupState>())
 {
 }
 

--- a/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
@@ -29,6 +29,7 @@
 #include <Nautilus/Interface/PagedVector/PagedVector.hpp>
 #include <Nautilus/Interface/PagedVector/PagedVectorRef.hpp>
 #include <Nautilus/Interface/Record.hpp>
+#include <Runtime/Execution/OperatorHandler.hpp>
 #include <Time/Timestamp.hpp>
 #include <CompilationContext.hpp>
 #include <ErrorHandling.hpp>

--- a/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
@@ -83,29 +83,30 @@ void HJBuildPhysicalOperator::compile(CompilationContext& compilationContext) co
         return;
     }
 
-    cleanupStateNautilusFunction = std::make_shared<CreateNewHashMapSliceArgs::NautilusCleanupExec>(compilationContext.registerFunction(
-        std::function([copyOfHashMapOptions = hashMapOptions](nautilus::val<HashMap*> hashMap)
-        {
-            const ChainedHashMapRef hashMapRef{
-                hashMap,
-                copyOfHashMapOptions.fieldKeys,
-                copyOfHashMapOptions.fieldValues,
-                copyOfHashMapOptions.entriesPerPage,
-                copyOfHashMapOptions.entrySize};
-            for (const auto entry : hashMapRef)
+    cleanupStateNautilusFunction
+        = std::make_shared<CreateNewHashMapSliceArgs::NautilusCleanupExec>(compilationContext.registerFunction(std::function(
+            [copyOfHashMapOptions = hashMapOptions](nautilus::val<HashMap*> hashMap)
             {
-                const ChainedHashMapRef::ChainedEntryRef entryRefReset{
-                    entry, hashMap, copyOfHashMapOptions.fieldKeys, copyOfHashMapOptions.fieldValues};
-                const auto state = entryRefReset.getValueMemArea();
-                nautilus::invoke(
-                    +[](int8_t* pagedVectorMemArea) -> void
-                    {
-                        auto* pagedVector = reinterpret_cast<PagedVector*>(pagedVectorMemArea);
-                        pagedVector->~PagedVector();
-                    },
-                    state);
-            }
-        })));
+                const ChainedHashMapRef hashMapRef{
+                    hashMap,
+                    copyOfHashMapOptions.fieldKeys,
+                    copyOfHashMapOptions.fieldValues,
+                    copyOfHashMapOptions.entriesPerPage,
+                    copyOfHashMapOptions.entrySize};
+                for (const auto entry : hashMapRef)
+                {
+                    const ChainedHashMapRef::ChainedEntryRef entryRefReset{
+                        entry, hashMap, copyOfHashMapOptions.fieldKeys, copyOfHashMapOptions.fieldValues};
+                    const auto state = entryRefReset.getValueMemArea();
+                    nautilus::invoke(
+                        +[](int8_t* pagedVectorMemArea) -> void
+                        {
+                            auto* pagedVector = reinterpret_cast<PagedVector*>(pagedVectorMemArea);
+                            pagedVector->~PagedVector();
+                        },
+                        state);
+                }
+            })));
 }
 
 void HJBuildPhysicalOperator::setup(ExecutionContext& executionCtx) const
@@ -196,9 +197,7 @@ HJBuildPhysicalOperator::HJBuildPhysicalOperator(
 }
 
 HJBuildPhysicalOperator::HJBuildPhysicalOperator(const HJBuildPhysicalOperator& other)
-    : StreamJoinBuildPhysicalOperator(other)
-    , hashMapOptions(other.hashMapOptions)
-    , cleanupStateNautilusFunction(nullptr)
+    : StreamJoinBuildPhysicalOperator(other), hashMapOptions(other.hashMapOptions), cleanupStateNautilusFunction(nullptr)
 {
 }
 

--- a/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
@@ -17,7 +17,6 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
-#include <mutex>
 #include <utility>
 #include <Identifiers/Identifiers.hpp>
 #include <Join/HashJoin/HJOperatorHandler.hpp>
@@ -80,47 +79,33 @@ void HJBuildPhysicalOperator::compile(CompilationContext& compilationContext) co
 {
     compileChild(compilationContext);
 
-    std::call_once(
-        cleanupState->once,
-        [this, &compilationContext]
-        {
-            cleanupState->cleanupStateNautilusFunction
-                = std::make_shared<CreateNewHashMapSliceArgs::NautilusCleanupExec>(compilationContext.registerFunction(std::function(
-                    [copyOfHashMapOptions = hashMapOptions](nautilus::val<HashMap*> hashMap)
-                    {
-                        const ChainedHashMapRef hashMapRef{
-                            hashMap,
-                            copyOfHashMapOptions.fieldKeys,
-                            copyOfHashMapOptions.fieldValues,
-                            copyOfHashMapOptions.entriesPerPage,
-                            copyOfHashMapOptions.entrySize};
-                        for (const auto entry : hashMapRef)
-                        {
-                            const ChainedHashMapRef::ChainedEntryRef entryRefReset{
-                                entry, hashMap, copyOfHashMapOptions.fieldKeys, copyOfHashMapOptions.fieldValues};
-                            const auto state = entryRefReset.getValueMemArea();
-                            nautilus::invoke(
-                                +[](int8_t* pagedVectorMemArea) -> void
-                                {
-                                    auto* pagedVector = reinterpret_cast<PagedVector*>(pagedVectorMemArea);
-                                    pagedVector->~PagedVector();
-                                },
-                                state);
-                        }
-                    })));
-        });
-}
-
-void HJBuildPhysicalOperator::setup(ExecutionContext& executionCtx) const
-{
-    StreamJoinBuildPhysicalOperator::setup(executionCtx);
-
-    PRECONDITION(cleanupState->cleanupStateNautilusFunction != nullptr, "Expected compiled cleanup function for hash join build operator");
-
-    auto* const operatorHandler = dynamic_cast<HJOperatorHandler*>(
-        nautilus::details::RawValueResolver<OperatorHandler*>::getRawValue(executionCtx.getGlobalOperatorHandler(operatorHandlerId)));
+    auto* const operatorHandler = dynamic_cast<HJOperatorHandler*>(compilationContext.getGlobalOperatorHandler(operatorHandlerId));
     PRECONDITION(operatorHandler != nullptr, "Expected HJOperatorHandler for {}", operatorHandlerId);
-    operatorHandler->trySetNautilusCleanupExec(cleanupState->cleanupStateNautilusFunction, joinBuildSide);
+    operatorHandler->trySetNautilusCleanupExec(
+        std::make_shared<CreateNewHashMapSliceArgs::NautilusCleanupExec>(compilationContext.registerFunction(std::function(
+            [copyOfHashMapOptions = hashMapOptions](nautilus::val<HashMap*> hashMap)
+            {
+                const ChainedHashMapRef hashMapRef{
+                    hashMap,
+                    copyOfHashMapOptions.fieldKeys,
+                    copyOfHashMapOptions.fieldValues,
+                    copyOfHashMapOptions.entriesPerPage,
+                    copyOfHashMapOptions.entrySize};
+                for (const auto entry : hashMapRef)
+                {
+                    const ChainedHashMapRef::ChainedEntryRef entryRefReset{
+                        entry, hashMap, copyOfHashMapOptions.fieldKeys, copyOfHashMapOptions.fieldValues};
+                    const auto state = entryRefReset.getValueMemArea();
+                    nautilus::invoke(
+                        +[](int8_t* pagedVectorMemArea) -> void
+                        {
+                            auto* pagedVector = reinterpret_cast<PagedVector*>(pagedVectorMemArea);
+                            pagedVector->~PagedVector();
+                        },
+                        state);
+                }
+            }))),
+        joinBuildSide);
 }
 
 void HJBuildPhysicalOperator::execute(ExecutionContext& ctx, Record& record) const
@@ -194,12 +179,11 @@ HJBuildPhysicalOperator::HJBuildPhysicalOperator(
     HashMapOptions hashMapOptions)
     : StreamJoinBuildPhysicalOperator(operatorHandlerId, joinBuildSide, std::move(timeFunction), bufferRef)
     , hashMapOptions(std::move(hashMapOptions))
-    , cleanupState(std::make_unique<CleanupState>())
 {
 }
 
 HJBuildPhysicalOperator::HJBuildPhysicalOperator(const HJBuildPhysicalOperator& other)
-    : StreamJoinBuildPhysicalOperator(other), hashMapOptions(other.hashMapOptions), cleanupState(std::make_unique<CleanupState>())
+    : StreamJoinBuildPhysicalOperator(other), hashMapOptions(other.hashMapOptions)
 {
 }
 

--- a/nes-physical-operators/src/Join/HashJoin/HJOperatorHandler.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJOperatorHandler.cpp
@@ -43,8 +43,8 @@ HJOperatorHandler::HJOperatorHandler(
     std::unique_ptr<WindowSlicesStoreInterface> sliceAndWindowStore,
     const uint64_t maxNumberOfBuckets)
     : StreamJoinOperatorHandler(inputOrigins, outputOriginId, std::move(sliceAndWindowStore))
-    , setupAlreadyCalledLeft(false)
-    , setupAlreadyCalledRight(false)
+    , leftCleanupStateNautilusFunctionInstalled(false)
+    , rightCleanupStateNautilusFunctionInstalled(false)
     , rollingAverageNumberOfKeys(RollingAverage<uint64_t>{100})
     , maxNumberOfBuckets(maxNumberOfBuckets)
 {
@@ -67,36 +67,32 @@ HJOperatorHandler::getCreateNewSlicesFunction(const CreateNewSlicesArguments& ne
         });
 }
 
-bool HJOperatorHandler::wasSetupCalled(const JoinBuildSideType& buildSide)
+bool HJOperatorHandler::trySetNautilusCleanupExec(
+    std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec> nautilusCleanupExec, const JoinBuildSideType& buildSide)
 {
     switch (buildSide)
     {
         case JoinBuildSideType::Right: {
             bool expectedValue = false;
-            return not setupAlreadyCalledRight.compare_exchange_strong(expectedValue, true);
+            if (!rightCleanupStateNautilusFunctionInstalled.compare_exchange_strong(expectedValue, true))
+            {
+                return false;
+            }
+            rightCleanupStateNautilusFunction = std::move(nautilusCleanupExec);
+            return true;
         }
         case JoinBuildSideType::Left: {
             bool expectedValue = false;
-            return not setupAlreadyCalledLeft.compare_exchange_strong(expectedValue, true);
+            if (!leftCleanupStateNautilusFunctionInstalled.compare_exchange_strong(expectedValue, true))
+            {
+                return false;
+            }
+            leftCleanupStateNautilusFunction = std::move(nautilusCleanupExec);
+            return true;
         }
     }
 
     std::unreachable();
-}
-
-void HJOperatorHandler::setNautilusCleanupExec(
-    std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec> nautilusCleanupExec, const JoinBuildSideType& buildSide)
-{
-    switch (buildSide)
-    {
-        case JoinBuildSideType::Right:
-            rightCleanupStateNautilusFunction = std::move(nautilusCleanupExec);
-            break;
-        case JoinBuildSideType::Left:
-            leftCleanupStateNautilusFunction = std::move(nautilusCleanupExec);
-            break;
-            std::unreachable();
-    }
 }
 
 std::vector<std::shared_ptr<CreateNewHashMapSliceArgs::NautilusCleanupExec>> HJOperatorHandler::getNautilusCleanupExec() const

--- a/nes-physical-operators/src/PhysicalOperator.cpp
+++ b/nes-physical-operators/src/PhysicalOperator.cpp
@@ -43,9 +43,14 @@ PhysicalOperatorConcept::PhysicalOperatorConcept(const OperatorId existingId) : 
 {
 }
 
-void PhysicalOperatorConcept::setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const
+void PhysicalOperatorConcept::compile(CompilationContext& compilationContext) const
 {
-    setupChild(executionCtx, compilationContext);
+    compileChild(compilationContext);
+}
+
+void PhysicalOperatorConcept::setup(ExecutionContext& executionCtx) const
+{
+    setupChild(executionCtx);
 }
 
 void PhysicalOperatorConcept::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
@@ -68,10 +73,18 @@ void PhysicalOperatorConcept::execute(ExecutionContext& executionCtx, Record& re
     executeChild(executionCtx, record);
 }
 
-void PhysicalOperatorConcept::setupChild(ExecutionContext& executionCtx, CompilationContext& compilationContext) const
+void PhysicalOperatorConcept::compileChild(CompilationContext& compilationContext) const
+{
+    if (const auto child = getChild())
+    {
+        child->compile(compilationContext);
+    }
+}
+
+void PhysicalOperatorConcept::setupChild(ExecutionContext& executionCtx) const
 {
     INVARIANT(getChild().has_value(), "Child operator is not set");
-    getChild().value().setup(executionCtx, compilationContext);
+    getChild().value().setup(executionCtx);
 }
 
 void PhysicalOperatorConcept::openChild(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
@@ -125,9 +138,14 @@ PhysicalOperator PhysicalOperator::withChild(PhysicalOperator child) const
     return {copy};
 }
 
-void PhysicalOperator::setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const
+void PhysicalOperator::compile(CompilationContext& compilationContext) const
 {
-    self->setup(executionCtx, compilationContext);
+    self->compile(compilationContext);
+}
+
+void PhysicalOperator::setup(ExecutionContext& executionCtx) const
+{
+    self->setup(executionCtx);
 }
 
 void PhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const

--- a/nes-physical-operators/src/PhysicalOperator.cpp
+++ b/nes-physical-operators/src/PhysicalOperator.cpp
@@ -83,32 +83,37 @@ void PhysicalOperatorConcept::compileChild(CompilationContext& compilationContex
 
 void PhysicalOperatorConcept::setupChild(ExecutionContext& executionCtx) const
 {
-    INVARIANT(getChild().has_value(), "Child operator is not set");
-    getChild().value().setup(executionCtx);
+    const auto child = getChild();
+    INVARIANT(child.has_value(), "Child operator is not set");
+    child->setup(executionCtx);
 }
 
 void PhysicalOperatorConcept::openChild(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
 {
-    INVARIANT(getChild().has_value(), "Child operator is not set");
-    getChild().value().open(executionCtx, recordBuffer);
+    const auto child = getChild();
+    INVARIANT(child.has_value(), "Child operator is not set");
+    child->open(executionCtx, recordBuffer);
 }
 
 void PhysicalOperatorConcept::closeChild(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
 {
-    INVARIANT(getChild().has_value(), "Child operator is not set");
-    getChild().value().close(executionCtx, recordBuffer);
+    const auto child = getChild();
+    INVARIANT(child.has_value(), "Child operator is not set");
+    child->close(executionCtx, recordBuffer);
 }
 
 void PhysicalOperatorConcept::executeChild(ExecutionContext& executionCtx, Record& record) const
 {
-    INVARIANT(getChild().has_value(), "Child operator is not set");
-    getChild().value().execute(executionCtx, record);
+    const auto child = getChild();
+    INVARIANT(child.has_value(), "Child operator is not set");
+    child->execute(executionCtx, record);
 }
 
 void PhysicalOperatorConcept::terminateChild(ExecutionContext& executionCtx) const
 {
-    INVARIANT(getChild().has_value(), "Child operator is not set");
-    getChild().value().terminate(executionCtx);
+    const auto child = getChild();
+    INVARIANT(child.has_value(), "Child operator is not set");
+    child->terminate(executionCtx);
 }
 
 PhysicalOperator::PhysicalOperator() = default;

--- a/nes-physical-operators/src/WindowBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/WindowBuildPhysicalOperator.cpp
@@ -22,7 +22,6 @@
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Time/Timestamp.hpp>
 #include <Watermark/TimeFunction.hpp>
-#include <CompilationContext.hpp>
 #include <ErrorHandling.hpp>
 #include <ExecutionContext.hpp>
 #include <PhysicalOperator.hpp>
@@ -87,7 +86,7 @@ void WindowBuildPhysicalOperator::close(ExecutionContext& executionCtx, RecordBu
         executionCtx.originId);
 }
 
-void WindowBuildPhysicalOperator::setup(ExecutionContext& executionCtx, CompilationContext&) const
+void WindowBuildPhysicalOperator::setup(ExecutionContext& executionCtx) const
 {
     auto operatorHandlerMemRef = executionCtx.getGlobalOperatorHandler(operatorHandlerId);
     invoke(registerActivePipeline, operatorHandlerMemRef);

--- a/nes-physical-operators/src/WindowProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/WindowProbePhysicalOperator.cpp
@@ -22,7 +22,6 @@
 #include <Runtime/QueryTerminationType.hpp>
 #include <Time/Timestamp.hpp>
 #include <Windowing/WindowMetaData.hpp>
-#include <CompilationContext.hpp>
 #include <ErrorHandling.hpp>
 #include <ExecutionContext.hpp>
 #include <PhysicalOperator.hpp>
@@ -75,10 +74,10 @@ WindowProbePhysicalOperator::WindowProbePhysicalOperator(OperatorHandlerId opera
 {
 }
 
-void WindowProbePhysicalOperator::setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const
+void WindowProbePhysicalOperator::setup(ExecutionContext& executionCtx) const
 {
-    /// Giving child operators the change to setup
-    setupChild(executionCtx, compilationContext);
+    /// Giving child operators the chance to setup
+    setupChild(executionCtx);
     invoke(setupProxy, executionCtx.getGlobalOperatorHandler(operatorHandlerId), executionCtx.pipelineContext);
 }
 

--- a/nes-query-engine/Interfaces.hpp
+++ b/nes-query-engine/Interfaces.hpp
@@ -49,7 +49,7 @@ public:
         TaskCallback,
         PipelineExecutionContext::ContinuationPolicy continuationPolicy)
         = 0;
-    virtual void emitPipelinePrepare(QueryId, const std::shared_ptr<RunningQueryPlanNode>&, TaskCallback) = 0;
+    virtual void emitPipelineCompile(QueryId, const std::shared_ptr<RunningQueryPlanNode>&, TaskCallback) = 0;
     virtual void emitPipelineStart(QueryId, const std::shared_ptr<RunningQueryPlanNode>&, TaskCallback) = 0;
     virtual void emitPendingPipelineStop(QueryId, std::shared_ptr<RunningQueryPlanNode>, TaskCallback) = 0;
     virtual void emitPipelineStop(QueryId, std::unique_ptr<RunningQueryPlanNode>, TaskCallback) = 0;

--- a/nes-query-engine/Interfaces.hpp
+++ b/nes-query-engine/Interfaces.hpp
@@ -49,6 +49,7 @@ public:
         TaskCallback,
         PipelineExecutionContext::ContinuationPolicy continuationPolicy)
         = 0;
+    virtual void emitPipelinePrepare(QueryId, const std::shared_ptr<RunningQueryPlanNode>&, TaskCallback) = 0;
     virtual void emitPipelineStart(QueryId, const std::shared_ptr<RunningQueryPlanNode>&, TaskCallback) = 0;
     virtual void emitPendingPipelineStop(QueryId, std::shared_ptr<RunningQueryPlanNode>, TaskCallback) = 0;
     virtual void emitPipelineStop(QueryId, std::unique_ptr<RunningQueryPlanNode>, TaskCallback) = 0;

--- a/nes-query-engine/QueryEngine.cpp
+++ b/nes-query-engine/QueryEngine.cpp
@@ -548,7 +548,7 @@ bool ThreadPool::WorkerThread::operator()(WorkTask& task) const
 
 bool ThreadPool::WorkerThread::operator()(CompilePipelineTask& compilePipeline) const
 {
-    LogContext logContext("Task", fmt::format("{}-{}", compilePipeline.queryId, compilePipeline.pipelineId));
+    const LogContext logContext("Task", fmt::format("{}-{}", compilePipeline.queryId, compilePipeline.pipelineId));
     if (terminating)
     {
         ENGINE_LOG_WARNING(

--- a/nes-query-engine/QueryEngine.cpp
+++ b/nes-query-engine/QueryEngine.cpp
@@ -534,6 +534,7 @@ bool ThreadPool::WorkerThread::operator()(WorkTask& task) const
             }
 
         );
+        INVARIANT(pipeline->isStarted, "Pipeline {}-{} must be started before executing tasks", task.queryId, pipeline->id);
         pool.statistic->onEvent(TaskExecutionStart{WorkerThread::id, task.queryId, pipeline->id, taskId, task.buf.getNumberOfTuples()});
         pipeline->stage->execute(task.buf, pec);
         pool.statistic->onEvent(TaskExecutionComplete{WorkerThread::id, task.queryId, pipeline->id, taskId});
@@ -572,6 +573,8 @@ bool ThreadPool::WorkerThread::operator()(CompilePipelineTask& compilePipeline) 
             [&](const TupleBuffer&, std::chrono::milliseconds)
             { INVARIANT(false, "Repeat pipeline compilation is currently not supported"); });
         pipeline->stage->compile(pec);
+        const auto wasCompiled = pipeline->isCompiled.exchange(true);
+        INVARIANT(!wasCompiled, "Pipeline {}-{} must not be compiled multiple times", compilePipeline.queryId, pipeline->id);
         return true;
     }
 
@@ -612,7 +615,10 @@ bool ThreadPool::WorkerThread::operator()(StartPipelineTask& startPipeline) cons
                     "Repeat pipeline setup is currently not supported. Although there is no inherit reason this wouldn't work, but its not "
                     "tested");
             });
+        INVARIANT(pipeline->isCompiled, "Pipeline {}-{} must be compiled before start", startPipeline.queryId, pipeline->id);
         pipeline->stage->start(pec);
+        const auto wasStarted = pipeline->isStarted.exchange(true);
+        INVARIANT(!wasStarted, "Pipeline {}-{} must not be started multiple times", startPipeline.queryId, pipeline->id);
         pool.statistic->onEvent(PipelineStart{WorkerThread::id, startPipeline.queryId, pipeline->id});
         return true;
     }
@@ -706,6 +712,11 @@ bool ThreadPool::WorkerThread::operator()(StopPipelineTask& stopPipelineTask) co
         });
 
     ENGINE_LOG_DEBUG("Stopping Pipeline {}-{}", stopPipelineTask.queryId, stopPipelineTask.pipeline->id);
+    INVARIANT(
+        stopPipelineTask.pipeline->isStarted,
+        "Pipeline {}-{} must be started before stop",
+        stopPipelineTask.queryId,
+        stopPipelineTask.pipeline->id);
     auto pipelineId = stopPipelineTask.pipeline->id;
     auto queryId = stopPipelineTask.queryId;
     stopPipelineTask.pipeline->stage->stop(pec);

--- a/nes-query-engine/QueryEngine.cpp
+++ b/nes-query-engine/QueryEngine.cpp
@@ -713,8 +713,8 @@ bool ThreadPool::WorkerThread::operator()(StopPipelineTask& stopPipelineTask) co
 
     ENGINE_LOG_DEBUG("Stopping Pipeline {}-{}", stopPipelineTask.queryId, stopPipelineTask.pipeline->id);
     INVARIANT(
-        stopPipelineTask.pipeline->isStarted,
-        "Pipeline {}-{} must be started before stop",
+        stopPipelineTask.pipeline->isCompiled,
+        "Pipeline {}-{} must be compiled before stop",
         stopPipelineTask.queryId,
         stopPipelineTask.pipeline->id);
     auto pipelineId = stopPipelineTask.pipeline->id;

--- a/nes-query-engine/QueryEngine.cpp
+++ b/nes-query-engine/QueryEngine.cpp
@@ -348,7 +348,7 @@ public:
         std::unreachable();
     }
 
-    void emitPipelinePrepare(QueryId qid, const std::shared_ptr<RunningQueryPlanNode>& node, TaskCallback callback) override
+    void emitPipelineCompile(QueryId qid, const std::shared_ptr<RunningQueryPlanNode>& node, TaskCallback callback) override
     {
         auto [complete, failure, success] = std::move(callback).take();
         auto wrappedCallback = TaskCallback{
@@ -356,7 +356,7 @@ public:
             std::move(success),
             TaskCallback::OnFailure(injectQueryFailure(node, std::move(failure.callback))),
         };
-        addInternalTask(PreparePipelineTask(qid, node->id, std::move(wrappedCallback), node));
+        addInternalTask(CompilePipelineTask(qid, node->id, std::move(wrappedCallback), node));
     }
 
     void emitPipelineStart(QueryId qid, const std::shared_ptr<RunningQueryPlanNode>& node, TaskCallback callback) override
@@ -448,7 +448,7 @@ public:
         bool operator()(WorkTask& task) const;
         bool operator()(StopQueryTask& stopQuery) const;
         bool operator()(StartQueryTask& startQuery) const;
-        bool operator()(PreparePipelineTask& preparePipeline) const;
+        bool operator()(CompilePipelineTask& compilePipeline) const;
         bool operator()(StartPipelineTask& startPipeline) const;
         bool operator()(PendingPipelineStopTask& pendingPipelineStop) const;
         bool operator()(StopPipelineTask& stopPipelineTask) const;
@@ -546,19 +546,19 @@ bool ThreadPool::WorkerThread::operator()(WorkTask& task) const
     return false;
 }
 
-bool ThreadPool::WorkerThread::operator()(PreparePipelineTask& preparePipeline) const
+bool ThreadPool::WorkerThread::operator()(CompilePipelineTask& compilePipeline) const
 {
-    LogContext logContext("Task", fmt::format("{}-{}", preparePipeline.queryId, preparePipeline.pipelineId));
+    LogContext logContext("Task", fmt::format("{}-{}", compilePipeline.queryId, compilePipeline.pipelineId));
     if (terminating)
     {
         ENGINE_LOG_WARNING(
-            "Pipeline Preparation {}-{} was skipped during Termination", preparePipeline.queryId, preparePipeline.pipelineId);
+            "Pipeline Compilation {}-{} was skipped during Termination", compilePipeline.queryId, compilePipeline.pipelineId);
         return false;
     }
 
-    if (auto pipeline = preparePipeline.pipeline.lock())
+    if (auto pipeline = compilePipeline.pipeline.lock())
     {
-        ENGINE_LOG_DEBUG("Prepare Pipeline Task for {}-{}", preparePipeline.queryId, pipeline->id);
+        ENGINE_LOG_DEBUG("Compile Pipeline Task for {}-{}", compilePipeline.queryId, pipeline->id);
         DefaultPEC pec(
             pool.numberOfThreads(),
             WorkerThread::id,
@@ -566,16 +566,16 @@ bool ThreadPool::WorkerThread::operator()(PreparePipelineTask& preparePipeline) 
             pool.bufferProvider,
             [](const TupleBuffer&, PipelineExecutionContext::ContinuationPolicy)
             {
-                INVARIANT(false, "Currently we assume that a pipeline cannot emit data during preparation");
+                INVARIANT(false, "Currently we assume that a pipeline cannot emit data during compilation");
                 return false;
             },
             [&](const TupleBuffer&, std::chrono::milliseconds)
-            { INVARIANT(false, "Repeat pipeline preparation is currently not supported"); });
-        pipeline->stage->prepare(pec);
+            { INVARIANT(false, "Repeat pipeline compilation is currently not supported"); });
+        pipeline->stage->compile(pec);
         return true;
     }
 
-    ENGINE_LOG_WARNING("Prepared pipeline is expired for {}-{}", preparePipeline.queryId, preparePipeline.pipelineId);
+    ENGINE_LOG_WARNING("Compiled pipeline is expired for {}-{}", compilePipeline.queryId, compilePipeline.pipelineId);
     return false;
 }
 

--- a/nes-query-engine/QueryEngine.cpp
+++ b/nes-query-engine/QueryEngine.cpp
@@ -348,6 +348,17 @@ public:
         std::unreachable();
     }
 
+    void emitPipelinePrepare(QueryId qid, const std::shared_ptr<RunningQueryPlanNode>& node, TaskCallback callback) override
+    {
+        auto [complete, failure, success] = std::move(callback).take();
+        auto wrappedCallback = TaskCallback{
+            std::move(complete),
+            std::move(success),
+            TaskCallback::OnFailure(injectQueryFailure(node, std::move(failure.callback))),
+        };
+        addInternalTask(PreparePipelineTask(qid, node->id, std::move(wrappedCallback), node));
+    }
+
     void emitPipelineStart(QueryId qid, const std::shared_ptr<RunningQueryPlanNode>& node, TaskCallback callback) override
     {
         auto [complete, failure, success] = std::move(callback).take();
@@ -437,6 +448,7 @@ public:
         bool operator()(WorkTask& task) const;
         bool operator()(StopQueryTask& stopQuery) const;
         bool operator()(StartQueryTask& startQuery) const;
+        bool operator()(PreparePipelineTask& preparePipeline) const;
         bool operator()(StartPipelineTask& startPipeline) const;
         bool operator()(PendingPipelineStopTask& pendingPipelineStop) const;
         bool operator()(StopPipelineTask& stopPipelineTask) const;
@@ -531,6 +543,39 @@ bool ThreadPool::WorkerThread::operator()(WorkTask& task) const
     ENGINE_LOG_WARNING(
         "Task {} for Query {}-{} is expired. Tuples: {}", taskId, task.queryId, task.pipelineId, task.buf.getNumberOfTuples());
     pool.statistic->onEvent(TaskExpired{WorkerThread::id, task.queryId, task.pipelineId, taskId});
+    return false;
+}
+
+bool ThreadPool::WorkerThread::operator()(PreparePipelineTask& preparePipeline) const
+{
+    LogContext logContext("Task", fmt::format("{}-{}", preparePipeline.queryId, preparePipeline.pipelineId));
+    if (terminating)
+    {
+        ENGINE_LOG_WARNING(
+            "Pipeline Preparation {}-{} was skipped during Termination", preparePipeline.queryId, preparePipeline.pipelineId);
+        return false;
+    }
+
+    if (auto pipeline = preparePipeline.pipeline.lock())
+    {
+        ENGINE_LOG_DEBUG("Prepare Pipeline Task for {}-{}", preparePipeline.queryId, pipeline->id);
+        DefaultPEC pec(
+            pool.numberOfThreads(),
+            WorkerThread::id,
+            pipeline->id,
+            pool.bufferProvider,
+            [](const TupleBuffer&, PipelineExecutionContext::ContinuationPolicy)
+            {
+                INVARIANT(false, "Currently we assume that a pipeline cannot emit data during preparation");
+                return false;
+            },
+            [&](const TupleBuffer&, std::chrono::milliseconds)
+            { INVARIANT(false, "Repeat pipeline preparation is currently not supported"); });
+        pipeline->stage->prepare(pec);
+        return true;
+    }
+
+    ENGINE_LOG_WARNING("Prepared pipeline is expired for {}-{}", preparePipeline.queryId, preparePipeline.pipelineId);
     return false;
 }
 

--- a/nes-query-engine/RunningQueryPlan.cpp
+++ b/nes-query-engine/RunningQueryPlan.cpp
@@ -88,19 +88,19 @@ std::shared_ptr<RunningQueryPlanNode> RunningQueryPlanNode::create(
     std::unique_ptr<ExecutablePipelineStage> stage,
     std::function<void(Exception)> unregisterWithError,
     CallbackRef planRef,
-    CallbackRef preparationCallback)
+    CallbackRef compilationCallback)
 {
     auto node = std::shared_ptr<RunningQueryPlanNode>(
         new RunningQueryPlanNode(pipelineId, std::move(successors), std::move(stage), std::move(unregisterWithError), std::move(planRef)),
         RunningQueryPlanNodeDeleter{.emitter = emitter, .queryId = queryId});
-    emitter.emitPipelinePrepare(
+    emitter.emitPipelineCompile(
         queryId,
         node,
         TaskCallback{TaskCallback::OnComplete(
-            [ENGINE_IF_LOG_TRACE(queryId, pipelineId, ) preparationCallback = std::move(preparationCallback)]() mutable
+            [ENGINE_IF_LOG_TRACE(queryId, pipelineId, ) compilationCallback = std::move(compilationCallback)]() mutable
             {
-                static_cast<void>(preparationCallback);
-                ENGINE_LOG_TRACE("Pipeline {}-{} was prepared", queryId, pipelineId);
+                static_cast<void>(compilationCallback);
+                ENGINE_LOG_TRACE("Pipeline {}-{} was compiled", queryId, pipelineId);
             })});
 
     return node;
@@ -122,7 +122,7 @@ std::
         ExecutableQueryPlan& queryPlan,
         std::function<void(Exception)> unregisterWithError,
         const CallbackRef& terminationCallbackRef,
-        const CallbackRef& pipelinePreparationCallbackRef,
+        const CallbackRef& pipelineCompilationCallbackRef,
         WorkEmitter& emitter)
 {
     std::vector<std::pair<std::unique_ptr<SourceHandle>, std::vector<std::shared_ptr<RunningQueryPlanNode>>>> sources;
@@ -148,7 +148,7 @@ std::
             std::move(pipeline->stage),
             unregisterWithError,
             terminationCallbackRef,
-            pipelinePreparationCallbackRef);
+            pipelineCompilationCallbackRef);
         pipelines.emplace_back(node);
         cache[pipeline] = std::move(node);
         return cache[pipeline];
@@ -181,15 +181,15 @@ std::pair<std::unique_ptr<RunningQueryPlan>, CallbackRef> RunningQueryPlan::star
     auto [terminationCallbackOwner, terminationCallbackRef] = Callback::create();
     terminationCallbackOwner.setCallback([listener] { listener->onDestruction(); });
 
-    /// Callback to track the lifetime of all prepare tasks.
-    auto [pipelinePreparationCallbackOwner, pipelinePreparationCallbackRef] = Callback::create();
+    /// Callback to track the lifetime of all compile tasks.
+    auto [pipelineCompilationCallbackOwner, pipelineCompilationCallbackRef] = Callback::create();
     /// Callback to track the lifetime of all start tasks.
     auto [pipelineStartCallbackOwner, pipelineStartCallbackRef] = Callback::create();
 
     /// The RunningQueryPlan object is the owner of all callbacks. If the RunningQueryPlan object is destroyed (i.e., stopped from a user,
     /// or because of a failure). The callbacks are cancelled, as they have become meaningless.
     auto runningPlan = std::unique_ptr<RunningQueryPlan>(new RunningQueryPlan(
-        std::move(terminationCallbackOwner), std::move(pipelinePreparationCallbackOwner), std::move(pipelineStartCallbackOwner)));
+        std::move(terminationCallbackOwner), std::move(pipelineCompilationCallbackOwner), std::move(pipelineStartCallbackOwner)));
 
     auto lock = runningPlan->internal.lock();
 
@@ -204,19 +204,19 @@ std::pair<std::unique_ptr<RunningQueryPlan>, CallbackRef> RunningQueryPlan::star
             listener->onFailure(std::move(exception));
         },
         terminationCallbackRef,
-        pipelinePreparationCallbackRef,
+        pipelineCompilationCallbackRef,
         emitter);
     internal.pipelines = std::move(pipelines);
 
-    /// Once all pipelines are prepared, schedule their start tasks.
-    internal.allPipelinesPrepared.setCallback(
+    /// Once all pipelines are compiled, schedule their start tasks.
+    internal.allPipelinesCompiled.setCallback(
         [&runningPlan = *runningPlan, queryId, &emitter, pipelineStartCallbackRef]() mutable
         {
             std::vector<std::shared_ptr<RunningQueryPlanNode>> pipelinesToStart;
             {
                 auto lock = runningPlan.internal.lock();
                 auto& internal = *lock;
-                ENGINE_LOG_DEBUG("Pipeline Preparation Completed");
+                ENGINE_LOG_DEBUG("Pipeline Compilation Completed");
                 for (const auto& weakRef : internal.pipelines)
                 {
                     if (auto strongRef = weakRef.lock())
@@ -307,17 +307,17 @@ RunningQueryPlan::stop(std::unique_ptr<RunningQueryPlan> runningQueryPlan)
     return {
         std::make_unique<StoppingQueryPlan>(
             std::move(internal.qep), std::move(internal.listeners), std::move(internal.allPipelinesExpired)),
-        [preparationCallbackOwner = std::move(internal.allPipelinesPrepared),
+        [compilationCallbackOwner = std::move(internal.allPipelinesCompiled),
          startCallbackOwner = std::move(internal.allPipelinesStarted),
          pipelines = std::move(internal.pipelines),
          sources = std::move(internal.sources)]() mutable
         {
             /// Destroying the sources needs to ensure that there is no concurrency on the sources vector.
-            /// The prepare and start callbacks may run concurrently so they need to be destroyed before the graph is torn down.
+            /// The compile and start callbacks may run concurrently so they need to be destroyed before the graph is torn down.
             /// The callback owner will block until the callback is either cancelled or completed. Completing the callback requires
             /// a lock on the AtomicState. Therefore, this callback needs to be called from outside the atomic state.
             startCallbackOwner = {};
-            preparationCallbackOwner = {};
+            compilationCallbackOwner = {};
             pipelines.clear();
             sources.clear();
         }
@@ -349,7 +349,7 @@ RunningQueryPlan::~RunningQueryPlan()
     auto& internal = *lock;
 
 
-    /// CRITICAL: Disable pipeline prepare and start callbacks during destruction to prevent race conditions.
+    /// CRITICAL: Disable pipeline compile and start callbacks during destruction to prevent race conditions.
     ///
     /// This prevents any pending pipeline callbacks from executing after the
     /// RunningQueryPlan starts being destroyed. Without this, callbacks could access
@@ -358,7 +358,7 @@ RunningQueryPlan::~RunningQueryPlan()
     /// The callbacks may have captured a raw pointer to this RunningQueryPlan during
     /// the start() method, and this ensures they cannot execute after destruction begins.
     internal.allPipelinesStarted = {};
-    internal.allPipelinesPrepared = {};
+    internal.allPipelinesCompiled = {};
 
     for (const auto& weakRef : internal.pipelines)
     {

--- a/nes-query-engine/RunningQueryPlan.cpp
+++ b/nes-query-engine/RunningQueryPlan.cpp
@@ -88,22 +88,19 @@ std::shared_ptr<RunningQueryPlanNode> RunningQueryPlanNode::create(
     std::unique_ptr<ExecutablePipelineStage> stage,
     std::function<void(Exception)> unregisterWithError,
     CallbackRef planRef,
-    CallbackRef setupCallback)
+    CallbackRef preparationCallback)
 {
     auto node = std::shared_ptr<RunningQueryPlanNode>(
         new RunningQueryPlanNode(pipelineId, std::move(successors), std::move(stage), std::move(unregisterWithError), std::move(planRef)),
         RunningQueryPlanNodeDeleter{.emitter = emitter, .queryId = queryId});
-    emitter.emitPipelineStart(
+    emitter.emitPipelinePrepare(
         queryId,
         node,
         TaskCallback{TaskCallback::OnComplete(
-            [ENGINE_IF_LOG_TRACE(queryId, pipelineId, ) setupCallback = std::move(setupCallback), weakRef = std::weak_ptr(node)]
+            [ENGINE_IF_LOG_TRACE(queryId, pipelineId, ) preparationCallback = std::move(preparationCallback)]() mutable
             {
-                if (const auto nodeLocked = weakRef.lock())
-                {
-                    ENGINE_LOG_TRACE("Pipeline {}-{} was initialized", queryId, pipelineId);
-                    nodeLocked->requiresTermination = true;
-                }
+                static_cast<void>(preparationCallback);
+                ENGINE_LOG_TRACE("Pipeline {}-{} was prepared", queryId, pipelineId);
             })});
 
     return node;
@@ -125,7 +122,7 @@ std::
         ExecutableQueryPlan& queryPlan,
         std::function<void(Exception)> unregisterWithError,
         const CallbackRef& terminationCallbackRef,
-        const CallbackRef& pipelineSetupCallbackRef,
+        const CallbackRef& pipelinePreparationCallbackRef,
         WorkEmitter& emitter)
 {
     std::vector<std::pair<std::unique_ptr<SourceHandle>, std::vector<std::shared_ptr<RunningQueryPlanNode>>>> sources;
@@ -151,7 +148,7 @@ std::
             std::move(pipeline->stage),
             unregisterWithError,
             terminationCallbackRef,
-            pipelineSetupCallbackRef);
+            pipelinePreparationCallbackRef);
         pipelines.emplace_back(node);
         cache[pipeline] = std::move(node);
         return cache[pipeline];
@@ -184,13 +181,15 @@ std::pair<std::unique_ptr<RunningQueryPlan>, CallbackRef> RunningQueryPlan::star
     auto [terminationCallbackOwner, terminationCallbackRef] = Callback::create();
     terminationCallbackOwner.setCallback([listener] { listener->onDestruction(); });
 
-    /// Callback to track the lifetime of all setup tasks.
-    auto [pipelineSetupCallbackOwner, pipelineSetupCallbackRef] = Callback::create();
+    /// Callback to track the lifetime of all prepare tasks.
+    auto [pipelinePreparationCallbackOwner, pipelinePreparationCallbackRef] = Callback::create();
+    /// Callback to track the lifetime of all start tasks.
+    auto [pipelineStartCallbackOwner, pipelineStartCallbackRef] = Callback::create();
 
-    /// The RunningQueryPlan object is the owner of both callbacks. If the RunningQueryPlan object is destroyed (i.e., stopped from a user,
-    /// or because of a failure). The Callbacks are cancelled, as they have become meaningless.
-    auto runningPlan = std::unique_ptr<RunningQueryPlan>(
-        new RunningQueryPlan(std::move(terminationCallbackOwner), std::move(pipelineSetupCallbackOwner)));
+    /// The RunningQueryPlan object is the owner of all callbacks. If the RunningQueryPlan object is destroyed (i.e., stopped from a user,
+    /// or because of a failure). The callbacks are cancelled, as they have become meaningless.
+    auto runningPlan = std::unique_ptr<RunningQueryPlan>(new RunningQueryPlan(
+        std::move(terminationCallbackOwner), std::move(pipelinePreparationCallbackOwner), std::move(pipelineStartCallbackOwner)));
 
     auto lock = runningPlan->internal.lock();
 
@@ -205,17 +204,54 @@ std::pair<std::unique_ptr<RunningQueryPlan>, CallbackRef> RunningQueryPlan::star
             listener->onFailure(std::move(exception));
         },
         terminationCallbackRef,
-        pipelineSetupCallbackRef,
+        pipelinePreparationCallbackRef,
         emitter);
     internal.pipelines = std::move(pipelines);
 
-    /// The QueryEngine uses the setup callback to start the sources once all pipelines have been set up, effectively starting the query.
-    /// The setup callback tracks the lifetimes of all pipeline setup tasks. Either a task will fail and terminate the query, which will cancel the setup callback.
-    /// Or the setup task completes and destroys the callback reference.
-    /// When the last setup task is destroyed, it sets the guard counter of the callback reference to 0, triggering the execution of setup callback.
+    /// Once all pipelines are prepared, schedule their start tasks.
+    internal.allPipelinesPrepared.setCallback(
+        [&runningPlan = *runningPlan, queryId, &emitter, pipelineStartCallbackRef]() mutable
+        {
+            std::vector<std::shared_ptr<RunningQueryPlanNode>> pipelinesToStart;
+            {
+                auto lock = runningPlan.internal.lock();
+                auto& internal = *lock;
+                ENGINE_LOG_DEBUG("Pipeline Preparation Completed");
+                for (const auto& weakRef : internal.pipelines)
+                {
+                    if (auto strongRef = weakRef.lock())
+                    {
+                        pipelinesToStart.emplace_back(std::move(strongRef));
+                    }
+                }
+            }
+
+            for (auto& pipeline : pipelinesToStart)
+            {
+                const auto pipelineId = pipeline->id;
+                emitter.emitPipelineStart(
+                    queryId,
+                    pipeline,
+                    TaskCallback{TaskCallback::OnComplete(
+                        [ENGINE_IF_LOG_TRACE(queryId, pipelineId, ) pipelineStartCallbackRef, weakRef = std::weak_ptr(pipeline)]() mutable
+                        {
+                            static_cast<void>(pipelineStartCallbackRef);
+                            if (const auto nodeLocked = weakRef.lock())
+                            {
+                                ENGINE_LOG_TRACE("Pipeline {}-{} was initialized", queryId, pipelineId);
+                                nodeLocked->requiresTermination = true;
+                            }
+                        })});
+            }
+        });
+
+    /// The QueryEngine uses the start callback to start the sources once all pipelines have been initialized, effectively starting the query.
+    /// The callback tracks the lifetimes of all pipeline start tasks. Either a task will fail and terminate the query, which will cancel the callback.
+    /// Or the start task completes and destroys the callback reference.
+    /// When the last start task is destroyed, it sets the guard counter of the callback reference to 0, triggering the execution of the callback.
     internal.allPipelinesStarted.setCallback(
         [
-                /// This reference is guaranteed to be alive. As the running callback holds the Callbacks owner object. The callback
+                /// This reference is guaranteed to be alive. As the running callback holds the callbacks owner object. The callback
                 /// guarantees, that its owner is either alive during the callback execution or that the callback will never execute
                 & runningPlan = *runningPlan,
                 queryId,
@@ -228,7 +264,7 @@ std::pair<std::unique_ptr<RunningQueryPlan>, CallbackRef> RunningQueryPlan::star
                 auto lock = runningPlan.internal.lock();
                 auto& internal = *lock;
 
-                ENGINE_LOG_DEBUG("Pipeline Setup Completed");
+                ENGINE_LOG_DEBUG("Pipeline Start Completed");
                 for (auto& [source, successors] : sources)
                 {
                     auto sourceId = source->getSourceId();
@@ -252,13 +288,12 @@ std::pair<std::unique_ptr<RunningQueryPlan>, CallbackRef> RunningQueryPlan::star
                             controller,
                             emitter));
                 }
-                /// release lock
             }
 
             listener->onRunning();
         });
 
-    return {std::move(runningPlan), pipelineSetupCallbackRef};
+    return {std::move(runningPlan), pipelineStartCallbackRef};
 }
 
 std::pair<std::unique_ptr<StoppingQueryPlan>, absl::AnyInvocable<void()>>
@@ -272,15 +307,17 @@ RunningQueryPlan::stop(std::unique_ptr<RunningQueryPlan> runningQueryPlan)
     return {
         std::make_unique<StoppingQueryPlan>(
             std::move(internal.qep), std::move(internal.listeners), std::move(internal.allPipelinesExpired)),
-        [callbackOwner = std::move(internal.allPipelinesStarted),
+        [preparationCallbackOwner = std::move(internal.allPipelinesPrepared),
+         startCallbackOwner = std::move(internal.allPipelinesStarted),
          pipelines = std::move(internal.pipelines),
          sources = std::move(internal.sources)]() mutable
         {
             /// Destroying the sources needs to ensure that there is no concurrency on the sources vector.
-            /// The setup callback may run concurrently so it is essential that the callback owner is destroyed before
-            /// however the callback owner will block until the callback is either cancelled or completed. Completing the callback requires
+            /// The prepare and start callbacks may run concurrently so they need to be destroyed before the graph is torn down.
+            /// The callback owner will block until the callback is either cancelled or completed. Completing the callback requires
             /// a lock on the AtomicState. Therefore, this callback needs to be called from outside the atomic state.
-            callbackOwner = {};
+            startCallbackOwner = {};
+            preparationCallbackOwner = {};
             pipelines.clear();
             sources.clear();
         }
@@ -312,15 +349,16 @@ RunningQueryPlan::~RunningQueryPlan()
     auto& internal = *lock;
 
 
-    /// CRITICAL: Disable pipeline setup callback during destruction to prevent race condition.
+    /// CRITICAL: Disable pipeline prepare and start callbacks during destruction to prevent race conditions.
     ///
-    /// This prevents any pending pipeline setup callbacks from executing after the
+    /// This prevents any pending pipeline callbacks from executing after the
     /// RunningQueryPlan starts being destroyed. Without this, callbacks could access
     /// partially destroyed object state, leading to use-after-free errors.
     ///
-    /// The callback may have captured a raw pointer to this RunningQueryPlan during
-    /// the start() method, and this ensures it cannot execute after destruction begins.
+    /// The callbacks may have captured a raw pointer to this RunningQueryPlan during
+    /// the start() method, and this ensures they cannot execute after destruction begins.
     internal.allPipelinesStarted = {};
+    internal.allPipelinesPrepared = {};
 
     for (const auto& weakRef : internal.pipelines)
     {

--- a/nes-query-engine/RunningQueryPlan.hpp
+++ b/nes-query-engine/RunningQueryPlan.hpp
@@ -84,6 +84,8 @@ struct RunningQueryPlanNode
     PipelineId id;
 
     std::atomic_bool requiresTermination = false;
+    std::atomic_bool isCompiled = false;
+    std::atomic_bool isStarted = false;
     std::atomic<ssize_t> pendingTasks = 0;
     std::vector<std::shared_ptr<RunningQueryPlanNode>> successors;
     std::unique_ptr<ExecutablePipelineStage> stage;

--- a/nes-query-engine/RunningQueryPlan.hpp
+++ b/nes-query-engine/RunningQueryPlan.hpp
@@ -60,7 +60,7 @@ struct RunningQueryPlanNode
         std::unique_ptr<ExecutablePipelineStage> stage,
         std::function<void(Exception)> unregisterWithError,
         CallbackRef planRef,
-        CallbackRef setupCallback);
+        CallbackRef preparationCallback);
 
 
     ~RunningQueryPlanNode();
@@ -150,13 +150,15 @@ private:
             std::vector<std::weak_ptr<RunningQueryPlanNode>> pipelines,
             std::unique_ptr<ExecutableQueryPlan> qep,
             CallbackOwner all_pipelines_expired,
-            CallbackOwner pipeline_setup_done)
+            CallbackOwner pipeline_preparation_done,
+            CallbackOwner pipeline_start_done)
             : listeners(std::move(listeners))
             , sources(std::move(sources))
             , pipelines(std::move(pipelines))
             , qep(std::move(qep))
             , allPipelinesExpired(std::move(all_pipelines_expired))
-            , allPipelinesStarted(std::move(pipeline_setup_done))
+            , allPipelinesPrepared(std::move(pipeline_preparation_done))
+            , allPipelinesStarted(std::move(pipeline_start_done))
         {
         }
 
@@ -173,20 +175,23 @@ private:
 
         /// The entire graph of the query has been destroyed.
         CallbackOwner allPipelinesExpired;
-        /// All pipelines have been initialized
+        /// All pipelines have been prepared.
+        CallbackOwner allPipelinesPrepared;
+        /// All pipelines have been started.
         CallbackOwner allPipelinesStarted;
     };
 
     folly::Synchronized<Internal, std::recursive_mutex> internal;
 
-    explicit RunningQueryPlan(CallbackOwner allPipelinesExpired, CallbackOwner pipelineSetupDone)
+    explicit RunningQueryPlan(CallbackOwner allPipelinesExpired, CallbackOwner pipelinePreparationDone, CallbackOwner pipelineStartDone)
         : internal(Internal(
               std::vector<std::shared_ptr<QueryLifetimeListener>>{},
               std::unordered_map<OriginId, std::shared_ptr<RunningSource>>{},
               std::vector<std::weak_ptr<RunningQueryPlanNode>>{},
               nullptr,
               std::move(allPipelinesExpired),
-              std::move(pipelineSetupDone)))
+              std::move(pipelinePreparationDone),
+              std::move(pipelineStartDone)))
     {
     }
 };

--- a/nes-query-engine/RunningQueryPlan.hpp
+++ b/nes-query-engine/RunningQueryPlan.hpp
@@ -60,7 +60,7 @@ struct RunningQueryPlanNode
         std::unique_ptr<ExecutablePipelineStage> stage,
         std::function<void(Exception)> unregisterWithError,
         CallbackRef planRef,
-        CallbackRef preparationCallback);
+        CallbackRef compilationCallback);
 
 
     ~RunningQueryPlanNode();
@@ -150,14 +150,14 @@ private:
             std::vector<std::weak_ptr<RunningQueryPlanNode>> pipelines,
             std::unique_ptr<ExecutableQueryPlan> qep,
             CallbackOwner all_pipelines_expired,
-            CallbackOwner pipeline_preparation_done,
+            CallbackOwner pipeline_compilation_done,
             CallbackOwner pipeline_start_done)
             : listeners(std::move(listeners))
             , sources(std::move(sources))
             , pipelines(std::move(pipelines))
             , qep(std::move(qep))
             , allPipelinesExpired(std::move(all_pipelines_expired))
-            , allPipelinesPrepared(std::move(pipeline_preparation_done))
+            , allPipelinesCompiled(std::move(pipeline_compilation_done))
             , allPipelinesStarted(std::move(pipeline_start_done))
         {
         }
@@ -175,22 +175,22 @@ private:
 
         /// The entire graph of the query has been destroyed.
         CallbackOwner allPipelinesExpired;
-        /// All pipelines have been prepared.
-        CallbackOwner allPipelinesPrepared;
+        /// All pipelines have been compiled.
+        CallbackOwner allPipelinesCompiled;
         /// All pipelines have been started.
         CallbackOwner allPipelinesStarted;
     };
 
     folly::Synchronized<Internal, std::recursive_mutex> internal;
 
-    explicit RunningQueryPlan(CallbackOwner allPipelinesExpired, CallbackOwner pipelinePreparationDone, CallbackOwner pipelineStartDone)
+    explicit RunningQueryPlan(CallbackOwner allPipelinesExpired, CallbackOwner pipelineCompilationDone, CallbackOwner pipelineStartDone)
         : internal(Internal(
               std::vector<std::shared_ptr<QueryLifetimeListener>>{},
               std::unordered_map<OriginId, std::shared_ptr<RunningSource>>{},
               std::vector<std::weak_ptr<RunningQueryPlanNode>>{},
               nullptr,
               std::move(allPipelinesExpired),
-              std::move(pipelinePreparationDone),
+              std::move(pipelineCompilationDone),
               std::move(pipelineStartDone)))
     {
     }

--- a/nes-query-engine/RunningQueryPlan.hpp
+++ b/nes-query-engine/RunningQueryPlan.hpp
@@ -150,15 +150,15 @@ private:
             std::vector<std::weak_ptr<RunningQueryPlanNode>> pipelines,
             std::unique_ptr<ExecutableQueryPlan> qep,
             CallbackOwner all_pipelines_expired,
-            CallbackOwner pipeline_compilation_done,
-            CallbackOwner pipeline_start_done)
+            CallbackOwner pipelineCompilationDone,
+            CallbackOwner pipelineStartDone)
             : listeners(std::move(listeners))
             , sources(std::move(sources))
             , pipelines(std::move(pipelines))
             , qep(std::move(qep))
             , allPipelinesExpired(std::move(all_pipelines_expired))
-            , allPipelinesCompiled(std::move(pipeline_compilation_done))
-            , allPipelinesStarted(std::move(pipeline_start_done))
+            , allPipelinesCompiled(std::move(pipelineCompilationDone))
+            , allPipelinesStarted(std::move(pipelineStartDone))
         {
         }
 

--- a/nes-query-engine/Task.cpp
+++ b/nes-query-engine/Task.cpp
@@ -119,6 +119,12 @@ WorkTask::WorkTask(
 {
 }
 
+PreparePipelineTask::PreparePipelineTask(
+    QueryId queryId, PipelineId pipelineId, TaskCallback callback, std::weak_ptr<RunningQueryPlanNode> pipeline)
+    : BaseTask(std::move(queryId), std::move(callback)), pipeline(std::move(pipeline)), pipelineId(std::move(pipelineId))
+{
+}
+
 StartPipelineTask::StartPipelineTask(
     QueryId queryId, PipelineId pipelineId, TaskCallback callback, std::weak_ptr<RunningQueryPlanNode> pipeline)
     : BaseTask(std::move(queryId), std::move(callback)), pipeline(std::move(pipeline)), pipelineId(std::move(pipelineId))

--- a/nes-query-engine/Task.cpp
+++ b/nes-query-engine/Task.cpp
@@ -119,7 +119,7 @@ WorkTask::WorkTask(
 {
 }
 
-PreparePipelineTask::PreparePipelineTask(
+CompilePipelineTask::CompilePipelineTask(
     QueryId queryId, PipelineId pipelineId, TaskCallback callback, std::weak_ptr<RunningQueryPlanNode> pipeline)
     : BaseTask(std::move(queryId), std::move(callback)), pipeline(std::move(pipeline)), pipelineId(std::move(pipelineId))
 {

--- a/nes-query-engine/Task.hpp
+++ b/nes-query-engine/Task.hpp
@@ -134,9 +134,9 @@ struct WorkTask : BaseTask
     TupleBuffer buf;
 };
 
-struct PreparePipelineTask : BaseTask
+struct CompilePipelineTask : BaseTask
 {
-    PreparePipelineTask(QueryId queryId, PipelineId pipelineId, TaskCallback callback, std::weak_ptr<RunningQueryPlanNode> pipeline);
+    CompilePipelineTask(QueryId queryId, PipelineId pipelineId, TaskCallback callback, std::weak_ptr<RunningQueryPlanNode> pipeline);
 
     std::weak_ptr<RunningQueryPlanNode> pipeline;
     PipelineId pipelineId = INVALID<PipelineId>;
@@ -208,7 +208,7 @@ using Task = std::variant<
     StopSourceTask,
     PendingPipelineStopTask,
     StopPipelineTask,
-    PreparePipelineTask,
+    CompilePipelineTask,
     StartPipelineTask>;
 
 void succeedTask(Task& task);

--- a/nes-query-engine/Task.hpp
+++ b/nes-query-engine/Task.hpp
@@ -134,6 +134,14 @@ struct WorkTask : BaseTask
     TupleBuffer buf;
 };
 
+struct PreparePipelineTask : BaseTask
+{
+    PreparePipelineTask(QueryId queryId, PipelineId pipelineId, TaskCallback callback, std::weak_ptr<RunningQueryPlanNode> pipeline);
+
+    std::weak_ptr<RunningQueryPlanNode> pipeline;
+    PipelineId pipelineId = INVALID<PipelineId>;
+};
+
 struct StartPipelineTask : BaseTask
 {
     StartPipelineTask(QueryId queryId, PipelineId pipelineId, TaskCallback callback, std::weak_ptr<RunningQueryPlanNode> pipeline);
@@ -200,6 +208,7 @@ using Task = std::variant<
     StopSourceTask,
     PendingPipelineStopTask,
     StopPipelineTask,
+    PreparePipelineTask,
     StartPipelineTask>;
 
 void succeedTask(Task& task);

--- a/nes-query-engine/tests/QueryPlanTest.cpp
+++ b/nes-query-engine/tests/QueryPlanTest.cpp
@@ -166,7 +166,7 @@ struct EmittedTask
     template <typename... TArgs>
     static std::unique_ptr<EmittedTask> setup(const RangeOf<KeyT> auto& stages, TArgs&&...);
 
-    ::testing::AssertionResult executeEmittedTask(Args&&);
+    ::testing::AssertionResult executeEmittedTask(Args);
 
     bool empty() const
     {
@@ -255,7 +255,7 @@ template <>
 template <typename... TArgs>
 std::unique_ptr<Terminations> Terminations::setup(const RangeOf<ExecutablePipelineStage*> auto& stages, TArgs&&... args)
 {
-    auto& emitter = std::get<0>(std::forward_as_tuple<TArgs>(args)...);
+    auto& emitter = std::get<0>(std::forward_as_tuple(std::forward<TArgs>(args)...));
     auto terminations = std::make_unique<Terminations>();
     for (auto* stage : stages)
     {
@@ -268,7 +268,7 @@ std::unique_ptr<Terminations> Terminations::setup(const RangeOf<ExecutablePipeli
 }
 
 template <>
-::testing::AssertionResult Terminations::executeEmittedTask(TerminatePipelineArgs&& args)
+::testing::AssertionResult Terminations::executeEmittedTask(TerminatePipelineArgs args)
 {
     TestPipelineExecutionContext pec{};
     EXPECT_CALL(pec, emitBuffer(::testing::_, ::testing::_)).Times(0);
@@ -298,7 +298,7 @@ template <typename... TArgs>
 std::unique_ptr<Compiles> Compiles::setup(const RangeOf<ExecutablePipelineStage*> auto& stages, TArgs&&... args)
 {
     auto compiles = std::make_unique<Compiles>();
-    auto& emitter = std::get<0>(std::forward_as_tuple<TArgs>(args)...);
+    auto& emitter = std::get<0>(std::forward_as_tuple(std::forward<TArgs>(args)...));
     for (auto* stage : stages)
     {
         EXPECT_CALL(emitter, emitPipelineCompile(::testing::_, StageMatcher(stage), ::testing::_))
@@ -310,7 +310,7 @@ std::unique_ptr<Compiles> Compiles::setup(const RangeOf<ExecutablePipelineStage*
 }
 
 template <>
-::testing::AssertionResult Compiles::executeEmittedTask(CompilePipelineArgs&& args)
+::testing::AssertionResult Compiles::executeEmittedTask(CompilePipelineArgs args)
 {
     TestPipelineExecutionContext pec{};
     EXPECT_CALL(pec, emitBuffer(::testing::_, ::testing::_)).Times(0);
@@ -319,6 +319,7 @@ template <>
         if (auto strongRef = args.target.lock())
         {
             strongRef->stage->compile(pec);
+            strongRef->isCompiled = true;
             args.callback.callOnSuccess();
         }
     }
@@ -343,7 +344,7 @@ template <typename... TArgs>
 std::unique_ptr<Setups> Setups::setup(const RangeOf<ExecutablePipelineStage*> auto& stages, TArgs&&... args)
 {
     auto setups = std::make_unique<Setups>();
-    auto& emitter = std::get<0>(std::forward_as_tuple<TArgs>(args)...);
+    auto& emitter = std::get<0>(std::forward_as_tuple(std::forward<TArgs>(args)...));
     for (auto* stage : stages)
     {
         EXPECT_CALL(emitter, emitPipelineStart(::testing::_, StageMatcher(stage), ::testing::_))
@@ -355,7 +356,7 @@ std::unique_ptr<Setups> Setups::setup(const RangeOf<ExecutablePipelineStage*> au
 }
 
 template <>
-::testing::AssertionResult Setups::executeEmittedTask(SetupPipelineArgs&& args)
+::testing::AssertionResult Setups::executeEmittedTask(SetupPipelineArgs args)
 {
     TestPipelineExecutionContext pec{};
     EXPECT_CALL(pec, emitBuffer(::testing::_, ::testing::_)).Times(0);
@@ -363,7 +364,9 @@ template <>
     {
         if (auto strongRef = args.target.lock())
         {
+            EXPECT_TRUE(strongRef->isCompiled);
             strongRef->stage->start(pec);
+            strongRef->isStarted = true;
             args.callback.callOnSuccess();
         }
     }
@@ -387,7 +390,7 @@ template <typename... TArgs>
 std::unique_ptr<SourceStops> SourceStops::setup(const RangeOf<OriginId> auto& originIds, TArgs&&... args)
 {
     auto setups = std::make_unique<SourceStops>();
-    auto& controller = std::get<0>(std::forward_as_tuple<TArgs>(args)...);
+    auto& controller = std::get<0>(std::forward_as_tuple(std::forward<TArgs>(args)...));
     for (auto originId : originIds)
     {
         EXPECT_CALL(controller, initializeSourceStop(::testing::_, ::testing::_, ::testing::_))
@@ -399,7 +402,7 @@ std::unique_ptr<SourceStops> SourceStops::setup(const RangeOf<OriginId> auto& or
 }
 
 template <>
-::testing::AssertionResult SourceStops::executeEmittedTask(SourceStopArgs&& stops)
+::testing::AssertionResult SourceStops::executeEmittedTask(SourceStopArgs stops)
 {
     if (auto target = stops.target.lock())
     {

--- a/nes-query-engine/tests/QueryPlanTest.cpp
+++ b/nes-query-engine/tests/QueryPlanTest.cpp
@@ -285,6 +285,51 @@ template <>
     return ::testing::AssertionSuccess();
 }
 
+struct PreparePipelineArgs
+{
+    std::weak_ptr<RunningQueryPlanNode> target;
+    TaskCallback callback;
+};
+
+using Prepares = EmittedTask<PreparePipelineArgs, ExecutablePipelineStage*>;
+
+template <>
+template <typename... TArgs>
+std::unique_ptr<Prepares> Prepares::setup(const RangeOf<ExecutablePipelineStage*> auto& stages, TArgs&&... args)
+{
+    auto prepares = std::make_unique<Prepares>();
+    auto& emitter = std::get<0>(std::forward_as_tuple<TArgs>(args)...);
+    for (auto* stage : stages)
+    {
+        EXPECT_CALL(emitter, emitPipelinePrepare(::testing::_, StageMatcher(stage), ::testing::_))
+            .WillOnce(::testing::Invoke([&prepares, stage](auto, const auto& prepare, auto callback)
+                                        { prepares->add(stage, std::move(prepare), std::move(callback)); }));
+    }
+
+    return prepares;
+}
+
+template <>
+::testing::AssertionResult Prepares::executeEmittedTask(PreparePipelineArgs&& args)
+{
+    TestPipelineExecutionContext pec{};
+    EXPECT_CALL(pec, emitBuffer(::testing::_, ::testing::_)).Times(0);
+    try
+    {
+        if (auto strongRef = args.target.lock())
+        {
+            strongRef->stage->prepare(pec);
+            args.callback.callOnSuccess();
+        }
+    }
+    catch (const Exception& e)
+    {
+        args.callback.callOnFailure(e);
+    }
+    args.callback.callOnComplete();
+    return ::testing::AssertionSuccess();
+}
+
 struct SetupPipelineArgs
 {
     std::weak_ptr<RunningQueryPlanNode> target;
@@ -412,15 +457,14 @@ TEST_F(QueryPlanTest, RunningQueryNodeSetup)
     auto stage1 = std::make_unique<TestPipeline>(pipeline1Ctrl);
     auto stage2 = std::make_unique<TestPipeline>(pipeline2Ctrl);
 
-    /// Verify that a setup and stop tasks have been emitted
+    /// Verify that prepare tasks have been emitted
     TestWorkEmitter emitter;
-    auto terminations = Terminations::setup(std::vector<ExecutablePipelineStage*>{stage1.get(), stage2.get()}, emitter);
-    auto setups = Setups::setup(std::vector<ExecutablePipelineStage*>{stage1.get(), stage2.get()}, emitter);
+    auto prepares = Prepares::setup(std::vector<ExecutablePipelineStage*>{stage1.get(), stage2.get()}, emitter);
 
-    /// Build chain of two pipelines. Verify that on construction of a RunningQueryPlan node a setup task has been submitted
+    /// Build chain of two pipelines. Verify that on construction of a RunningQueryPlan node a prepare task has been submitted
     auto sink
         = RunningQueryPlanNode::create(QueryId(1), PipelineId(1), emitter, {}, std::move(stage2), [](auto) { }, expirationRef, setupRef);
-    EXPECT_THAT(*setups, testing::SizeIs(1));
+    EXPECT_THAT(*prepares, testing::SizeIs(1));
     auto pipeline = RunningQueryPlanNode::create(
         QueryId(1),
         PipelineId(2),
@@ -430,16 +474,13 @@ TEST_F(QueryPlanTest, RunningQueryNodeSetup)
         [](auto) { },
         std::move(expirationRef),
         std::move(setupRef));
-    EXPECT_THAT(*setups, testing::SizeIs(2));
+    EXPECT_THAT(*prepares, testing::SizeIs(2));
 
-    /// Run all setup tasks.
-    EXPECT_TRUE(setups->handleAll());
-    EXPECT_THAT(*terminations, testing::IsEmpty());
+    /// Run all prepare tasks.
+    EXPECT_TRUE(prepares->handleAll());
 
     /// Destroy root pipeline
     EXPECT_TRUE(destroyPipeline(std::move(pipeline)));
-    EXPECT_TRUE(terminations->handle(pipeline1Ctrl->stage));
-    EXPECT_TRUE(terminations->handle(pipeline2Ctrl->stage));
 }
 
 /// If a running query plan is dropped, it should perform a hard stop: e.g. no pipelines should be terminated.
@@ -457,13 +498,14 @@ TEST_F(QueryPlanTest, RunningQueryPlanDefaultDestructor)
     TestQueryLifetimeController controller;
     TestWorkEmitter emitter;
 
-    /// The RunningQueryPlan Requested Setup for all Pipelines in the QueryPlan.
-    auto setups = Setups::setup(stdv::values(test.stages), emitter);
+    /// The RunningQueryPlan requested preparation for all pipelines in the query plan.
+    auto prepares = Prepares::setup(stdv::values(test.stages), emitter);
     auto listener = std::make_shared<TestQueryLifetimeListener>();
     EXPECT_CALL(*listener, onDestruction()).Times(1);
     EXPECT_CALL(*listener, onRunning()).Times(0);
     {
         auto runningQueryPlan = RunningQueryPlan::start(QueryId(0), std::move(queryPlan), controller, emitter, listener);
+        EXPECT_TRUE(prepares->waitForTasks(2));
     }
     EXPECT_TRUE(srcCtrl->waitUntilDestroyed());
     EXPECT_FALSE(srcCtrl->wasOpened());
@@ -483,14 +525,15 @@ TEST_F(QueryPlanTest, RunningQueryPlanDispose)
     TestQueryLifetimeController controller;
     TestWorkEmitter emitter;
 
-    /// The RunningQueryPlan Requested Setup for all Pipelines in the QueryPlan.
-    auto setups = Setups::setup(stdv::values(test.stages), emitter);
+    /// The RunningQueryPlan requested preparation for all pipelines in the query plan.
+    auto prepares = Prepares::setup(stdv::values(test.stages), emitter);
     auto listener = std::make_shared<TestQueryLifetimeListener>();
     EXPECT_CALL(*listener, onDestruction()).Times(0);
     EXPECT_CALL(*listener, onRunning()).Times(0);
 
     {
         auto runningQueryPlan = dropRef(RunningQueryPlan::start(QueryId(0), std::move(queryPlan), controller, emitter, listener));
+        EXPECT_TRUE(prepares->waitForTasks(2));
         RunningQueryPlan::dispose(std::move(runningQueryPlan));
     }
 
@@ -511,8 +554,8 @@ TEST_F(QueryPlanTest, RunningQueryPlanTestInitialPipelineSetup)
     TestQueryLifetimeController controller;
     TestWorkEmitter emitter;
 
-    /// The RunningQueryPlan Requested Setup for all Pipelines in the QueryPlan.
-    auto setups = Setups::setup(stdv::values(test.stages), emitter);
+    /// The RunningQueryPlan requested preparation for all pipelines in the query plan.
+    auto prepares = Prepares::setup(stdv::values(test.stages), emitter);
 
     auto listener = std::make_shared<TestQueryLifetimeListener>();
     EXPECT_CALL(*listener, onDestruction()).Times(1);
@@ -520,7 +563,7 @@ TEST_F(QueryPlanTest, RunningQueryPlanTestInitialPipelineSetup)
 
     {
         auto runningQueryPlan = RunningQueryPlan::start(QueryId(0), std::move(queryPlan), controller, emitter, listener);
-        EXPECT_TRUE(setups->waitForTasks(2));
+        EXPECT_TRUE(prepares->waitForTasks(2));
         EXPECT_FALSE(srcCtrl->waitUntilOpened());
     }
 
@@ -554,7 +597,8 @@ TEST_F(QueryPlanTest, RunningQueryPlanTestSourceSetup)
     TestQueryLifetimeController controller;
     TestWorkEmitter emitter;
 
-    /// The RunningQueryPlan Requested Setup for all Pipelines in the QueryPlan.
+    /// The RunningQueryPlan requested preparation and setup for all pipelines in the query plan.
+    auto prepares = Prepares::setup(stdv::values(test.stages), emitter);
     auto setups = Setups::setup(stdv::values(test.stages), emitter);
     auto terminations = Terminations::setup(stdv::values(test.stages), emitter);
 
@@ -568,6 +612,8 @@ TEST_F(QueryPlanTest, RunningQueryPlanTestSourceSetup)
         EXPECT_FALSE(srcCtrl->wasOpened());
         EXPECT_FALSE(srcCtrl->wasClosed());
 
+        EXPECT_TRUE(prepares->waitForTasks(2));
+        EXPECT_TRUE(prepares->handleAll());
         EXPECT_TRUE(setups->waitForTasks(2));
         EXPECT_TRUE(setups->handleAll());
 
@@ -600,7 +646,8 @@ TEST_F(QueryPlanTest, RunningQueryPlanTestPartialConstruction)
     TestQueryLifetimeController controller;
     TestWorkEmitter emitter;
 
-    /// The RunningQueryPlan Requested Setup for all Pipelines in the QueryPlan.
+    /// The RunningQueryPlan requested preparation and setup for all pipelines in the query plan.
+    auto prepares = Prepares::setup(stdv::values(test.stages), emitter);
     auto setups = Setups::setup(stdv::values(test.stages), emitter);
     auto terminations = Terminations::setup(std::vector{test.stages[pipeline1]}, emitter);
 
@@ -614,6 +661,8 @@ TEST_F(QueryPlanTest, RunningQueryPlanTestPartialConstruction)
         auto runningQueryPlan = dropRef(RunningQueryPlan::start(QueryId(0), std::move(queryPlan), controller, emitter, listener));
         EXPECT_FALSE(srcCtrl->waitUntilOpened());
 
+        EXPECT_TRUE(prepares->waitForTasks(3));
+        EXPECT_TRUE(prepares->handleAll());
         EXPECT_TRUE(setups->waitForTasks(3));
         /// Only setup the pipeline1 pipeline
         EXPECT_TRUE(setups->handle(test.stages[pipeline1]));
@@ -654,13 +703,15 @@ TEST_F(QueryPlanTest, RefCountTestSourceEoS)
 
     auto sourceStops = SourceStops::setup(std::vector{test.sourceIds.at(source)}, controller);
 
-    /// The RunningQueryPlan Requested Setup for all Pipelines in the QueryPlan.
+    /// The RunningQueryPlan requested preparation and setup for all pipelines in the query plan.
+    auto prepares = Prepares::setup(stdv::values(test.stages), emitter);
     auto setups = Setups::setup(stdv::values(test.stages), emitter);
     auto terminations = Terminations::setup(stdv::values(test.stages), emitter);
 
     {
         auto runningQueryPlan = dropRef(RunningQueryPlan::start(QueryId(0), std::move(queryPlan), controller, emitter, listener));
 
+        EXPECT_TRUE(prepares->handleAll());
         EXPECT_TRUE(setups->handleAll());
         EXPECT_TRUE(test.sourceControls[source]->waitUntilOpened());
         EXPECT_FALSE(test.sourceControls[source]->waitUntilClosed());
@@ -697,12 +748,14 @@ TEST_F(QueryPlanTest, RefCountTestMultipleSourceOneOfThemEoS)
     TestQueryLifetimeController controller;
     TestWorkEmitter emitter;
 
-    /// The RunningQueryPlan Requested Setup for all Pipelines in the QueryPlan.
+    /// The RunningQueryPlan requested preparation and setup for all pipelines in the query plan.
     /// No pipeline is terminated, because p is kept alive by source1
     auto sourceStops = SourceStops::setup(std::vector{test.sourceIds.at(source)}, controller);
+    auto prepares = Prepares::setup(stdv::values(test.stages), emitter);
     auto setups = Setups::setup(stdv::values(test.stages), emitter);
     {
         auto runningQueryPlan = dropRef(RunningQueryPlan::start(QueryId(0), std::move(queryPlan), controller, emitter, listener));
+        EXPECT_TRUE(prepares->handleAll());
         EXPECT_TRUE(setups->handleAll());
         EXPECT_TRUE(test.sourceControls[source]->waitUntilOpened());
         EXPECT_TRUE(test.sourceControls[source1]->waitUntilOpened());
@@ -728,7 +781,8 @@ TEST_F(QueryPlanTest, DisposingQueryPlanWhileSourceIsAboutToBeTerminated)
     TestQueryLifetimeController controller;
     TestWorkEmitter emitter;
 
-    /// The RunningQueryPlan Requested Setup for all Pipelines in the QueryPlan.
+    /// The RunningQueryPlan requested preparation and setup for all pipelines in the query plan.
+    auto prepares = Prepares::setup(stdv::values(test.stages), emitter);
     auto setups = Setups::setup(stdv::values(test.stages), emitter);
     auto sourceStops = SourceStops::setup(std::vector{test.sourceIds.at(source)}, controller);
 
@@ -738,6 +792,8 @@ TEST_F(QueryPlanTest, DisposingQueryPlanWhileSourceIsAboutToBeTerminated)
 
     {
         auto runningQueryPlan = dropRef(RunningQueryPlan::start(QueryId(0), std::move(queryPlan), controller, emitter, listener));
+        EXPECT_TRUE(prepares->waitForTasks(2));
+        EXPECT_TRUE(prepares->handleAll());
         EXPECT_TRUE(setups->waitForTasks(2));
         EXPECT_TRUE(setups->handleAll());
         srcCtrl->injectEoS();
@@ -762,7 +818,8 @@ TEST_F(QueryPlanTest, DestroyingQueryPlanWhileSourceIsAboutToBeTerminated)
     TestQueryLifetimeController controller;
     TestWorkEmitter emitter;
 
-    /// The RunningQueryPlan Requested Setup for all Pipelines in the QueryPlan.
+    /// The RunningQueryPlan requested preparation and setup for all pipelines in the query plan.
+    auto prepares = Prepares::setup(stdv::values(test.stages), emitter);
     auto setups = Setups::setup(stdv::values(test.stages), emitter);
     auto sourceStops = SourceStops::setup(std::vector{test.sourceIds.at(source)}, controller);
 
@@ -773,6 +830,8 @@ TEST_F(QueryPlanTest, DestroyingQueryPlanWhileSourceIsAboutToBeTerminated)
 
     {
         auto runningQueryPlan = dropRef(RunningQueryPlan::start(QueryId(0), std::move(queryPlan), controller, emitter, listener));
+        EXPECT_TRUE(prepares->waitForTasks(2));
+        EXPECT_TRUE(prepares->handleAll());
         EXPECT_TRUE(setups->waitForTasks(2));
         EXPECT_TRUE(setups->handleAll());
         srcCtrl->injectEoS();

--- a/nes-query-engine/tests/QueryPlanTest.cpp
+++ b/nes-query-engine/tests/QueryPlanTest.cpp
@@ -285,32 +285,32 @@ template <>
     return ::testing::AssertionSuccess();
 }
 
-struct PreparePipelineArgs
+struct CompilePipelineArgs
 {
     std::weak_ptr<RunningQueryPlanNode> target;
     TaskCallback callback;
 };
 
-using Prepares = EmittedTask<PreparePipelineArgs, ExecutablePipelineStage*>;
+using Compiles = EmittedTask<CompilePipelineArgs, ExecutablePipelineStage*>;
 
 template <>
 template <typename... TArgs>
-std::unique_ptr<Prepares> Prepares::setup(const RangeOf<ExecutablePipelineStage*> auto& stages, TArgs&&... args)
+std::unique_ptr<Compiles> Compiles::setup(const RangeOf<ExecutablePipelineStage*> auto& stages, TArgs&&... args)
 {
-    auto prepares = std::make_unique<Prepares>();
+    auto compiles = std::make_unique<Compiles>();
     auto& emitter = std::get<0>(std::forward_as_tuple<TArgs>(args)...);
     for (auto* stage : stages)
     {
-        EXPECT_CALL(emitter, emitPipelinePrepare(::testing::_, StageMatcher(stage), ::testing::_))
-            .WillOnce(::testing::Invoke([&prepares, stage](auto, const auto& prepare, auto callback)
-                                        { prepares->add(stage, std::move(prepare), std::move(callback)); }));
+        EXPECT_CALL(emitter, emitPipelineCompile(::testing::_, StageMatcher(stage), ::testing::_))
+            .WillOnce(::testing::Invoke([&compiles, stage](auto, const auto& compile, auto callback)
+                                        { compiles->add(stage, std::move(compile), std::move(callback)); }));
     }
 
-    return prepares;
+    return compiles;
 }
 
 template <>
-::testing::AssertionResult Prepares::executeEmittedTask(PreparePipelineArgs&& args)
+::testing::AssertionResult Compiles::executeEmittedTask(CompilePipelineArgs&& args)
 {
     TestPipelineExecutionContext pec{};
     EXPECT_CALL(pec, emitBuffer(::testing::_, ::testing::_)).Times(0);
@@ -318,7 +318,7 @@ template <>
     {
         if (auto strongRef = args.target.lock())
         {
-            strongRef->stage->prepare(pec);
+            strongRef->stage->compile(pec);
             args.callback.callOnSuccess();
         }
     }
@@ -457,14 +457,14 @@ TEST_F(QueryPlanTest, RunningQueryNodeSetup)
     auto stage1 = std::make_unique<TestPipeline>(pipeline1Ctrl);
     auto stage2 = std::make_unique<TestPipeline>(pipeline2Ctrl);
 
-    /// Verify that prepare tasks have been emitted
+    /// Verify that compile tasks have been emitted
     TestWorkEmitter emitter;
-    auto prepares = Prepares::setup(std::vector<ExecutablePipelineStage*>{stage1.get(), stage2.get()}, emitter);
+    auto compiles = Compiles::setup(std::vector<ExecutablePipelineStage*>{stage1.get(), stage2.get()}, emitter);
 
-    /// Build chain of two pipelines. Verify that on construction of a RunningQueryPlan node a prepare task has been submitted
+    /// Build chain of two pipelines. Verify that on construction of a RunningQueryPlan node a compile task has been submitted
     auto sink
         = RunningQueryPlanNode::create(QueryId(1), PipelineId(1), emitter, {}, std::move(stage2), [](auto) { }, expirationRef, setupRef);
-    EXPECT_THAT(*prepares, testing::SizeIs(1));
+    EXPECT_THAT(*compiles, testing::SizeIs(1));
     auto pipeline = RunningQueryPlanNode::create(
         QueryId(1),
         PipelineId(2),
@@ -474,10 +474,10 @@ TEST_F(QueryPlanTest, RunningQueryNodeSetup)
         [](auto) { },
         std::move(expirationRef),
         std::move(setupRef));
-    EXPECT_THAT(*prepares, testing::SizeIs(2));
+    EXPECT_THAT(*compiles, testing::SizeIs(2));
 
-    /// Run all prepare tasks.
-    EXPECT_TRUE(prepares->handleAll());
+    /// Run all compile tasks.
+    EXPECT_TRUE(compiles->handleAll());
 
     /// Destroy root pipeline
     EXPECT_TRUE(destroyPipeline(std::move(pipeline)));
@@ -498,14 +498,14 @@ TEST_F(QueryPlanTest, RunningQueryPlanDefaultDestructor)
     TestQueryLifetimeController controller;
     TestWorkEmitter emitter;
 
-    /// The RunningQueryPlan requested preparation for all pipelines in the query plan.
-    auto prepares = Prepares::setup(stdv::values(test.stages), emitter);
+    /// The RunningQueryPlan requested compilation for all pipelines in the query plan.
+    auto compiles = Compiles::setup(stdv::values(test.stages), emitter);
     auto listener = std::make_shared<TestQueryLifetimeListener>();
     EXPECT_CALL(*listener, onDestruction()).Times(1);
     EXPECT_CALL(*listener, onRunning()).Times(0);
     {
         auto runningQueryPlan = RunningQueryPlan::start(QueryId(0), std::move(queryPlan), controller, emitter, listener);
-        EXPECT_TRUE(prepares->waitForTasks(2));
+        EXPECT_TRUE(compiles->waitForTasks(2));
     }
     EXPECT_TRUE(srcCtrl->waitUntilDestroyed());
     EXPECT_FALSE(srcCtrl->wasOpened());
@@ -525,15 +525,15 @@ TEST_F(QueryPlanTest, RunningQueryPlanDispose)
     TestQueryLifetimeController controller;
     TestWorkEmitter emitter;
 
-    /// The RunningQueryPlan requested preparation for all pipelines in the query plan.
-    auto prepares = Prepares::setup(stdv::values(test.stages), emitter);
+    /// The RunningQueryPlan requested compilation for all pipelines in the query plan.
+    auto compiles = Compiles::setup(stdv::values(test.stages), emitter);
     auto listener = std::make_shared<TestQueryLifetimeListener>();
     EXPECT_CALL(*listener, onDestruction()).Times(0);
     EXPECT_CALL(*listener, onRunning()).Times(0);
 
     {
         auto runningQueryPlan = dropRef(RunningQueryPlan::start(QueryId(0), std::move(queryPlan), controller, emitter, listener));
-        EXPECT_TRUE(prepares->waitForTasks(2));
+        EXPECT_TRUE(compiles->waitForTasks(2));
         RunningQueryPlan::dispose(std::move(runningQueryPlan));
     }
 
@@ -554,8 +554,8 @@ TEST_F(QueryPlanTest, RunningQueryPlanTestInitialPipelineSetup)
     TestQueryLifetimeController controller;
     TestWorkEmitter emitter;
 
-    /// The RunningQueryPlan requested preparation for all pipelines in the query plan.
-    auto prepares = Prepares::setup(stdv::values(test.stages), emitter);
+    /// The RunningQueryPlan requested compilation for all pipelines in the query plan.
+    auto compiles = Compiles::setup(stdv::values(test.stages), emitter);
 
     auto listener = std::make_shared<TestQueryLifetimeListener>();
     EXPECT_CALL(*listener, onDestruction()).Times(1);
@@ -563,7 +563,7 @@ TEST_F(QueryPlanTest, RunningQueryPlanTestInitialPipelineSetup)
 
     {
         auto runningQueryPlan = RunningQueryPlan::start(QueryId(0), std::move(queryPlan), controller, emitter, listener);
-        EXPECT_TRUE(prepares->waitForTasks(2));
+        EXPECT_TRUE(compiles->waitForTasks(2));
         EXPECT_FALSE(srcCtrl->waitUntilOpened());
     }
 
@@ -597,8 +597,8 @@ TEST_F(QueryPlanTest, RunningQueryPlanTestSourceSetup)
     TestQueryLifetimeController controller;
     TestWorkEmitter emitter;
 
-    /// The RunningQueryPlan requested preparation and setup for all pipelines in the query plan.
-    auto prepares = Prepares::setup(stdv::values(test.stages), emitter);
+    /// The RunningQueryPlan requested compilation and setup for all pipelines in the query plan.
+    auto compiles = Compiles::setup(stdv::values(test.stages), emitter);
     auto setups = Setups::setup(stdv::values(test.stages), emitter);
     auto terminations = Terminations::setup(stdv::values(test.stages), emitter);
 
@@ -612,8 +612,8 @@ TEST_F(QueryPlanTest, RunningQueryPlanTestSourceSetup)
         EXPECT_FALSE(srcCtrl->wasOpened());
         EXPECT_FALSE(srcCtrl->wasClosed());
 
-        EXPECT_TRUE(prepares->waitForTasks(2));
-        EXPECT_TRUE(prepares->handleAll());
+        EXPECT_TRUE(compiles->waitForTasks(2));
+        EXPECT_TRUE(compiles->handleAll());
         EXPECT_TRUE(setups->waitForTasks(2));
         EXPECT_TRUE(setups->handleAll());
 
@@ -646,8 +646,8 @@ TEST_F(QueryPlanTest, RunningQueryPlanTestPartialConstruction)
     TestQueryLifetimeController controller;
     TestWorkEmitter emitter;
 
-    /// The RunningQueryPlan requested preparation and setup for all pipelines in the query plan.
-    auto prepares = Prepares::setup(stdv::values(test.stages), emitter);
+    /// The RunningQueryPlan requested compilation and setup for all pipelines in the query plan.
+    auto compiles = Compiles::setup(stdv::values(test.stages), emitter);
     auto setups = Setups::setup(stdv::values(test.stages), emitter);
     auto terminations = Terminations::setup(std::vector{test.stages[pipeline1]}, emitter);
 
@@ -661,8 +661,8 @@ TEST_F(QueryPlanTest, RunningQueryPlanTestPartialConstruction)
         auto runningQueryPlan = dropRef(RunningQueryPlan::start(QueryId(0), std::move(queryPlan), controller, emitter, listener));
         EXPECT_FALSE(srcCtrl->waitUntilOpened());
 
-        EXPECT_TRUE(prepares->waitForTasks(3));
-        EXPECT_TRUE(prepares->handleAll());
+        EXPECT_TRUE(compiles->waitForTasks(3));
+        EXPECT_TRUE(compiles->handleAll());
         EXPECT_TRUE(setups->waitForTasks(3));
         /// Only setup the pipeline1 pipeline
         EXPECT_TRUE(setups->handle(test.stages[pipeline1]));
@@ -703,15 +703,15 @@ TEST_F(QueryPlanTest, RefCountTestSourceEoS)
 
     auto sourceStops = SourceStops::setup(std::vector{test.sourceIds.at(source)}, controller);
 
-    /// The RunningQueryPlan requested preparation and setup for all pipelines in the query plan.
-    auto prepares = Prepares::setup(stdv::values(test.stages), emitter);
+    /// The RunningQueryPlan requested compilation and setup for all pipelines in the query plan.
+    auto compiles = Compiles::setup(stdv::values(test.stages), emitter);
     auto setups = Setups::setup(stdv::values(test.stages), emitter);
     auto terminations = Terminations::setup(stdv::values(test.stages), emitter);
 
     {
         auto runningQueryPlan = dropRef(RunningQueryPlan::start(QueryId(0), std::move(queryPlan), controller, emitter, listener));
 
-        EXPECT_TRUE(prepares->handleAll());
+        EXPECT_TRUE(compiles->handleAll());
         EXPECT_TRUE(setups->handleAll());
         EXPECT_TRUE(test.sourceControls[source]->waitUntilOpened());
         EXPECT_FALSE(test.sourceControls[source]->waitUntilClosed());
@@ -748,14 +748,14 @@ TEST_F(QueryPlanTest, RefCountTestMultipleSourceOneOfThemEoS)
     TestQueryLifetimeController controller;
     TestWorkEmitter emitter;
 
-    /// The RunningQueryPlan requested preparation and setup for all pipelines in the query plan.
+    /// The RunningQueryPlan requested compilation and setup for all pipelines in the query plan.
     /// No pipeline is terminated, because p is kept alive by source1
     auto sourceStops = SourceStops::setup(std::vector{test.sourceIds.at(source)}, controller);
-    auto prepares = Prepares::setup(stdv::values(test.stages), emitter);
+    auto compiles = Compiles::setup(stdv::values(test.stages), emitter);
     auto setups = Setups::setup(stdv::values(test.stages), emitter);
     {
         auto runningQueryPlan = dropRef(RunningQueryPlan::start(QueryId(0), std::move(queryPlan), controller, emitter, listener));
-        EXPECT_TRUE(prepares->handleAll());
+        EXPECT_TRUE(compiles->handleAll());
         EXPECT_TRUE(setups->handleAll());
         EXPECT_TRUE(test.sourceControls[source]->waitUntilOpened());
         EXPECT_TRUE(test.sourceControls[source1]->waitUntilOpened());
@@ -781,8 +781,8 @@ TEST_F(QueryPlanTest, DisposingQueryPlanWhileSourceIsAboutToBeTerminated)
     TestQueryLifetimeController controller;
     TestWorkEmitter emitter;
 
-    /// The RunningQueryPlan requested preparation and setup for all pipelines in the query plan.
-    auto prepares = Prepares::setup(stdv::values(test.stages), emitter);
+    /// The RunningQueryPlan requested compilation and setup for all pipelines in the query plan.
+    auto compiles = Compiles::setup(stdv::values(test.stages), emitter);
     auto setups = Setups::setup(stdv::values(test.stages), emitter);
     auto sourceStops = SourceStops::setup(std::vector{test.sourceIds.at(source)}, controller);
 
@@ -792,8 +792,8 @@ TEST_F(QueryPlanTest, DisposingQueryPlanWhileSourceIsAboutToBeTerminated)
 
     {
         auto runningQueryPlan = dropRef(RunningQueryPlan::start(QueryId(0), std::move(queryPlan), controller, emitter, listener));
-        EXPECT_TRUE(prepares->waitForTasks(2));
-        EXPECT_TRUE(prepares->handleAll());
+        EXPECT_TRUE(compiles->waitForTasks(2));
+        EXPECT_TRUE(compiles->handleAll());
         EXPECT_TRUE(setups->waitForTasks(2));
         EXPECT_TRUE(setups->handleAll());
         srcCtrl->injectEoS();
@@ -818,8 +818,8 @@ TEST_F(QueryPlanTest, DestroyingQueryPlanWhileSourceIsAboutToBeTerminated)
     TestQueryLifetimeController controller;
     TestWorkEmitter emitter;
 
-    /// The RunningQueryPlan requested preparation and setup for all pipelines in the query plan.
-    auto prepares = Prepares::setup(stdv::values(test.stages), emitter);
+    /// The RunningQueryPlan requested compilation and setup for all pipelines in the query plan.
+    auto compiles = Compiles::setup(stdv::values(test.stages), emitter);
     auto setups = Setups::setup(stdv::values(test.stages), emitter);
     auto sourceStops = SourceStops::setup(std::vector{test.sourceIds.at(source)}, controller);
 
@@ -830,8 +830,8 @@ TEST_F(QueryPlanTest, DestroyingQueryPlanWhileSourceIsAboutToBeTerminated)
 
     {
         auto runningQueryPlan = dropRef(RunningQueryPlan::start(QueryId(0), std::move(queryPlan), controller, emitter, listener));
-        EXPECT_TRUE(prepares->waitForTasks(2));
-        EXPECT_TRUE(prepares->handleAll());
+        EXPECT_TRUE(compiles->waitForTasks(2));
+        EXPECT_TRUE(compiles->handleAll());
         EXPECT_TRUE(setups->waitForTasks(2));
         EXPECT_TRUE(setups->handleAll());
         srcCtrl->injectEoS();

--- a/nes-query-engine/tests/QueryPlanTest.cpp
+++ b/nes-query-engine/tests/QueryPlanTest.cpp
@@ -574,6 +574,39 @@ TEST_F(QueryPlanTest, RunningQueryPlanTestInitialPipelineSetup)
     EXPECT_FALSE(srcCtrl->wasClosed());
 }
 
+TEST_F(QueryPlanTest, RunningQueryPlanEmitsStartTasksOnlyAfterAllPipelinesAreCompiled)
+{
+    Testing::TestingHarness test;
+    auto builder = test.buildNewQuery();
+    auto source = builder.addSource();
+    auto pipeline = builder.addPipeline({source});
+    builder.addSink({pipeline});
+    auto queryPlan = test.addNewQuery(std::move(builder));
+    auto srcCtrl = test.sourceControls[source];
+
+    TestQueryLifetimeController controller;
+    TestWorkEmitter emitter;
+
+    auto compiles = Compiles::setup(stdv::values(test.stages), emitter);
+    auto setups = Setups::setup(stdv::values(test.stages), emitter);
+
+    auto listener = std::make_shared<TestQueryLifetimeListener>();
+    EXPECT_CALL(*listener, onDestruction()).Times(1);
+    EXPECT_CALL(*listener, onRunning()).Times(0);
+
+    {
+        auto runningQueryPlan = RunningQueryPlan::start(QueryId(0), std::move(queryPlan), controller, emitter, listener);
+        EXPECT_TRUE(compiles->waitForTasks(2));
+        EXPECT_TRUE(setups->empty());
+        EXPECT_TRUE(compiles->handleAll());
+        EXPECT_TRUE(setups->waitForTasks(2));
+        EXPECT_FALSE(srcCtrl->waitUntilOpened());
+    }
+
+    EXPECT_TRUE(srcCtrl->waitUntilDestroyed());
+    EXPECT_FALSE(srcCtrl->wasClosed());
+}
+
 /// Happy Path:
 /// 1. Start the Query which should emit pipeline SetupTasks.
 /// 2. AFTER we handle all SetupTasks. We expect the SourceThread to start

--- a/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.hpp
+++ b/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.hpp
@@ -170,7 +170,7 @@ struct TestWorkEmitter : WorkEmitter
         emitWork,
         (QueryId, const std::shared_ptr<RunningQueryPlanNode>&, TupleBuffer, TaskCallback, PipelineExecutionContext::ContinuationPolicy),
         (override));
-    MOCK_METHOD(void, emitPipelinePrepare, (QueryId, const std::shared_ptr<RunningQueryPlanNode>&, TaskCallback), (override));
+    MOCK_METHOD(void, emitPipelineCompile, (QueryId, const std::shared_ptr<RunningQueryPlanNode>&, TaskCallback), (override));
     MOCK_METHOD(void, emitPipelineStart, (QueryId, const std::shared_ptr<RunningQueryPlanNode>&, TaskCallback), (override));
     MOCK_METHOD(void, emitPendingPipelineStop, (QueryId, std::shared_ptr<RunningQueryPlanNode>, TaskCallback), (override));
     MOCK_METHOD(void, emitPipelineStop, (QueryId, std::unique_ptr<RunningQueryPlanNode>, TaskCallback), (override));

--- a/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.hpp
+++ b/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.hpp
@@ -170,6 +170,7 @@ struct TestWorkEmitter : WorkEmitter
         emitWork,
         (QueryId, const std::shared_ptr<RunningQueryPlanNode>&, TupleBuffer, TaskCallback, PipelineExecutionContext::ContinuationPolicy),
         (override));
+    MOCK_METHOD(void, emitPipelinePrepare, (QueryId, const std::shared_ptr<RunningQueryPlanNode>&, TaskCallback), (override));
     MOCK_METHOD(void, emitPipelineStart, (QueryId, const std::shared_ptr<RunningQueryPlanNode>&, TaskCallback), (override));
     MOCK_METHOD(void, emitPendingPipelineStop, (QueryId, std::shared_ptr<RunningQueryPlanNode>, TaskCallback), (override));
     MOCK_METHOD(void, emitPipelineStop, (QueryId, std::unique_ptr<RunningQueryPlanNode>, TaskCallback), (override));

--- a/nes-runtime/include/CompilationContext.hpp
+++ b/nes-runtime/include/CompilationContext.hpp
@@ -14,20 +14,29 @@
 #pragma once
 
 #include <functional>
+#include <memory>
+#include <unordered_map>
+#include <Identifiers/Identifiers.hpp>
+#include <Runtime/Execution/OperatorHandler.hpp>
 #include <Engine.hpp>
+#include <ErrorHandling.hpp>
 #include <val_concepts.hpp>
 
 namespace NES
 {
 
-/// Similar to the execution context, this class provides access to functionality for compiling code in a pipeline.
 class CompilationContext
 {
-    /// We assume that a compilation context always outlives the engine
     const nautilus::engine::NautilusEngine& engine; /// NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+    const std::unordered_map<OperatorHandlerId, std::shared_ptr<OperatorHandler>>& operatorHandlers;
 
 public:
-    explicit CompilationContext(const nautilus::engine::NautilusEngine& engine) : engine(engine) { }
+    explicit CompilationContext(
+        const nautilus::engine::NautilusEngine& engine,
+        const std::unordered_map<OperatorHandlerId, std::shared_ptr<OperatorHandler>>& operatorHandlers)
+        : engine(engine), operatorHandlers(operatorHandlers)
+    {
+    }
 
     template <typename R, typename... FunctionArguments>
     auto registerFunction(R (*fnptr)(nautilus::val<FunctionArguments>...)) const
@@ -39,6 +48,14 @@ public:
     auto registerFunction(std::function<R(nautilus::val<FunctionArguments>...)> func) const
     {
         return engine.registerFunction<R, FunctionArguments...>(func);
+    }
+
+    [[nodiscard]] OperatorHandler* getGlobalOperatorHandler(const OperatorHandlerId operatorHandlerId) const
+    {
+        const auto it = operatorHandlers.find(operatorHandlerId);
+        PRECONDITION(it != operatorHandlers.end(), "Expected operator handler for {}", operatorHandlerId);
+        PRECONDITION(it->second != nullptr, "Expected operator handler for {}", operatorHandlerId);
+        return it->second.get();
     }
 };
 }

--- a/nes-runtime/include/Pipelines/CompiledExecutablePipelineStage.hpp
+++ b/nes-runtime/include/Pipelines/CompiledExecutablePipelineStage.hpp
@@ -36,7 +36,7 @@ public:
         std::shared_ptr<Pipeline> pipeline,
         std::unordered_map<OperatorHandlerId, std::shared_ptr<OperatorHandler>> operatorHandler,
         nautilus::engine::Options options);
-    void prepare(PipelineExecutionContext& pipelineExecutionContext) override;
+    void compile(PipelineExecutionContext& pipelineExecutionContext) override;
     void start(PipelineExecutionContext& pipelineExecutionContext) override;
     void execute(const TupleBuffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext) override;
     void stop(PipelineExecutionContext& pipelineExecutionContext) override;

--- a/nes-runtime/include/Pipelines/CompiledExecutablePipelineStage.hpp
+++ b/nes-runtime/include/Pipelines/CompiledExecutablePipelineStage.hpp
@@ -36,6 +36,7 @@ public:
         std::shared_ptr<Pipeline> pipeline,
         std::unordered_map<OperatorHandlerId, std::shared_ptr<OperatorHandler>> operatorHandler,
         nautilus::engine::Options options);
+    void prepare(PipelineExecutionContext& pipelineExecutionContext) override;
     void start(PipelineExecutionContext& pipelineExecutionContext) override;
     void execute(const TupleBuffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext) override;
     void stop(PipelineExecutionContext& pipelineExecutionContext) override;

--- a/nes-runtime/include/Pipelines/CompiledExecutablePipelineStage.hpp
+++ b/nes-runtime/include/Pipelines/CompiledExecutablePipelineStage.hpp
@@ -13,6 +13,7 @@
 */
 #pragma once
 
+#include <atomic>
 #include <iostream>
 #include <memory>
 #include <unordered_map>
@@ -51,6 +52,8 @@ private:
     nautilus::engine::CallableFunction<void, PipelineExecutionContext*, const TupleBuffer*, const Arena*> compiledPipelineFunction;
     std::unordered_map<OperatorHandlerId, std::shared_ptr<OperatorHandler>> operatorHandlers;
     std::shared_ptr<Pipeline> pipeline;
+    std::atomic_bool isCompiled = false;
+    std::atomic_bool isStarted = false;
 };
 
 }

--- a/nes-runtime/src/Pipelines/CompiledExecutablePipelineStage.cpp
+++ b/nes-runtime/src/Pipelines/CompiledExecutablePipelineStage.cpp
@@ -112,8 +112,11 @@ std::ostream& CompiledExecutablePipelineStage::toString(std::ostream& os) const
     return os << "CompiledExecutablePipelineStage()";
 }
 
-void CompiledExecutablePipelineStage::prepare(PipelineExecutionContext&)
+void CompiledExecutablePipelineStage::compile(PipelineExecutionContext& pipelineExecutionContext)
 {
+    pipelineExecutionContext.setOperatorHandlers(operatorHandlers);
+    CompilationContext compilationCtx{engine};
+    pipeline->getRootOperator().compile(compilationCtx);
     compiledPipelineFunction = this->compilePipeline();
 }
 
@@ -122,8 +125,7 @@ void CompiledExecutablePipelineStage::start(PipelineExecutionContext& pipelineEx
     pipelineExecutionContext.setOperatorHandlers(operatorHandlers);
     Arena arena(pipelineExecutionContext.getBufferManager());
     ExecutionContext ctx(std::addressof(pipelineExecutionContext), std::addressof(arena));
-    CompilationContext compilationCtx{engine};
-    pipeline->getRootOperator().setup(ctx, compilationCtx);
+    pipeline->getRootOperator().setup(ctx);
 }
 
 }

--- a/nes-runtime/src/Pipelines/CompiledExecutablePipelineStage.cpp
+++ b/nes-runtime/src/Pipelines/CompiledExecutablePipelineStage.cpp
@@ -112,6 +112,11 @@ std::ostream& CompiledExecutablePipelineStage::toString(std::ostream& os) const
     return os << "CompiledExecutablePipelineStage()";
 }
 
+void CompiledExecutablePipelineStage::prepare(PipelineExecutionContext&)
+{
+    compiledPipelineFunction = this->compilePipeline();
+}
+
 void CompiledExecutablePipelineStage::start(PipelineExecutionContext& pipelineExecutionContext)
 {
     pipelineExecutionContext.setOperatorHandlers(operatorHandlers);
@@ -119,7 +124,6 @@ void CompiledExecutablePipelineStage::start(PipelineExecutionContext& pipelineEx
     ExecutionContext ctx(std::addressof(pipelineExecutionContext), std::addressof(arena));
     CompilationContext compilationCtx{engine};
     pipeline->getRootOperator().setup(ctx, compilationCtx);
-    compiledPipelineFunction = this->compilePipeline();
 }
 
 }

--- a/nes-runtime/src/Pipelines/CompiledExecutablePipelineStage.cpp
+++ b/nes-runtime/src/Pipelines/CompiledExecutablePipelineStage.cpp
@@ -49,7 +49,9 @@ CompiledExecutablePipelineStage::CompiledExecutablePipelineStage(
 
 void CompiledExecutablePipelineStage::execute(const TupleBuffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext)
 {
-    /// we call the compiled pipeline function with an input buffer and the execution context
+    PRECONDITION(isCompiled.load(), "CompiledExecutablePipelineStage must be compiled before execute");
+    PRECONDITION(isStarted.load(), "CompiledExecutablePipelineStage must be started before execute");
+
     pipelineExecutionContext.setOperatorHandlers(operatorHandlers);
     Arena arena(pipelineExecutionContext.getBufferManager());
     compiledPipelineFunction(std::addressof(pipelineExecutionContext), std::addressof(inputTupleBuffer), std::addressof(arena));
@@ -101,6 +103,8 @@ CompiledExecutablePipelineStage::compilePipeline() const
 
 void CompiledExecutablePipelineStage::stop(PipelineExecutionContext& pipelineExecutionContext)
 {
+    PRECONDITION(isStarted.load(), "CompiledExecutablePipelineStage must be started before stop");
+
     pipelineExecutionContext.setOperatorHandlers(operatorHandlers);
     Arena arena(pipelineExecutionContext.getBufferManager());
     ExecutionContext ctx(std::addressof(pipelineExecutionContext), std::addressof(arena));
@@ -114,18 +118,25 @@ std::ostream& CompiledExecutablePipelineStage::toString(std::ostream& os) const
 
 void CompiledExecutablePipelineStage::compile(PipelineExecutionContext& pipelineExecutionContext)
 {
+    PRECONDITION(!isCompiled.load(), "CompiledExecutablePipelineStage must not be compiled multiple times");
+
     pipelineExecutionContext.setOperatorHandlers(operatorHandlers);
-    CompilationContext compilationCtx{engine};
+    CompilationContext compilationCtx{engine, operatorHandlers};
     pipeline->getRootOperator().compile(compilationCtx);
     compiledPipelineFunction = this->compilePipeline();
+    isCompiled.store(true);
 }
 
 void CompiledExecutablePipelineStage::start(PipelineExecutionContext& pipelineExecutionContext)
 {
+    PRECONDITION(isCompiled.load(), "CompiledExecutablePipelineStage must be compiled before start");
+    PRECONDITION(!isStarted.load(), "CompiledExecutablePipelineStage must not be started multiple times");
+
     pipelineExecutionContext.setOperatorHandlers(operatorHandlers);
     Arena arena(pipelineExecutionContext.getBufferManager());
     ExecutionContext ctx(std::addressof(pipelineExecutionContext), std::addressof(arena));
     pipeline->getRootOperator().setup(ctx);
+    isStarted.store(true);
 }
 
 }


### PR DESCRIPTION
This PR separates executable pipeline compilation from runtime setup in the query engine. Previously, parts of pipeline compilation happened during setup/startup. With this change, the query engine now performs pipeline compilation in an explicit compilation phase first, and only runs runtime initialization afterwards.

We now:
- Added a clear split between pipeline compile(...) and start(...)/setup(...)
- Updated the query engine lifecycle so that:
   - all pipeline compile tasks are emitted and completed first
   - pipeline start tasks are only scheduled afterwards
- Moved compilation-specific work out of runtime setup in physical operators

Thus, with this change:
- CompiledExecutablePipelineStage::compile(...) now performs:
   - physical operator compilation
   - Nautilus function generation/registration
- CompiledExecutablePipelineStage::start(...) now performs only runtime initialization

Tested and benchmarked no systest runtime degradation. 