### PR TITLE
fix: update OSPO action references to canonical org path

### DIFF
--- a/.github/workflows/development_metrics.yml
+++ b/.github/workflows/development_metrics.yml
@@ -31,7 +31,7 @@ jobs:
           echo "period=${{ github.event.inputs.fromdate }}..${{ github.event.inputs.todate }}" >> "$GITHUB_ENV"
 
       - name: Get metrics for Issues
-        uses: github/issue-metrics@v3
+        uses: github-community-projects/issue-metrics@v3
         env:
           SEARCH_QUERY: 'repo:nebulastream/nebulastream-public is:issue created:${{ env.period }} -reason:"not planned"'
 
@@ -39,7 +39,7 @@ jobs:
         run: mv issue_metrics.md metrics_for_issues.md
 
       - name: Get metrics for PRs
-        uses: github/issue-metrics@v3
+        uses: github-community-projects/issue-metrics@v3
         env:
           SEARCH_QUERY: 'repo:nebulastream/nebulastream-public is:pr created:${{ env.period }} -reason:"not planned"'
           REPORT_TITLE: 'Metrics for PRs'


### PR DESCRIPTION
Updates GitHub Actions workflow references from the legacy `github/` org path to the canonical `github-community-projects/` path.

The following OSPO actions have been transferred to the `github-community-projects` organization:

| Legacy path | Canonical path |
|---|---|
| `github/issue-metrics` | `github-community-projects/issue-metrics` |

While GitHub's repo redirect ensures the old paths still work today, updating to the canonical path avoids depending on the redirect and ensures long-term stability.

**No functional changes** - the same action versions are referenced.
