### PR TITLE
chore(Systest): log config error msgs

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   nix-build:
     name: "Nix Build"
-    timeout-minutes: 60
+    timeout-minutes: 90
     runs-on: [ ubuntu-latest ]
     steps:
       - name: Checkout repository

--- a/nes-systests/systest/src/SystestStarter.cpp
+++ b/nes-systests/systest/src/SystestStarter.cpp
@@ -503,31 +503,39 @@ int main(int argc, const char** argv)
     const auto startTime = std::chrono::high_resolution_clock::now();
     NES::Thread::initializeThread(NES::Host("systest"), "main");
 
-    auto config = parseConfiguration(argc, argv);
-    NES::SystestExecutor executor(std::move(config));
-    const auto result = executor.executeSystests();
-
-    switch (result.returnType)
+    CPPTRACE_TRY
     {
-        case SystestExecutorResult::ReturnType::SUCCESS: {
-            const auto endTime = std::chrono::high_resolution_clock::now();
-            const auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime);
-            fmt::print(
-                "{}\nTotal execution time: {} ms ({:.3f} seconds)\n",
-                result.outputMessage,
-                duration.count(),
-                std::chrono::duration_cast<std::chrono::duration<double>>(duration).count());
-            return 0;
+        auto config = parseConfiguration(argc, argv);
+        NES::SystestExecutor executor(std::move(config));
+        const auto result = executor.executeSystests();
+
+        switch (result.returnType)
+        {
+            case SystestExecutorResult::ReturnType::SUCCESS: {
+                const auto endTime = std::chrono::high_resolution_clock::now();
+                const auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime);
+                fmt::print(
+                    "{}\nTotal execution time: {} ms ({:.3f} seconds)\n",
+                    result.outputMessage,
+                    duration.count(),
+                    std::chrono::duration_cast<std::chrono::duration<double>>(duration).count());
+                return 0;
+            }
+            case SystestExecutorResult::ReturnType::FAILED: {
+                auto endTime = std::chrono::high_resolution_clock::now();
+                auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime);
+                PRECONDITION(result.errorCode, "Returning with as 'FAILED_WITH_EXCEPTION_CODE', but did not provide error code");
+                NES_ERROR("{}", result.outputMessage);
+                std::cout << result.outputMessage << '\n';
+                std::cout << "Total execution time: " << duration.count() << " ms ("
+                          << std::chrono::duration_cast<std::chrono::duration<double>>(duration).count() << " seconds)" << '\n';
+                return result.errorCode.value();
+            }
         }
-        case SystestExecutorResult::ReturnType::FAILED: {
-            auto endTime = std::chrono::high_resolution_clock::now();
-            auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime);
-            PRECONDITION(result.errorCode, "Returning with as 'FAILED_WITH_EXCEPTION_CODE', but did not provide error code");
-            NES_ERROR("{}", result.outputMessage);
-            std::cout << result.outputMessage << '\n';
-            std::cout << "Total execution time: " << duration.count() << " ms ("
-                      << std::chrono::duration_cast<std::chrono::duration<double>>(duration).count() << " seconds)" << '\n';
-            return result.errorCode.value();
-        }
+    }
+    CPPTRACE_CATCH(const NES::Exception& e)
+    {
+        NES::tryLogCurrentException();
+        return NES::getCurrentErrorCode();
     }
 }


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Prior, the systeststarter would swallog config errors, printing a stacktrace without any valuable information.
This is obviously super frustrating, given that a minor type/config error triggers this problem and then requires intense analysis/debugging, instead of quickly scanning the error log.

You can reproduce it by setting `--worker.query_engine.query_engine.number_of_worker_threads=16` as config (contains query_engine twice)