### PR TITLE
fix(Rust): use forked corrosion for proper incremental builds

### DIFF
--- a/cmake/EnableRust.cmake
+++ b/cmake/EnableRust.cmake
@@ -41,10 +41,11 @@ if (${USING_LIBCXX})
 endif ()
 
 include(FetchContent)
+set(CORROSION_NO_HOSTBUILD ON CACHE BOOL "Enable proper incremental builds for Rust targets")
 FetchContent_Declare(
         Corrosion
-        GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-        GIT_TAG v0.5.2
+        GIT_REPOSITORY https://github.com/nebulastream/corrosion.git
+        GIT_TAG v0.6.1-always-dirty-fix
 )
 
 FetchContent_MakeAvailable(Corrosion)

--- a/cmake/EnableRust.cmake
+++ b/cmake/EnableRust.cmake
@@ -41,10 +41,11 @@ if (${USING_LIBCXX})
 endif ()
 
 include(FetchContent)
+set(CORROSION_NO_HOSTBUILD ON CACHE BOOL "Enable proper incremental builds for Rust targets")
 FetchContent_Declare(
         Corrosion
-        GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-        GIT_TAG v0.5.2
+        GIT_REPOSITORY https://github.com/ls-1801/corrosion.git
+        GIT_TAG fix/avoid-always-dirty-targets
 )
 
 FetchContent_MakeAvailable(Corrosion)


### PR DESCRIPTION
## Summary
- Switches corrosion from upstream v0.5.2 to a [fork based on v0.6.1](https://github.com/ls-1801/corrosion/tree/fix/avoid-always-dirty-targets) that adds `CORROSION_NO_HOSTBUILD` support
- With this option, corrosion uses `add_custom_command` with depfile tracking instead of `add_custom_target`, so ninja correctly reports "no work to do" when Rust sources haven't changed
- Previously, every `ninja` invocation would re-run cargo and relink ~50 targets even when nothing changed

See: https://github.com/corrosion-rs/corrosion/issues/624

## Test plan
- [x] Clean configure + full build succeeds
- [x] Second `ninja` invocation reports `ninja: no work to do.`
- [x] Touching a Rust source file triggers cargo rebuild + relinking
- [x] Third `ninja` invocation after rebuild reports `ninja: no work to do.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

