### PR TITLE
fix(vcpkg): patch libuuid UBSan signed left-shift in randutils.c

### DIFF
--- a/.github/workflows/clang_tidy_diff.yml
+++ b/.github/workflows/clang_tidy_diff.yml
@@ -76,13 +76,13 @@ jobs:
         with:
           image_name: nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{matrix.sanitizer}}
           run: |
-            git diff -U0 ${{ inputs.base_sha }} -- ':!*.inc' ':!*nes-rust-bindings' | clang-tidy-diff-19.py -clang-tidy-binary clang-tidy-19 -p1 -path build -export-fixes clang-tidy-result/fixes.yml  -checks='-*,readability-duplicate-include' -j $(nproc)
+            git diff -U0 ${{ inputs.base_sha }} -- ':!*.inc' ':!*nes-rust-bindings' ':!vcpkg/**' | clang-tidy-diff-19.py -clang-tidy-binary clang-tidy-19 -p1 -path build -export-fixes clang-tidy-result/fixes.yml  -checks='-*,readability-duplicate-include' -j $(nproc)
       - uses: ./.github/steps/run-in-container
         name: Run Clang Tidy with all Checks
         with:
           image_name: nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{matrix.sanitizer}}
           run: |
-            git diff -U0 ${{ inputs.base_sha }} -- ':!*.inc' ':!*nes-rust-bindings' | clang-tidy-diff-19.py -clang-tidy-binary clang-tidy-19 -p1 -path build -export-fixes clang-tidy-result/fixes.yml -j $(nproc)
+            git diff -U0 ${{ inputs.base_sha }} -- ':!*.inc' ':!*nes-rust-bindings' ':!vcpkg/**' | clang-tidy-diff-19.py -clang-tidy-binary clang-tidy-19 -p1 -path build -export-fixes clang-tidy-result/fixes.yml -j $(nproc)
       - name: Upload Clang-Tidy Results
         if: ${{ !cancelled() && !github.event.act }}
         uses: actions/upload-artifact@v4

--- a/docs/technical/dependency.md
+++ b/docs/technical/dependency.md
@@ -134,6 +134,13 @@ nautilus.
 
 Nautilus is not currently on vcpkg.
 
+### libuuid
+
+The vcpkg libuuid port uses an unmaintained standalone fork from SourceForge (v1.0.3, circa 2013) rather than the
+upstream [util-linux](https://github.com/util-linux/util-linux) source. Our custom port patches a signed left-shift
+undefined behavior in `randutils.c` that was fixed upstream in 2020
+([util-linux@3534b2c7](https://github.com/util-linux/util-linux/commit/3534b2c7c7)).
+
 ### Scope Guard
 
 [Scope Guard](https://github.com/Neargye/scope_guard) is not currently on vcpkg.

--- a/scripts/check_preamble.py
+++ b/scripts/check_preamble.py
@@ -89,6 +89,10 @@ VENDORED_FILES = {
     "nes-systests/utils/SystestPlugin/NES-Systest-Runner/gradlew.bat",
     "vcpkg/vcpkg-registry/ports/llvm/portfile.cmake",
     "vcpkg/vcpkg-registry/ports/cpptrace/portfile.cmake",
+    "vcpkg/vcpkg-registry/ports/libuuid/CMakeLists.txt",
+    "vcpkg/vcpkg-registry/ports/libuuid/config.linux.h",
+    "vcpkg/vcpkg-registry/ports/libuuid/portfile.cmake",
+    "vcpkg/vcpkg-registry/ports/libuuid/unofficial-libuuid-config.cmake.in",
 }
 
 if __name__ == "__main__":

--- a/vcpkg/vcpkg-registry/ports/libuuid/0001-fix-signed-left-shift-ubsan.patch
+++ b/vcpkg/vcpkg-registry/ports/libuuid/0001-fix-signed-left-shift-ubsan.patch
@@ -1,0 +1,23 @@
+diff --git a/randutils.c b/randutils.c
+index 1234567..abcdefg 100644
+--- a/randutils.c
++++ b/randutils.c
+@@ -31,6 +31,7 @@ int random_get_fd(void)
+ {
+ 	int i, fd;
+ 	struct timeval	tv;
++	unsigned int n_pid, n_uid;
+
+ 	gettimeofday(&tv, 0);
+ 	fd = open("/dev/urandom", O_RDONLY);
+@@ -42,7 +43,9 @@ int random_get_fd(void)
+ 		if (i >= 0)
+ 			fcntl(fd, F_SETFD, i | FD_CLOEXEC);
+ 	}
+-	srand((getpid() << 16) ^ getuid() ^ tv.tv_sec ^ tv.tv_usec);
++	n_pid = getpid();
++	n_uid = getuid();
++	srand((n_pid << 16) ^ n_uid ^ tv.tv_sec ^ tv.tv_usec);
+
+ #ifdef DO_JRAND_MIX
+ 	ul_jrand_seed[0] = getpid() ^ (tv.tv_sec & 0xFFFF);

--- a/vcpkg/vcpkg-registry/ports/libuuid/CMakeLists.txt
+++ b/vcpkg/vcpkg-registry/ports/libuuid/CMakeLists.txt
@@ -1,0 +1,64 @@
+cmake_minimum_required(VERSION 3.21)
+project(libuuid C)
+
+configure_file(config.linux.h config.h COPYONLY)
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+add_library(uuid STATIC
+    clear.c
+    compare.c
+    copy.c
+    gen_uuid.c
+    isnull.c
+    pack.c
+    parse.c
+    randutils.c
+    unpack.c
+    unparse.c
+    uuid_time.c
+)
+target_compile_options(uuid PRIVATE -include "${CMAKE_CURRENT_BINARY_DIR}/config.h")
+target_include_directories(uuid PUBLIC "$<INSTALL_INTERFACE:include>")
+
+add_executable(test_uuid test_uuid.c)
+target_link_libraries(test_uuid uuid)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    install(FILES uuid.h DESTINATION include/uuid)
+endif()
+
+install(
+    TARGETS uuid
+    EXPORT uuid_targets
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+)
+
+include(CMakePackageConfigHelpers)
+set(PACKAGE_CONFIG_FILE "${CMAKE_CURRENT_BINARY_DIR}/unofficial-libuuid-config.cmake")
+set(INSTALL_CONFIG_DIR  "${CMAKE_INSTALL_LIBDIR}/cmake/unofficial-libuuid")
+
+configure_package_config_file(unofficial-libuuid-config.cmake.in
+    "${PACKAGE_CONFIG_FILE}"
+    INSTALL_DESTINATION "${INSTALL_CONFIG_DIR}"
+)
+
+export(EXPORT uuid_targets
+    NAMESPACE unofficial::UUID::
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/unofficial-libuuid-targets.cmake"
+)
+
+install(EXPORT uuid_targets
+    NAMESPACE unofficial::UUID::
+    FILE unofficial-libuuid-targets.cmake
+    DESTINATION "${INSTALL_CONFIG_DIR}"
+)
+
+install(
+    FILES
+        "${PACKAGE_CONFIG_FILE}"
+    DESTINATION
+        "${INSTALL_CONFIG_DIR}"
+)

--- a/vcpkg/vcpkg-registry/ports/libuuid/config.linux.h
+++ b/vcpkg/vcpkg-registry/ports/libuuid/config.linux.h
@@ -1,0 +1,13 @@
+#define HAVE_DECL__SC_HOST_NAME_MAX 1
+#define HAVE_INTTYPES_H 1
+#define HAVE_NETINET_IN_H 1
+#define HAVE_SRANDOM 1
+#define HAVE_STDINT_H 1
+#define HAVE_STDLIB_H 1
+#define HAVE_SYS_FILE_H 1
+#define HAVE_SYS_IOCTL_H 1
+#define HAVE_SYS_SOCKET_H 1
+#define HAVE_SYS_TIME_H 1
+#define HAVE_UNISTD_H 1
+#define HAVE_USLEEP 1
+#define PACKAGE_STRING "libuuid 1.0.3"

--- a/vcpkg/vcpkg-registry/ports/libuuid/portfile.cmake
+++ b/vcpkg/vcpkg-registry/ports/libuuid/portfile.cmake
@@ -1,0 +1,42 @@
+set(LIBUUID_VERSION 1.0.3)
+
+vcpkg_from_sourceforge(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libuuid
+    FILENAME "libuuid-${LIBUUID_VERSION}.tar.gz"
+    SHA512 77488caccc66503f6f2ded7bdfc4d3bc2c20b24a8dc95b2051633c695e99ec27876ffbafe38269b939826e1fdb06eea328f07b796c9e0aaca12331a787175507
+    PATCHES
+    0001-fix-signed-left-shift-ubsan.patch
+)
+
+file(COPY
+    "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt"
+    "${CMAKE_CURRENT_LIST_DIR}/config.linux.h"
+    "${CMAKE_CURRENT_LIST_DIR}/unofficial-libuuid-config.cmake.in"
+    DESTINATION "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+set(prefix "${CURRENT_INSTALLED_DIR}")
+set(exec_prefix \$\{prefix\})
+set(libdir \$\{exec_prefix\}/lib)
+set(includedir \$\{prefix\}/include)
+configure_file("${SOURCE_PATH}/uuid.pc.in" "${SOURCE_PATH}/uuid.pc" @ONLY)
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+    file(INSTALL "${SOURCE_PATH}/uuid.pc" DESTINATION "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+endif()
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    file(INSTALL "${SOURCE_PATH}/uuid.pc" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+endif()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/unofficial-libuuid PACKAGE_NAME unofficial-libuuid)
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+
+vcpkg_copy_pdbs()

--- a/vcpkg/vcpkg-registry/ports/libuuid/unofficial-libuuid-config.cmake.in
+++ b/vcpkg/vcpkg-registry/ports/libuuid/unofficial-libuuid-config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/unofficial-libuuid-targets.cmake")

--- a/vcpkg/vcpkg-registry/ports/libuuid/vcpkg.json
+++ b/vcpkg/vcpkg-registry/ports/libuuid/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "libuuid",
+  "version": "1.0.3",
+  "port-version": 17,
+  "description": "Universally unique id library",
+  "homepage": "https://sourceforge.net/projects/libuuid/",
+  "license": "BSD-3-Clause",
+  "supports": "!osx & !windows",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a vcpkg overlay port for `libuuid` that patches a signed left-shift undefined behavior in `randutils.c`:

```c
srand((getpid() << 16) ^ getuid() ^ tv.tv_sec ^ tv.tv_usec);
```

`getpid()` returns `int`, so left-shifting by 16 overflows when the PID exceeds 32767. Upstream util-linux fixed this in commit `3534b2c7c7` by storing the result in `unsigned int` before shifting. The vcpkg port (SourceForge libuuid v1.0.3) is incredibly old and never picked up the fix, so we apply the same patch via our overlay.

This unblocks clean UBSan runs (`sanitizer: undefined` in `nightly_matrix.yaml`), which exercise libuuid via `nes-common/src/Util/UUID.cpp`'s `uuid_generate` call.

## Notes

The original branch also bumped nightly ctest/job timeouts to compensate for tuple-buffer-leak instrumentation overhead. That commit was dropped during rebase: the matrix rewrite in `fa5ca766c0` deleted the `test-other-configs` job it was patching, and the new `build_and_test.yml` already runs ctest with higher timeouts (unit `2400`, systest `4800`, docker `2400`) and splits tuple-buffer-leak runs into separate matrix entries.

## Test plan

- [ ] Nightly UBSan jobs no longer fail on libuuid randutils.c shift