### PR TITLE
fix(Formatter): break dependency cycle

### DIFF
--- a/nes-input-formatters/CMakeLists.txt
+++ b/nes-input-formatters/CMakeLists.txt
@@ -20,10 +20,8 @@ get_source(nes-input-formatters NES_SOURCE_PARSERS_SOURCE_FILES)
 add_library(nes-input-formatters ${NES_SOURCE_PARSERS_SOURCE_FILES})
 
 # Exposing TupleBuffer (nes-memory) and PipelineExecutionContext (nes-executable) from public APIs
-target_link_libraries(nes-input-formatters PUBLIC nes-memory nes-executable PRIVATE nes-common nes-configurations nes-runtime nes-executable nes-physical-operators)
+target_link_libraries(nes-input-formatters PUBLIC nes-memory nes-executable PRIVATE nes-common nes-configurations nes-runtime nes-executable)
 
-
-# 'Private' nes-input-formatters library that exposes internal headers
 target_include_directories(nes-input-formatters PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/InputFormatters>
         $<INSTALL_INTERFACE:include/nebulastream/>

--- a/nes-input-formatters/include/InputFormatterProvider/InputFormatterTupleBufferRef.hpp
+++ b/nes-input-formatters/include/InputFormatterProvider/InputFormatterTupleBufferRef.hpp
@@ -31,7 +31,6 @@
 #include <Arena.hpp>
 #include <ErrorHandling.hpp>
 #include <ExecutionContext.hpp>
-#include <PhysicalOperator.hpp>
 #include <val.hpp>
 #include <val_ptr.hpp>
 

--- a/nes-input-formatters/src/InputFormatterTupleBufferRefProvider.cpp
+++ b/nes-input-formatters/src/InputFormatterTupleBufferRefProvider.cpp
@@ -22,7 +22,6 @@
 #include <Sources/SourceDescriptor.hpp>
 #include <ErrorHandling.hpp>
 #include <InputFormatIndexerRegistry.hpp>
-#include <ScanPhysicalOperator.hpp>
 
 namespace NES
 {


### PR DESCRIPTION
refactor: fold nes-input-formatter-provider into nes-input-formatters to break circular dependency

