### PR TITLE
Fix simdjson object ends at buffer boundary bug

### DIFF
--- a/nes-input-formatters/include/InputFormatters/InputFormatter.hpp
+++ b/nes-input-formatters/include/InputFormatters/InputFormatter.hpp
@@ -249,10 +249,11 @@ private:
         static void finalizeTrailingIndexPhase() { tlIndexPhaseResult.numTuplesWithoutTrailing += 1; }
 
         static void constructAndIndexTrailingSpanningTuple(
-            const std::vector<StagedBuffer>& stagedBuffers, const InputFormatter& inputFormatter, Arena& arenaRef)
+            const std::vector<StagedBuffer>& stagedBuffers,
+            const InputFormatter& inputFormatter,
+            Arena& arenaRef,
+            const size_t sizeOfTrailingSpanningTuple)
         {
-            const auto sizeOfTrailingSpanningTuple
-                = calculateSizeOfSpanningTuple(stagedBuffers, inputFormatter.indexerMetaData.getTupleDelimitingBytes().size());
             allocateForTrailingSpanningTuple(arenaRef, sizeOfTrailingSpanningTuple);
             const auto trailingSpanningTupleBuffers = std::span(stagedBuffers).subspan(0, stagedBuffers.size());
             processSpanningTuple<typename FormatterType::IndexerMetaData>(
@@ -270,7 +271,10 @@ private:
         {
             const auto sizeOfLeadingSpanningTuple = calculateSizeOfSpanningTuple(
                 leadingSpanningTupleBuffers, inputFormatter.indexerMetaData.getTupleDelimitingBytes().size());
-
+            if (sizeOfLeadingSpanningTuple <= inputFormatter.indexerMetaData.getTupleDelimitingBytes().size() * 2)
+            {
+                return;
+            }
             allocateForLeadingSpanningTuple(arenaRef, sizeOfLeadingSpanningTuple);
             processSpanningTuple<typename FormatterType::IndexerMetaData>(
                 leadingSpanningTupleBuffers, tlIndexPhaseResult.leadingSpanningTuple, inputFormatter.indexerMetaData);
@@ -280,20 +284,6 @@ private:
                     std::bit_cast<const char*>(tlIndexPhaseResult.leadingSpanningTuple.data()),
                     tlIndexPhaseResult.leadingSpanningTuple.size()},
                 inputFormatter.indexerMetaData);
-        }
-
-    private:
-        static void allocateForLeadingSpanningTuple(Arena& arenaRef, const size_t sizeOfLeadingSpanningTuple)
-        {
-            tlIndexPhaseResult.hasLeadingSpanningTupleBool = true;
-            auto byteSpan = arenaRef.allocateMemory(sizeOfLeadingSpanningTuple);
-            tlIndexPhaseResult.leadingSpanningTuple = std::span<char>(std::bit_cast<char*>(byteSpan.data()), byteSpan.size());
-        }
-
-        static void allocateForTrailingSpanningTuple(Arena& arenaRef, const size_t sizeOfTrailingSpanningTuple)
-        {
-            auto byteSpan = arenaRef.allocateMemory(sizeOfTrailingSpanningTuple);
-            tlIndexPhaseResult.trailingSpanningTuple = std::span<char>(std::bit_cast<char*>(byteSpan.data()), byteSpan.size());
         }
 
         static size_t
@@ -308,6 +298,20 @@ private:
             }
             sizeOfSpanningTuple += spanningTupleBuffers.back().getLeadingBytes().size();
             return sizeOfSpanningTuple;
+        }
+
+    private:
+        static void allocateForLeadingSpanningTuple(Arena& arenaRef, const size_t sizeOfLeadingSpanningTuple)
+        {
+            tlIndexPhaseResult.hasLeadingSpanningTupleBool = true;
+            auto byteSpan = arenaRef.allocateMemory(sizeOfLeadingSpanningTuple);
+            tlIndexPhaseResult.leadingSpanningTuple = std::span<char>(std::bit_cast<char*>(byteSpan.data()), byteSpan.size());
+        }
+
+        static void allocateForTrailingSpanningTuple(Arena& arenaRef, const size_t sizeOfTrailingSpanningTuple)
+        {
+            auto byteSpan = arenaRef.allocateMemory(sizeOfTrailingSpanningTuple);
+            tlIndexPhaseResult.trailingSpanningTuple = std::span<char>(std::bit_cast<char*>(byteSpan.data()), byteSpan.size());
         }
     };
 
@@ -332,7 +336,15 @@ private:
         {
             return false;
         }
-        IndexPhaseResultBuilder::constructAndIndexTrailingSpanningTuple(stagedBuffers.getSpanningBuffers(), *inputFormatter, *arenaRef);
+        const auto sizeOfTrailingSpanningTuple = IndexPhaseResultBuilder::calculateSizeOfSpanningTuple(
+            stagedBuffers.getSpanningBuffers(), inputFormatter->indexerMetaData.getTupleDelimitingBytes().size());
+        /// If the spanning tuple consists only of delimiters, it is empty and we can skip processing it
+        if (sizeOfTrailingSpanningTuple <= inputFormatter->indexerMetaData.getTupleDelimitingBytes().size() * 2)
+        {
+            return false;
+        }
+        IndexPhaseResultBuilder::constructAndIndexTrailingSpanningTuple(
+            stagedBuffers.getSpanningBuffers(), *inputFormatter, *arenaRef, sizeOfTrailingSpanningTuple);
         IndexPhaseResultBuilder::finalizeTrailingIndexPhase();
         return true;
     }

--- a/nes-input-formatters/tests/UnitTests/SpecificSequenceTest.cpp
+++ b/nes-input-formatters/tests/UnitTests/SpecificSequenceTest.cpp
@@ -186,6 +186,67 @@ TEST_F(SpecificSequenceTest, testMultiplePartiallyFilledBuffers)
            {.sequenceNumber = SequenceNumber(3), .rawBytes = ",129"}}});
 }
 
+/// Constructs an empty spanning tuple, since it starts with a '\n' (and the SequenceShredder contains a buffer '0' containing a '\n'
+TEST_F(SpecificSequenceTest, simdJSONFirstObjectEndsAtBufferBoundary)
+{
+    using namespace InputFormatterTestUtil;
+    using enum TestDataTypes;
+    using TestTuple = std::tuple<int32_t>;
+    runTest<TestTuple>(TestConfig<TestTuple>{
+        .numRequiredBuffers = 3, /// 2 buffer for raw data, 1 buffer for results
+        .sizeOfRawBuffers = 16,
+        .sizeOfFormattedBuffers = 16,
+        .parserConfig = {.parserType = "JSON", .tupleDelimiter = "\n", .fieldDelimiter = ""},
+        .testSchema = {INT32},
+        .memoryLayoutType = MemoryLayoutType::ROW_LAYOUT,
+        .expectedResults = {WorkerThreadResults<TestTuple>{{{TestTuple(12)}}}},
+        .rawBytesPerThread = {/* buffer 1 */ {.sequenceNumber = SequenceNumber(1), .rawBytes = "\n{\"Field_0\":12}\n"}}});
+}
+
+/// SIMDJSON detects a complete tuple '{"Field_0":567}' in buffer 2, this leads to an empty spanning tuple between the ending '}'-byte
+/// of buffer 2 and the starting '\n'-byte of buffer 3 (leading spanning tuple)
+TEST_F(SpecificSequenceTest, simdJSONObjectEndsAtBufferBoundaryLeading)
+{
+    using namespace InputFormatterTestUtil;
+    using enum TestDataTypes;
+    using TestTuple = std::tuple<int32_t>;
+    runTest<TestTuple>(TestConfig<TestTuple>{
+        .numRequiredBuffers = 3, /// 2 buffer for raw data, 1 buffer for results
+        .sizeOfRawBuffers = 16,
+        .sizeOfFormattedBuffers = 20,
+        .parserConfig = {.parserType = "JSON", .tupleDelimiter = "\n", .fieldDelimiter = ""},
+        .testSchema = {INT32},
+        .memoryLayoutType = MemoryLayoutType::ROW_LAYOUT,
+        .expectedResults
+        = {WorkerThreadResults<TestTuple>{{{TestTuple(1234), TestTuple(567)}}}, WorkerThreadResults<TestTuple>{{{TestTuple(89)}}}},
+        .rawBytesPerThread
+        = {/* buffer 1 */ {.sequenceNumber = SequenceNumber(1), .rawBytes = "{\"Field_0\":1234}"},
+           /* buffer 2 */ {.sequenceNumber = SequenceNumber(2), .rawBytes = "\n{\"Field_0\":567}"},
+           /* buffer 3 */ {.sequenceNumber = SequenceNumber(3), .rawBytes = "\n{\"Field_0\":89}\n"}}});
+}
+
+/// SIMDJSON detects a complete tuple '{"Field_0":567}' in buffer 3, this leads to an empty spanning tuple between the ending '}'-byte
+/// of buffer 2 and the starting '\n'-byte of buffer 3 (trailing spanning tuple)
+TEST_F(SpecificSequenceTest, simdJSONObjectEndsAtBufferBoundaryTrailing)
+{
+    using namespace InputFormatterTestUtil;
+    using enum TestDataTypes;
+    using TestTuple = std::tuple<int32_t>;
+    runTest<TestTuple>(TestConfig<TestTuple>{
+        .numRequiredBuffers = 3, /// 2 buffer for raw data, 1 buffer for results
+        .sizeOfRawBuffers = 16,
+        .sizeOfFormattedBuffers = 20,
+        .parserConfig = {.parserType = "JSON", .tupleDelimiter = "\n", .fieldDelimiter = ""},
+        .testSchema = {INT32},
+        .memoryLayoutType = MemoryLayoutType::ROW_LAYOUT,
+        .expectedResults
+        = {WorkerThreadResults<TestTuple>{{{TestTuple(89)}}}, WorkerThreadResults<TestTuple>{{{TestTuple(1234), TestTuple(567)}}}},
+
+        .rawBytesPerThread
+        = {/* buffer 1 */ {.sequenceNumber = SequenceNumber(1), .rawBytes = "{\"Field_0\":1234}"},
+           /* buffer 3 */ {.sequenceNumber = SequenceNumber(3), .rawBytes = "\n{\"Field_0\":89}\n"},
+           /* buffer 2 */ {.sequenceNumber = SequenceNumber(2), .rawBytes = "\n{\"Field_0\":567}"}}});
+}
 }
 
 /// NOLINTEND(readability-magic-numbers)

--- a/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONFIF.hpp
+++ b/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONFIF.hpp
@@ -82,10 +82,10 @@ struct SIMDJSONMetaData
 
     {
         PRECONDITION(
-            config.fieldDelimiter.size() == 1,
-            "Delimiters must be of size '1 byte', but the field delimiter was {} (size {})",
-            config.fieldDelimiter,
-            config.fieldDelimiter.size());
+            config.tupleDelimiter.size() == 1,
+            "Delimiters must be of size '1 byte', but the tuple delimiter was {} (size {})",
+            config.tupleDelimiter,
+            config.tupleDelimiter.size());
 
         /// We expect the names in the json file to not be source qualified
         for (const auto& fieldName : tupleBufferRef.getAllFieldNames())


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
In contrast to the CSVInputFormatIndexer, SIMDJSON does depend on newlines to detect complete JSON documents/objects.
If the final curly brace of JSON document/object is the last byte of a buffer, SIMDJSON detects it and reports 0 trailing bytes.
The InputFormatter then creates an empty spanning tuple between that curly brace and the newline, which is the first byte of the next buffer.
This commit enables the InputFormatter to handle such empty spanning tuples.
The additional SpecificSequenceTests test three different cases for when/how this behavior can show up. Non of these tests passes prior to this commit.