### PR TITLE
fix(ci): enable debug logs for nightly RelWithDebInfo

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -131,7 +131,13 @@ jobs:
         with:
           ref: ${{ needs.fetch-current-main-commit.outputs.sha }}
       - name: Configure NebulaStream
-        run: cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_args.arg }}
+        shell: bash
+        run: |
+          log_level_arg=()
+          if [[ "${{ matrix.build_type }}" == "RelWithDebInfo" ]]; then
+            log_level_arg=(-DNES_LOG_LEVEL=DEBUG)
+          fi
+          cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_args.arg }} "${log_level_arg[@]}"
       - name: Build NebulaStream
         shell: bash
         run: |


### PR DESCRIPTION
Nightly RelWithDebInfo was failing because some existing BATS tests grep for INFO/DEBUG worker log lines, but RelWithDebInfo defaults NES_LOG_LEVEL to WARN, so those messages are compiled out.

This PR fixes that by passing -DNES_LOG_LEVEL=DEBUG for the nightly RelWithDebInfo config in test-other-configs.
