### PR TITLE
fix(grpc): Remove unused `QueryTerminationType` from `stopQuery` RPC

### DIFF
--- a/grpc/SingleNodeWorkerRPCService.proto
+++ b/grpc/SingleNodeWorkerRPCService.proto
@@ -40,9 +40,7 @@ message StartQueryRequest {
 }
 
 message StopQueryRequest {
-    enum QueryTerminationType {Graceful = 0; HardStop = 1; Failure = 2; Invalid = 3;};
-    NES.SerializableQueryId queryId = 2;
-    QueryTerminationType terminationType = 3;
+    NES.SerializableQueryId queryId = 1;
 }
 
 enum QueryState {

--- a/nes-frontend/src/QueryManager/EmbeddedWorkerQuerySubmissionBackend.cpp
+++ b/nes-frontend/src/QueryManager/EmbeddedWorkerQuerySubmissionBackend.cpp
@@ -20,7 +20,7 @@
 #include <Listeners/QueryLog.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <QueryManager/QueryManager.hpp>
-#include <Runtime/QueryTerminationType.hpp>
+
 #include <Util/Logger/impl/NesLogger.hpp>
 #include <ErrorHandling.hpp>
 #include <QueryStatus.hpp>
@@ -62,7 +62,7 @@ std::expected<void, Exception> EmbeddedWorkerQuerySubmissionBackend::start(Query
 
 std::expected<void, Exception> EmbeddedWorkerQuerySubmissionBackend::stop(QueryId queryId)
 {
-    return worker.stopQuery(queryId, QueryTerminationType::Graceful);
+    return worker.stopQuery(queryId);
 }
 
 std::expected<LocalQueryStatusSnapshot, Exception> EmbeddedWorkerQuerySubmissionBackend::status(QueryId queryId) const

--- a/nes-frontend/src/QueryManager/GRPCQuerySubmissionBackend.cpp
+++ b/nes-frontend/src/QueryManager/GRPCQuerySubmissionBackend.cpp
@@ -172,7 +172,6 @@ std::expected<void, Exception> GRPCQuerySubmissionBackend::stop(QueryId queryId)
     grpc::ClientContext context;
     StopQueryRequest request;
     *request.mutable_queryid() = QueryPlanSerializationUtil::serializeQueryId(queryId);
-    request.set_terminationtype(StopQueryRequest::Graceful);
     google::protobuf::Empty response;
 
     const auto status = stub->StopQuery(&context, request, &response);

--- a/nes-runtime/include/Runtime/NodeEngine.hpp
+++ b/nes-runtime/include/Runtime/NodeEngine.hpp
@@ -18,7 +18,7 @@
 #include <Listeners/QueryLog.hpp>
 #include <Listeners/SystemEventListener.hpp>
 #include <Runtime/BufferManager.hpp>
-#include <Runtime/QueryTerminationType.hpp>
+
 #include <Sources/SourceProvider.hpp>
 #include <CompiledQueryPlan.hpp>
 #include <QueryEngine.hpp>
@@ -52,7 +52,7 @@ public:
     void startQuery(QueryId queryId);
     /// Termination will happen asynchronously, thus the query might very well be running for an indeterminate time after this method has
     /// been called.
-    void stopQuery(QueryId queryId, QueryTerminationType terminationType);
+    void stopQuery(QueryId queryId);
 
     [[nodiscard]] std::shared_ptr<BufferManager> getBufferManager() { return bufferManager; }
 

--- a/nes-runtime/src/Runtime/NodeEngine.cpp
+++ b/nes-runtime/src/Runtime/NodeEngine.cpp
@@ -22,7 +22,7 @@
 #include <Listeners/QueryLog.hpp>
 #include <Listeners/SystemEventListener.hpp>
 #include <Runtime/BufferManager.hpp>
-#include <Runtime/QueryTerminationType.hpp>
+
 #include <Util/AtomicState.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <folly/Synchronized.h>
@@ -124,7 +124,7 @@ void NodeEngine::startQuery(QueryId queryId)
     }
 }
 
-void NodeEngine::stopQuery(QueryId queryId, QueryTerminationType)
+void NodeEngine::stopQuery(QueryId queryId)
 {
     PRECONDITION(queryId != INVALID_QUERY_ID, "QueryId must be not invalid!");
     NES_INFO("Stop {}", queryId);

--- a/nes-single-node-worker/include/SingleNodeWorker.hpp
+++ b/nes-single-node-worker/include/SingleNodeWorker.hpp
@@ -22,7 +22,7 @@
 #include <Listeners/QueryLog.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <Runtime/NodeEngine.hpp>
-#include <Runtime/QueryTerminationType.hpp>
+
 #include <Util/Pointers.hpp>
 #include <CompositeStatisticListener.hpp>
 #include <ErrorHandling.hpp>
@@ -67,11 +67,9 @@ public:
     /// @param queryId identifies the registered query
     std::expected<void, Exception> startQuery(QueryId queryId) noexcept;
 
-    /// Stops the Query and moves it into the StoppedState. The exact semantics and guarantees depend on the chosen
-    ///  QueryTerminationType
+    /// Stops the Query and moves it into the StoppedState.
     /// @param queryId identifies the registered query
-    /// @param terminationType dictates what happens with in in-flight data
-    std::expected<void, Exception> stopQuery(QueryId queryId, QueryTerminationType terminationType) noexcept;
+    std::expected<void, Exception> stopQuery(QueryId queryId) noexcept;
 
     /// Summary structure for query.
     [[nodiscard]] std::expected<LocalQueryStatusSnapshot, Exception> getQueryStatus(QueryId queryId) const noexcept;

--- a/nes-single-node-worker/src/GrpcService.cpp
+++ b/nes-single-node-worker/src/GrpcService.cpp
@@ -20,7 +20,7 @@
 #include <utility>
 #include <Identifiers/Identifiers.hpp>
 #include <Plans/LogicalPlan.hpp>
-#include <Runtime/QueryTerminationType.hpp>
+
 #include <Serialization/QueryPlanSerializationUtil.hpp>
 #include <cpptrace/basic.hpp>
 #include <cpptrace/from_current.hpp>
@@ -126,10 +126,9 @@ grpc::Status GRPCServer::StartQuery(grpc::ServerContext* context, const StartQue
 grpc::Status GRPCServer::StopQuery(grpc::ServerContext* context, const StopQueryRequest* request, google::protobuf::Empty*)
 {
     const auto queryId = QueryPlanSerializationUtil::deserializeQueryId(request->queryid());
-    const auto terminationType = static_cast<QueryTerminationType>(request->terminationtype());
     CPPTRACE_TRY
     {
-        getValueOrThrow(delegate.stopQuery(queryId, terminationType));
+        getValueOrThrow(delegate.stopQuery(queryId));
         return grpc::Status::OK;
     }
     CPPTRACE_CATCH(const Exception& e)

--- a/nes-single-node-worker/src/SingleNodeWorker.cpp
+++ b/nes-single-node-worker/src/SingleNodeWorker.cpp
@@ -30,7 +30,7 @@
 #include <Listeners/QueryLog.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <Runtime/NodeEngineBuilder.hpp>
-#include <Runtime/QueryTerminationType.hpp>
+
 #include <Util/Logger/Logger.hpp>
 #include <Util/PlanRenderer.hpp>
 #include <Util/Pointers.hpp>
@@ -144,12 +144,12 @@ std::expected<void, Exception> SingleNodeWorker::startQuery(QueryId queryId) noe
     std::unreachable();
 }
 
-std::expected<void, Exception> SingleNodeWorker::stopQuery(QueryId queryId, QueryTerminationType type) noexcept
+std::expected<void, Exception> SingleNodeWorker::stopQuery(QueryId queryId) noexcept
 {
     CPPTRACE_TRY
     {
         PRECONDITION(queryId != INVALID_QUERY_ID, "QueryId must be not invalid!");
-        nodeEngine->stopQuery(queryId, type);
+        nodeEngine->stopQuery(queryId);
         return {};
     }
     CPPTRACE_CATCH(...)


### PR DESCRIPTION
Closes #1565

## Summary
- Remove the `QueryTerminationType` parameter from `NodeEngine::stopQuery`, `SingleNodeWorker::stopQuery`, and all callers
- Remove the `QueryTerminationType` enum and `terminationType` field from the `StopQueryRequest` proto message
- The parameter was accepted but **never used** — `NodeEngine::stopQuery` had it as an unnamed parameter and unconditionally called `queryEngine->stop(queryId)` regardless of termination type
- `QueryTerminationType` itself is kept in C++ since it is still used internally by the query engine for source termination tracking and operator handlers