### PR TITLE
fix(Systest): Support Void sinks in the systest harness

### DIFF
--- a/nes-systests/sinks/VoidSink.test
+++ b/nes-systests/sinks/VoidSink.test
@@ -1,0 +1,21 @@
+# name: sinks/VoidSink.test
+# description: Void sink discards all tuples; no result file is produced and the systest harness must skip the output check.
+# groups: [Sources]
+
+SELECT ID, VALUE, TIMESTAMP
+FROM File(
+	'small/stream8.csv' AS `SOURCE`.FILE_PATH,
+	'CSV' AS PARSER.`TYPE`,
+	SCHEMA(id UINT64 NOT NULL, value UINT64 NOT NULL, timestamp UINT64 NOT NULL) AS `SOURCE`.`SCHEMA`)
+INTO Void();
+----
+
+CREATE SINK discard(id UINT64 NOT NULL, value UINT64 NOT NULL, timestamp UINT64 NOT NULL) TYPE Void;
+
+SELECT ID, VALUE, TIMESTAMP
+FROM File(
+	'small/stream8.csv' AS `SOURCE`.FILE_PATH,
+	'CSV' AS PARSER.`TYPE`,
+	SCHEMA(id UINT64 NOT NULL, value UINT64 NOT NULL, timestamp UINT64 NOT NULL) AS `SOURCE`.`SCHEMA`)
+INTO discard;
+----

--- a/nes-systests/systest/src/SystestBinder.cpp
+++ b/nes-systests/systest/src/SystestBinder.cpp
@@ -96,14 +96,16 @@ public:
             [this, schema, sinkType](
                 const std::string_view assignedSinkName, std::filesystem::path filePath) -> std::expected<SinkDescriptor, Exception>
             {
-                std::unordered_map<std::string, std::string> config{{"file_path", std::move(filePath)}};
+                std::unordered_map<std::string, std::string> config{};
                 std::unordered_map<std::string, std::string> formatConfig{};
                 if (sinkType == "File")
                 {
+                    config["file_path"] = std::move(filePath);
                     config["output_format"] = "CSV";
                 }
                 else if (toUpperCase(sinkType) == "CHECKSUM")
                 {
+                    config["file_path"] = std::move(filePath);
                     formatConfig["quote_strings"] = "true";
                 }
 
@@ -711,9 +713,13 @@ struct SystestBinder::Impl
         auto formatConfig = sinkOperator->getFormatConfig();
         auto schema = sinkOperator->getSchema();
         sinkConfig.erase("file_path");
-        sinkConfig.emplace("file_path", resultFile);
-
-        if (not(sinkConfig.contains("output_format")) and sinkOperator->getSinkType() != "CHECKSUM")
+        /// Only inject a file_path for a file sink or checksum sink
+        if (toUpperCase(sinkOperator->getSinkType()) == "FILE" or toUpperCase(sinkOperator->getSinkType()) == "CHECKSUM")
+        {
+            sinkConfig.emplace("file_path", resultFile);
+        }
+        if (not(sinkConfig.contains("output_format")) and sinkOperator->getSinkType() != "CHECKSUM"
+            and sinkOperator->getSinkType() != "VOID")
         {
             sinkConfig.emplace("output_format", "CSV");
         }

--- a/nes-systests/systest/src/SystestResultCheck.cpp
+++ b/nes-systests/systest/src/SystestResultCheck.cpp
@@ -36,6 +36,7 @@
 #include <DataTypes/DataTypeProvider.hpp>
 #include <DataTypes/Schema.hpp>
 #include <Identifiers/NESStrongType.hpp>
+#include <Operators/Sinks/SinkLogicalOperator.hpp>
 #include <Util/Logger/Formatter.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <Util/Ranges.hpp>
@@ -753,6 +754,26 @@ namespace NES
 {
 std::optional<std::string> checkResult(const Systest::RunningQuery& runningQuery)
 {
+    /// Void sinks discard all tuples and produce no result file, so there is nothing to check.
+    if (runningQuery.systestQuery.planInfoOrException.has_value())
+    {
+        const auto sinkOperators
+            = getOperatorByType<SinkLogicalOperator>(runningQuery.systestQuery.planInfoOrException.value().queryPlan.getGlobalPlan());
+        if (not sinkOperators.empty())
+        {
+            if (const auto sinkOp = sinkOperators.at(0).tryGetAs<SinkLogicalOperator>(); sinkOp.has_value()
+                and sinkOp.value()->getSinkDescriptor().has_value()
+                and toUpperCase(sinkOp.value()->getSinkDescriptor().value().getSinkType()) == "VOID")
+            {
+                NES_INFO(
+                    "Skipping result check for {}:{} because it writes to a Void sink.",
+                    runningQuery.systestQuery.testName,
+                    runningQuery.systestQuery.queryIdInFile);
+                return std::nullopt;
+            }
+        }
+    }
+
     static constexpr std::string_view SchemaMismatchMessage = "\n\n"
                                                               "Schema Mismatch\n"
                                                               "---------------";


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

The systest harness unconditionally injected `file_path` (and defaulted `output_format=CSV`) into every sink's config. `VoidSink` rejects unknown keys, so any query using `INTO Void()` or a `CREATE SINK ... TYPE Void` definition failed at binding time. In addition, the result check always expected a result file on disk, which does not exist for a sink that discards its tuples.

Changes:
- `SystestBinder::registerSink` / `setInlineSink`: only inject `file_path` for non-Void sinks, and keep the `output_format` default off for both `CHECKSUM` and `VOID`. `CHECKSUM` continues to receive `file_path` (its output still goes to a file).
- `SystestResultCheck::checkResult`: when the query's root sink is of type `VOID`, log and return `std::nullopt` instead of attempting to read a (non-existent) result file.
- New systest `nes-systests/sinks/VoidSink.test` exercising both the inline `INTO Void()` form and the named `CREATE SINK ... TYPE Void` form.

## Verifying this change

- `nes-systests/sinks/VoidSink.test` — both queries PASS.
- `nes-systests/sinks/InlineSink.test` — all 5 queries PASS (regression for the inline-sink path).
- `nes-systests/sources/Generator.test` — all 9 queries PASS (regression for CHECKSUM sinks, which share the same code paths and still need `file_path`).

## What components does this pull request potentially affect?

- Systest harness (`nes-systests/systest/src/SystestBinder.cpp`, `SystestResultCheck.cpp`)
- No runtime / query-engine changes; `VoidSink` itself is unchanged.