### PR TITLE
fix(CI): stop the 24h E2E from silently passing while the query errors out

### DIFF
--- a/.github/workflows/execute_query.yml
+++ b/.github/workflows/execute_query.yml
@@ -23,8 +23,10 @@ on:
         required: false
         type: string
         default: |
+          CREATE WORKER 'localhost:8080' SET ('localhost:9090' AS DATA);
           CREATE LOGICAL SOURCE endless(val_1 UINT32 NOT NULL, ts UINT64 NOT NULL);
           CREATE PHYSICAL SOURCE FOR endless TYPE Generator SET(
+              'localhost:8080' AS `SOURCE`.`HOST`,
               'ALL' as `SOURCE`.STOP_GENERATOR_WHEN_SEQUENCE_FINISHES,
               'CSV' as PARSER.`TYPE`,
               1 AS `SOURCE`.SEED,
@@ -32,15 +34,11 @@ on:
               'FIXED' AS `SOURCE`.GENERATOR_RATE_TYPE,
               'EMIT_RATE 1000' AS `SOURCE`.GENERATOR_RATE_CONFIG,
               'SEQUENCE UINT32 0 200000000 1, SEQUENCE UINT64 0 200000000 1' AS `SOURCE`.GENERATOR_SCHEMA);
-          CREATE SINK someSink1(ENDLESS.TS UINT64 NOT NULL) TYPE File SET('/dev/null' as `SINK`.FILE_PATH, 'CSV' as `SINK`.OUTPUT_FORMAT);
-          CREATE SINK someSink2(ENDLESS.val_1 UINT32 NOT NULL, ENDLESS.TS UINT64 NOT NULL) TYPE File SET('/dev/null' as `SINK`.FILE_PATH, 'CSV' as `SINK`.OUTPUT_FORMAT);
-          CREATE SINK someSink3(val_plus_1 UINT32 NOT NULL) TYPE File SET('/dev/null' as `SINK`.FILE_PATH, 'CSV' as `SINK`.OUTPUT_FORMAT);
-          CREATE SINK someSink4(ENDLESS.agg_val_1 FLOAT64 NOT NULL) TYPE File SET('/dev/null' as `SINK`.FILE_PATH, 'CSV' as `SINK`.OUTPUT_FORMAT);
           SHOW QUERIES;
-          SELECT TS FROM ENDLESS INTO SOMESINK1;
-          SELECT * FROM ENDLESS INTO SOMESINK2;
-          SELECT val_1 + UINT32(1) AS val_plus_1 FROM ENDLESS INTO SOMESINK3;
-          SELECT AVG(val_1) AS agg_val_1 FROM ENDLESS WINDOW TUMBLING(ts, SIZE 1 SEC) INTO SOMESINK4;
+          SELECT TS FROM ENDLESS INTO Void('localhost:8080' AS `SINK`.`HOST`);
+          SELECT * FROM ENDLESS INTO Void('localhost:8080' AS `SINK`.`HOST`);
+          SELECT val_1 + UINT32(1) AS val_plus_1 FROM ENDLESS INTO Void('localhost:8080' AS `SINK`.`HOST`);
+          SELECT AVG(val_1) AS agg_val_1 FROM ENDLESS WINDOW TUMBLING(ts, SIZE 1 SEC) INTO Void('localhost:8080' AS `SINK`.`HOST`);
 
 jobs:
   execute-query:
@@ -82,21 +80,48 @@ jobs:
       - name: Build and Test
         shell: bash
         run: |
+          set -o pipefail
           cmake -GNinja -B build -DExternalData_OBJECT_STORES=/test-file-cache -DNES_LOG_LEVEL=DEBUG
           cmake --build build -j -- -k 0
 
-          build/nes-single-node-worker/nes-single-node-worker > worker.log 2>&1 &
+          build/nes-single-node-worker/nes-single-node-worker --data_address=localhost:9090 > worker.log 2>&1 &
           WORKER_PID=$!
 
           sleep 5
 
-          timeout --foreground ${{inputs.runtime_seconds}} bash -c '{ cat query.sql; sleep ${{inputs.runtime_seconds}}; } | exec build/nes-frontend/apps/nes-repl --on-exit WAIT_FOR_QUERY_TERMINATION -s localhost:8080' || EXIT_CODE=$?
+          # Stream queries directly into the REPL via stdin redirection — no
+          # producer-side `sleep` keeping the bash pipeline open after the REPL
+          # has exited. With FAIL_FAST (also the non-interactive default) the
+          # REPL exits non-zero on the first statement error, which `timeout`
+          # then reports as the child's exit code instead of swallowing it.
+          # Exit-code interpretation:
+          #   124    → timeout fired ⇒ REPL was alive for the full duration
+          #            and exited cleanly on SIGTERM ⇒ pass
+          #   0      → REPL exited cleanly before timeout, i.e. all queries
+          #            terminated on their own ⇒ unexpected for an endless
+          #            stress test ⇒ fail
+          #   *      → REPL errored (FAIL_FAST on bad statement, etc.) ⇒ fail
+          EXIT_CODE=0
+          timeout --foreground "${{inputs.runtime_seconds}}" \
+            build/nes-frontend/apps/nes-repl \
+              --on-exit WAIT_FOR_QUERY_TERMINATION \
+              -e FAIL_FAST \
+              -s localhost:8080 \
+            < query.sql || EXIT_CODE=$?
 
-          # verify that the timeout has terminated nebuli.
-          if [ "${EXIT_CODE:-0}" -ne 124 ]; then
-            echo "✗ FAILURE: Unexpected exit code: ${EXIT_CODE}"
-            exit 1
-          fi
+          case "${EXIT_CODE}" in
+            124)
+              echo "✓ REPL ran for the full ${{inputs.runtime_seconds}}s and was terminated by timeout"
+              ;;
+            0)
+              echo "✗ FAILURE: REPL exited cleanly before timeout — queries terminated unexpectedly or never deployed"
+              exit 1
+              ;;
+            *)
+              echo "✗ FAILURE: REPL exited with non-zero code ${EXIT_CODE}"
+              exit 1
+              ;;
+          esac
 
           # stop worker
           kill $WORKER_PID

--- a/nes-frontend/apps/repl/ReplStarter.cpp
+++ b/nes-frontend/apps/repl/ReplStarter.cpp
@@ -298,6 +298,7 @@ int main(int argc, char** argv)
         replClient.run();
 
         bool hasError = false;
+        const auto exitStopToken = SignalHandler::terminationToken();
         /// NOLINTNEXTLINE(bugprone-unchecked-optional-access) validated by argparse .choices()
         switch (magic_enum::enum_cast<OnExitBehavior>(program.get<std::string>("--on-exit")).value())
         {
@@ -318,10 +319,14 @@ int main(int argc, char** argv)
                 }
                 [[clang::fallthrough]];
             case OnExitBehavior::WAIT_FOR_QUERY_TERMINATION:
-                while (!queryManager->getRunningQueries().empty())
+                while (!queryManager->getRunningQueries().empty() && !exitStopToken.stop_requested())
                 {
                     NES_DEBUG("Waiting for termination")
                     std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                }
+                if (exitStopToken.stop_requested())
+                {
+                    NES_WARNING("Termination signal received; aborting on-exit wait");
                 }
                 break;
             case OnExitBehavior::DO_NOTHING:

--- a/nes-frontend/apps/repl/tests/sql-file-tests/distributed.bats
+++ b/nes-frontend/apps/repl/tests/sql-file-tests/distributed.bats
@@ -247,6 +247,33 @@ assert_json_contains() {
   [ "$duration" -ge 10 ]
 }
 
+@test "WAIT_FOR_QUERY_TERMINATION exits cleanly on SIGTERM" {
+  setup_distributed tests/topologies/1-node.yaml
+
+  # non_infinite_query.sql configures the source to produce data for 10000ms,
+  # so WAIT_FOR_QUERY_TERMINATION would normally make nes-repl block ~10s.
+  # Send SIGTERM to nes-repl mid-wait and verify the on-exit loop exits well
+  # before the 10s mark and reports the warning.
+  (
+    tail -f /dev/null | docker compose exec -T nes-repl bash -c \
+      "nes-repl -f JSON --on-exit WAIT_FOR_QUERY_TERMINATION </workdir/tests/sql-file-tests/good/non_infinite_query.sql"
+  ) &
+  REPL_BG=$!
+
+  # Give the REPL time to deploy the query and enter the on-exit wait loop.
+  sleep 3
+
+  start_time=$(date +%s)
+  docker compose exec -T nes-repl pkill -TERM -f "^nes-repl"
+  wait $REPL_BG
+  end_time=$(date +%s)
+
+  duration=$((end_time - start_time))
+  # SIGTERM should break the wait loop within a couple of polling intervals,
+  # well before the query's natural 10s end.
+  [ "$duration" -le 3 ]
+}
+
 @test "launch query and terminate query on exit behavior" {
   setup_distributed tests/topologies/1-node.yaml
 


### PR DESCRIPTION
## Why

The `stress-test` (24 h E2E) job in the nightly workflow was reporting **green every night even when the test query never ran**. The job logs show, on 2026-05-01, `failed to process with error code (2029) : invalid statement; \`SOURCE\`.\`HOST\` was not set` four seconds after the build finished — and then 23 hours of nothing — and the job concluded as **success**.

Three independent bugs were colliding to produce that false green:

1. **Workflow shape.** The step ran the REPL inside
   `timeout 23h bash -c '{ cat query.sql; sleep 23h; } | exec nes-repl ...'`
   and asserted `EXIT_CODE == 124` for "REPL was alive the whole time". The producer-side `sleep` keeps the bash pipeline open even after the REPL has died, so `timeout` always fires and the assertion always passes. nes-repl could exit fast on any error and the job would still report success.

2. **REPL signal handling.** Even with the workflow fixed to use a direct stdin redirect, `timeout`'s SIGTERM was silently swallowed: the SIGTERM handler set a `stop_token`, but the `WAIT_FOR_QUERY_TERMINATION` poll loop in `main()` never read it. The REPL only died on SIGKILL (exit 137), making clean shutdown impossible.

3. **Test query.** The default `query_config` in `execute_query.yml` was incomplete for the non-embedded REPL path: no `CREATE WORKER`, no `SOURCE.HOST`/`SINK.HOST`, and four `File` sinks pointed at `/dev/null` which the file sink can't `unlink`. The first bug was hiding all of this — both the source-statement validation error and the runtime "cannot remove \`/dev/null\`" failure on every query startup.

## What

Two commits:

- **`fix(REPL): honor SIGTERM during on-exit wait loop`** — `WAIT_FOR_QUERY_TERMINATION` (and the `STOP_QUERIES` fallthrough) now check `exitStopToken.stop_requested()` in the loop condition and emit a warning when termination was signal-driven. Adds a distributed-bats regression test that sends SIGTERM mid-wait and asserts the REPL exits within a couple of polling intervals.

- **`fix(CI): catch REPL exit codes properly in execute_query.yml`** — Replaces the bash-pipeline-with-sleep construct with a direct stdin redirect, passes `-e FAIL_FAST` explicitly, and now interprets exit codes as: \`124\` ⇒ pass, \`0\` ⇒ fail (queries terminated early), anything else ⇒ fail. Fixes the test query to actually deploy: \`CREATE WORKER 'localhost:8080' SET ('localhost:9090' AS DATA)\`, \`SOURCE.HOST\`/\`SINK.HOST\` on every source and sink, \`--data_address=localhost:9090\` on the worker, and \`Void\` sinks instead of \`File('/dev/null')\`.

## Evidence on real CI

Both runs were triggered on a temporarily-trimmed nightly (only the stress-test job, with \`runtime_seconds=300\`) so the verification cycle is short. The trim was in a separate commit that has been dropped; it's not part of this PR.

| Run | Code under test | Outcome |
|---|---|---|
| [25273331722](https://github.com/nebulastream/nebulastream/actions/runs/25273331722) | workflow fix only, query still bad | **failure** in 3 s after build — \`✗ FAILURE: REPL exited with non-zero code 237\` (FAIL_FAST on the bad source statement). Demonstrates the workflow no longer hides REPL errors. |
| [25273982619](https://github.com/nebulastream/nebulastream/actions/runs/25273982619) | both fixes + query fix | **success** at 5 min — \`✓ REPL ran for the full 300s and was terminated by timeout\` (exit 124). Demonstrates the success path actually runs the queries for the configured duration. |

## Test plan

- [x] Local repro: bash construct on the bad query → old workflow logic returns 124 (false green); new logic returns 237 (correctly fails).
- [x] Local fix-check: bash construct on the fixed query → exit 124 in exactly the timeout duration; queries deploy and run.
- [x] Local bats: \`bats --filter "WAIT_FOR_QUERY_TERMINATION exits cleanly on SIGTERM"\` → \`ok\` in ~10 s.
- [x] CI failure run on real workflow.
- [x] CI success run on real workflow with 5-minute runtime.
- [ ] Reviewer to confirm the trimmed-nightly verification approach is acceptable (the actual workflow change keeps the 23 h default).