### PR TITLE
fix(sql-parser): fix negative float parsing error

### DIFF
--- a/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
+++ b/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
@@ -331,15 +331,39 @@ void AntlrSQLQueryPlanCreator::exitArithmeticUnary(AntlrSQLParser::ArithmeticUna
     {
         throw InvalidQuerySyntax("Parser is confused at {}", context->getText());
     }
-    LogicalFunction function;
+    auto opTokenType = context->op->getType();
+    if (context->valueExpression() != nullptr && !helpers.top().constantBuilder.empty())
+    {
+        auto& constant = helpers.top().constantBuilder.back();
+        if (constant == context->valueExpression()->getText())
+        {
+            switch (opTokenType)
+            {
+                case AntlrSQLLexer::PLUS:
+                    return;
+                case AntlrSQLLexer::MINUS:
+                    if (!constant.empty() && constant.front() == '-')
+                    {
+                        constant.erase(0, 1);
+                    }
+                    else
+                    {
+                        constant.insert(0, 1, '-');
+                    }
+                    return;
+                default:
+                    break;
+            }
+        }
+    }
 
     if (helpers.top().functionBuilder.empty())
     {
         throw InvalidQuerySyntax("Expected unary operator, got nothing: {}", context->getText());
     }
+    LogicalFunction function;
     const auto innerFunction = helpers.top().functionBuilder.back();
     helpers.top().functionBuilder.pop_back();
-    auto opTokenType = context->op->getType();
     switch (opTokenType)
     {
         case AntlrSQLLexer::PLUS:
@@ -347,7 +371,7 @@ void AntlrSQLQueryPlanCreator::exitArithmeticUnary(AntlrSQLParser::ArithmeticUna
             break;
         case AntlrSQLLexer::MINUS:
             function = MulLogicalFunction(
-                ConstantValueLogicalFunction(DataTypeProvider::provideDataType(DataType::Type::UINT64), "-1"), innerFunction);
+                ConstantValueLogicalFunction(DataTypeProvider::provideDataType(DataType::Type::INT64), "-1"), innerFunction);
             break;
         default:
             throw InvalidQuerySyntax("Unknown Arithmetic Binary Operator: {} of type: {}", context->op->getText(), opTokenType);

--- a/nes-sql-parser/tests/StatementBinderTest.cpp
+++ b/nes-sql-parser/tests/StatementBinderTest.cpp
@@ -26,6 +26,7 @@
 #include <DataTypes/DataTypeProvider.hpp>
 #include <DataTypes/Schema.hpp>
 #include <Identifiers/Identifiers.hpp>
+#include <Operators/SelectionLogicalOperator.hpp>
 #include <Operators/Sinks/InlineSinkLogicalOperator.hpp>
 #include <Operators/Sources/InlineSourceLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
@@ -95,6 +96,66 @@ TEST_F(StatementBinderTest, BindQuery)
     const auto statement = binder->parseAndBindSingle(queryString);
     ASSERT_TRUE(statement.has_value());
     ASSERT_TRUE(std::holds_alternative<QueryStatement>(*statement));
+}
+
+TEST_F(StatementBinderTest, BindQueryWithNegativeTypedFloatLiteralInWherePredicate)
+{
+    const std::string queryString = "SELECT a FROM inputStream WHERE b > FLOAT64(-0.5) AND b < FLOAT64(0.5) INTO outputStream";
+    const auto statement = binder->parseAndBindSingle(queryString);
+    ASSERT_TRUE(statement.has_value());
+    ASSERT_TRUE(std::holds_alternative<QueryStatement>(*statement));
+
+    const auto plan = std::get<QueryStatement>(*statement).plan;
+    const auto selectionOperators = getOperatorByType<SelectionLogicalOperator>(plan);
+    ASSERT_EQ(selectionOperators.size(), 1);
+
+    const auto predicate = selectionOperators.front()->getPredicate().explain(ExplainVerbosity::Short);
+    EXPECT_EQ(predicate, "B > -0.5 AND B < 0.5");
+}
+
+TEST_F(StatementBinderTest, BindQueryWithPositiveTypedFloatLiteralInWherePredicate)
+{
+    const std::string queryString = "SELECT a FROM inputStream WHERE b < FLOAT64(+0.5) INTO outputStream";
+    const auto statement = binder->parseAndBindSingle(queryString);
+    ASSERT_TRUE(statement.has_value());
+    ASSERT_TRUE(std::holds_alternative<QueryStatement>(*statement));
+
+    const auto plan = std::get<QueryStatement>(*statement).plan;
+    const auto selectionOperators = getOperatorByType<SelectionLogicalOperator>(plan);
+    ASSERT_EQ(selectionOperators.size(), 1);
+
+    const auto predicate = selectionOperators.front()->getPredicate().explain(ExplainVerbosity::Short);
+    EXPECT_EQ(predicate, "B < 0.5");
+}
+
+TEST_F(StatementBinderTest, BindQueryWithDoubleNegativeTypedFloatLiteralInWherePredicate)
+{
+    const std::string queryString = "SELECT a FROM inputStream WHERE b < FLOAT64(- -0.5) INTO outputStream";
+    const auto statement = binder->parseAndBindSingle(queryString);
+    ASSERT_TRUE(statement.has_value());
+    ASSERT_TRUE(std::holds_alternative<QueryStatement>(*statement));
+
+    const auto plan = std::get<QueryStatement>(*statement).plan;
+    const auto selectionOperators = getOperatorByType<SelectionLogicalOperator>(plan);
+    ASSERT_EQ(selectionOperators.size(), 1);
+
+    const auto predicate = selectionOperators.front()->getPredicate().explain(ExplainVerbosity::Short);
+    EXPECT_EQ(predicate, "B < 0.5");
+}
+
+TEST_F(StatementBinderTest, BindQueryWithUnaryMinusOnFieldInWherePredicate)
+{
+    const std::string queryString = "SELECT a FROM inputStream WHERE -b < FLOAT64(0.5) INTO outputStream";
+    const auto statement = binder->parseAndBindSingle(queryString);
+    ASSERT_TRUE(statement.has_value());
+    ASSERT_TRUE(std::holds_alternative<QueryStatement>(*statement));
+
+    const auto plan = std::get<QueryStatement>(*statement).plan;
+    const auto selectionOperators = getOperatorByType<SelectionLogicalOperator>(plan);
+    ASSERT_EQ(selectionOperators.size(), 1);
+
+    const auto predicate = selectionOperators.front()->getPredicate().explain(ExplainVerbosity::Short);
+    EXPECT_EQ(predicate, "-1 * B < 0.5");
 }
 
 TEST_F(StatementBinderTest, Nullable)

--- a/nes-systests/bug/NegativeFloatLiteralInWherePredicate.test
+++ b/nes-systests/bug/NegativeFloatLiteralInWherePredicate.test
@@ -1,0 +1,39 @@
+# name: bug/NegativeFloatLiteralInWherePredicate.test
+# description: Reproduces the misparsing of negative typed literals in WHERE predicates during query registration
+# groups: [Bug, Selection, Parser]
+
+CREATE LOGICAL SOURCE stream(doublee FLOAT64 NOT NULL);
+CREATE PHYSICAL SOURCE FOR stream TYPE File;
+ATTACH INLINE
+-1.0
+-0.25
+0.25
+1.0
+
+CREATE SINK sinkStream(stream.doublee FLOAT64 NOT NULL) TYPE File;
+
+SELECT *
+FROM stream
+WHERE doublee > FLOAT64(-0.5) AND doublee < FLOAT64(0.5)
+INTO sinkStream;
+----
+-0.25
+0.25
+
+CREATE LOGICAL SOURCE intStream(value INT64 NOT NULL);
+CREATE PHYSICAL SOURCE FOR intStream TYPE File;
+ATTACH INLINE
+-2
+-1
+0
+1
+
+CREATE SINK sinkIntStream(intStream.value INT64 NOT NULL) TYPE File;
+
+SELECT *
+FROM intStream
+WHERE value > INT64(-2) AND value < INT64(1)
+INTO sinkIntStream;
+----
+-1
+0


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This pull request fixes incorrect parsing of negative typed float literals in `WHERE` predicates, such as `FLOAT64(-0.5)`. Previously, unary minus could bind to the wrong expression during logical plan construction, which led to malformed predicates or query compilation failures. See the [corresponding issue](https://github.com/nebulastream/nebulastream/issues/1585) for further details about the bug.

The change list is as follows:

- Fixed unary minus handling in the SQL parser so negative constant literals remain attached to the literal instead of being rewritten against an unrelated expression.
- Changed unary negation fallback handling to use a signed constant instead of `UINT64(-1)`.
- Added parser-level regression coverage for negative typed float literals in `WHERE` predicates.
- Added a system-level regression test that validates the correct end-to-end behavior for `FLOAT64(-0.5)` in a predicate.


## Verifying this change
This change is tested by:
- Added a parser regression test in `StatementBinderTest` that verifies the predicate is parsed as `B > -0.5 AND B < 0.5`
- Added a systest `bug/NegativeFloatLiteralInWherePredicate.test` that validates correct query results for a negative typed float literal in a `WHERE` clause


## What components does this pull request potentially affect?
- SQL Parser
- Logical plan construction
- QueryCompiler
- System-level tests
- Parser/unit test coverage


## Documentation
- The change is reflected in the necessary documentation, e.g., design document, in-code documentation.
- All necessary methods (no getter, setter, or constructor) have a documentation.

## Issue Closed by this pull request:

This PR closes #1585, closes #1572 
