### PR TITLE
fix(build): fix Docker BUILD_TYPE arg scoping

### DIFF
--- a/docker/frontend/cli.dockerfile
+++ b/docker/frontend/cli.dockerfile
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1
 ARG TAG=latest
-ARG BUILD_TYPE=RelWithDebInfo
 ARG RUNTIME_TAG=${TAG}
 FROM nebulastream/nes-development:${TAG} AS build
+ARG BUILD_TYPE=RelWithDebInfo
 
 USER root
 ADD . /home/ubuntu/src

--- a/docker/frontend/repl-embedded.dockerfile
+++ b/docker/frontend/repl-embedded.dockerfile
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1
 ARG TAG=latest
-ARG BUILD_TYPE=RelWithDebInfo
 ARG RUNTIME_TAG=${TAG}
 FROM nebulastream/nes-development:${TAG} AS build
+ARG BUILD_TYPE=RelWithDebInfo
 
 USER root
 ADD . /home/ubuntu/src

--- a/docker/frontend/repl.dockerfile
+++ b/docker/frontend/repl.dockerfile
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1
 ARG TAG=latest
-ARG BUILD_TYPE=RelWithDebInfo
 ARG RUNTIME_TAG=${TAG}
 FROM nebulastream/nes-development:${TAG} AS build
+ARG BUILD_TYPE=RelWithDebInfo
 
 USER root
 ADD . /home/ubuntu/src

--- a/docker/single-node-worker/SingleNodeWorker.dockerfile
+++ b/docker/single-node-worker/SingleNodeWorker.dockerfile
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1
 ARG TAG=latest
-ARG BUILD_TYPE=RelWithDebInfo
 ARG RUNTIME_TAG=${TAG}
 FROM nebulastream/nes-development:${TAG} AS build
+ARG BUILD_TYPE=RelWithDebInfo
 
 USER root
 ADD . /home/ubuntu/src


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

Previously, in the dockerfiles of frontend and single-node-worker, `BUILD_TYPE` was declared before `FROM`. However, Docker build args declared before `FROM` are not available in later stages unless re-declared. This was leading to, for example, still producing `RelWithDebInfo` configuration from cached build layer even when `BUILD_TYPE=Benchmark` was set.

This pull request fixes Docker build argument scoping for the frontend and single-node-worker images so that `BUILD_TYPE` is applied correctly during CMake configuration.


## Verifying this change
This change is tested by
- Verifying that the affected Dockerfiles now declare `BUILD_TYPE` inside the build stage before the `cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE}` invocation.
- Manual validation can be done by rebuilding the images with an explicit `BUILD_TYPE` such as `Benchmark` and checking that CMake configures the expected build type.