### PR TITLE
fix(Aggregation): Skip NULL inputs in MIN/MAX/SUM/AVG/MEDIAN

### DIFF
--- a/docs/technical/null_handling.md
+++ b/docs/technical/null_handling.md
@@ -247,10 +247,12 @@ SELECT * FROM left INNER JOIN right ON (id = id2) WINDOW TUMBLING(ts, size 1 sec
 
 #### SUM, AVG, MIN, MAX, MEDIAN
 
-If **any input value is NULL**, the aggregation result is **NULL**.
+NULL inputs are **skipped**. The aggregate is only `NULL` when **every** input in the window is `NULL`; otherwise the aggregation is computed over the non-null inputs alone (SQL-standard behavior).
 
 ```sql
--- Source: ts=0 value=0 | ts=20 value=3 | ts=50 value=1 | ts=100 value=2 | ts=150 value=NULL
+-- Source: ts=0 value=0 | ts=20 value=3 | ts=50 value=1
+--         ts=100 value=2 | ts=150 value=NULL
+--         ts=300 value=NULL | ts=350 value=NULL
 
 SELECT SUM(value), MAX(value), MIN(value), AVG(value), MEDIAN(value)
 FROM stream WINDOW TUMBLING(ts, size 100 ms);
@@ -259,16 +261,12 @@ FROM stream WINDOW TUMBLING(ts, size 100 ms);
 | Window      | SUM  | MAX  | MIN  | AVG  | MEDIAN |
 |-------------|------|------|------|------|--------|
 | [0, 100)    | 4    | 3    | 0    | 1.33 | 1      |
-| [100, 200)  | NULL | NULL | NULL | NULL | NULL   |
+| [100, 200)  | 2    | 2    | 2    | 2.0  | 2.0    |
+| [300, 400)  | NULL | NULL | NULL | NULL | NULL   |
 
-Window [0, 100) contains only non-null values (0, 3, 1), so aggregations work normally.
-Window [100, 200) contains value=2 and value=NULL — the presence of NULL makes the result NULL.
-
-To aggregate only over non-null values, pre-filter with `NOT ISNULL()`:
-
-```sql
-SELECT SUM(value) FROM stream WHERE NOT ISNULL(value) WINDOW TUMBLING(ts, size 100 ms);
-```
+- Window `[0, 100)` contains only non-null values `{0, 3, 1}`.
+- Window `[100, 200)` contains `{2, NULL}`. The `NULL` is skipped and the aggregations are computed over `{2}`.
+- Window `[300, 400)` contains only `NULL` values, so every aggregation returns `NULL`.
 
 #### COUNT
 
@@ -294,7 +292,9 @@ FROM stream GROUP BY id WINDOW TUMBLING(ts, size 1 sec);
 NULL keys form **their own group** — all rows with a NULL key are aggregated together.
 
 ```sql
--- Source: (ts=0, id=NULL, value=NULL), (ts=10, id=NULL, value=1), (ts=20, id=1, value=2), (ts=40, id=3, value=NULL)
+-- Source: (ts=0, id=NULL, value=NULL), (ts=10, id=NULL, value=1),
+--         (ts=20, id=1, value=2),     (ts=30, id=1, value=3),
+--         (ts=40, id=3, value=NULL),  (ts=50, id=3, value=NULL)
 
 SELECT id, SUM(value), COUNT(value), COUNT(ts)
 FROM stream GROUP BY id WINDOW TUMBLING(ts, size 1 sec);
@@ -302,9 +302,12 @@ FROM stream GROUP BY id WINDOW TUMBLING(ts, size 1 sec);
 
 | id   | SUM  | COUNT(value) | COUNT(ts) |
 |------|------|-------------|-----------|
-| NULL | NULL | 1           | 2         |
+| NULL | 1    | 1           | 2         |
 | 1    | 5    | 2           | 2         |
 | 3    | NULL | 0           | 2         |
+
+The `id=NULL` group has values `{NULL, 1}` — `SUM` skips the `NULL` and returns `1`.
+The `id=3` group has values `{NULL, NULL}` — `SUM` returns `NULL` because every input was `NULL`.
 
 ### ISNULL Function
 
@@ -333,7 +336,7 @@ SELECT ISNULL(CONCAT(a, b)) FROM stream;       -- true if the concat result is N
 | `NOT` | NULL → NULL | Yes, if operand nullable |
 | `CONCAT` | Either operand NULL → NULL | Yes, if any operand nullable |
 | `ISNULL(x)` | Returns TRUE/FALSE | **Always NOT NULL** |
-| `SUM`, `AVG`, `MIN`, `MAX`, `MEDIAN` | Any NULL input → NULL result | Yes, if input nullable |
+| `SUM`, `AVG`, `MIN`, `MAX`, `MEDIAN` | Skips NULLs; result is NULL only if **every** input is NULL | Yes, if input nullable |
 | `COUNT(field)` | Skips NULLs | **Always NOT NULL** |
 | Filter (WHERE) | NULL predicate → row excluded | N/A |
 | Projection | Pass-through | Preserves nullability |

--- a/nes-physical-operators/src/Aggregation/Function/AvgAggregationPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Aggregation/Function/AvgAggregationPhysicalFunction.cpp
@@ -53,32 +53,34 @@ void AvgAggregationPhysicalFunction::lift(
     const auto value = inputFunction.execute(record, pipelineMemoryProvider.arena);
     if (inputType.nullable)
     {
-        /// If the value is null and we do not include null values, we need to set the multiplication factor to 0
-        const auto multiplicationFactor
-            = nautilus::select(not includeNullValues and value.isNull(), nautilus::val<int8_t>{0}, nautilus::val<int8_t>{1});
+        /// SQL-standard: AVG always skips NULL inputs from both the running sum and count.
+        const auto multiplicationFactor = nautilus::select(value.isNull(), nautilus::val<int8_t>{0}, nautilus::val<int8_t>{1});
 
-        /// Reading old sum and count from the aggregation state. The sum is stored at the beginning of the aggregation state and the count is stored after the sum
+        /// Reading old sum and count from the aggregation state. The sum is stored at the beginning of the aggregation state and the count is stored after the sum.
         const auto memAreaSum = static_cast<nautilus::val<int8_t*>>(aggregationState + nautilus::val<uint64_t>{1});
         const auto memAreaCount = memAreaSum + nautilus::val<uint64_t>(resultType.getSizeInBytesWithoutNull());
         const auto isNull = readNull(aggregationState);
-        const auto sum = VarVal::readVarValFromMemory(memAreaSum, resultType, isNull);
+        const auto sum = VarVal::readVarValFromMemory(memAreaSum, resultType, nautilus::val<bool>(false));
         const auto count = VarVal::readNonNullableVarValFromMemory(memAreaCount, countType);
 
-        /// Updating the sum and count with the new value
-        const auto newSum = (sum + (value * multiplicationFactor)).castToType(resultType.type);
+        /// Updating the sum and count: skip NULL inputs entirely
+        const auto sumPlusValue = (sum + value).castToType(resultType.type);
+        const auto newSum = VarVal::select(value.isNull(), sum, sumPlusValue);
         const auto newCount = count + multiplicationFactor;
 
-        /// Writing the new isNull, sum, and count back to the aggregation state
+        /// Writing the new sum and count back to the aggregation state
         newSum.writeToMemory(memAreaSum);
         newCount.writeToMemory(memAreaCount);
-        storeNull(aggregationState, newSum.isNull());
+
+        /// Stay null only while every input has been NULL
+        storeNull(aggregationState, isNull and value.isNull());
     }
     else
     {
         /// Reading old sum and count from the aggregation state. The sum is stored at the beginning of the aggregation state and the count is stored after the sum
         const auto memAreaSum = static_cast<nautilus::val<int8_t*>>(aggregationState);
         const auto memAreaCount = memAreaSum + nautilus::val<uint64_t>(resultType.getSizeInBytesWithoutNull());
-        const auto sum = VarVal::readNonNullableVarValFromMemory(memAreaSum, resultType);
+        const auto sum = VarVal::readVarValFromMemory(memAreaSum, resultType, nautilus::val<bool>(false));
         const auto count = VarVal::readNonNullableVarValFromMemory(memAreaCount, countType);
 
         /// Updating the sum and count with the new value
@@ -102,14 +104,14 @@ void AvgAggregationPhysicalFunction::combine(
         const auto memAreaSum1 = static_cast<nautilus::val<int8_t*>>(aggregationState1 + nautilus::val<uint64_t>{1});
         const auto memAreaCount1 = memAreaSum1 + nautilus::val<uint64_t>(resultType.getSizeInBytesWithoutNull());
         const auto isNull1 = readNull(aggregationState1);
-        const auto sum1 = VarVal::readVarValFromMemory(memAreaSum1, resultType, isNull1);
+        const auto sum1 = VarVal::readVarValFromMemory(memAreaSum1, resultType, nautilus::val<bool>(false));
         const auto count1 = VarVal::readNonNullableVarValFromMemory(memAreaCount1, countType);
 
         /// Reading the sum and count from the second aggregation state
         const auto memAreaSum2 = static_cast<nautilus::val<int8_t*>>(aggregationState2 + nautilus::val<uint64_t>{1});
         const auto memAreaCount2 = memAreaSum2 + nautilus::val<uint64_t>(resultType.getSizeInBytesWithoutNull());
         const auto isNull2 = readNull(aggregationState2);
-        const auto sum2 = VarVal::readVarValFromMemory(memAreaSum2, resultType, isNull2);
+        const auto sum2 = VarVal::readVarValFromMemory(memAreaSum2, resultType, nautilus::val<bool>(false));
         const auto count2 = VarVal::readNonNullableVarValFromMemory(memAreaCount2, countType);
 
         /// Combining the sum and count
@@ -119,7 +121,9 @@ void AvgAggregationPhysicalFunction::combine(
         /// Writing the new sum, count and null back to the first aggregation state
         newSum.writeToMemory(memAreaSum1);
         newCount.writeToMemory(memAreaCount1);
-        storeNull(aggregationState1, newSum.isNull());
+
+        /// SQL-standard: only stay null when both partitions are still empty
+        storeNull(aggregationState1, isNull1 and isNull2);
     }
     else
     {
@@ -149,11 +153,19 @@ Record AvgAggregationPhysicalFunction::lower(const nautilus::val<AggregationStat
 {
     if (inputType.nullable)
     {
+        /// If no non-null value was observed the running count is zero. Short-circuit to NULL to avoid a divide-by-zero
+        /// and to honour SQL-standard semantics for AVG over an empty (or all-NULL) input set.
+        const auto isNull = readNull(aggregationState);
+        if (isNull)
+        {
+            const VarVal nullResult{nautilus::val<uint64_t>(0), true, nautilus::val<bool>(true)};
+            return Record({{resultFieldIdentifier, nullResult.castToType(resultType.type)}});
+        }
+
         /// Reading the sum and count from the aggregation state
         const auto memAreaSum = static_cast<nautilus::val<int8_t*>>(aggregationState + nautilus::val<uint64_t>{1});
         const auto memAreaCount = memAreaSum + nautilus::val<uint64_t>(resultType.getSizeInBytesWithoutNull());
-        const auto isNull = readNull(aggregationState);
-        const auto sum = VarVal::readVarValFromMemory(memAreaSum, resultType, isNull);
+        const auto sum = VarVal::readVarValFromMemory(memAreaSum, resultType, nautilus::val<bool>(false));
         const auto count = VarVal::readNonNullableVarValFromMemory(memAreaCount, countType);
 
         /// Calculating the average and returning a record with the result
@@ -177,6 +189,12 @@ void AvgAggregationPhysicalFunction::reset(const nautilus::val<AggregationState*
     /// Resetting the isNull, sum, and count to 0
     const auto memArea = static_cast<nautilus::val<int8_t*>>(aggregationState);
     nautilus::memset(memArea, 0, getSizeOfStateInBytes());
+
+    /// Initialize the null flag to "no value seen yet"; it flips to false on the first non-null input
+    if (inputType.nullable)
+    {
+        storeNull(aggregationState, true);
+    }
 }
 
 void AvgAggregationPhysicalFunction::cleanup(nautilus::val<AggregationState*>)
@@ -188,7 +206,7 @@ size_t AvgAggregationPhysicalFunction::getSizeOfStateInBytes() const
     /// Size of isNull + size of the sum value (accumulated in resultType) + size of the count value
     const auto sumSize = resultType.getSizeInBytesWithoutNull();
     const auto countTypeSize = countType.getSizeInBytesWithoutNull();
-    return (inputType.nullable and includeNullValues ? sizeof(bool) : 0) + sumSize + countTypeSize;
+    return (inputType.nullable ? sizeof(bool) : 0) + sumSize + countTypeSize;
 }
 
 AggregationPhysicalFunctionRegistryReturnType AggregationPhysicalFunctionGeneratedRegistrar::RegisterAvgAggregationPhysicalFunction(

--- a/nes-physical-operators/src/Aggregation/Function/CountAggregationPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Aggregation/Function/CountAggregationPhysicalFunction.cpp
@@ -107,7 +107,7 @@ void CountAggregationPhysicalFunction::cleanup(nautilus::val<AggregationState*>)
 
 size_t CountAggregationPhysicalFunction::getSizeOfStateInBytes() const
 {
-    return resultType.getSizeInBytesWithNull();
+    return resultType.getSizeInBytesWithoutNull();
 }
 
 AggregationPhysicalFunctionRegistryReturnType AggregationPhysicalFunctionGeneratedRegistrar::RegisterCountAggregationPhysicalFunction(

--- a/nes-physical-operators/src/Aggregation/Function/MaxAggregationPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Aggregation/Function/MaxAggregationPhysicalFunction.cpp
@@ -61,13 +61,14 @@ void MaxAggregationPhysicalFunction::lift(
         const auto memAreaMax = static_cast<nautilus::val<int8_t*>>(aggregationState + nautilus::val<uint64_t>{1});
         const auto max = VarVal::readVarValFromMemory(memAreaMax, inputType, isNull);
 
-        /// If value is null or max is smaller than value --> keep the current max
-        const auto valueOrMax = VarVal::select(value.isNull(), max, value);
-        const auto newMax = VarVal::select((valueOrMax > max).getRawValueAs<nautilus::val<bool>>(), valueOrMax, max);
+        /// SQL-standard: skip NULL inputs
+        const auto valueIsNotNull = not value.isNull();
+        const auto adoptValue = valueIsNotNull and (isNull or (value > max).getRawValueAs<nautilus::val<bool>>());
+        const auto newMax = VarVal::select(adoptValue, value, max);
         newMax.writeToMemory(memAreaMax);
 
-        /// Updating the null value
-        const auto newIsNull = isNull or value.isNull();
+        /// Stay null only while every input has been NULL
+        const auto newIsNull = isNull and value.isNull();
         storeNull(aggregationState, newIsNull);
     }
 }
@@ -99,13 +100,13 @@ void MaxAggregationPhysicalFunction::combine(
         const auto max1 = VarVal::readVarValFromMemory(memAreaMax1, inputType, isNull1);
         const auto max2 = VarVal::readVarValFromMemory(memAreaMax2, inputType, isNull2);
 
-        /// Updating the null value
-        const auto newIsNull = isNull1 or isNull2;
+        /// SQL-standard: only stay null when both partitions are still empty
+        const auto newIsNull = isNull1 and isNull2;
         storeNull(aggregationState1, newIsNull);
 
-        /// If max1 or max2 is null, the result is null. Otherwise, it is the maximum of max1 and max2
+        /// If state1 is empty take max2, if state2 is empty take max1, otherwise take the pairwise max
         const auto max1OrMax2 = VarVal::select((max1 > max2).getRawValueAs<nautilus::val<bool>>(), max1, max2);
-        const auto newMax = VarVal::select(newIsNull, max1, max1OrMax2);
+        const auto newMax = VarVal::select(isNull1, max2, VarVal::select(isNull2, max1, max1OrMax2));
         newMax.writeToMemory(memAreaMax1);
     }
 }
@@ -137,10 +138,10 @@ Record MaxAggregationPhysicalFunction::lower(const nautilus::val<AggregationStat
 
 void MaxAggregationPhysicalFunction::reset(const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&)
 {
-    /// Resetting the null value
+    /// Initialize the null flag to "no value seen yet" so the first non-null input becomes the running max
     if (inputType.nullable)
     {
-        storeNull(aggregationState, false);
+        storeNull(aggregationState, true);
     }
 
     /// Resetting the max value to the minimum value

--- a/nes-physical-operators/src/Aggregation/Function/MedianAggregationPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Aggregation/Function/MedianAggregationPhysicalFunction.cpp
@@ -57,20 +57,27 @@ void MedianAggregationPhysicalFunction::lift(
     const nautilus::val<AggregationState*>& aggregationState, PipelineMemoryProvider& pipelineMemoryProvider, const Record& record)
 {
     const auto value = inputFunction.execute(record, pipelineMemoryProvider.arena);
-    auto memArea = static_cast<nautilus::val<int8_t*>>(aggregationState);
     if (inputType.nullable)
     {
-        /// Reading the current null value and combining it with the one of the record
-        const auto oldContainsNull = readNull(aggregationState);
-        storeNull(aggregationState, value.isNull() or oldContainsNull);
+        /// SQL-standard: NULL inputs are not part of the median set, so skip writing them. Flip the null flag to
+        /// false the first time we see a non-null value.
+        if (not value.isNull())
+        {
+            storeNull(aggregationState, false);
 
-        /// Skipping the first byte (null)
-        memArea += nautilus::val<uint64_t>{1};
+            /// Skipping the first byte (null); the paged vector lives right after it.
+            const auto memArea = static_cast<nautilus::val<int8_t*>>(aggregationState) + nautilus::val<uint64_t>{1};
+            PagedVectorRef pagedVectorRef(BorrowedNautilusBuffer::from(memArea), tupleLayout);
+            pagedVectorRef.pushBack(record, pipelineMemoryProvider.bufferProvider);
+        }
     }
-
-    /// Adding the record to the paged vector. We are storing the full record in the paged vector for now.
-    PagedVectorRef pagedVectorRef(BorrowedNautilusBuffer::from(memArea), tupleLayout);
-    pagedVectorRef.pushBack(record, pipelineMemoryProvider.bufferProvider);
+    else
+    {
+        /// Adding the record to the paged vector. We are storing the full record in the paged vector for now.
+        const auto memArea = static_cast<nautilus::val<int8_t*>>(aggregationState);
+        PagedVectorRef pagedVectorRef(BorrowedNautilusBuffer::from(memArea), tupleLayout);
+        pagedVectorRef.pushBack(record, pipelineMemoryProvider.bufferProvider);
+    }
 }
 
 void MedianAggregationPhysicalFunction::combine(
@@ -84,11 +91,10 @@ void MedianAggregationPhysicalFunction::combine(
 
     if (inputType.nullable)
     {
-        /// Combining the null values
+        /// SQL-standard: only stay null when both partitions are still empty (no non-null value seen on either side)
         const auto containsNull1 = readNull(aggregationState1);
         const auto containsNull2 = readNull(aggregationState2);
-        const auto newContainsNull = containsNull1 or containsNull2;
-        storeNull(aggregationState1, newContainsNull);
+        storeNull(aggregationState1, containsNull1 and containsNull2);
 
         /// Skipping the first byte (null)
         memArea1 += nautilus::val<uint64_t>{1};
@@ -111,7 +117,8 @@ void MedianAggregationPhysicalFunction::combine(
 Record MedianAggregationPhysicalFunction::lower(
     const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider& pipelineMemoryProvider)
 {
-    /// If it contains null values, we simply return a null value
+    /// SQL-standard: if no non-null value was observed, the null flag is still set and the paged vector is empty,
+    /// so we return NULL. The early skip below also guards the numberOfEntries > 0 invariant.
     auto containsNull = nautilus::val<bool>{false};
     if (inputType.nullable)
     {
@@ -237,8 +244,8 @@ void MedianAggregationPhysicalFunction::reset(
 
     if (inputType.nullable)
     {
-        const auto memArea = static_cast<nautilus::val<int8_t*>>(aggregationState);
-        nautilus::memset(memArea, 0, 1);
+        /// Initialize the null flag to "no value seen yet" so all-NULL windows correctly emit NULL
+        storeNull(aggregationState, true);
     }
 }
 

--- a/nes-physical-operators/src/Aggregation/Function/MinAggregationPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Aggregation/Function/MinAggregationPhysicalFunction.cpp
@@ -61,13 +61,14 @@ void MinAggregationPhysicalFunction::lift(
         const auto memAreaMin = static_cast<nautilus::val<int8_t*>>(aggregationState + nautilus::val<uint64_t>{1});
         const auto min = VarVal::readVarValFromMemory(memAreaMin, inputType, isNull);
 
-        /// If value is null or min is smaller than value --> keep the current min
-        const auto valueOrMin = VarVal::select(value.isNull(), min, value);
-        const auto newMin = VarVal::select((valueOrMin < min).getRawValueAs<nautilus::val<bool>>(), valueOrMin, min);
+        /// SQL-standard: skip NULL inputs
+        const auto valueIsNotNull = not value.isNull();
+        const auto adoptValue = valueIsNotNull and (isNull or (value < min).getRawValueAs<nautilus::val<bool>>());
+        const auto newMin = VarVal::select(adoptValue, value, min);
         newMin.writeToMemory(memAreaMin);
 
-        /// Updating the null value
-        const auto newIsNull = isNull or value.isNull();
+        /// Stay null only while every input has been NULL
+        const auto newIsNull = isNull and value.isNull();
         storeNull(aggregationState, newIsNull);
     }
 }
@@ -99,13 +100,13 @@ void MinAggregationPhysicalFunction::combine(
         const auto min1 = VarVal::readVarValFromMemory(memAreaMin1, inputType, isNull1);
         const auto min2 = VarVal::readVarValFromMemory(memAreaMin2, inputType, isNull2);
 
-        /// Updating the null value
-        const auto newIsNull = isNull1 or isNull2;
+        /// SQL-standard: only stay null when both partitions are still empty
+        const auto newIsNull = isNull1 and isNull2;
         storeNull(aggregationState1, newIsNull);
 
-        /// If min1 or min2 is null, the result is null. Otherwise, it is the minimum of min1 and min2
+        /// If state1 is empty take min2; if state2 is empty take min1; otherwise take the pairwise min
         const auto min1OrMin2 = VarVal::select((min1 < min2).getRawValueAs<nautilus::val<bool>>(), min1, min2);
-        const auto newMin = VarVal::select(newIsNull, min1, min1OrMin2);
+        const auto newMin = VarVal::select(isNull1, min2, VarVal::select(isNull2, min1, min1OrMin2));
         newMin.writeToMemory(memAreaMin1);
     }
 }
@@ -137,10 +138,10 @@ Record MinAggregationPhysicalFunction::lower(const nautilus::val<AggregationStat
 
 void MinAggregationPhysicalFunction::reset(const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&)
 {
-    /// Resetting the null value
+    /// Initialize the null flag to "no value seen yet" so the first non-null input becomes the running min
     if (inputType.nullable)
     {
-        storeNull(aggregationState, false);
+        storeNull(aggregationState, true);
     }
 
     /// Resetting the min value to the maximum value

--- a/nes-physical-operators/src/Aggregation/Function/SumAggregationPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Aggregation/Function/SumAggregationPhysicalFunction.cpp
@@ -27,6 +27,7 @@
 #include <AggregationPhysicalFunctionRegistry.hpp>
 #include <ExecutionContext.hpp>
 #include <val_arith.hpp>
+#include <val_bool.hpp>
 #include <val_concepts.hpp>
 #include <val_ptr.hpp>
 
@@ -45,15 +46,16 @@ void SumAggregationPhysicalFunction::lift(
     const auto value = inputFunction.execute(record, pipelineMemoryProvider.arena);
     if (inputType.nullable)
     {
-        /// If the value is null and we do not include null values, we need to set the multiplication factor to 0
+        /// SQL-standard: skip NULL inputs
         const auto memAreaSum = static_cast<nautilus::val<int8_t*>>(aggregationState + nautilus::val<uint64_t>{1});
-        const auto isNull = readNull(aggregationState) or value.isNull();
-        const auto sum = VarVal::readVarValFromMemory(memAreaSum, inputType, isNull);
-
-        /// If value is null, we keep the old value. Otherwise, we add the value to the sum.
-        const auto newSum = VarVal::select(isNull, sum, (sum + value).castToType(inputType.type));
+        const auto isNull = readNull(aggregationState);
+        const auto sum = VarVal::readVarValFromMemory(memAreaSum, inputType, nautilus::val<bool>(false));
+        const auto sumPlusValue = (sum + value).castToType(inputType.type);
+        const auto newSum = VarVal::select(value.isNull(), sum, sumPlusValue);
         newSum.writeToMemory(memAreaSum);
-        storeNull(aggregationState, isNull);
+
+        /// Stay null only while every input has been NULL
+        storeNull(aggregationState, isNull and value.isNull());
     }
     else
     {
@@ -77,19 +79,19 @@ void SumAggregationPhysicalFunction::combine(
         /// Reading the sum from the first aggregation state
         const auto memAreaSum1 = static_cast<nautilus::val<int8_t*>>(aggregationState1 + nautilus::val<uint64_t>{1});
         const auto isNull1 = readNull(aggregationState1);
-        const auto sum1 = VarVal::readVarValFromMemory(memAreaSum1, inputType, isNull1);
+        const auto sum1 = VarVal::readVarValFromMemory(memAreaSum1, inputType, nautilus::val<bool>(false));
 
         /// Reading the sum from the second aggregation state
         const auto memAreaSum2 = static_cast<nautilus::val<int8_t*>>(aggregationState2 + nautilus::val<uint64_t>{1});
         const auto isNull2 = readNull(aggregationState2);
-        const auto sum2 = VarVal::readVarValFromMemory(memAreaSum2, inputType, isNull2);
+        const auto sum2 = VarVal::readVarValFromMemory(memAreaSum2, inputType, nautilus::val<bool>(false));
 
-        /// Combining the sum
+        /// Combining the sum and writing it back to the first aggregation state
         const auto newSum = (sum1 + sum2).castToType(inputType.type);
-
-        /// Writing the new sum and null back to the first aggregation state
         newSum.writeToMemory(memAreaSum1);
-        storeNull(aggregationState1, newSum.isNull());
+
+        /// SQL-standard: only stay null when both partitions are still empty
+        storeNull(aggregationState1, isNull1 and isNull2);
     }
     else
     {
@@ -139,6 +141,12 @@ void SumAggregationPhysicalFunction::reset(const nautilus::val<AggregationState*
     /// Resetting the sum to 0
     const auto memArea = static_cast<nautilus::val<int8_t*>>(aggregationState);
     nautilus::memset(memArea, 0, getSizeOfStateInBytes());
+
+    /// Initialize the null flag to "no value seen yet"; it flips to false on the first non-null input
+    if (inputType.nullable)
+    {
+        storeNull(aggregationState, true);
+    }
 }
 
 void SumAggregationPhysicalFunction::cleanup(nautilus::val<AggregationState*>)

--- a/nes-systests/operator/aggregation/WindowAggregationNull.test
+++ b/nes-systests/operator/aggregation/WindowAggregationNull.test
@@ -41,6 +41,17 @@ ATTACH INLINE
 1,,2004
 1,,3000
 
+CREATE LOGICAL SOURCE stream4(ts UINT64 NOT NULL, value INT32);
+CREATE PHYSICAL SOURCE FOR stream4 TYPE File;
+ATTACH INLINE
+0,
+250,
+500,
+750,
+1000,23
+1250,24
+1500,1
+1750,
 
 CREATE SINK sink0(start UINT64 NOT NULL, end UINT64 NOT NULL, valueSum INT32) TYPE File;
 CREATE SINK sink1(start UINT64 NOT NULL, end UINT64 NOT NULL, valueSum INT32, valueMax INT32, valueMin INT32, valueAvg FLOAT64, valueMedian FLOAT64) TYPE File;
@@ -48,16 +59,16 @@ CREATE SINK sink2(start UINT64 NOT NULL, end UINT64 NOT NULL, id INT32, valueSum
 
 
 # Checking if a sum over a tumbling window works with null values in the value field
-# We expect NULLs to be ignored in value fields for SUM aggregation
+# We expect NULLs to be ignored in value fields for SUM aggregation (SQL standard: NULL only when every input is NULL)
 SELECT start, end, SUM(value) as valueSum
 FROM stream WINDOW TUMBLING(ts, size 100 ms)
 INTO sink0;
 ----
 0,100,4
-100,200,NULL
+100,200,2
 200,300,10
 300,400,9
-500,600,NULL
+500,600,10
 
 
 # Checking if all aggregation function over a sliding window works with null values in the value field
@@ -68,13 +79,13 @@ INTO sink1;
 ----
 0,100,4,3,0,1.333333,1
 50,150,3,2,1,1.5,1.5
-100,200,NULL,NULL,NULL,NULL,NULL
-150,250,NULL,NULL,NULL,NULL,NULL
+100,200,2,2,2,2.0,2.0
+150,250,10,10,10,10.0,10.0
 200,300,10,10,10,10.0,10.0
 300,400,9,4,1,2.25,2.0
 350,450,9,4,1,2.25,2.0
-450,550,NULL,NULL,NULL,NULL,NULL
-500,600,NULL,NULL,NULL,NULL,NULL
+450,550,10,11,-1,5.0,5.0
+500,600,10,11,-1,5.0,5.0
 
 
 # Keyed aggregation with only null values in the key
@@ -91,8 +102,8 @@ GROUP BY id
 WINDOW TUMBLING(ts, size 1 sec)
 INTO sink2;
 ----
-0,1000,NULL,NULL,NULL,NULL,NULL,1,2
-1000,2000,NULL,NULL,NULL,NULL,NULL,1,2
+0,1000,NULL,1,1,1,1.0,1,2
+1000,2000,NULL,4,4,4,4.0,1,2
 
 # Keyed aggregation with and w/o null values in the key
 SELECT start, end, id,
@@ -107,11 +118,11 @@ GROUP BY id
 WINDOW TUMBLING(ts, size 1 sec)
 INTO sink2;
 ----
-0,1000,NULL,NULL,NULL,NULL,NULL,1,2
+0,1000,NULL,1,1,1,1.0,1,2
 0,1000,1,5,2,3,2.5,2,2
 0,1000,3,NULL,NULL,NULL,NULL,0,2
-1000,2000,NULL,NULL,NULL,NULL,NULL,1,2
-1000,2000,1,NULL,NULL,NULL,NULL,1,2
+1000,2000,NULL,4,4,4,4.0,1,2
+1000,2000,1,5,5,5,5.0,1,2
 1000,2000,3,NULL,NULL,NULL,NULL,0,1
 
 SELECT start, end, MAX(value), MIN(value), AVG(value), MEDIAN(value)
@@ -121,3 +132,18 @@ INTO File();
 ----
 2000,3000,NULL,NULL,NULL,NULL
 3000,4000,NULL,NULL,NULL,NULL
+
+
+SELECT start, end,
+       SUM(value) AS valueSum,
+       MIN(value) AS valueMin,
+       MAX(value) AS valueMax,
+       AVG(value) AS valueAvg,
+       MEDIAN(value) AS valueMedian,
+       COUNT(value) AS valueCount,
+       COUNT(*) AS countStarCount
+FROM stream4 WINDOW TUMBLING(ts, size 1 sec)
+INTO File();
+----
+0,1000,NULL,NULL,NULL,NULL,NULL,0,4
+1000,2000,48,1,24,16,23,3,4


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

This PR fixes the aggregation behavior for `NULL` inputs so that `MIN`, `MAX`, `SUM`, `AVG`, and `MEDIAN` skip `NULL` values per the SQL standard.

Closes #1573 . See the issue for full details.

## Verifying this change

Covered by the systests added in this PR.