### PR TITLE
feat(optimizer) barrier rules

### DIFF
--- a/nes-query-optimizer/include/Rules/Barriers/FixedPlanStructureBarrier.hpp
+++ b/nes-query-optimizer/include/Rules/Barriers/FixedPlanStructureBarrier.hpp
@@ -1,0 +1,41 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <set>
+#include <string_view>
+#include <typeindex>
+#include <typeinfo>
+
+#include <Plans/LogicalPlan.hpp>
+#include <Rules/Rule.hpp>
+
+namespace NES
+{
+class FixedPlanStructureBarrier
+{
+public:
+    static constexpr std::string_view NAME = "PlanStructureBarrier";
+
+    [[nodiscard]] static const std::type_info& getType();
+    [[nodiscard]] static std::string_view getName();
+    [[nodiscard]] std::set<std::type_index> dependsOn() const;
+    [[nodiscard]] std::set<std::type_index> requiredBy() const;
+    [[nodiscard]] LogicalPlan apply(LogicalPlan queryPlan) const;
+    bool operator==(const FixedPlanStructureBarrier& other) const;
+};
+
+static_assert(RuleConcept<FixedPlanStructureBarrier, LogicalPlan>);
+}

--- a/nes-query-optimizer/include/Rules/RuleManager.hpp
+++ b/nes-query-optimizer/include/Rules/RuleManager.hpp
@@ -16,11 +16,15 @@
 
 #include <cstddef>
 #include <queue>
+#include <ranges>
 #include <set>
 #include <typeindex>
 #include <unordered_map>
 #include <vector>
+
 #include <Rules/Rule.hpp>
+#include <Util/PlanRenderer.hpp>
+#include <fmt/ranges.h>
 #include <ErrorHandling.hpp>
 
 namespace NES
@@ -33,7 +37,7 @@ namespace NES
  * Rules are registered via addRule(). Each rule may declare dependencies on other rule
  * types through Rule::dependsOn() and Rule::requiredBy(). The RuleManager builds a directed
  * acyclic graph (DAG) from these declarations and performs a topological sort when
- * getSequence() is called.
+ * getSequence() is called. The order of rules that don't depend on each other is nondeterministic.
  *
  * Constraints:
  * - At most one rule per concrete type may be registered.
@@ -124,8 +128,35 @@ public:
         {
             throw InvalidOptimizerRuleset("cycle detected in rule dependencies");
         }
-
         return sequence;
+    }
+
+    [[nodiscard]] std::string explain(ExplainVerbosity verbosity) const
+    {
+        const auto seq = getSequence();
+
+        if (verbosity == ExplainVerbosity::Short)
+        {
+            return fmt::format(
+                "RuleManager({})", fmt::join(seq | std::views::transform([](const auto& rule) { return rule.getName(); }), ", "));
+        }
+
+        std::string out = "RuleManager(\n";
+        for (size_t i = 0; i < seq.size(); ++i)
+        {
+            const auto& rule = seq[i];
+            out += fmt::format(
+                "\t[{}] RULE({}) DEPENDS_ON({}) REQUIRED_BY({})\n",
+                i + 1,
+                rule.getName(),
+                fmt::join(
+                    rule.dependsOn() | std::views::transform([this](std::type_index ruleType) { return rules.at(ruleType).getName(); }),
+                    ", "),
+                fmt::join(
+                    rule.requiredBy() | std::views::transform([this](std::type_index ruleType) { return rules.at(ruleType).getName(); }),
+                    ", "));
+        }
+        return out + ")";
     }
 
 private:

--- a/nes-query-optimizer/src/Phases/RuleBasedOptimizer.cpp
+++ b/nes-query-optimizer/src/Phases/RuleBasedOptimizer.cpp
@@ -16,14 +16,19 @@
 #include <Phases/RuleBasedOptimizer.hpp>
 
 #include <utility>
+
 #include <Plans/LogicalPlan.hpp>
+#include <Rules/Barriers/FixedPlanStructureBarrier.hpp>
 #include <Rules/RuleManager.hpp>
+#include <Rules/Semantic/OriginIdInferenceRule.hpp>
 #include <Rules/Static/DecideFieldMappings.hpp>
 #include <Rules/Static/DecideFieldOrder.hpp>
 #include <Rules/Static/DecideJoinTypesRule.hpp>
 #include <Rules/Static/DecideMemoryLayoutRule.hpp>
 #include <Rules/Static/RedundantProjectionRemovalRule.hpp>
 #include <Rules/Static/RedundantUnionRemovalRule.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <Util/PlanRenderer.hpp>
 #include <QueryOptimizerConfiguration.hpp>
 
 namespace NES
@@ -39,7 +44,10 @@ RuleBasedOptimizer::RuleBasedOptimizer(QueryOptimizerConfiguration defaultQueryO
     ruleManager.addRule(RedundantProjectionRemovalRule{});
     ruleManager.addRule(DecideFieldMappings{});
     ruleManager.addRule(DecideFieldOrder{});
+    ruleManager.addRule(OriginIdInferenceRule{});
+    ruleManager.addRule(FixedPlanStructureBarrier{});
 
+    NES_DEBUG("rule based optimizers rule sequence: {}", ruleManager.explain(ExplainVerbosity::Debug));
     ruleSequence = ruleManager.getSequence();
 }
 

--- a/nes-query-optimizer/src/Phases/SemanticAnalyzer.cpp
+++ b/nes-query-optimizer/src/Phases/SemanticAnalyzer.cpp
@@ -25,9 +25,10 @@
 #include <Rules/Semantic/InlineSinkBindingRule.hpp>
 #include <Rules/Semantic/InlineSourceBindingRule.hpp>
 #include <Rules/Semantic/LogicalSourceExpansionRule.hpp>
-#include <Rules/Semantic/OriginIdInferenceRule.hpp>
 #include <Rules/Semantic/SinkBindingRule.hpp>
 #include <Rules/Semantic/TypeInferenceRule.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <Util/PlanRenderer.hpp>
 
 namespace NES
 {
@@ -45,9 +46,9 @@ SemanticAnalyzer::SemanticAnalyzer(
     ruleManager.addRule(LogicalSourceExpansionRule{this->sourceCatalog});
     ruleManager.addRule(InferModelResolutionRule{this->modelCatalog});
     ruleManager.addRule(TypeInferenceRule{});
-    ruleManager.addRule(OriginIdInferenceRule{});
     ruleManager.addRule(CalcTargetOrderRule{});
 
+    NES_DEBUG("semantic analysers rule sequence: {}", ruleManager.explain(ExplainVerbosity::Debug));
     this->ruleSequence = ruleManager.getSequence();
 }
 

--- a/nes-query-optimizer/src/Rules/Barriers/CMakeLists.txt
+++ b/nes-query-optimizer/src/Rules/Barriers/CMakeLists.txt
@@ -11,10 +11,5 @@
 # limitations under the License.
 
 add_source_files(nes-query-optimizer
-        DecideJoinTypesRule.cpp
-        DecideMemoryLayoutRule.cpp
-        RedundantUnionRemovalRule.cpp
-        RedundantProjectionRemovalRule.cpp
-        DecideFieldMappings.cpp
-        DecideFieldOrder.cpp
-        OriginIdInferenceRule.cpp)
+        FixedPlanStructureBarrier.cpp
+)

--- a/nes-query-optimizer/src/Rules/Barriers/FixedPlanStructureBarrier.cpp
+++ b/nes-query-optimizer/src/Rules/Barriers/FixedPlanStructureBarrier.cpp
@@ -1,0 +1,59 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Rules/Barriers/FixedPlanStructureBarrier.hpp>
+
+#include <set>
+#include <string_view>
+#include <typeindex>
+#include <typeinfo>
+
+#include <Plans/LogicalPlan.hpp>
+
+namespace NES
+{
+
+const std::type_info& FixedPlanStructureBarrier::getType()
+{
+    return typeid(FixedPlanStructureBarrier);
+}
+
+std::string_view FixedPlanStructureBarrier::getName()
+{
+    return NAME;
+}
+
+/// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+std::set<std::type_index> FixedPlanStructureBarrier::dependsOn() const
+{
+    return {};
+}
+
+/// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+std::set<std::type_index> FixedPlanStructureBarrier::requiredBy() const
+{
+    return {};
+}
+
+/// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+LogicalPlan FixedPlanStructureBarrier::apply(LogicalPlan queryPlan) const
+{
+    return queryPlan;
+}
+
+bool FixedPlanStructureBarrier::operator==(const FixedPlanStructureBarrier&) const
+{
+    return true;
+}
+}

--- a/nes-query-optimizer/src/Rules/CMakeLists.txt
+++ b/nes-query-optimizer/src/Rules/CMakeLists.txt
@@ -10,5 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_subdirectory(Barriers)
 add_subdirectory(Semantic)
 add_subdirectory(Static)

--- a/nes-query-optimizer/src/Rules/Semantic/CMakeLists.txt
+++ b/nes-query-optimizer/src/Rules/Semantic/CMakeLists.txt
@@ -14,7 +14,6 @@ add_source_files(nes-query-optimizer
         InlineSinkBindingRule.cpp
         InlineSourceBindingRule.cpp
         LogicalSourceExpansionRule.cpp
-        OriginIdInferenceRule.cpp
         TypeInferenceRule.cpp
         SinkBindingRule.cpp
         InferModelResolutionRule.cpp

--- a/nes-query-optimizer/src/Rules/Semantic/InferModelResolutionRule.cpp
+++ b/nes-query-optimizer/src/Rules/Semantic/InferModelResolutionRule.cpp
@@ -87,7 +87,7 @@ std::set<std::type_index> InferModelResolutionRule::dependsOn() const
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 std::set<std::type_index> InferModelResolutionRule::requiredBy() const
 {
-    return {typeid(TypeInferenceRule), typeid(OriginIdInferenceRule)};
+    return {typeid(TypeInferenceRule)};
 }
 
 bool InferModelResolutionRule::operator==(const InferModelResolutionRule& other) const

--- a/nes-query-optimizer/src/Rules/Static/DecideFieldMappings.cpp
+++ b/nes-query-optimizer/src/Rules/Static/DecideFieldMappings.cpp
@@ -35,6 +35,7 @@
 #include <Operators/Sinks/SinkLogicalOperator.hpp>
 #include <Operators/Sources/SourceDescriptorLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
+#include <Rules/Barriers/FixedPlanStructureBarrier.hpp>
 #include <Schema/Field.hpp>
 #include <Traits/FieldMappingTrait.hpp>
 #include <Traits/TraitSet.hpp>
@@ -228,7 +229,7 @@ std::string_view DecideFieldMappings::getName()
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 std::set<std::type_index> DecideFieldMappings::dependsOn() const
 {
-    return {};
+    return {typeid(FixedPlanStructureBarrier)};
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Static/DecideFieldOrder.cpp
+++ b/nes-query-optimizer/src/Rules/Static/DecideFieldOrder.cpp
@@ -33,6 +33,7 @@
 #include <Operators/Reorderer.hpp>
 #include <Operators/Sinks/SinkLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
+#include <Rules/Barriers/FixedPlanStructureBarrier.hpp>
 #include <Schema/Binder.hpp>
 #include <Schema/Field.hpp>
 #include <Traits/FieldOrderingTrait.hpp>
@@ -139,7 +140,7 @@ std::string_view DecideFieldOrder::getName()
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 std::set<std::type_index> DecideFieldOrder::dependsOn() const
 {
-    return {};
+    return {typeid(FixedPlanStructureBarrier)};
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Static/DecideJoinTypesRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/DecideJoinTypesRule.cpp
@@ -31,6 +31,7 @@
 #include <Operators/LogicalOperator.hpp>
 #include <Operators/Windows/JoinLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
+#include <Rules/Barriers/FixedPlanStructureBarrier.hpp>
 #include <Traits/JoinImplementationTypeTrait.hpp>
 #include <Traits/Trait.hpp>
 #include <Traits/TraitSet.hpp>
@@ -96,7 +97,7 @@ std::string_view DecideJoinTypesRule::getName()
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 std::set<std::type_index> DecideJoinTypesRule::dependsOn() const
 {
-    return {};
+    return {typeid(FixedPlanStructureBarrier)};
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Static/DecideMemoryLayoutRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/DecideMemoryLayoutRule.cpp
@@ -22,6 +22,7 @@
 #include <Interface/BufferRef/LowerSchemaProvider.hpp>
 #include <Operators/LogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
+#include <Rules/Barriers/FixedPlanStructureBarrier.hpp>
 #include <Rules/Static/DecideJoinTypesRule.hpp>
 #include <Rules/Static/RedundantUnionRemovalRule.hpp>
 #include <Traits/MemoryLayoutTypeTrait.hpp>
@@ -44,7 +45,7 @@ std::string_view DecideMemoryLayoutRule::getName()
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 std::set<std::type_index> DecideMemoryLayoutRule::dependsOn() const
 {
-    return {typeid(DecideJoinTypesRule), typeid(RedundantUnionRemovalRule)};
+    return {typeid(FixedPlanStructureBarrier)};
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Static/OriginIdInferenceRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/OriginIdInferenceRule.cpp
@@ -30,6 +30,7 @@
 #include <Operators/OriginIdAssigner.hpp>
 #include <Operators/Sources/SourceDescriptorLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
+#include <Rules/Barriers/FixedPlanStructureBarrier.hpp>
 #include <Rules/Semantic/InlineSourceBindingRule.hpp>
 #include <Rules/Semantic/LogicalSourceExpansionRule.hpp>
 #include <Traits/OutputOriginIdsTrait.hpp>
@@ -89,7 +90,7 @@ std::string_view OriginIdInferenceRule::getName()
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 std::set<std::type_index> OriginIdInferenceRule::dependsOn() const
 {
-    return {typeid(InlineSourceBindingRule), typeid(LogicalSourceExpansionRule)};
+    return {typeid(FixedPlanStructureBarrier)};
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Static/RedundantProjectionRemovalRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/RedundantProjectionRemovalRule.cpp
@@ -22,11 +22,13 @@
 #include <utility>
 #include <vector>
 
+
 #include <Functions/FieldAccessLogicalFunction.hpp>
 #include <Operators/LogicalOperator.hpp>
 #include <Operators/LogicalOperatorFwd.hpp>
 #include <Operators/ProjectionLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
+#include <Rules/Barriers/FixedPlanStructureBarrier.hpp>
 #include <Rules/Static/DecideFieldMappings.hpp>
 #include <Rules/Static/DecideFieldOrder.hpp>
 #include <Schema/Binder.hpp>
@@ -54,7 +56,7 @@ std::set<std::type_index> RedundantProjectionRemovalRule::dependsOn() const
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 std::set<std::type_index> RedundantProjectionRemovalRule::requiredBy() const
 {
-    return {typeid(DecideFieldMappings), typeid(DecideFieldOrder)};
+    return {typeid(FixedPlanStructureBarrier)};
 }
 
 bool RedundantProjectionRemovalRule::operator==(const RedundantProjectionRemovalRule&) const

--- a/nes-query-optimizer/src/Rules/Static/RedundantUnionRemovalRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/RedundantUnionRemovalRule.cpp
@@ -21,10 +21,12 @@
 #include <typeinfo>
 #include <utility>
 #include <vector>
+
 #include <Operators/LogicalOperator.hpp>
 #include <Operators/LogicalOperatorFwd.hpp>
 #include <Operators/UnionLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
+#include <Rules/Barriers/FixedPlanStructureBarrier.hpp>
 #include <Rules/Static/DecideFieldMappings.hpp>
 #include <Rules/Static/DecideFieldOrder.hpp>
 
@@ -52,7 +54,7 @@ std::set<std::type_index> RedundantUnionRemovalRule::dependsOn() const
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 std::set<std::type_index> RedundantUnionRemovalRule::requiredBy() const
 {
-    return {typeid(DecideFieldMappings), typeid(DecideFieldOrder)};
+    return {typeid(FixedPlanStructureBarrier)};
 }
 
 bool RedundantUnionRemovalRule::operator==(const RedundantUnionRemovalRule&) const

--- a/nes-query-optimizer/tests/Rules/RuleManagerTest.cpp
+++ b/nes-query-optimizer/tests/Rules/RuleManagerTest.cpp
@@ -21,6 +21,7 @@
 #include <typeinfo>
 #include <vector>
 #include <Rules/Rule.hpp>
+#include <Util/PlanRenderer.hpp>
 #include <gtest/gtest.h>
 
 namespace NES
@@ -155,6 +156,26 @@ TEST_F(RuleManagerTest, FailureOnSequencingWithMissingRule)
     manager.addRule(AvailableRule3{});
 
     ASSERT_ANY_THROW({ auto sequence = manager.getSequence(); });
+}
+
+TEST_F(RuleManagerTest, Explain)
+{
+    RuleManager<std::nullptr_t> manager;
+
+    manager.addRule(ThirdTestRule{});
+    manager.addRule(FourthTestRule{});
+    manager.addRule(FirstTestRule{});
+    manager.addRule(SecondTestRule{});
+
+    ASSERT_EQ(manager.explain(ExplainVerbosity::Short), "RuleManager(FirstTestRule, SecondTestRule, ThirdTestRule, FourthTestRule)");
+    ASSERT_EQ(
+        manager.explain(ExplainVerbosity::Debug),
+        "RuleManager(\n"
+        "\t[1] RULE(FirstTestRule) DEPENDS_ON() REQUIRED_BY()\n"
+        "\t[2] RULE(SecondTestRule) DEPENDS_ON(FirstTestRule) REQUIRED_BY()\n"
+        "\t[3] RULE(ThirdTestRule) DEPENDS_ON(FirstTestRule, SecondTestRule) REQUIRED_BY(FourthTestRule)\n"
+        "\t[4] RULE(FourthTestRule) DEPENDS_ON(SecondTestRule) REQUIRED_BY()\n"
+        ")");
 }
 
 


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

This PR adds the concept of barrier rules in the logical optimizer.
Their aim is to not implement any optimizations themselves, but to make the dependencies between rules easier to depict.  

To make this behavior easier to debug, the function `RuleManager::explain()` was also added.


## Verifying this change
* All existing tests continue to run 

## What components does this pull request potentially affect?
* optimizer


## Issue Closed by this pull request:

This PR closes #1583 
