### PR TITLE
feat(memory): prefill buffer pool with marker in debug builds

### DIFF
--- a/nes-memory/BufferManager.cpp
+++ b/nes-memory/BufferManager.cpp
@@ -14,7 +14,9 @@
 #include <Runtime/BufferManager.hpp>
 
 #include <algorithm>
+#include <array>
 #include <atomic>
+#include <bit>
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
@@ -139,6 +141,13 @@ void BufferManager::initialize(uint32_t withAlignment)
     const size_t offsetBetweenBuffers = allocatedAreaSize;
     allocatedAreaSize *= numOfBuffers;
     basePointer = static_cast<uint8_t*>(memoryResource->allocate(allocatedAreaSize, withAlignment));
+
+#ifndef NDEBUG
+    constexpr std::array marker{'N', 'E', 'B', 'U', 'S', 'T', 'R', 'M'};
+    /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): basePointer is freshly allocated raw storage aligned to >= alignof(uint64_t).
+    std::fill_n(reinterpret_cast<uint64_t*>(basePointer), allocatedAreaSize / sizeof(uint64_t), std::bit_cast<uint64_t>(marker));
+#endif
+
     NES_TRACE(
         "Allocated {} bytes with alignment {} buffer size {} num buffer {} controlBlockSize {} {}",
         allocatedAreaSize,

--- a/nes-memory/include/Runtime/BufferManager.hpp
+++ b/nes-memory/include/Runtime/BufferManager.hpp
@@ -50,6 +50,11 @@ namespace NES
  * Unpooled buffers are either allocated on the spot or served via a previously allocated, unpooled buffer that has
  * been returned to the BufferManager by some component.
  *
+ * Debug-only marker fill: in debug builds the pooled memory area is prefilled with the ASCII pattern "NEBUSTRM"
+ * (repeated). This turns code paths that rely on freshly-allocated buffers being zeroed into visible bugs
+ * (e.g. a sink that forgets to trim by the formatted byte count will emit "NEBUSTRM..." trailing garbage
+ * instead of silently passing thanks to an implicit zero terminator). When debugging a buffer-handling
+ * issue, grep dumps/logs for "NEBUSTRM" or 0x4D5254535542454E to spot reads of uninitialized buffer memory.
  */
 class BufferManager final : public std::enable_shared_from_this<BufferManager>, public BufferRecycler, public AbstractBufferProvider
 {


### PR DESCRIPTION
## Summary
In debug builds, prefill the buffer pool's freshly-allocated storage
with the repeating ASCII marker `NEBUSTRM` (as `uint64_t`) right after
`memoryResource->allocate`. Reads from uninitialized regions of a
tuple buffer now show up as an obvious recognizable pattern in dumps
and test output, instead of whatever bytes the allocator happened to
hand back.

Guarded by `#ifndef NDEBUG` — zero cost in release.

## Test plan
- [ ] Debug build: a deliberately uninitialized read returns the marker
- [ ] Release build: no change in BufferManager init behavior

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 6 in a stack** made with GitButler:
- <kbd>&nbsp;6&nbsp;</kbd> #1605 
- <kbd>&nbsp;5&nbsp;</kbd> #1604 
- <kbd>&nbsp;4&nbsp;</kbd> #1603 
- <kbd>&nbsp;3&nbsp;</kbd> #1602 
- <kbd>&nbsp;2&nbsp;</kbd> #1601 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #1600 
<!-- GitButler Footer Boundary Bottom -->

