### PR TITLE
fix(sources): generator emits tuples larger than one buffer

### DIFF
--- a/nes-plugins/Sources/GeneratorSource/GeneratorSource.cpp
+++ b/nes-plugins/Sources/GeneratorSource/GeneratorSource.cpp
@@ -72,6 +72,7 @@ void GeneratorSource::open(std::shared_ptr<AbstractBufferProvider>)
 {
     this->generatorStartTime = std::chrono::system_clock::now();
     this->startOfInterval = std::chrono::system_clock::now();
+    this->tuplesStream.str("");
     NES_TRACE("Opening GeneratorSource.");
 }
 
@@ -88,8 +89,14 @@ void GeneratorSource::close()
     }
 }
 
-Source::FillTupleBufferResult GeneratorSource::fillTupleBuffer(TupleBuffer& tupleBuffer, const std::stop_token& stopToken)
+Source::FillTupleBufferResult GeneratorSource::fillTupleBuffer(TupleBuffer& tupleBuffer, const std::stop_token&)
 {
+    /// the generator indicated that it will not produce anymore data and the tupleStream is empty.
+    if (this->generator.shouldStop() && tuplesStream.tellp() == 0)
+    {
+        return FillTupleBufferResult::eos();
+    }
+
     try
     {
         const auto elapsedTime
@@ -116,46 +123,31 @@ Source::FillTupleBufferResult GeneratorSource::fillTupleBuffer(TupleBuffer& tupl
             }
         }
 
-        /// Generating the required number of tuples. Any tuples that do not fit into the tuple buffer, we add to the orphanTuples and emit
-        /// a warning. Also, we first add the orphanTuples to the tuple buffer, before adding newly-created once.
-        const size_t rawTBSize = tupleBuffer.getBufferSize();
+        auto currentBuffer = tupleBuffer.getAvailableMemoryArea<std::ostream::char_type>();
+        /// Generating the required number of tuples. Any tuples that do not fit into the tuple buffer, the content is persisted in the tupleStream.
         uint64_t curTupleCount = 0;
         size_t writtenBytes = 0;
         while (curTupleCount < numberOfTuplesToGenerate)
         {
-            if (this->generator.shouldStop() || stopToken.stop_requested())
+            const size_t bytesRead = tuplesStream.readsome(currentBuffer.data(), static_cast<std::streamsize>(currentBuffer.size()));
+            writtenBytes += bytesRead;
+            currentBuffer = currentBuffer.subspan(bytesRead);
+            if (currentBuffer.empty())
             {
                 break;
             }
 
-            auto insertedBytes = tuplesStream.tellp();
-            if (not orphanTuples.empty())
+            tuplesStream.str("");
+            if (this->generator.shouldStop())
             {
-                tuplesStream << orphanTuples;
-                orphanTuples.clear();
+                break;
             }
             this->generator.generateTuple(tuplesStream);
-            ++generatedTuplesCounter;
-            insertedBytes = tuplesStream.tellp() - insertedBytes;
-            if (writtenBytes + insertedBytes > rawTBSize)
-            {
-                this->orphanTuples = tuplesStream.str().substr(writtenBytes, tuplesStream.str().length() - writtenBytes);
-                NES_WARNING("Not all required tuples fit into buffer of size {}. {} are left over", rawTBSize, tuplesStream.str().size());
-                break;
-            }
-            writtenBytes += insertedBytes;
             ++curTupleCount;
+            tuplesStream.seekg(0, std::ios::beg);
         }
 
-        if (curTupleCount == 0 || stopToken.stop_requested())
-        {
-            return FillTupleBufferResult::eos();
-        }
-
-        tuplesStream.read(tupleBuffer.getAvailableMemoryArea<std::istream::char_type>().data(), writtenBytes);
         ++generatedBuffers;
-        tuplesStream.str("");
-        NES_TRACE("Wrote {} bytes", writtenBytes);
 
         /// Calculating how long to sleep. The whole method should take the duration of the flushInterval. If we have some time left, we
         /// sleep for the remaining duration. If there is no time left, we print a warning.

--- a/nes-plugins/Sources/GeneratorSource/GeneratorSource.hpp
+++ b/nes-plugins/Sources/GeneratorSource/GeneratorSource.hpp
@@ -79,9 +79,6 @@ private:
     std::chrono::time_point<std::chrono::system_clock> startOfInterval;
     std::chrono::milliseconds flushInterval;
     std::unique_ptr<GeneratorRate> generatorRate;
-
-    /// if inserting a set of generated tuples into the buffer would overflow it, this string saves them so it can be inserted into the next buffer
-    std::string orphanTuples;
 };
 
 struct ConfigParametersGenerator

--- a/nes-systests/sources/Generator.test
+++ b/nes-systests/sources/Generator.test
@@ -170,3 +170,35 @@ INTO generator_sink_text;
 17,yellow,X
 18,brown,bl5
 19,yellow,IgiKX
+
+# Testing tuple generation larger than one buffer
+CREATE LOGICAL SOURCE generator_large_text(id UINT64 NOT NULL, text VARSIZED NOT NULL);
+CREATE PHYSICAL SOURCE FOR generator_large_text TYPE GENERATOR SET(
+    'ONE' as `SOURCE`.STOP_GENERATOR_WHEN_SEQUENCE_FINISHES,
+    1 as `SOURCE`.SEED,
+    'SEQUENCE UINT64 0 20 1, RANDOMSTR 8192 8192' AS `SOURCE`.GENERATOR_SCHEMA
+);
+CREATE SINK generator_sink_text_with_size(generator_large_text.id UINT64 NOT NULL, length UINT64 NOT NULL) TYPE File;
+SELECT id, OCTET_LENGTH(text) as length FROM generator_large_text
+INTO generator_sink_text_with_size;
+----
+0,8192
+1,8192
+2,8192
+3,8192
+4,8192
+5,8192
+6,8192
+7,8192
+8,8192
+9,8192
+10,8192
+11,8192
+12,8192
+13,8192
+14,8192
+15,8192
+16,8192
+17,8192
+18,8192
+19,8192


### PR DESCRIPTION
## Summary
The `GeneratorSource` could not emit tuples whose serialized form was
larger than a single tuple buffer. The old code kept leftover bytes in
an `orphanTuples` string and tried to re-prepend them on the next
`fillTupleBuffer` call, but a tuple that was *itself* bigger than the
buffer hit the "doesn't fit" path every iteration and the source
produced no output.

This rewrites the spill mechanism to use the existing `tuplesStream`
(`std::stringstream`) as the persistent buffer:

- `generateTuple` writes one tuple at a time into the stream.
- `fillTupleBuffer` drains as many bytes as fit via `readsome`,
  advancing through the available memory area.
- When the stream is empty and the generator has more to give, the
  next tuple is generated. Otherwise the partial buffer is returned.
- EOS is reported only when the generator has signaled stop *and*
  the spill stream is drained — so the final partial buffer is no
  longer dropped.

Removes the `orphanTuples` member and the byte-accounting logic that
went with it.

## What changed
- `nes-plugins/Sources/GeneratorSource/GeneratorSource.{cpp,hpp}` —
  rewrite the fill loop, drop `orphanTuples`, reset spill stream on
  `open`.
- `nes-systests/sources/Generator.test` — new case using
  `RANDOMSTR 4096` and `OCTET_LENGTH` to assert every row arrives at
  the configured length.

## Test plan
- [ ] `ctest -R Generator` passes
- [ ] New 4096-byte RANDOMSTR case emits all 20 rows with length 4096
- [ ] Existing small-tuple Generator tests still pass

> Depends on #1602 (`OCTET_LENGTH`) for the new systest case.

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 6 in a stack** made with GitButler:
- <kbd>&nbsp;6&nbsp;</kbd> #1605 
- <kbd>&nbsp;5&nbsp;</kbd> #1604 
- <kbd>&nbsp;4&nbsp;</kbd> #1603 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #1602 
- <kbd>&nbsp;2&nbsp;</kbd> #1601 
- <kbd>&nbsp;1&nbsp;</kbd> #1600 
<!-- GitButler Footer Boundary Bottom -->

