### PR TITLE
feat(cli): accept optional `nullable` flag on YAML schema fields

### DIFF
--- a/nes-frontend/apps/cli/CLIStarter.cpp
+++ b/nes-frontend/apps/cli/CLIStarter.cpp
@@ -333,9 +333,12 @@ struct convert<NES::CLI::SchemaField>
 {
     static bool decode(const Node& node, NES::CLI::SchemaField& rhs)
     {
-        acceptKeys({"name", "type"}, node);
+        acceptKeys({"name", "type", "nullable"}, node);
         rhs.name = bindIdentifierName(getValue<std::string>(node, "name"));
+
+        const bool nullable = getOrDefault<bool>(node, "nullable", false);
         rhs.type = stringToFieldType(getValue<std::string>(node, "type"));
+        rhs.type.nullable = nullable;
         return true;
     }
 };

--- a/nes-frontend/apps/cli/tests/bad/invalid_nullable_value.yaml
+++ b/nes-frontend/apps/cli/tests/bad/invalid_nullable_value.yaml
@@ -1,0 +1,46 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# `nullable` must be a boolean. A non-bool value should be rejected.
+query: |
+  SELECT * FROM stream INTO sink
+sinks:
+  - name: sink
+    host: worker-1:8080
+    schema:
+      - name: stream$value
+        type: UINT64
+    type: Void
+logical:
+  - name: stream
+    schema:
+      - name: value
+        type: UINT64
+        nullable: maybe
+physical:
+  - logical: stream
+    host: worker-1:8080
+    parser_config:
+      type: CSV
+      field_delimiter: ","
+    type: Generator
+    source_config:
+      generator_rate_type: FIXED
+      generator_rate_config: emit_rate 10
+      stop_generator_when_sequence_finishes: ONE
+      seed: 1
+      generator_schema: |
+        SEQUENCE UINT64 0 100 1
+workers:
+  - host: worker-1:8080
+    data_address: worker-1:9090
+    max_operators: 10000

--- a/nes-frontend/apps/cli/tests/good/nullable-schema.yaml
+++ b/nes-frontend/apps/cli/tests/good/nullable-schema.yaml
@@ -1,0 +1,71 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Exercises the optional `nullable` flag on schema fields.
+# - `id`        omits `nullable` (must default to false / NOT_NULLABLE)
+# - `value`     explicitly sets `nullable: true`
+# - `label`     explicitly sets `nullable: false`
+
+query: |
+  SELECT
+    *
+  FROM
+    GENERATOR_SOURCE
+  INTO
+    VOID_SINK
+sinks:
+  - name: VOID_SINK
+    host: worker-1:8080
+    schema:
+      - name: GENERATOR_SOURCE$id
+        type: UINT64
+      - name: GENERATOR_SOURCE$value
+        type: FLOAT64
+        nullable: true
+      - name: GENERATOR_SOURCE$label
+        type: UINT64
+        nullable: false
+    type: Void
+
+logical:
+  - name: GENERATOR_SOURCE
+    schema:
+      - name: id
+        type: UINT64
+      - name: value
+        type: FLOAT64
+        nullable: true
+      - name: label
+        type: UINT64
+        nullable: false
+
+physical:
+  - logical: GENERATOR_SOURCE
+    host: worker-1:8080
+    parser_config:
+      type: CSV
+      field_delimiter: ","
+    type: Generator
+    source_config:
+      generator_rate_type: FIXED
+      generator_rate_config: emit_rate 10
+      stop_generator_when_sequence_finishes: NONE
+      seed: 1
+      generator_schema: |
+        SEQUENCE UINT64 0 100 1
+        NORMAL_DISTRIBUTION FLOAT64 0 1
+        SEQUENCE UINT64 0 5 1
+
+workers:
+  - host: worker-1:8080
+    data_address: worker-1:9090
+    max_operators: 10000

--- a/nes-frontend/apps/cli/tests/offline.bats
+++ b/nes-frontend/apps/cli/tests/offline.bats
@@ -494,3 +494,30 @@ bad_topology() {
   [[ "$output" == *"only-digit names are reserved"* ]]
 }
 
+# --- Nullable schema field tests ---
+# Schema fields accept an optional `nullable: <bool>` flag (defaults to false).
+# These tests pin: (1) `true`/`false`/omitted all parse, (2) the schema-field
+# keyset includes `nullable` so it's not rejected as unknown, (3) a non-bool
+# value is rejected with the right error.
+
+@test "nullable: dump succeeds with mixed nullable schema fields" {
+  run $NES_CLI -t tests/good/nullable-schema.yaml dump
+  [ "$status" -eq 0 ]
+}
+
+@test "nullable: appears in the schema-field accepted-keys list" {
+  # Trip the unknown-key check by adding a bogus sibling of `nullable`. The
+  # error message lists the accepted keys, which must now include `nullable`.
+  local f=$(bad_topology '/^logical:/,/^[a-z]/s/        type: FLOAT64/        type: FLOAT64\n        bogus_key: true/')
+  run $NES_CLI -d -t "$f" dump
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Unknown key 'bogus_key'"* ]]
+  [[ "$output" == *"name, type, nullable"* ]]
+}
+
+@test "nullable: non-bool value is rejected" {
+  run $NES_CLI -d -t tests/bad/invalid_nullable_value.yaml dump
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Invalid value for 'nullable'"* ]]
+}
+


### PR DESCRIPTION
## Summary
- Schema fields in the topology YAML now accept an optional `nullable: <bool>` key (default `false`) that is propagated to the resulting `DataType`.
- `acceptKeys` for `SchemaField` was extended to include `nullable`, so unknown-key errors continue to fire for everything else.
- Added offline.bats coverage: happy-path dump, accepted-keys list, non-bool rejection. Fixture: `tests/good/nullable-schema.yaml`; negative case: `tests/bad/invalid_nullable_value.yaml`.

## Test plan
- [x] `cmake --build cmake-build-debug --target nes-cli -j`
- [x] `bats nes-frontend/apps/cli/tests/offline.bats --filter nullable` (3 tests pass)
- [ ] Full `offline.bats` run in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)