### PR TITLE
fix(CI): enable sccache daemon and propagate build errors

### DIFF
--- a/.github/steps/run-in-container/action.yml
+++ b/.github/steps/run-in-container/action.yml
@@ -39,4 +39,4 @@ runs:
              -e SCCACHE_BUCKET -e SCCACHE_ENDPOINT -e SCCACHE_REGION -e SCCACHE_S3_USE_SSL \
              -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY \
              ${{inputs.image_name}} \
-              /usr/bin/bash -c "${DOCKER_LOGIN_CMD}"'${{inputs.run}}'
+              /usr/bin/bash -e -c "${DOCKER_LOGIN_CMD}"'${{inputs.run}}'

--- a/.github/steps/setup-sccache/action.yml
+++ b/.github/steps/setup-sccache/action.yml
@@ -59,7 +59,6 @@ runs:
             echo "SCCACHE_S3_USE_SSL=true"
             echo "AWS_ACCESS_KEY_ID=$IN_ACCESS_KEY"
             echo "AWS_SECRET_ACCESS_KEY=$IN_SECRET_KEY"
-            echo "SCCACHE_NO_DAEMON=1"
           } >> "$GITHUB_ENV"
         else
           # Pick a cache dir. Default to a stable path under RUNNER_TEMP so it
@@ -75,6 +74,5 @@ runs:
           {
             echo "SCCACHE_DIR=$LOCAL_DIR"
             echo "SCCACHE_CACHE_SIZE=$IN_LOCAL_SIZE"
-            echo "SCCACHE_NO_DAEMON=1"
           } >> "$GITHUB_ENV"
         fi


### PR DESCRIPTION
## Summary
- Drop `SCCACHE_NO_DAEMON=1` in `setup-sccache` so sccache runs as a daemon during the build. Without the daemon, each compile spawned its own in-process sccache (fresh S3 client + TLS handshake, no retry), and under high ninja parallelism this raced and produced intermittent "Timed out waiting for server startup" failures (e.g. run [25999260485 / job 76419712107](https://github.com/nebulastream/nebulastream/actions/runs/25999260485/job/76419712107)).
- Pass `-e` to the in-container `bash` in `run-in-container` so a failed `cmake --build` actually fails the step instead of being masked by the trailing `sccache --show-stats` / `sccache --stop-server` commands. In the linked run, ninja stopped at [16/575] but the step reported success — only ctest surfaced the breakage as 50 `_NOT_BUILT` tests and 3 missing-binary failures.

The original "run without daemon so sccache works across docker run boundaries" rationale doesn't apply: each CI job runs a single `cmake --build` inside a single container, so the daemon's lifetime already matches the build's. Inter-container sharing was never going to work anyway.

## Test plan
- [ ] CI on this branch is green (especially `x64 libstdcxx RelWithDebInfo thread`, which flaked previously)
- [ ] sccache stats in the build log show >1 compile request — confirms the daemon is actually receiving work
- [ ] Build wall time on a cache-hot job is no worse than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)