### PR TITLE
docs(Frontend): use correct field_delimiter key in CSV examples

### DIFF
--- a/docs/nebulastream-frontend.md
+++ b/docs/nebulastream-frontend.md
@@ -340,7 +340,7 @@ physical:
     host: worker-1:8080
     parser_config:
       type: CSV
-      fieldDelimiter: ","
+      field_delimiter: ","
     type: Generator
     source_config:
       generator_rate_type: FIXED
@@ -385,7 +385,7 @@ physical:
     host: worker-1:8080
     parser_config:
       type: CSV
-      fieldDelimiter: ","
+      field_delimiter: ","
     type: Generator
     source_config:
       generator_rate_type: FIXED
@@ -427,7 +427,7 @@ physical:
     host: worker-1:8080
     parser_config:
       type: CSV
-      fieldDelimiter: ","
+      field_delimiter: ","
     type: Generator
     source_config:
       generator_rate_type: FIXED
@@ -476,7 +476,7 @@ physical:
     host: worker-1:8080 # source located at worker-1
     parser_config:
       type: CSV
-      fieldDelimiter: ","
+      field_delimiter: ","
     type: Generator
     source_config:
       generator_rate_type: FIXED
@@ -603,7 +603,7 @@ physical:
     host: worker-1:8080
     parser_config:
       type: CSV
-      fieldDelimiter: ","
+      field_delimiter: ","
     type: generator
     source_config:
       generator_schema: NORMAL_DISTRIBUTION FLOAT64 0 1,NORMAL_DISTRIBUTION FLOAT64 0 1,NORMAL_DISTRIBUTION FLOAT64 0 1,NORMAL_DISTRIBUTION FLOAT64 0 1,


### PR DESCRIPTION
## Summary
- Fix five CSV `parser_config` examples in `docs/nebulastream-frontend.md` that used `fieldDelimiter` (camelCase) instead of the accepted `field_delimiter` (snake_case).
- The YAML parser rejects unknown keys, so the docs as-is would fail config validation; the snake_case form matches the working fixtures under `nes-frontend/apps/cli/tests/good/`.

## Test plan
- [ ] Skim the rendered doc to confirm the YAML still reads naturally.
- [ ] (Optional) Run one of the example configs through the CLI to confirm it loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)