### PR TITLE
fix(CI): fix nightly clang-tidy job

### DIFF
--- a/nes-logical-operators/src/Plans/LogicalPlan.cpp
+++ b/nes-logical-operators/src/Plans/LogicalPlan.cpp
@@ -79,7 +79,7 @@ LogicalPlan& LogicalPlan::operator=(const LogicalPlan& other)
 }
 
 LogicalPlan::LogicalPlan(LogicalPlan&& other) noexcept
-    : queryId(other.queryId), rootOperators(std::move(other.rootOperators)), originalSql(std::move(other.originalSql))
+    : queryId(std::move(other.queryId)), rootOperators(std::move(other.rootOperators)), originalSql(std::move(other.originalSql))
 {
 }
 


### PR DESCRIPTION
## Summary
The nightly clang-tidy run on `main` (e.g. [run 26322603899](https://github.com/nebulastream/nebulastream/actions/runs/26322603899/job/77494386900)) fails on a single `error`.

The offending check is `performance-move-constructor-init` on `LogicalPlan`'s move constructor at `nes-logical-operators/src/Plans/LogicalPlan.cpp:82`: `queryId` was being copy-initialized from `other.queryId` instead of moved, while the rest of the members were already `std::move`d.

Fix: wrap `other.queryId` in `std::move(...)` so the move ctor uses `QueryId`'s move constructor.

## Test plan
- [ ] Nightly clang-tidy job passes (or at least no longer fails on this diagnostic).