### PR TITLE
ci(sccache): bump startup/idle timeouts and add pre-build heartbeat

### DIFF
--- a/.github/steps/run-in-container/action.yml
+++ b/.github/steps/run-in-container/action.yml
@@ -37,6 +37,7 @@ runs:
              $DOCKER_LOGIN_ARGS \
              -v $(pwd):$(pwd) -e HOME=$(pwd) --workdir $(pwd) -u $(id -u):$(id -g) \
              -e SCCACHE_BUCKET -e SCCACHE_ENDPOINT -e SCCACHE_REGION -e SCCACHE_S3_USE_SSL \
+             -e SCCACHE_STARTUP_TIMEOUT -e SCCACHE_IDLE_TIMEOUT \
              -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY \
              ${{inputs.image_name}} \
               /usr/bin/bash -e -c "${DOCKER_LOGIN_CMD}"'${{inputs.run}}'

--- a/.github/steps/setup-sccache/action.yml
+++ b/.github/steps/setup-sccache/action.yml
@@ -49,6 +49,16 @@ runs:
       run: |
         set -euo pipefail
 
+        # Defaults raised over sccache's built-ins: the S3 handshake can take
+        # longer than the 10s startup default under ninja's parallel launch,
+        # which manifests as "Timed out waiting for server startup" on the
+        # first compile. Idle timeout is bumped so the daemon survives the
+        # CMake configure + Rust crate compile gap before ninja kicks off.
+        {
+          echo "SCCACHE_STARTUP_TIMEOUT=60"
+          echo "SCCACHE_IDLE_TIMEOUT=1800"
+        } >> "$GITHUB_ENV"
+
         # Decide mode: remote requires all four S3 inputs to be non-empty.
         if [[ -n "$IN_BUCKET" && -n "$IN_ENDPOINT" && -n "$IN_ACCESS_KEY" && -n "$IN_SECRET_KEY" ]]; then
           echo "::notice::sccache configured for remote S3 cache (bucket=$IN_BUCKET)"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -70,8 +70,11 @@ jobs:
           run: |
             source .github/.env/test-${{ matrix.sanitizer }}.env
             echo "=== sccache config before build ==="
+            sccache --start-server
             sccache --show-stats
             cmake -GNinja -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_flags }}
+            echo "=== sccache heartbeat before cmake --build ==="
+            sccache --show-stats
             cmake --build build -j -- -k 0
             echo "=== sccache stats after build ==="
             sccache --show-stats

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -69,6 +69,7 @@ jobs:
         run: |
           source .github/.env/test-${{matrix.sanitizer}}.env
           echo "=== sccache config before build ==="
+          sccache --start-server
           sccache --show-stats
           cmake --build build -j ${{steps.number-of-jobs.outputs.number_of_jobs}}  -- -k 0
           echo "=== sccache stats after build ==="


### PR DESCRIPTION
## Summary
`sccache: error: Timed out waiting for server startup` failure seen on
nightlies (e.g. [job 77494395140](https://github.com/nebulastream/nebulastream/actions/runs/26322603899/job/77494395140)).

Two changes:

- Export `SCCACHE_STARTUP_TIMEOUT=60` (default 10 s) and `SCCACHE_IDLE_TIMEOUT=1800` from `setup-sccache`, and forward them into the build container via `run-in-container`. The startup bump gives the S3-backed daemon room to come up under ninja's parallel launch; the idle bump keeps the daemon alive across the CMake configure + Rust crate compile gap.
- Make the daemon start explicit (`sccache --start-server` before `--show-stats`) and add a `sccache --show-stats` heartbeat right before `cmake --build`, so a future failure log tells us whether the daemon was still up at the moment ninja took over.


## Test plan
- [ ] CI builds pass on this branch (sccache step shows the daemon alive at heartbeat).
- [ ] No regression on local-cache (fork-PR) mode.