### PR TITLE
Populate nix cache from base branch and minor improvements

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,6 +38,16 @@ jobs:
     with:
       head_sha: ${{ needs.fetch-current-main-commit.outputs.sha }}
 
+  nix-build:
+    name: "Run Nix Build"
+    needs: [ fetch-current-main-commit ]
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/nix-build.yml
+    with:
+      head_sha: ${{ needs.fetch-current-main-commit.outputs.sha }}
+
   full-clang-tidy:
     needs: [ fetch-current-main-commit, get-dev-images ]
     uses: ./.github/workflows/clang_tidy_full.yml

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -27,6 +27,9 @@ jobs:
 
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-flakehub: false
+          use-gha-cache: true
 
       - name: Configure via devShell
         run: |

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -8,6 +8,10 @@ on:
         required: true
         description: "ref of the branch"
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   nix-build:
     name: "Nix Build"
@@ -22,9 +26,7 @@ jobs:
           submodules: recursive
 
       - uses: DeterminateSystems/nix-installer-action@main
-
-      - name: Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
+      - uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: Configure via devShell
         run: |

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -7,6 +7,12 @@ on:
         type: string
         required: true
         description: "ref of the branch"
+  workflow_dispatch:
+    inputs:
+      head_sha:
+        type: string
+        required: false
+        description: "ref of the branch"
 
 permissions:
   contents: read
@@ -21,7 +27,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.head_sha }}
+          ref: ${{ inputs.head_sha || github.sha }}
           fetch-depth: 0
           submodules: recursive
 


### PR DESCRIPTION
Gh caches seem to be isolated on the PR ref level:
> Caches are isolated by branch/tag scope. A workflow can restore caches from the current branch and the default branch; PR workflows can also restore caches from the PR’s base branch. But they cannot restore caches from sibling branches. For PR-triggered runs, caches are created under the merge ref refs/pull/.../merge, and those caches “can only be restored by re-runs of the pull request”; they cannot be restored by the base branch or by other PRs targeting that base branch.

https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching

Thus, we did not reuse nix caches. But cache reuse from main / the base branch is possible. With this PR add to the nightly run the nix build on main such that reuse is possible.

Unfortunately, there is no way to test it without merging the new nightly job.