### PR TITLE
fix(build): keep sccache safe under -march=native, and exercise Benchmark in PR CI

### DIFF
--- a/.github/ci/pr_matrix.yaml
+++ b/.github/ci/pr_matrix.yaml
@@ -89,7 +89,7 @@ jobs:
   - name: "{arch} {stdlib} {build_type} (unit+systest+docker)"
     arch: [x64, arm64]
     stdlib: [libcxx, libstdcxx]
-    build_type: [RelWithDebInfo, Release]
+    build_type: [RelWithDebInfo, Release, Benchmark]
     sanitizer: none
     runner: github-{arch}
     tests: [unit, systest, docker]

--- a/cmake/UseCompilerCache.cmake
+++ b/cmake/UseCompilerCache.cmake
@@ -21,13 +21,67 @@ endif ()
 find_program(SCCACHE_EXECUTABLE sccache)
 find_program(CCACHE_EXECUTABLE ccache)
 
+# When NES_BUILD_NATIVE is on, `-march=native` resolves per-host. A shared compiler cache
+# keys on the literal command line and would otherwise hand back an object built for a
+# richer ISA than the consumer has → SIGILL at runtime. Ask the clang driver what cc1
+# target-cpu + target-feature flags it would actually pass for `-march=native` on this
+# host, hash them, and feed the hash into the cache key via each compiler cache's
+# documented "factor data into hash" knob:
+#   sccache: SCCACHE_C_CUSTOM_CACHE_BUSTER (string value, README "Separating caches")
+#   ccache:  CCACHE_EXTRAFILES              (file path, ccache.dev manual `extra_files_to_hash`)
+# Delivered through a `cmake -E env` launcher prefix so CMAKE_CXX_FLAGS stays clean.
+set(_NES_CACHE_ENV_PREFIX "")
+if (NES_BUILD_NATIVE)
+    execute_process(
+            COMMAND "${CMAKE_CXX_COMPILER}" -march=native "-###" -x c -c /dev/null
+            OUTPUT_QUIET
+            ERROR_VARIABLE _clang_driver_dump
+            RESULT_VARIABLE _probe_rc)
+    set(_target_facts "")
+    if (_probe_rc EQUAL 0)
+        # Clang `-###` prints the cc1 invocation with each arg quoted, e.g.
+        #   "-target-cpu" "skylake-avx512" "-target-feature" "+avx2" ...
+        string(REGEX MATCHALL "\"-target-cpu\" \"[^\"]+\"" _cpu_args "${_clang_driver_dump}")
+        string(REGEX MATCHALL "\"-target-feature\" \"[^\"]+\"" _feat_args "${_clang_driver_dump}")
+        foreach (_arg IN LISTS _cpu_args _feat_args)
+            string(REGEX REPLACE "\"(-target-(cpu|feature))\" \"([^\"]+)\"" "\\1=\\3" _arg "${_arg}")
+            list(APPEND _target_facts "${_arg}")
+        endforeach ()
+        list(SORT _target_facts)
+    endif ()
+    if (_target_facts)
+        string(REPLACE ";" "\n" _target_facts_text "${_target_facts}")
+        set(_NES_CPU_FINGERPRINT_FILE "${CMAKE_BINARY_DIR}/cpu_fingerprint.txt")
+        file(WRITE "${_NES_CPU_FINGERPRINT_FILE}" "${_target_facts_text}\n")
+        string(SHA256 _cpu_fp_hash "${_target_facts_text}")
+        string(SUBSTRING "${_cpu_fp_hash}" 0 16 _cpu_fp_hash)
+        message(STATUS "Native CPU fingerprint: ${_cpu_fp_hash} (-> ${_NES_CPU_FINGERPRINT_FILE})")
+        # Diagnostic: dump the full fact list so two builds on the same SKU can be confirmed
+        # to produce identical fingerprints (i.e. no volatile non-CPU input is leaking in).
+        foreach (_f IN LISTS _target_facts)
+            message(STATUS "  fact: ${_f}")
+        endforeach ()
+        set(_NES_CACHE_ENV_PREFIX
+                "${CMAKE_COMMAND};-E;env;SCCACHE_C_CUSTOM_CACHE_BUSTER=${_cpu_fp_hash};CCACHE_EXTRAFILES=${_NES_CPU_FINGERPRINT_FILE}")
+    else ()
+        # Fail closed: without a usable fingerprint a shared cache could hand back an
+        # object compiled for an ISA the consumer doesn't have. Better a slow build than
+        # a SIGILL at runtime.
+        message(WARNING "NES_BUILD_NATIVE: could not extract -target-cpu/-target-feature from "
+                "${CMAKE_CXX_COMPILER} -### output; disabling compiler cache to avoid "
+                "cross-ISA cache pollution")
+        set(USE_BUILD_CACHE OFF CACHE BOOL "Use sccache or ccache to speed up rebuilds" FORCE)
+        return()
+    endif ()
+endif ()
+
 if (SCCACHE_EXECUTABLE)
     message(STATUS "Using sccache: ${SCCACHE_EXECUTABLE}")
-    set(CMAKE_CXX_COMPILER_LAUNCHER "${SCCACHE_EXECUTABLE}")
-    set(CMAKE_C_COMPILER_LAUNCHER "${SCCACHE_EXECUTABLE}")
+    set(CMAKE_CXX_COMPILER_LAUNCHER ${_NES_CACHE_ENV_PREFIX} "${SCCACHE_EXECUTABLE}")
+    set(CMAKE_C_COMPILER_LAUNCHER ${_NES_CACHE_ENV_PREFIX} "${SCCACHE_EXECUTABLE}")
 elseif (CCACHE_EXECUTABLE)
     message(STATUS "Using ccache: ${CCACHE_EXECUTABLE}")
-    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_EXECUTABLE}")
+    set(CMAKE_CXX_COMPILER_LAUNCHER ${_NES_CACHE_ENV_PREFIX} "${CCACHE_EXECUTABLE}")
 
     if (NES_ENABLE_PRECOMPILED_HEADERS)
         set(CMAKE_PCH_INSTANTIATE_TEMPLATES ON)


### PR DESCRIPTION
## Summary

- Fingerprint the host's effective ISA (clang `-### -x c -c /dev/null`, parsing the cc1 `-target-cpu` + `-target-feature` flags) and fold it into the sccache/ccache key via `SCCACHE_EXTRA_HASH_FILES` / `CCACHE_EXTRAFILES`, applied through a `cmake -E env` launcher prefix — no `CMAKE_CXX_FLAGS` pollution. Only kicks in when `NES_BUILD_NATIVE` is `ON` (i.e. Benchmark builds today).
- If the probe yields nothing, fail closed: flip `USE_BUILD_CACHE` off and return, rather than risk a cross-ISA cache hit.
- Add `Benchmark` to the optimized-builds entry in `pr_matrix.yaml` so PR-CI actually compiles and tests Benchmark builds (unit + systest + docker) for x64/libcxx, x64/libstdcxx, and arm64/libcxx — alongside RelWithDebInfo and Release.

## Why

The `Log Level Tests (Benchmark)` shard added in #1608 started SIGILL'ing on 2026-05-26 (`LogLevelTest.testLogLevel ***Exception: Illegal`). Root cause: `CMAKE_BUILD_TYPE=Benchmark` force-enables `NES_BUILD_NATIVE`, which adds `-march=native`. sccache keys on the literal compile command, so the token `-march=native` looks identical across GitHub-hosted runners — but it expands to a different `-target-cpu` / feature set per CPU family. A hit produced on a Skylake-AVX512 runner gets reused on a runner without those instructions, and the test process dies on the first AVX-512 opcode it executes.

Until this PR, no PR-CI shard compiled Benchmark builds end-to-end with the full test suite; the regression-surface for that build type was effectively just the tiny `testLogLevel` target. Wiring it into the main matrix means future Benchmark-mode bugs get caught alongside everything else.

## Test plan

- [ ] Verify `cmake -B build -DCMAKE_BUILD_TYPE=Benchmark` logs `Native CPU fingerprint: <hex>` and writes `<build>/cpu_fingerprint.txt`.
- [ ] Inspect a compile command in `<build>/compile_commands.json` for a Benchmark build — should NOT contain any synthetic `-DNES_NATIVE_*` flags; fingerprint is delivered via the launcher env, not source flags.
- [ ] Confirm CI Benchmark shards (x64/libcxx, x64/libstdcxx, arm64/libcxx) build and pass unit + systest + docker test groups.
- [ ] Re-run the same PR on a runner pool with mixed CPU families and check sccache stats — different runner families should produce distinct cache entries (no cross-pollination), same family should still hit.
- [ ] On failure of the probe (e.g. force-set `CMAKE_CXX_COMPILER` to something that doesn't emit `-target-cpu`), confirm the WARNING fires and the build proceeds with the cache disabled rather than poisoned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)