### PR TITLE
feat(Functions): adds 'Contains' string function

### DIFF
--- a/nes-plugins/Functions/ContainsFunction/CMakeLists.txt
+++ b/nes-plugins/Functions/ContainsFunction/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(${PROJECT_SOURCE_DIR}/cmake/PluginRegistrationUtil.cmake)
+
+add_plugin_as_library(Contains LogicalFunction nes-logical-operators-registry contains_logical_function_plugin_library ContainsLogicalFunction.cpp)
+add_plugin_as_library(Contains PhysicalFunction nes-physical-operators-registry contains_physical_function_plugin_library ContainsPhysicalFunction.cpp)
+
+target_include_directories(contains_logical_function_plugin_library PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/)
+target_include_directories(contains_physical_function_plugin_library PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/)

--- a/nes-plugins/Functions/ContainsFunction/ContainsLogicalFunction.cpp
+++ b/nes-plugins/Functions/ContainsFunction/ContainsLogicalFunction.cpp
@@ -1,0 +1,136 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <ContainsLogicalFunction.hpp>
+
+#include <algorithm>
+#include <optional>
+#include <ranges>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/DataTypeProvider.hpp>
+#include <DataTypes/Schema.hpp>
+#include <Functions/LogicalFunction.hpp>
+#include <Serialization/DataTypeSerializationUtil.hpp>
+#include <Serialization/LogicalFunctionReflection.hpp>
+#include <Util/PlanRenderer.hpp>
+#include <Util/Reflection.hpp>
+#include <fmt/format.h>
+#include <ErrorHandling.hpp>
+#include <LogicalFunctionRegistry.hpp>
+#include <SerializableVariantDescriptor.pb.h>
+
+namespace NES
+{
+
+ContainsLogicalFunction::ContainsLogicalFunction(LogicalFunction haystack, LogicalFunction needle)
+    : haystack(std::move(haystack)), needle(std::move(needle)), dataType(DataTypeProvider::provideDataType(DataType::Type::BOOLEAN))
+{
+}
+
+bool ContainsLogicalFunction::operator==(const ContainsLogicalFunction& rhs) const
+{
+    return haystack == rhs.haystack and needle == rhs.needle;
+}
+
+DataType ContainsLogicalFunction::getDataType() const
+{
+    return dataType;
+}
+
+ContainsLogicalFunction ContainsLogicalFunction::withDataType(const DataType& dataType) const
+{
+    auto copy = *this;
+    copy.dataType = dataType;
+    return copy;
+}
+
+LogicalFunction ContainsLogicalFunction::withInferredDataType(const Schema& schema) const
+{
+    const auto newChildren = getChildren() | std::views::transform([&schema](auto& child) { return child.withInferredDataType(schema); })
+        | std::ranges::to<std::vector>();
+    for (const auto& child : newChildren)
+    {
+        if (not child.getDataType().isType(DataType::Type::VARSIZED))
+        {
+            throw DifferentFieldTypeExpected("ContainsLogicalFunction expects VARSIZED children, but got {}", child.getDataType());
+        }
+    }
+    auto newDataType = this->getDataType();
+    newDataType.nullable = std::ranges::any_of(newChildren, [](const auto& child) { return child.getDataType().nullable; });
+    return withDataType(newDataType).withChildren(newChildren);
+}
+
+std::vector<LogicalFunction> ContainsLogicalFunction::getChildren() const
+{
+    return {haystack, needle};
+}
+
+ContainsLogicalFunction ContainsLogicalFunction::withChildren(const std::vector<LogicalFunction>& children) const
+{
+    PRECONDITION(children.size() == 2, "ContainsLogicalFunction requires exactly two children, but got {}", children.size());
+    auto copy = *this;
+    copy.haystack = children[0];
+    copy.needle = children[1];
+    return copy;
+}
+
+std::string_view ContainsLogicalFunction::getType() const
+{
+    return NAME;
+}
+
+std::string ContainsLogicalFunction::explain(ExplainVerbosity verbosity) const
+{
+    return fmt::format("CONTAINS({}, {})", haystack.explain(verbosity), needle.explain(verbosity));
+}
+
+Reflected Reflector<ContainsLogicalFunction>::operator()(const ContainsLogicalFunction& function) const
+{
+    return reflect(detail::ReflectedContainsLogicalFunction{
+        .haystack = std::make_optional<LogicalFunction>(function.haystack),
+        .needle = std::make_optional<LogicalFunction>(function.needle)});
+}
+
+ContainsLogicalFunction Unreflector<ContainsLogicalFunction>::operator()(const Reflected& reflected) const
+{
+    auto [haystack, needle] = unreflect<detail::ReflectedContainsLogicalFunction>(reflected);
+
+    if (!haystack.has_value() || !needle.has_value())
+    {
+        throw CannotDeserialize("ContainsLogicalFunction is missing a child");
+    }
+
+    return ContainsLogicalFunction{haystack.value(), needle.value()};
+}
+
+LogicalFunctionRegistryReturnType
+LogicalFunctionGeneratedRegistrar::RegisterContainsLogicalFunction(LogicalFunctionRegistryArguments arguments)
+{
+    if (!arguments.reflected.isEmpty())
+    {
+        return unreflect<ContainsLogicalFunction>(arguments.reflected);
+    }
+    if (arguments.children.size() != 2)
+    {
+        throw CannotDeserialize("ContainsLogicalFunction requires exactly two children, but got {}", arguments.children.size());
+    }
+    return ContainsLogicalFunction(arguments.children[0], arguments.children[1]);
+}
+
+}

--- a/nes-plugins/Functions/ContainsFunction/ContainsLogicalFunction.hpp
+++ b/nes-plugins/Functions/ContainsFunction/ContainsLogicalFunction.hpp
@@ -1,0 +1,84 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/Schema.hpp>
+#include <Functions/LogicalFunction.hpp>
+#include <Util/Logger/Formatter.hpp>
+#include <Util/PlanRenderer.hpp>
+#include <Util/Reflection.hpp>
+#include <SerializableVariantDescriptor.pb.h>
+
+namespace NES
+{
+
+class ContainsLogicalFunction final
+{
+public:
+    static constexpr std::string_view NAME = "Contains";
+
+    ContainsLogicalFunction(LogicalFunction haystack, LogicalFunction needle);
+    [[nodiscard]] bool operator==(const ContainsLogicalFunction& rhs) const;
+
+    [[nodiscard]] DataType getDataType() const;
+    [[nodiscard]] ContainsLogicalFunction withDataType(const DataType& dataType) const;
+    [[nodiscard]] LogicalFunction withInferredDataType(const Schema& schema) const;
+
+    [[nodiscard]] std::vector<LogicalFunction> getChildren() const;
+    [[nodiscard]] ContainsLogicalFunction withChildren(const std::vector<LogicalFunction>& children) const;
+
+    [[nodiscard]] std::string_view getType() const;
+    [[nodiscard]] std::string explain(ExplainVerbosity verbosity) const;
+
+private:
+    LogicalFunction haystack;
+    LogicalFunction needle;
+    DataType dataType;
+
+    friend struct Reflector<ContainsLogicalFunction>;
+};
+
+template <>
+struct Reflector<ContainsLogicalFunction>
+{
+    Reflected operator()(const ContainsLogicalFunction& function) const;
+};
+
+template <>
+struct Unreflector<ContainsLogicalFunction>
+{
+    ContainsLogicalFunction operator()(const Reflected& reflected) const;
+};
+
+static_assert(LogicalFunctionConcept<ContainsLogicalFunction>);
+
+}
+
+namespace NES::detail
+{
+struct ReflectedContainsLogicalFunction
+{
+    std::optional<LogicalFunction> haystack;
+    std::optional<LogicalFunction> needle;
+};
+}
+
+FMT_OSTREAM(NES::ContainsLogicalFunction);

--- a/nes-plugins/Functions/ContainsFunction/ContainsPhysicalFunction.cpp
+++ b/nes-plugins/Functions/ContainsFunction/ContainsPhysicalFunction.cpp
@@ -1,0 +1,81 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <ContainsPhysicalFunction.hpp>
+
+#include <cstdint>
+#include <string_view>
+#include <utility>
+
+#include <Functions/PhysicalFunction.hpp>
+#include <Nautilus/DataTypes/VarVal.hpp>
+#include <Nautilus/DataTypes/VariableSizedData.hpp>
+#include <Nautilus/Interface/Record.hpp>
+#include <nautilus/function.hpp>
+#include <Arena.hpp>
+#include <ErrorHandling.hpp>
+#include <ExecutionContext.hpp>
+#include <PhysicalFunctionRegistry.hpp>
+#include <val.hpp>
+
+namespace NES
+{
+
+ContainsPhysicalFunction::ContainsPhysicalFunction(PhysicalFunction haystackPhysicalFunction, PhysicalFunction needlePhysicalFunction)
+    : haystackPhysicalFunction(std::move(haystackPhysicalFunction)), needlePhysicalFunction(std::move(needlePhysicalFunction))
+{
+}
+
+namespace
+{
+bool containsString(const int8_t* haystackPtr, uint64_t haystackSize, const int8_t* needlePtr, uint64_t needleSize)
+{
+    /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    const std::string_view haystack(reinterpret_cast<const char*>(haystackPtr), haystackSize);
+    /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    const std::string_view needle(reinterpret_cast<const char*>(needlePtr), needleSize);
+    return haystack.contains(needle);
+}
+}
+
+VarVal ContainsPhysicalFunction::execute(const Record& record, ArenaRef& arena) const
+{
+    const auto haystackValue = haystackPhysicalFunction.execute(record, arena);
+    const auto needleValue = needlePhysicalFunction.execute(record, arena);
+
+    const bool nullable = haystackValue.isNullable() or needleValue.isNullable();
+    const auto isNull = nautilus::val<bool>(nullable) and (haystackValue.isNull() or needleValue.isNull());
+
+    /// Mirrors ConcatPhysicalFunction: if any input is NULL, skip the native call — getContent()
+    /// on a NULL VARSIZED returns a pointer we must not dereference.
+    if (isNull)
+    {
+        return VarVal{nautilus::val<bool>(false), nullable, isNull};
+    }
+
+    const auto haystack = haystackValue.getRawValueAs<VariableSizedData>();
+    const auto needle = needleValue.getRawValueAs<VariableSizedData>();
+    const auto result = nautilus::invoke(containsString, haystack.getContent(), haystack.getSize(), needle.getContent(), needle.getSize());
+    return VarVal{result, nullable, isNull};
+}
+
+PhysicalFunctionRegistryReturnType
+PhysicalFunctionGeneratedRegistrar::RegisterContainsPhysicalFunction(PhysicalFunctionRegistryArguments physicalFunctionRegistryArguments)
+{
+    PRECONDITION(physicalFunctionRegistryArguments.childFunctions.size() == 2, "Contains function must have exactly two child functions");
+    return ContainsPhysicalFunction(
+        physicalFunctionRegistryArguments.childFunctions[0], physicalFunctionRegistryArguments.childFunctions[1]);
+}
+
+}

--- a/nes-plugins/Functions/ContainsFunction/ContainsPhysicalFunction.hpp
+++ b/nes-plugins/Functions/ContainsFunction/ContainsPhysicalFunction.hpp
@@ -1,0 +1,39 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <Functions/PhysicalFunction.hpp>
+#include <Nautilus/DataTypes/VarVal.hpp>
+#include <Nautilus/Interface/Record.hpp>
+#include <Arena.hpp>
+#include <ExecutionContext.hpp>
+
+namespace NES
+{
+
+class ContainsPhysicalFunction final
+{
+public:
+    ContainsPhysicalFunction(PhysicalFunction haystackPhysicalFunction, PhysicalFunction needlePhysicalFunction);
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
+
+private:
+    PhysicalFunction haystackPhysicalFunction;
+    PhysicalFunction needlePhysicalFunction;
+};
+
+static_assert(PhysicalFunctionConcept<ContainsPhysicalFunction>);
+
+}

--- a/nes-systests/function/varsized/Contains.test
+++ b/nes-systests/function/varsized/Contains.test
@@ -1,0 +1,165 @@
+# name: Contains
+# description: CONTAINS(haystack, needle) returns whether haystack contains needle as a substring.
+#              Covers edge cases on non-null VARSIZED, SQL-standard three-valued logic with NULL,
+#              and configuration errors.
+# groups: [Function, Text, Projection, Selection, NullHandling]
+
+
+# ============================================================================
+# Section 1 — edge cases on non-null VARSIZED inputs
+# ============================================================================
+
+# Row layout: pairs that exercise size, position, and overlap boundaries.
+CREATE LOGICAL SOURCE edges(id UINT64 NOT NULL, haystack VARSIZED NOT NULL, needle VARSIZED NOT NULL);
+CREATE PHYSICAL SOURCE FOR edges TYPE File;
+ATTACH INLINE
+1,abcdef,abc
+2,abcdef,def
+3,abcdef,cde
+4,abcdef,abcdef
+5,abcdef,xyz
+6,abcdef,abcx
+7,abcdef,abcdefg
+8,abc,abcdef
+9,aab,b
+10,aaaa,aa
+11,,
+12,,abc
+13,abc,
+14,a,a
+15,a,A
+
+CREATE SINK edgeResultSink(edges.id UINT64 NOT NULL, result BOOLEAN NOT NULL) TYPE File;
+
+# 1 — prefix, suffix, middle, identical, disjoint, off-by-one, oversized needle,
+#     single-char overlap, repeated-char overlap, both empty, empty haystack,
+#     empty needle, single-char identical, case sensitivity
+SELECT id, CONTAINS(haystack, needle) AS result FROM edges INTO edgeResultSink;
+----
+1,true
+2,true
+3,true
+4,true
+5,false
+6,false
+7,false
+8,false
+9,true
+10,true
+11,true
+12,false
+13,true
+14,true
+15,false
+
+
+# ============================================================================
+# Section 2 — selection (WHERE) with edge cases
+# ============================================================================
+
+CREATE SINK edgeIdSink(edges.id UINT64 NOT NULL) TYPE File;
+
+# Constant needle "abc": matches every haystack that contains it. Note the
+# empty-needle case (row 13) and the empty-haystack case (rows 11, 12) are
+# already covered by the field-driven projection above; the SQL parser does
+# not accept an empty VARSIZED literal so we cannot probe that side via a
+# constant here.
+SELECT id FROM edges WHERE CONTAINS(haystack, VARSIZED("abc")) INTO edgeIdSink;
+----
+1
+2
+3
+4
+5
+6
+7
+8
+13
+
+
+# ============================================================================
+# Section 3 — SQL three-valued logic for NULL
+# ============================================================================
+# Per SQL standard, predicates on NULL operands evaluate to UNKNOWN (rendered
+# as NULL in scalar context). WHERE keeps only rows where the predicate is
+# TRUE — rows where it is UNKNOWN/NULL are dropped.
+
+CREATE LOGICAL SOURCE nullable(id UINT64 NOT NULL, haystack VARSIZED, needle VARSIZED);
+CREATE PHYSICAL SOURCE FOR nullable TYPE File;
+ATTACH INLINE
+1,hello world,ell
+2,hello world,xyz
+3,,ell
+4,hello world,
+5,,
+6,hello world,hello world
+
+CREATE SINK nullableResultSink(nullable.id UINT64 NOT NULL, result BOOLEAN) TYPE File;
+CREATE SINK nullableIsNullSink(nullable.id UINT64 NOT NULL, result BOOLEAN, result_isnull BOOLEAN NOT NULL) TYPE File;
+CREATE SINK nullableIdSink(nullable.id UINT64 NOT NULL) TYPE File;
+
+# Projection: NULL on either side propagates to a NULL result.
+SELECT id, CONTAINS(haystack, needle) AS result FROM nullable INTO nullableResultSink;
+----
+1,true
+2,false
+3,NULL
+4,NULL
+5,NULL
+6,true
+
+# ISNULL wrapping the predicate confirms three-valued-logic shape:
+# result is NULL exactly when haystack or needle is NULL.
+SELECT id, CONTAINS(haystack, needle) AS result, ISNULL(CONTAINS(haystack, needle)) AS result_isnull
+FROM nullable INTO nullableIsNullSink;
+----
+1,true,false
+2,false,false
+3,NULL,true
+4,NULL,true
+5,NULL,true
+6,true,false
+
+# Selection: rows where the predicate is NULL are filtered out (only TRUE
+# survives a WHERE clause under three-valued logic).
+SELECT id FROM nullable WHERE CONTAINS(haystack, needle) INTO nullableIdSink;
+----
+1
+6
+
+
+# ============================================================================
+# Section 4 — negative tests (configuration errors)
+# ============================================================================
+
+# Non-VARSIZED argument: the logical function rejects non-VARSIZED children
+# during schema inference. DifferentFieldTypeExpected = 2006.
+CREATE LOGICAL SOURCE numericStream(value INT32 NOT NULL);
+CREATE PHYSICAL SOURCE FOR numericStream TYPE File;
+ATTACH INLINE
+42
+
+SELECT CONTAINS(value, VARSIZED("foo")) AS result FROM numericStream INTO File();
+----
+Error 2006
+
+# Other-side non-VARSIZED argument is rejected too.
+CREATE LOGICAL SOURCE mixedStream(haystack VARSIZED NOT NULL, n INT32 NOT NULL);
+CREATE PHYSICAL SOURCE FOR mixedStream TYPE File;
+ATTACH INLINE
+abc,1
+
+SELECT CONTAINS(haystack, n) AS result FROM mixedStream INTO File();
+----
+Error 2006
+
+# Wrong arity (1 argument): the registry's RegisterContainsLogicalFunction
+# rejects anything other than two children. CannotDeserialize = 2002.
+SELECT CONTAINS(haystack) AS result FROM edges INTO File();
+----
+Error 2002
+
+# Wrong arity (3 arguments): same gate.
+SELECT CONTAINS(haystack, needle, needle) AS result FROM edges INTO File();
+----
+Error 2002


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Adds 'Contains' function on VarSized/Strings.
Includes null handling and negative tests.
Does not include UTF8 tests, since we don't properly support UTF8 (or rather different string formats).

Lives in nes-plugins, may be moved into nes-logical/physical-operators if you consider it core functionality, though I'd like to keep it in nes-plugins as a showcase.