### PR TITLE
perf(logger): avoid evaluating disabled log arguments

### DIFF
--- a/nes-common/include/Util/Logger/Logger.hpp
+++ b/nes-common/include/Util/Logger/Logger.hpp
@@ -122,7 +122,10 @@ struct LogCaller<LogLevel::LOG_WARNING>
 #define SUPPRESS_UNUSED_WARNING(...) \
     do \
     { \
-        [](auto&&... args) { ((void)args, ...); }(__VA_ARGS__); \
+        if (false) \
+        { \
+            [](auto&&... args) { ((void)args, ...); }(__VA_ARGS__); \
+        } \
     } while (0)
 
 

--- a/nes-common/tests/UnitTests/Util/LogLevelTest.cpp
+++ b/nes-common/tests/UnitTests/Util/LogLevelTest.cpp
@@ -21,17 +21,34 @@
 
 #include <Util/Logger/impl/NesLogger.hpp>
 #include <magic_enum/magic_enum.hpp>
-#include <BaseUnitTest.hpp>
 
 namespace NES
 {
+namespace
+{
+int markArgumentEvaluated(bool& argumentEvaluated)
+{
+    argumentEvaluated = true;
+    return 0;
+}
+}
 
-class LogLevelTest : public Testing::BaseUnitTest
+class LogLevelTest : public testing::Test
 {
 };
 
+TEST_F(LogLevelTest, suppressUnusedWarningDoesNotEvaluateArguments)
+{
+    bool argumentEvaluated = false;
+    SUPPRESS_UNUSED_WARNING(markArgumentEvaluated(argumentEvaluated));
+    EXPECT_FALSE(argumentEvaluated);
+}
+
 TEST_F(LogLevelTest, testLogLevel)
 {
+#if defined(NES_BENCHMARKS_NATIVE_MODE)
+    GTEST_SKIP() << "Skipping log emission in native benchmark builds";
+#endif
     constexpr auto filePath = "LogLevelTest.log";
     Logger::setupLogging(filePath, LogLevel::LOG_TRACE);
 


### PR DESCRIPTION
This PR updates the NES logging macros to make disabled log levels cheaper in no-debug build. The new NES_LOG checks the configured compile-time log level via if constexpr, so log calls below the selected level are removed. Specifically, we avoid running `expensiveFunction` in calls such as:
```
NES_DEBUG("{}", expensiveFunction());
```

Compare here the `calls` output with and whithout if(false) https://godbolt.org/z/5346eW51T