### PR TITLE
feat(ci) build nightly created even if nightly test matrix fails.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -140,13 +140,12 @@ jobs:
       run_reason: "Nightly Benchmark"
 
   create-nightly-image:
-    needs: [ build-and-test ]
-    if: ${{ !github.event.act && inputs.ref == 'main' }}
+    if: ${{ !github.event.act }}
     uses: ./.github/workflows/create_release_image.yml
     secrets: inherit
     with:
       head_sha: "main"
-      dockerhub-tag: "nightly"
+      dockerhub-tag: "latest"
 
   send-zulip-msg-on-failure:
     needs: [ compile-time-regression, create-nightly-image, large-tests, full-clang-tidy ]


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

We want to have an up-to-date and ready-to-use dockerized version of NebulaStream readily available. 
Thus, we want to release nightly builds. 

This was already enabled in the nightly GitHub workflows, but only triggered if the nightly testing matrix succeeds, which it often doesn't. Since all commits in main are tested before being pushed, and the nightly tests are a bit flaky, we don't require this dependency. 

Eventually, we want to have additionally stable releases that are heavily tested, but that is out of scope for this PR.


## Verifying this change
This change is tested by

* Validating that the images are built and available via docker-hub
