### PR TITLE
fix(Nightly): Fix clang-tidy full

### DIFF
--- a/nes-logical-operators/src/Operators/ProjectionLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/ProjectionLogicalOperator.cpp
@@ -254,14 +254,14 @@ Unreflector<TypedLogicalOperator<ProjectionLogicalOperator>>::operator()(const R
 {
     auto [asterisk, projections] = context.unreflect<detail::ReflectedProjectionLogicalOperator>(reflected);
 
-    std::vector<ProjectionLogicalOperator::Projection> parsedProjections;
-    parsedProjections.reserve(projections.size());
-
-    for (auto [identifier, function] : projections)
-    {
-        parsedProjections.emplace_back(identifier, function);
-    }
-
+    auto parsedProjections = projections
+        | std::views::transform(
+                                 [](const auto& proj)
+                                 {
+                                     const auto& [identifier, function] = proj;
+                                     return ProjectionLogicalOperator::Projection{identifier, function};
+                                 })
+        | std::ranges::to<std::vector>();
     return TypedLogicalOperator<ProjectionLogicalOperator>{std::move(parsedProjections), ProjectionLogicalOperator::Asterisk(asterisk)};
 }
 


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

The nightly `clang-tidy-full` check flagged a manual accumulation loop in `ProjectionLogicalOperator`'s unreflector (`modernize-loop-convert` / `modernize-use-ranges`). Replaced the `reserve` + range-for + `emplace_back` with a `std::views::transform | std::ranges::to<std::vector>()` pipeline.

## Verifying this change

This change is tested by running our existing tests; behavior is unchanged.

## What components does this pull request potentially affect?

- nes-logical-operators (`ProjectionLogicalOperator` unreflection)

## Documentation

- No documentation changes needed.
