### PR TITLE
feat(systest): allow skipping serialization validation

### DIFF
--- a/nes-systests/systest/include/QuerySubmitter.hpp
+++ b/nes-systests/systest/include/QuerySubmitter.hpp
@@ -26,11 +26,16 @@
 namespace NES::Systest
 {
 
+struct QuerySubmitterOptions
+{
+    bool validateQueryPlanSerialization = true;
+};
+
 /// Interface for submitting queries to a NebulaStream Worker.
 class QuerySubmitter
 {
 public:
-    explicit QuerySubmitter(std::unique_ptr<QueryManager> queryManager);
+    explicit QuerySubmitter(std::unique_ptr<QueryManager> queryManager, QuerySubmitterOptions options = {});
     std::expected<DistributedQueryId, Exception> registerQuery(const DistributedLogicalPlan& plan);
     void startQuery(const DistributedQueryId& query);
     void stopQuery(const DistributedQueryId& query);
@@ -41,6 +46,7 @@ public:
 
 private:
     UniquePtr<QueryManager> queryManager;
+    QuerySubmitterOptions querySubmitterOptions;
     std::unordered_set<DistributedQueryId> ids;
 };
 }

--- a/nes-systests/systest/include/SystestConfiguration.hpp
+++ b/nes-systests/systest/include/SystestConfiguration.hpp
@@ -68,6 +68,8 @@ public:
     BoolOption remoteWorker = {"remote_worker", "false", "use remote worker"};
     StringOption clusterConfigPath = {"cluster_config", TEST_CONFIGURATION_DIR "/topologies/two-node.yaml", "cluster configuration"};
     BoolOption showQueryPerformance = {"show_query_performance", "false", "print per-query performance timing in the console output"};
+    BoolOption validateQueryPlanSerialization
+        = {"validate_query_plan_serialization", "true", "validate query plan serialization before registering queries"};
     BoolOption endlessMode = {"query_compiler_config", "false", "continuously issue queries to the worker"};
 
     bool excludeGroupsConfiguredInDisableConfig = false;

--- a/nes-systests/systest/include/SystestRunner.hpp
+++ b/nes-systests/systest/include/SystestRunner.hpp
@@ -40,6 +40,7 @@ namespace NES::Systest
 struct SystestQuery;
 struct RunningQuery;
 class QuerySubmitter;
+struct QuerySubmitterOptions;
 
 /// Pad size of (PASSED / FAILED) in the console output of the systest to have a nicely looking output
 static constexpr auto padSizeSuccess = 120;
@@ -72,7 +73,8 @@ inline std::string discardPerformanceMessage(RunningQuery&)
     const SystestClusterConfiguration& clusterConfig,
     const SingleNodeWorkerConfiguration& configuration,
     SystestProgressTracker& progressTracker,
-    const QueryPerformanceMessageBuilder& queryPerformanceMessage);
+    const QueryPerformanceMessageBuilder& queryPerformanceMessage,
+    const QuerySubmitterOptions& querySubmitterOptions);
 
 /// Run queries remote on the single-node-worker specified by the URI
 /// @return returns a collection of failed queries
@@ -81,7 +83,8 @@ inline std::string discardPerformanceMessage(RunningQuery&)
     uint64_t numConcurrentQueries,
     const SystestClusterConfiguration& clusterConfig,
     SystestProgressTracker& progressTracker,
-    const QueryPerformanceMessageBuilder& queryPerformanceMessage);
+    const QueryPerformanceMessageBuilder& queryPerformanceMessage,
+    const QuerySubmitterOptions& querySubmitterOptions);
 
 /// Serialized to BenchmarkResults.json via rfl::json::write. The field names below are the JSON keys.
 struct BenchmarkResult
@@ -101,7 +104,8 @@ struct BenchmarkResult
     const SingleNodeWorkerConfiguration& configuration,
     std::vector<BenchmarkResult>& benchmarkResults,
     const SystestClusterConfiguration& clusterConfig,
-    SystestProgressTracker& progressTracker);
+    SystestProgressTracker& progressTracker,
+    const QuerySubmitterOptions& querySubmitterOptions);
 
 /// Prints the error message, if the query has failed/passed and the expected and result tuples, like below
 /// function/arithmetical/FunctionDiv:4..................................Passed

--- a/nes-systests/systest/src/QuerySubmitter.cpp
+++ b/nes-systests/systest/src/QuerySubmitter.cpp
@@ -36,38 +36,41 @@
 namespace NES::Systest
 {
 
-QuerySubmitter::QuerySubmitter(std::unique_ptr<QueryManager> queryManager) : queryManager(std::move(queryManager))
+QuerySubmitter::QuerySubmitter(std::unique_ptr<QueryManager> queryManager, QuerySubmitterOptions options)
+    : queryManager(std::move(queryManager)), querySubmitterOptions(options)
 {
 }
 
 std::expected<DistributedQueryId, Exception> QuerySubmitter::registerQuery(const DistributedLogicalPlan& plan)
 {
-    /// Make sure the queryplan is passed through serialization logic.
-    std::unordered_map<Host, std::vector<std::string>> serializationErrorsPerWorker;
-    for (const auto& [grpc, localPlans] : plan)
+    if (querySubmitterOptions.validateQueryPlanSerialization)
     {
-        for (const auto& localPlan : localPlans)
+        std::unordered_map<Host, std::vector<std::string>> serializationErrorsPerWorker;
+        for (const auto& [grpc, localPlans] : plan)
         {
-            const auto serialized = QueryPlanSerializationUtil::serializeQueryPlan(localPlan);
-            const auto deserialized = QueryPlanSerializationUtil::deserializeQueryPlan(serialized);
-            if (deserialized != localPlan)
+            for (const auto& localPlan : localPlans)
             {
-                serializationErrorsPerWorker[grpc].emplace_back(fmt::format(
-                    "Query plan serialization is wrong: plan != deserialize(serialize(plan)), with plan:\n{} and "
-                    "deserialize(serialize(plan)):\n{}",
-                    explain(localPlan, ExplainVerbosity::Debug),
-                    explain(deserialized, ExplainVerbosity::Debug)));
+                const auto serialized = QueryPlanSerializationUtil::serializeQueryPlan(localPlan);
+                const auto deserialized = QueryPlanSerializationUtil::deserializeQueryPlan(serialized);
+                if (deserialized != localPlan)
+                {
+                    serializationErrorsPerWorker[grpc].emplace_back(fmt::format(
+                        "Query plan serialization is wrong: plan != deserialize(serialize(plan)), with plan:\n{} and "
+                        "deserialize(serialize(plan)):\n{}",
+                        explain(localPlan, ExplainVerbosity::Debug),
+                        explain(deserialized, ExplainVerbosity::Debug)));
+                }
             }
+        }
+
+        if (not serializationErrorsPerWorker.empty())
+        {
+            const auto exception = CannotSerialize("Encountered serialization errors: {}", serializationErrorsPerWorker);
+            return std::unexpected(exception);
         }
     }
 
-    if (serializationErrorsPerWorker.empty())
-    {
-        return queryManager->registerQuery(plan);
-    }
-
-    const auto exception = CannotSerialize("Encountered serialization errors: {}", serializationErrorsPerWorker);
-    return std::unexpected(exception);
+    return queryManager->registerQuery(plan);
 }
 
 void QuerySubmitter::startQuery(const DistributedQueryId& query)

--- a/nes-systests/systest/src/SystestConfiguration.cpp
+++ b/nes-systests/systest/src/SystestConfiguration.cpp
@@ -31,6 +31,7 @@ std::vector<BaseOption*> SystestConfiguration::getOptions()
         &testGroups,
         &disabledTestFiles,
         &testDataDir,
+        &validateQueryPlanSerialization,
         &endlessMode,
         &excludeGroups,
         &remoteWorker,

--- a/nes-systests/systest/src/SystestExecutor.cpp
+++ b/nes-systests/systest/src/SystestExecutor.cpp
@@ -198,13 +198,7 @@ void SystestExecutor::runEndlessMode(const std::vector<Systest::SystestQuery>& q
 
     if (config.remoteWorker.getValue())
     {
-        runEndlessRemote(
-            queriesByOverride,
-            rng,
-            numberConcurrentQueries,
-            config.clusterConfig,
-            progressTracker,
-            querySubmitterOptions);
+        runEndlessRemote(queriesByOverride, rng, numberConcurrentQueries, config.clusterConfig, progressTracker, querySubmitterOptions);
     }
     else
     {
@@ -355,12 +349,7 @@ SystestExecutorResult SystestExecutor::executeSystests()
                                                           { return fmt::format(" in {}", runningQuery.getElapsedTime()); }}
                 : Systest::QueryPerformanceMessageBuilder{Systest::discardPerformanceMessage};
             auto failed = runQueriesAtRemoteWorker(
-                queries,
-                numberConcurrentQueries,
-                config.clusterConfig,
-                progressTracker,
-                performanceMessage,
-                querySubmitterOptions);
+                queries, numberConcurrentQueries, config.clusterConfig, progressTracker, performanceMessage, querySubmitterOptions);
             failedQueries.insert(failedQueries.end(), failed.begin(), failed.end());
         }
         else

--- a/nes-systests/systest/src/SystestExecutor.cpp
+++ b/nes-systests/systest/src/SystestExecutor.cpp
@@ -89,16 +89,23 @@ void exitOnFailureIfNeeded(const std::vector<Systest::RunningQuery>& failedQueri
     std::exit(1); ///NOLINT(concurrency-mt-unsafe)
 }
 
+Systest::QuerySubmitterOptions querySubmitterOptionsFromConfig(const SystestConfiguration& config)
+{
+    return {.validateQueryPlanSerialization = config.validateQueryPlanSerialization.getValue()};
+}
+
 [[noreturn]] void runEndlessRemote(
     const OverrideQueriesMap& queriesByOverride,
     std::mt19937& rng,
     const uint64_t numberConcurrentQueries,
     const SystestClusterConfiguration& clusterConfig,
-    Systest::SystestProgressTracker& progressTracker)
+    Systest::SystestProgressTracker& progressTracker,
+    const Systest::QuerySubmitterOptions& querySubmitterOptions)
 {
     auto workerCatalog = std::make_shared<WorkerCatalog>(clusterConfig.workers);
 
-    Systest::QuerySubmitter querySubmitter(std::make_unique<QueryManager>(std::move(workerCatalog), createGRPCBackend()));
+    Systest::QuerySubmitter querySubmitter(
+        std::make_unique<QueryManager>(std::move(workerCatalog), createGRPCBackend()), querySubmitterOptions);
 
     while (true)
     {
@@ -126,7 +133,8 @@ void exitOnFailureIfNeeded(const std::vector<Systest::RunningQuery>& failedQueri
     const uint64_t numberConcurrentQueries,
     const SystestClusterConfiguration& clusterConfig,
     const SingleNodeWorkerConfiguration& baseConfiguration,
-    Systest::SystestProgressTracker& progressTracker)
+    Systest::SystestProgressTracker& progressTracker,
+    const Systest::QuerySubmitterOptions& querySubmitterOptions)
 {
     while (true)
     {
@@ -148,7 +156,7 @@ void exitOnFailureIfNeeded(const std::vector<Systest::RunningQuery>& failedQueri
             auto workerCatalog = std::make_shared<WorkerCatalog>(clusterConfig.workers);
 
             Systest::QuerySubmitter querySubmitter(
-                std::make_unique<QueryManager>(std::move(workerCatalog), createEmbeddedBackend(configCopy)));
+                std::make_unique<QueryManager>(std::move(workerCatalog), createEmbeddedBackend(configCopy)), querySubmitterOptions);
 
             auto shuffledQueries = queriesForConfig;
             std::ranges::shuffle(shuffledQueries, rng);
@@ -186,15 +194,28 @@ void SystestExecutor::runEndlessMode(const std::vector<Systest::SystestQuery>& q
     }
 
     std::mt19937 rng(std::random_device{}());
+    const auto querySubmitterOptions = querySubmitterOptionsFromConfig(config);
 
     if (config.remoteWorker.getValue())
     {
-        runEndlessRemote(queriesByOverride, rng, numberConcurrentQueries, config.clusterConfig, progressTracker);
+        runEndlessRemote(
+            queriesByOverride,
+            rng,
+            numberConcurrentQueries,
+            config.clusterConfig,
+            progressTracker,
+            querySubmitterOptions);
     }
     else
     {
         runEndlessLocal(
-            queriesByOverride, rng, numberConcurrentQueries, config.clusterConfig, singleNodeWorkerConfiguration, progressTracker);
+            queriesByOverride,
+            rng,
+            numberConcurrentQueries,
+            config.clusterConfig,
+            singleNodeWorkerConfiguration,
+            progressTracker,
+            querySubmitterOptions);
     }
 }
 
@@ -323,6 +344,7 @@ SystestExecutorResult SystestExecutor::executeSystests()
             std::ranges::shuffle(queries, rng);
         }
         const auto numberConcurrentQueries = config.numberConcurrentQueries.getValue();
+        const auto querySubmitterOptions = querySubmitterOptionsFromConfig(config);
         std::vector<Systest::RunningQuery> failedQueries;
         if (config.remoteWorker.getValue())
         {
@@ -332,8 +354,13 @@ SystestExecutorResult SystestExecutor::executeSystests()
                 ? Systest::QueryPerformanceMessageBuilder{[](Systest::RunningQuery& runningQuery)
                                                           { return fmt::format(" in {}", runningQuery.getElapsedTime()); }}
                 : Systest::QueryPerformanceMessageBuilder{Systest::discardPerformanceMessage};
-            auto failed
-                = runQueriesAtRemoteWorker(queries, numberConcurrentQueries, config.clusterConfig, progressTracker, performanceMessage);
+            auto failed = runQueriesAtRemoteWorker(
+                queries,
+                numberConcurrentQueries,
+                config.clusterConfig,
+                progressTracker,
+                performanceMessage,
+                querySubmitterOptions);
             failedQueries.insert(failedQueries.end(), failed.begin(), failed.end());
         }
         else
@@ -375,7 +402,12 @@ SystestExecutorResult SystestExecutor::executeSystests()
                 progressTracker.reset();
                 progressTracker.setTotalQueries(benchmarkQueries.size());
                 auto failed = runQueriesAndBenchmark(
-                    benchmarkQueries, singleNodeWorkerConfiguration, benchmarkResults, config.clusterConfig, progressTracker);
+                    benchmarkQueries,
+                    singleNodeWorkerConfiguration,
+                    benchmarkResults,
+                    config.clusterConfig,
+                    progressTracker,
+                    querySubmitterOptions);
                 failedQueries.insert(failedQueries.end(), failed.begin(), failed.end());
                 const auto serializedResults = rfl::json::write(benchmarkResults, rfl::json::pretty);
                 std::cout << serializedResults;
@@ -406,7 +438,13 @@ SystestExecutorResult SystestExecutor::executeSystests()
                                                                   { return fmt::format(" in {}", runningQuery.getElapsedTime()); }}
                         : Systest::QueryPerformanceMessageBuilder{Systest::discardPerformanceMessage};
                     auto failed = runQueriesAtLocalWorker(
-                        queriesForConfig, numberConcurrentQueries, config.clusterConfig, configCopy, progressTracker, performanceMessage);
+                        queriesForConfig,
+                        numberConcurrentQueries,
+                        config.clusterConfig,
+                        configCopy,
+                        progressTracker,
+                        performanceMessage,
+                        querySubmitterOptions);
                     failedQueries.insert(failedQueries.end(), failed.begin(), failed.end());
                 }
             }

--- a/nes-systests/systest/src/SystestRunner.cpp
+++ b/nes-systests/systest/src/SystestRunner.cpp
@@ -437,12 +437,13 @@ std::vector<RunningQuery> runQueriesAndBenchmark(
     const SingleNodeWorkerConfiguration& configuration,
     std::vector<BenchmarkResult>& benchmarkResults,
     const SystestClusterConfiguration& clusterConfig,
-    SystestProgressTracker& progressTracker)
+    SystestProgressTracker& progressTracker,
+    const QuerySubmitterOptions& querySubmitterOptions)
 {
     auto catalog = std::make_shared<WorkerCatalog>(clusterConfig.workers);
 
     auto worker = std::make_unique<QueryManager>(std::move(catalog), createEmbeddedBackend(configuration));
-    QuerySubmitter submitter(std::move(worker));
+    QuerySubmitter submitter(std::move(worker), querySubmitterOptions);
     std::vector<std::shared_ptr<RunningQuery>> ranQueries;
     progressTracker.reset();
     progressTracker.setTotalQueries(queries.size());
@@ -576,11 +577,13 @@ std::vector<RunningQuery> runQueriesAtLocalWorker(
     const SystestClusterConfiguration& clusterConfig,
     const SingleNodeWorkerConfiguration& configuration,
     SystestProgressTracker& progressTracker,
-    const QueryPerformanceMessageBuilder& queryPerformanceMessage)
+    const QueryPerformanceMessageBuilder& queryPerformanceMessage,
+    const QuerySubmitterOptions& querySubmitterOptions)
 {
     auto catalog = std::make_shared<WorkerCatalog>(clusterConfig.workers);
 
-    QuerySubmitter submitter(std::make_unique<QueryManager>(std::move(catalog), createEmbeddedBackend(configuration)));
+    QuerySubmitter submitter(
+        std::make_unique<QueryManager>(std::move(catalog), createEmbeddedBackend(configuration)), querySubmitterOptions);
     return runQueries(queries, numConcurrentQueries, submitter, progressTracker, queryPerformanceMessage);
 }
 
@@ -589,7 +592,8 @@ std::vector<RunningQuery> runQueriesAtRemoteWorker(
     const uint64_t numConcurrentQueries,
     const SystestClusterConfiguration& clusterConfig,
     SystestProgressTracker& progressTracker,
-    const QueryPerformanceMessageBuilder& queryPerformanceMessage)
+    const QueryPerformanceMessageBuilder& queryPerformanceMessage,
+    const QuerySubmitterOptions& querySubmitterOptions)
 {
     auto catalog = std::make_shared<WorkerCatalog>(clusterConfig.workers);
 
@@ -612,7 +616,7 @@ std::vector<RunningQuery> runQueriesAtRemoteWorker(
     progressTracker.setTotalQueries(queriesWithoutConfigurationOverrides.size());
 
     auto remoteQueryManager = std::make_unique<QueryManager>(std::move(catalog), createGRPCBackend());
-    QuerySubmitter submitter(std::move(remoteQueryManager));
+    QuerySubmitter submitter(std::move(remoteQueryManager), querySubmitterOptions);
     return runQueries(queriesWithoutConfigurationOverrides, numConcurrentQueries, submitter, progressTracker, queryPerformanceMessage);
 }
 

--- a/nes-systests/systest/src/SystestStarter.cpp
+++ b/nes-systests/systest/src/SystestStarter.cpp
@@ -114,6 +114,9 @@ void configureArgumentParser(ArgumentParser& program)
         .default_value(false)
         .implicit_value(true);
     program.add_argument("--show-query-performance").flag().help("print per-query performance timing in the console output");
+    program.add_argument("--skip-query-plan-serialization-validation")
+        .flag()
+        .help("skip the systest query plan serialize/deserialize validation before query registration");
 }
 
 void loadDisableConfig(const ArgumentParser& program, NES::SystestConfiguration& config)
@@ -385,6 +388,11 @@ void applyExecutionOptions(const ArgumentParser& program, NES::SystestConfigurat
     if (program.is_used("--show-query-performance"))
     {
         config.showQueryPerformance = true;
+    }
+
+    if (program.is_used("--skip-query-plan-serialization-validation"))
+    {
+        config.validateQueryPlanSerialization = false;
     }
 
     if (program.is_used("--endless"))


### PR DESCRIPTION
Currently, systest always tests for correct serialization of queries. For large highly nested predicate queries de/serialization is very expensive and can take multiple seconds. We add the option to skip this test step with `--skip-query-plan-serialization-validation`.