### PR TITLE
ci(nightly): only publish :latest image on main branch

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -141,7 +141,10 @@ jobs:
       run_reason: "Nightly Benchmark"
 
   create-nightly-image:
-    if: ${{ !github.event.act }}
+    # Only publish the `:latest` release image when the nightly job actually runs on `main`
+    # (scheduled run, or a manual dispatch from the `main` branch). This prevents anyone
+    # triggering the nightly on a different branch from unintentionally overwriting `:latest`.
+    if: ${{ !github.event.act && github.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/create_release_image.yml
     secrets: inherit
     with:


### PR DESCRIPTION
## Problem

The `NES Nightly` workflow can be triggered via `workflow_dispatch` from any branch (the `head_sha` input even defaults to `main` for testing). However, the `create-nightly-image` job unconditionally pushed the executable images to the `:latest` Docker tag, only excluding `act` runs.

As a result, **anyone triggering the nightly workflow from a non-`main` branch would unintentionally overwrite the published `:latest` release image.**

## Fix

Gate the `create-nightly-image` job on `github.ref == 'refs/heads/main'`. This evaluates to:

- `true` for the scheduled cron run (always runs on the default branch `main`)
- `true` for a manual dispatch from the `main` branch
- `false` for a manual dispatch from any other branch

So `:latest` is only published when the nightly actually runs on `main`. All other nightly jobs (tests, benchmarks, clang-tidy, etc.) are unaffected and still run on whichever branch is dispatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)