### PR TITLE
test(common): skip NES signal handler under AddressSanitizer

### DIFF
--- a/nes-common/src/Util/Signal.cpp
+++ b/nes-common/src/Util/Signal.cpp
@@ -49,22 +49,35 @@ const char* signalName(int signal)
 /// And resolving symbols would require fork/exec a new process with a dedicated binary which needs to be shipped alongside NebulaStream.
 /// For now the signal handler is unsafe and will potentially not work with a corrupted heap, which is still an improvement over not having
 /// any idea where the system has crashed.
-void SignalHandler(int signal)
+[[maybe_unused]] void SignalHandler(int signal)
 {
     fmt::print(stderr, "Caught signal {}\n", signalName(signal));
     printStackTrace();
     _exit(signal);
 }
 
-void registerSignalHandler(int signalNo, void (*handler)(int))
+[[maybe_unused]] void registerSignalHandler(int signalNo, void (*handler)(int))
 {
     std::ignore = signal(signalNo, handler);
 }
 }
 
+#if defined(__has_feature)
+    #if __has_feature(address_sanitizer)
+        #define NES_BUILT_WITH_ASAN 1
+    #endif
+#endif
+
 void NES::setupSignalHandlers()
 {
     cpptrace::register_terminate_handler();
+#ifdef NES_BUILT_WITH_ASAN
+    /// When built with AddressSanitizer, do NOT install our own SIGSEGV/SIGFPE handlers.
+    /// ASan installs its own handler that produces a precise report (faulting address, read/write,
+    /// and — for poisoned-heap accesses — allocation/free stacks). Overriding it with our cpptrace
+    /// handler would suppress that report. SIGABRT (used by ASan to terminate) is left untouched.
+#else
     registerSignalHandler(SIGSEGV, SignalHandler);
     registerSignalHandler(SIGFPE, SignalHandler);
+#endif
 }

--- a/nes-common/src/Util/Signal.cpp
+++ b/nes-common/src/Util/Signal.cpp
@@ -62,16 +62,10 @@ const char* signalName(int signal)
 }
 }
 
-#if defined(__has_feature)
-    #if __has_feature(address_sanitizer)
-        #define NES_BUILT_WITH_ASAN 1
-    #endif
-#endif
-
 void NES::setupSignalHandlers()
 {
     cpptrace::register_terminate_handler();
-#ifdef NES_BUILT_WITH_ASAN
+#if defined(__has_feature) && __has_feature(address_sanitizer)
     /// When built with AddressSanitizer, do NOT install our own SIGSEGV/SIGFPE handlers.
     /// ASan installs its own handler that produces a precise report (faulting address, read/write,
     /// and — for poisoned-heap accesses — allocation/free stacks). Overriding it with our cpptrace


### PR DESCRIPTION
## Problem

When NebulaStream is built with AddressSanitizer (ASan), `NES::setupSignalHandlers()` installed its own SIGSEGV/SIGFPE handler (a cpptrace stack dump). Because this handler was registered after the runtime started, it shadowed ASan's own SIGSEGV handler. As a result, when a memory error caused a fault, ASan never got to print its crash report — we only see the generic cpptrace dump, losing the precise faulting address, read/write classification, and allocation/free stacks that make ASan reports actionable.

## Fix

Guard the SIGSEGV/SIGFPE registration on AddressSanitizer detection via `__has_feature(address_sanitizer)`.

Under ASan, NES no longer installs its handler, so ASan's own handler produces the precise SEGV / heap report. SIGABRT (which ASan uses to terminate) is left untouched. The two now-unused file-local helpers are marked `[[maybe_unused]]` to satisfy `-Werror=unused-function` in ASan builds.

## Impact

Normal (non-ASan) builds are unaffected: the macro is undefined, so the NES cpptrace handler is registered exactly as before. Only ASan builds change behavior, and only to defer to ASan's superior crash reporting.

## Demo

ASan build, null-pointer write injected into `SystestStarter.cpp:main()`:

```cpp
volatile int* p = nullptr;
*p = 42;
```

### Before (pre-fix — NES handler shadows ASan)

```
Caught signal SIGSEGV
EXIT=11
```

That is the full output. The NES `SignalHandler` ran first, attempted `cpptrace::raw_trace::current().resolve().print_with_snippets()`, but under ASan the resolve path produced nothing before `_exit(11)`. ASan never ran. No faulting address, no PC, no allocation context.

### After (this PR — NES handler skipped under ASan)

```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==75647==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0xaaaac7cece0c bp 0xffffc05922e0 sp 0xffffc0591ea0 T0)
==75647==The signal is caused by a WRITE memory access.
==75647==Hint: address points to the zero page.
    #0 0xaaaac7cece0c in main /workspaces/nebulastream2/nes-systests/systest/src/SystestStarter.cpp:506:12
    #1 0xffffba2f84c0 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #2 0xffffba2f8594 in __libc_start_main csu/../csu/libc-start.c:360:3
    #3 0xaaaac7c085ac in _start (.../systest+0x87a85ac)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /workspaces/nebulastream2/nes-systests/systest/src/SystestStarter.cpp:506:12 in main
==75647==ABORTING
```

Faulting address, access type (WRITE), PC, symbolized frames, file:line. Actionable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)