### PR TITLE
fix(data-types): make DataType::join symmetric for incompatible types

### DIFF
--- a/nes-data-types/src/DataTypes/DataType.cpp
+++ b/nes-data-types/src/DataTypes/DataType.cpp
@@ -355,7 +355,8 @@ std::optional<DataType> DataType::join(const DataType& otherDataType) const
         {
             return {DataTypeProvider::provideDataType(Type::CHAR, isNullableResult)};
         }
-        return {DataTypeProvider::provideDataType(Type::UNDEFINED, isNullableResult)};
+        NES_WARNING("Cannot join {} and {}", *this, otherDataType);
+        return std::nullopt;
     }
     if (this->type == Type::BOOLEAN)
     {
@@ -363,7 +364,8 @@ std::optional<DataType> DataType::join(const DataType& otherDataType) const
         {
             return {DataTypeProvider::provideDataType(Type::BOOLEAN, isNullableResult)};
         }
-        return {DataTypeProvider::provideDataType(Type::UNDEFINED, isNullableResult)};
+        NES_WARNING("Cannot join {} and {}", *this, otherDataType);
+        return std::nullopt;
     }
     NES_WARNING("Cannot join {} and {}", *this, otherDataType);
     return std::nullopt;

--- a/nes-data-types/tests/UnitTests/API/NumericTypeConversionTest.cpp
+++ b/nes-data-types/tests/UnitTests/API/NumericTypeConversionTest.cpp
@@ -12,6 +12,7 @@
     limitations under the License.
 */
 
+#include <utility>
 #include <DataTypes/DataType.hpp>
 #include <DataTypes/DataTypeProvider.hpp>
 #include <Util/Logger/LogLevel.hpp>
@@ -397,4 +398,41 @@ INSTANTIATE_TEST_CASE_P(
             magic_enum::enum_name(info.param.rightIsNullable),
             magic_enum::enum_name(info.param.expectedResult.type));
     });
+
+/// Joining a non-numeric type with a numeric or other non-matching type must symmetrically return nullopt.
+/// Regression test for asymmetry where e.g. INT32.join(BOOLEAN) returned nullopt but BOOLEAN.join(INT32) returned UNDEFINED.
+class JoinIncompatibleTypesTest : public Testing::BaseUnitTest,
+                                  public ::testing::WithParamInterface<std::pair<DataType::Type, DataType::Type>>
+{
+public:
+    static void SetUpTestSuite() { Logger::setupLogging("JoinIncompatibleTypesTest.log", LogLevel::LOG_DEBUG); }
+};
+
+TEST_P(JoinIncompatibleTypesTest, BothDirectionsReturnNullopt)
+{
+    const auto [leftType, rightType] = GetParam();
+    const auto left = DataTypeProvider::provideDataType(leftType);
+    const auto right = DataTypeProvider::provideDataType(rightType);
+    const auto leftRight = left.join(right);
+    const auto rightLeft = right.join(left);
+    EXPECT_FALSE(leftRight.has_value()) << "Expected nullopt for " << left << ".join(" << right << ")";
+    EXPECT_FALSE(rightLeft.has_value()) << "Expected nullopt for " << right << ".join(" << left << ")";
+}
+
+INSTANTIATE_TEST_CASE_P(
+    JoinIncompatibleTypesTest,
+    JoinIncompatibleTypesTest,
+    ::testing::Values(
+        std::pair{DataType::Type::INT32, DataType::Type::BOOLEAN},
+        std::pair{DataType::Type::INT64, DataType::Type::BOOLEAN},
+        std::pair{DataType::Type::UINT32, DataType::Type::BOOLEAN},
+        std::pair{DataType::Type::FLOAT32, DataType::Type::BOOLEAN},
+        std::pair{DataType::Type::FLOAT64, DataType::Type::BOOLEAN},
+        std::pair{DataType::Type::INT32, DataType::Type::CHAR},
+        std::pair{DataType::Type::INT64, DataType::Type::CHAR},
+        std::pair{DataType::Type::FLOAT64, DataType::Type::CHAR},
+        std::pair{DataType::Type::BOOLEAN, DataType::Type::CHAR},
+        std::pair{DataType::Type::BOOLEAN, DataType::Type::VARSIZED},
+        std::pair{DataType::Type::CHAR, DataType::Type::VARSIZED},
+        std::pair{DataType::Type::INT32, DataType::Type::VARSIZED}));
 }


### PR DESCRIPTION
## Summary
- `INT32.join(BOOLEAN)` returned `std::nullopt`, but `BOOLEAN.join(INT32)` returned a `DataType{UNDEFINED}` value. Same asymmetry for any numeric vs `CHAR`. Callers checking `has_value()` (e.g. `AddLogicalFunction::withInferredDataType`) silently accepted one direction and threw `DifferentFieldTypeExpected` for the other.
- `CHAR`/`BOOLEAN` branches now return `std::nullopt` when the other operand is a non-matching type, matching the existing numeric-vs-non-numeric branch (and emitting the same `NES_WARNING` for parity).
- Concat is unaffected: it already rejects any join result that is not `VARSIZED`.

## Test plan
- [x] New parameterized regression `JoinIncompatibleTypesTest.BothDirectionsReturnNullopt` in `nes-data-types/tests/UnitTests/API/NumericTypeConversionTest.cpp` covers all incompatible primitive pairs in both directions.
- [x] Existing `NumericTypeConversionTest.SimpleTest` (52 cases) still passes.
- [x] Full debug build passes (`cmake --build cmake-build-debug -j`).
- [x] `clang-tidy-diff` clean on the change.