### PR TITLE
refactor(input-formatters): drop ad-hoc BufferManager from SequenceShredder

### DIFF
--- a/nes-input-formatters/include/InputFormatters/InputFormatter.hpp
+++ b/nes-input-formatters/include/InputFormatters/InputFormatter.hpp
@@ -65,7 +65,7 @@ public:
         , inputFormatIndexer(std::move(inputFormatIndexer))
         , projections(memoryProvider->getAllFieldNames())
         , memoryProvider(std::move(memoryProvider))
-        , sequenceShredder(std::make_unique<SequenceShredder>(this->inputFormatIndexer->getTupleDelimitingBytes().size()))
+        , sequenceShredder(std::make_unique<SequenceShredder>())
     {
     }
 

--- a/nes-input-formatters/include/InputFormatters/RawTupleBuffer.hpp
+++ b/nes-input-formatters/include/InputFormatters/RawTupleBuffer.hpp
@@ -87,6 +87,12 @@ public:
     /// Typically, these are the bytes of spanning tuple that _starts_ in the staged buffer.
     [[nodiscard]] std::string_view getTrailingBytes(const size_t sizeOfTupleDelimiter) const
     {
+        /// The start-of-stream sentinel that anchors the first leading spanning tuple owns no buffer (empty view).
+        /// It contributes no trailing bytes, so return early before the (delimiter-size-based) bounds check below.
+        if (rawBuffer.getBufferView().empty())
+        {
+            return {};
+        }
         INVARIANT(
             sizeOfBufferInBytes >= offsetOfLastTupleDelimiter + sizeOfTupleDelimiter,
             "Invalid trailing bytes. Size of buffer: {} < {} (offsetOfLastTupleDelimiter: {} + sizeOfTupleDelimiter: {}",

--- a/nes-input-formatters/include/InputFormatters/SequenceShredder.hpp
+++ b/nes-input-formatters/include/InputFormatters/SequenceShredder.hpp
@@ -70,7 +70,7 @@ class SequenceShredder
     static constexpr size_t INITIAL_SIZE_OF_SPANNING_TUPLE_BUFFER = 1024;
 
 public:
-    explicit SequenceShredder(size_t sizeOfTupleDelimiterInBytes);
+    SequenceShredder();
     /// Destructor validates (final) state of spanning tuple buffer
     ~SequenceShredder();
 

--- a/nes-input-formatters/private/SpanningTupleBuffer.hpp
+++ b/nes-input-formatters/private/SpanningTupleBuffer.hpp
@@ -76,7 +76,7 @@ public:
         SequenceNumber lastSequenceNumber = INVALID<SequenceNumber>;
     };
 
-    explicit SpanningTupleBuffer(size_t initialSize, TupleBuffer dummyBuffer);
+    explicit SpanningTupleBuffer(size_t initialSize);
 
     /// First, checks if the prior entry at the index of 'sequenceNumber' contains the expected prior ABA iteration number and is used up
     /// If not, returns as 'NOT_IN_RANGE'

--- a/nes-input-formatters/private/SpanningTupleBufferState.hpp
+++ b/nes-input-formatters/private/SpanningTupleBufferState.hpp
@@ -147,8 +147,10 @@ public:
 
     SpanningTupleBufferEntry() = default;
 
-    /// Sets the state of the first entry to a value that allows triggering the first leading spanning tuple of a stream
-    void setStateOfFirstIndex(TupleBuffer dummyBuffer);
+    /// Sets the state of the first entry to a value that allows triggering the first leading spanning tuple of a stream.
+    /// The first entry is a start-of-stream sentinel: it owns no buffer and only carries the atomic state that anchors the
+    /// first leading spanning tuple (acting as a virtual leading delimiter before the very first byte of the stream).
+    void setStateOfFirstIndex();
 
     /// A thread can claim a spanning tuple by claiming the first buffer of the spanning tuple (SpanningTuple).
     /// Multiple threads may concurrently call 'tryClaimSpanningTuple()', but only one thread can successfully claim the SpanningTuple.

--- a/nes-input-formatters/src/SequenceShredder.cpp
+++ b/nes-input-formatters/src/SequenceShredder.cpp
@@ -40,18 +40,9 @@
 namespace NES
 {
 
-SequenceShredder::SequenceShredder(const size_t sizeOfTupleDelimiterInBytes)
+SequenceShredder::SequenceShredder()
 {
-    /// This dummy manager only ever hands out a single pooled buffer, so it needs no unpooled budget.
-    constexpr uint32_t dummyBufferSize = 1;
-    constexpr NES::BufferAlignment bufferAlignment{64};
-    constexpr double unpooledMemoryFraction = 0.0;
-    auto dummyBuffer
-        = BufferManager::create(
-              dummyBufferSize, unpooledMemoryFraction, bufferAlignment, dummyBufferSize, std::make_shared<NesDefaultMemoryAllocator>())
-              ->getBufferBlocking();
-    dummyBuffer.setNumberOfTuples(sizeOfTupleDelimiterInBytes);
-    this->spanningTupleBuffer = std::make_unique<SpanningTupleBuffer>(INITIAL_SIZE_OF_SPANNING_TUPLE_BUFFER, std::move(dummyBuffer));
+    this->spanningTupleBuffer = std::make_unique<SpanningTupleBuffer>(INITIAL_SIZE_OF_SPANNING_TUPLE_BUFFER);
 }
 
 SequenceShredder::~SequenceShredder()

--- a/nes-input-formatters/src/SpanningTupleBuffer.cpp
+++ b/nes-input-formatters/src/SpanningTupleBuffer.cpp
@@ -37,11 +37,10 @@
 namespace NES
 {
 
-SpanningTupleBuffer::SpanningTupleBuffer(const size_t initialSize, TupleBuffer dummyBuffer)
-    : buffer(std::vector<SpanningTupleBufferEntry>(initialSize))
+SpanningTupleBuffer::SpanningTupleBuffer(const size_t initialSize) : buffer(std::vector<SpanningTupleBufferEntry>(initialSize))
 {
     PRECONDITION(initialSize > 0, "Constructing an SpanningTupleBuffer with an initial size of 0 is not allowed");
-    buffer.at(0).setStateOfFirstIndex(std::move(dummyBuffer));
+    buffer.at(0).setStateOfFirstIndex();
 }
 
 SpanningTupleBuffer::WithoutDelimiterSearchResult

--- a/nes-input-formatters/src/SpanningTupleBufferState.cpp
+++ b/nes-input-formatters/src/SpanningTupleBufferState.cpp
@@ -108,7 +108,13 @@ std::optional<StagedBuffer> SpanningTupleBufferEntry::tryClaimSpanningTuple(cons
 {
     if (this->atomicState.tryClaimSpanningTuple(abaItNumber))
     {
-        INVARIANT(this->trailingBufferRef.getReferenceCounter() != 0, "Tried to claim a trailing buffer with a nullptr");
+        /// The start-of-stream sentinel (very first entry, first iteration) owns no backing buffer (null data pointer). It
+        /// anchors the first leading spanning tuple but contributes no bytes, so we hand back an empty StagedBuffer for it.
+        if (!this->trailingBufferRef)
+        {
+            this->atomicState.setUsedTrailingBuffer();
+            return {StagedBuffer{}};
+        }
         const auto stagedBuffer
             = StagedBuffer(RawTupleBuffer{std::move(this->trailingBufferRef)}, firstDelimiterOffset, lastDelimiterOffset);
         this->atomicState.setUsedTrailingBuffer();
@@ -117,10 +123,10 @@ std::optional<StagedBuffer> SpanningTupleBufferEntry::tryClaimSpanningTuple(cons
     return std::nullopt;
 }
 
-void SpanningTupleBufferEntry::setStateOfFirstIndex(TupleBuffer dummyBuffer)
+void SpanningTupleBufferEntry::setStateOfFirstIndex()
 {
-    /// The first entry is a dummy that makes sure that we can resolve the first tuple in the first buffer
-    this->trailingBufferRef = std::move(dummyBuffer);
+    /// The first entry is a start-of-stream sentinel. It owns no buffer; it only carries the atomic state that lets the
+    /// SpanningTupleBuffer resolve the first tuple in the first buffer (acting as a virtual leading delimiter).
     this->atomicState.setStateOfFirstEntry();
     this->firstDelimiterOffset = 0;
     this->lastDelimiterOffset = 0;

--- a/nes-input-formatters/tests/UnitTests/ConcurrentSynchronizationTest.cpp
+++ b/nes-input-formatters/tests/UnitTests/ConcurrentSynchronizationTest.cpp
@@ -59,7 +59,7 @@ public:
             const NES::SequenceNumberType upperBound,
             const std::optional<NES::SequenceNumberType> fixedSeed,
             const NES::TupleBuffer& dummyBuffer)
-            : sequenceShredder(SequenceShredder{1}), currentSequenceNumber(1), completionLatch(NUM_THREADS)
+            : currentSequenceNumber(1), completionLatch(NUM_THREADS)
         {
             for (size_t i = 0; i < NUM_THREADS; ++i)
             {


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

The `SequenceShredder` seeded the first slot of its spanning-tuple ring buffer with a "dummy" `TupleBuffer` obtained from a **throwaway `BufferManager::create(1, 1)`**. That `BufferManager` stayed alive (via the buffer's recycler holding `shared_from_this`) until the dummy was consumed when the first tuple was read — so it was constructed and then destroyed at a seemingly random later point in time.

The visible symptom was **confusing debug logs**: for every source, a brand-new `BufferManager` would appear to be created and then, seemingly at random, destroyed once the first tuple was read (`BufferManager configuration bufferSize=1 numOfBuffers=1 ...` followed shortly by `Calling BufferManager::destroy()`). This made logs hard to read and suggested phantom allocators springing into and out of existence.

The dummy buffer's contents were in fact **never read**: it only needed to be a claimable, delimiter-bearing sentinel that anchors the first leading spanning tuple while contributing zero bytes. This PR replaces it with a **backing-free start-of-stream sentinel**, so no `BufferManager` is created at all:

- The first ring-buffer entry holds no `TupleBuffer` (`setStateOfFirstIndex()` only sets the atomic state).
- `tryClaimSpanningTuple()` hands back an empty `StagedBuffer` for the sentinel, detected via a **non-atomic null-pointer check** (`operator!`) on the trailing buffer reference (cheaper than reading the atomic reference counter).
- `getTrailingBytes()` returns empty for the (empty-view) sentinel before its delimiter-size bounds check.
- Drops the now-unused `sizeOfTupleDelimiterInBytes` constructor parameter of `SequenceShredder` / `SpanningTupleBuffer`.

No throwaway `BufferManager`, no confusing create/destroy logs.

## Verifying this change

- Input-formatter unit tests pass, including the multi-threaded **exhaustive concurrency test** (`ConcurrentSynchronizationTest`) and the start-of-buffer edge cases in `SpecificSequenceTest` (e.g. `simdJSONFirstObjectEndsAtBufferBoundary`).
- Correctness validated at scale: the **DEBS benchmark** (GB-scale CSV) passes all queries with matching checksums.
- Performance is unchanged: a head-to-head DEBS benchmark (20 runs each, `-b`, COMPILER, 16 threads) shows the new logic **within run-to-run noise** of the old (no per-query delta beyond combined stddev).

## What components does this pull request potentially affect?

- InputFormatters (CSV/JSON spanning-tuple resolution via `SequenceShredder` / `SpanningTupleBuffer`)

## Documentation
- In-code documentation updated: the sentinel rationale is documented at `setStateOfFirstIndex`, `tryClaimSpanningTuple`, and `getTrailingBytes`.

## Issue Closed by this pull request:

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)