### PR TITLE
added reflect to reflectionContext

### DIFF
--- a/nes-common/include/Identifiers/Identifier.hpp
+++ b/nes-common/include/Identifiers/Identifier.hpp
@@ -87,7 +87,7 @@ private:
 template <>
 struct Reflector<Identifier>
 {
-    Reflected operator()(const Identifier& identifier) const;
+    Reflected operator()(const Identifier& identifier, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-common/include/Identifiers/QualifiedIdentifier.hpp
+++ b/nes-common/include/Identifiers/QualifiedIdentifier.hpp
@@ -390,7 +390,10 @@ inline Identifier::operator QualifiedIdentifierBase<std::dynamic_extent>() const
 template <size_t Extent>
 struct Reflector<QualifiedIdentifierBase<Extent>>
 {
-    Reflected operator()(const QualifiedIdentifierBase<Extent>& identifierList) const { return reflect(fmt::format("{}", identifierList)); }
+    Reflected operator()(const QualifiedIdentifierBase<Extent>& identifierList, const ReflectionContext& context) const
+    {
+        return context.reflect(fmt::format("{}", identifierList));
+    }
 };
 
 template <>

--- a/nes-common/include/Util/Reflection.hpp
+++ b/nes-common/include/Util/Reflection.hpp
@@ -47,42 +47,4 @@ namespace NES
 /// For forward declarations only, use ReflectionFwd.hpp
 /// For core functionality without container specializations, use ReflectionCore.hpp
 
-namespace detail
-{
-/// Helper to reflect a single field at compile-time
-/// Must be defined after all reflect() overloads so they're visible during instantiation
-template <typename T, size_t Index>
-auto reflect_field_at_index(const T& data)
-{
-    using NamedTupleType = rfl::named_tuple_t<T>;
-    using FieldType = rfl::tuple_element_t<Index, typename NamedTupleType::Fields>;
-    const auto fieldName = typename FieldType::Name().str();
-
-    /// Get reference to the field using rfl's field introspection
-    auto view = rfl::to_view(data);
-    const auto& fieldValue = rfl::get<Index>(view);
-
-    return std::make_pair(fieldName, reflect(*fieldValue));
-}
-
-/// Reflect an aggregate type field-by-field to build a Generic::Object
-/// Must be defined after all reflect() overloads so they're visible during instantiation
-template <typename T>
-Reflected reflect_aggregate_impl(const T& data)
-{
-    using NamedTupleType = rfl::named_tuple_t<T>;
-    constexpr size_t numFields = NamedTupleType::size();
-
-    rfl::Generic::Object obj;
-
-    /// Reflect each field and add to the object
-    [&]<size_t... Is>(std::index_sequence<Is...>)
-    {
-        ((obj[reflect_field_at_index<T, Is>(data).first] = *reflect_field_at_index<T, Is>(data).second), ...);
-    }(std::make_index_sequence<numFields>{});
-
-    return Reflected{rfl::Generic::Object{std::move(obj)}};
-}
-}
-
 }

--- a/nes-common/include/Util/Reflection/NESStrongTypeReflection.hpp
+++ b/nes-common/include/Util/Reflection/NESStrongTypeReflection.hpp
@@ -28,7 +28,10 @@ namespace NES
 template <typename T, typename Tag, T Invalid, T Initial>
 struct Reflector<NESStrongType<T, Tag, Invalid, Initial>>
 {
-    Reflected operator()(const NESStrongType<T, Tag, Invalid, Initial>& data) const { return reflect(data.getRawValue()); }
+    Reflected operator()(const NESStrongType<T, Tag, Invalid, Initial>& data, const ReflectionContext& context) const
+    {
+        return context.reflect(data.getRawValue());
+    }
 };
 
 template <typename T, typename Tag, T Invalid, T Initial>
@@ -43,7 +46,10 @@ struct Unreflector<NESStrongType<T, Tag, Invalid, Initial>>
 template <typename Tag, StringLiteral Invalid>
 struct Reflector<NESStrongStringType<Tag, Invalid>>
 {
-    Reflected operator()(const NESStrongStringType<Tag, Invalid>& data) const { return reflect(data.getRawValue()); }
+    Reflected operator()(const NESStrongStringType<Tag, Invalid>& data, const ReflectionContext& context) const
+    {
+        return context.reflect(data.getRawValue());
+    }
 };
 
 template <typename Tag, StringLiteral Invalid>
@@ -58,7 +64,10 @@ struct Unreflector<NESStrongStringType<Tag, Invalid>>
 template <typename Tag>
 struct Reflector<NESStrongUUIDType<Tag>>
 {
-    Reflected operator()(const NESStrongUUIDType<Tag>& data) const { return reflect(data.getRawValue()); }
+    Reflected operator()(const NESStrongUUIDType<Tag>& data, const ReflectionContext& context) const
+    {
+        return context.reflect(data.getRawValue());
+    }
 };
 
 template <typename Tag>

--- a/nes-common/include/Util/Reflection/OptionalReflection.hpp
+++ b/nes-common/include/Util/Reflection/OptionalReflection.hpp
@@ -23,11 +23,11 @@ namespace NES
 template <typename T>
 struct Reflector<std::optional<T>>
 {
-    Reflected operator()(const std::optional<T>& data) const
+    Reflected operator()(const std::optional<T>& data, const ReflectionContext& context) const
     {
         if (data.has_value())
         {
-            return reflect(data.value());
+            return context.reflect(data.value());
         }
         return Reflected{std::nullopt};
     }

--- a/nes-common/include/Util/Reflection/PairReflection.hpp
+++ b/nes-common/include/Util/Reflection/PairReflection.hpp
@@ -28,11 +28,11 @@ namespace NES
 template <typename T1, typename T2>
 struct Reflector<std::pair<T1, T2>>
 {
-    Reflected operator()(const std::pair<T1, T2>& data) const
+    Reflected operator()(const std::pair<T1, T2>& data, const ReflectionContext& context) const
     {
         std::vector<rfl::Generic> arr;
-        arr.push_back(*reflect(data.first));
-        arr.push_back(*reflect(data.second));
+        arr.push_back(*context.reflect(data.first));
+        arr.push_back(*context.reflect(data.second));
         return Reflected{rfl::Generic::Array{std::move(arr)}};
     }
 };

--- a/nes-common/include/Util/Reflection/ReflectionCore.hpp
+++ b/nes-common/include/Util/Reflection/ReflectionCore.hpp
@@ -64,6 +64,8 @@ private:
 template <typename T>
 struct Unreflector;
 
+template <typename T>
+struct Reflector;
 
 /// Type has an Unreflector that takes Reflected and ReflectionContext parameters
 template <typename T>
@@ -86,6 +88,24 @@ concept HasExplicitUnreflector = HasTwoParamUnreflector<T> || ContextfulUnreflec
 /// Type is a primitive type (arithmetic or string)
 template <typename T>
 concept Primitive = std::is_arithmetic_v<T> || std::is_same_v<T, std::string>;
+
+/// Type has a Reflector that takes Reflected and ReflectionContext parameters
+template <typename T>
+concept HasTwoParamReflector = requires(const T& data, const class ReflectionContext& ctx) {
+    { Reflector<T>{}(data, ctx) } -> std::same_as<Reflected>;
+};
+
+/// Type has a contextful Reflector (constructor-based context passing)
+template <typename T>
+concept ContextfulReflector = requires(const T& value, const class ReflectionContext& ctx) {
+    typename Reflector<T>::ContextType;
+    { Reflector<T>{std::declval<typename Reflector<T>::ContextType>()} };
+    { Reflector<T>{std::declval<typename Reflector<T>::ContextType>()}(value, ctx) } -> std::same_as<Reflected>;
+};
+
+/// Type has any explicit Reflector specialization
+template <typename T>
+concept HasExplicitReflector = HasTwoParamReflector<T> || ContextfulReflector<T>;
 
 /// Context object for deserialization that allows passing configuration or state down the call chain.
 ///
@@ -159,6 +179,45 @@ public:
         return unreflect_with_context_impl<T>(data);
     }
 
+    template <typename T>
+    [[nodiscard]] Reflected reflect(const T&) const
+    {
+        static_assert(
+            always_false_v<T>,
+            "No reflection overload available for this type. "
+            "Options: 1) Add a Reflector<T> specialization, "
+            "2) Make the type an aggregate, "
+            "3) For primitives/enums, ensure proper includes.");
+    }
+
+    template <typename T>
+    requires HasTwoParamReflector<T>
+    [[nodiscard]] Reflected reflect(const T& data) const
+    {
+        return Reflector<T>{}(data, *this);
+    }
+
+    /// Overload for types with contextful Reflector (constructor-based context passing)
+    template <typename T>
+    requires ContextfulReflector<T>
+    [[nodiscard]] Reflected reflect(const T& data) const
+    {
+        if (const auto it = context.find(std::type_index(typeid(typename Reflector<T>::ContextType))); it != context.end())
+        {
+            return Reflector<T>{std::any_cast<typename Reflector<T>::ContextType>(it->second)}(data, *this);
+        }
+        throw CannotSerialize(
+            "Serialization context of type {} for type {} not found", NAMEOF_TYPE(typename Reflector<T>::ContextType), NAMEOF_TYPE(T));
+    }
+
+    /// Overload for aggregate types without explicit Reflector (field-by-field deserialization)
+    template <typename T>
+    requires(!HasExplicitReflector<T>) && std::is_class_v<T> && std::is_aggregate_v<T>
+    Reflected reflect(const T& data) const
+    {
+        return reflect_with_context_impl<T>(data);
+    }
+
 private:
     template <typename T>
     T unreflect_with_context_impl(const Reflected& data) const
@@ -199,6 +258,18 @@ private:
                 }
             },
             generic.variant());
+    }
+
+    template <typename T>
+    Reflected reflect_with_context_impl(const T& data) const
+    {
+        using NamedTupleType = rfl::named_tuple_t<T>;
+        constexpr size_t numFields = NamedTupleType::size();
+
+        rfl::Generic::Object object;
+        [&]<size_t... Is>(std::index_sequence<Is...>) { (reflect_field<T, Is>(data, object), ...); }(std::make_index_sequence<numFields>{});
+
+        return Reflected{rfl::Generic{std::move(object)}};
     }
 
     template <typename T>
@@ -298,6 +369,22 @@ private:
         return this->unreflect<FieldValueType>(Reflected{fieldResult.value()});
     }
 
+    template <typename T, size_t Index>
+    void reflect_field(const T& data, rfl::Generic::Object& object) const
+    {
+        using NamedTupleType = rfl::named_tuple_t<T>;
+        using FieldType = rfl::tuple_element_t<Index, typename NamedTupleType::Fields>;
+        const auto fieldName = typename FieldType::Name().str();
+
+        /// Extract the field value from the aggregate via rfl::to_named_tuple
+        const auto namedTuple = rfl::to_named_tuple(data);
+        const auto& fieldValue = rfl::get<Index>(namedTuple);
+
+        /// Recursively reflect through the context so nested contextful reflectors get the context
+        Reflected reflected = this->reflect(fieldValue);
+        object[fieldName] = *reflected;
+    }
+
     template <typename T, typename Tuple, size_t... Is>
     T construct_from_tuple_impl(Tuple&& values, std::index_sequence<Is...>) const
     {
@@ -324,90 +411,6 @@ private:
     }
 };
 
-template <typename T>
-[[nodiscard]] Reflected reflect(const T& data);
-
-template <typename T>
-struct Reflector;
-
-namespace detail
-{
-template <typename T>
-Reflected reflect_aggregate_impl(const T& data);
-}
-
-/// Overload for types with explicit Reflector specialization
-/// Checks if Reflector<T> can be default-constructed (i.e., has a specialization)
-/// This takes precedence over all other overloads
-template <typename T>
-requires requires { Reflector<T>{}; }
-Reflected reflect(const T& data)
-{
-    return Reflector<T>{}(data);
-}
-
-/// Overload for primitive types (arithmetic, string, enum) without custom Reflector
-template <typename T>
-requires(std::is_arithmetic_v<T> || std::is_same_v<T, std::string> || std::is_enum_v<T>) && (!requires { Reflector<T>{}; })
-Reflected reflect(const T& data)
-{
-    if constexpr (std::is_same_v<T, bool> || std::is_same_v<T, std::string>)
-    {
-        return Reflected{rfl::Generic{data}};
-    }
-    else if constexpr (std::is_integral_v<T>)
-    {
-        return Reflected{rfl::Generic{static_cast<int64_t>(data)}};
-    }
-    else if constexpr (std::is_floating_point_v<T>)
-    {
-        return Reflected{rfl::Generic{static_cast<double>(data)}};
-    }
-    else if constexpr (std::is_enum_v<T>)
-    {
-        /// Serialize enums as their underlying integer value
-        return Reflected{rfl::Generic{static_cast<int64_t>(static_cast<std::underlying_type_t<T>>(data))}};
-    }
-    else
-    {
-        static_assert(always_false_v<T>, "Unsupported primitive type");
-    }
-}
-
-/// Overload for pointer types without custom Reflector
-template <typename T>
-requires std::is_pointer_v<T> && (!requires { Reflector<T>{}; })
-Reflected reflect(const T& data)
-{
-    if (data == nullptr)
-    {
-        return Reflected{std::nullopt};
-    }
-    /// Dereference and reflect the pointed-to value
-    return reflect(*data);
-}
-
-/// Overload for aggregate types without custom Reflector - use field-by-field reflection
-template <typename T>
-requires std::is_class_v<T> && std::is_aggregate_v<T> && (!requires { Reflector<T>{}; })
-Reflected reflect(const T& data)
-{
-    return detail::reflect_aggregate_impl(data);
-}
-
-/// Fallback overload for types that don't match any other overload
-/// This provides a clear compile-time error message
-template <typename T>
-Reflected reflect(const T&)
-{
-    static_assert(
-        always_false_v<T>,
-        "No reflection overload available for this type. "
-        "Options: 1) Add a Reflector<T> specialization, "
-        "2) Make the type an aggregate, "
-        "3) For primitives/enums, ensure proper includes.");
-}
-
 namespace detail
 {
 /// Helper to reflect a single field at compile-time
@@ -425,13 +428,34 @@ auto reflect_field_at_index(const T& data);
 template <>
 struct Reflector<Reflected>
 {
-    Reflected operator()(const Reflected& field) const { return field; }
+    Reflected operator()(const Reflected& field, const ReflectionContext&) const { return field; }
 };
 
 template <>
 struct Unreflector<Reflected>
 {
     Reflected operator()(const Reflected& field, const ReflectionContext&) const { return field; }
+};
+
+/// Reflector for primitive types (arithmetic and string)
+template <Primitive T>
+struct Reflector<T>
+{
+    Reflected operator()(const T& data, const ReflectionContext&) const
+    {
+        if constexpr (std::is_same_v<T, bool> || std::is_same_v<T, std::string>)
+        {
+            return Reflected{rfl::Generic{data}};
+        }
+        else if constexpr (std::is_integral_v<T>)
+        {
+            return Reflected{rfl::Generic{static_cast<int64_t>(data)}};
+        }
+        else if constexpr (std::is_floating_point_v<T>)
+        {
+            return Reflected{rfl::Generic{static_cast<double>(data)}};
+        }
+    }
 };
 
 /// Unreflector for primitive types (arithmetic and string)
@@ -446,6 +470,17 @@ struct Unreflector<T>
             throw CannotDeserialize("Failed to unreflect given data, rfl error: {}", optional.error().what());
         }
         return optional.value();
+    }
+};
+
+/// Reflector for enum types
+template <typename T>
+requires std::is_enum_v<T>
+struct Reflector<T>
+{
+    Reflected operator()(const T& data, const ReflectionContext&) const
+    {
+        return Reflected{rfl::Generic{static_cast<int64_t>(static_cast<std::underlying_type_t<T>>(data))}};
     }
 };
 
@@ -471,6 +506,21 @@ struct Unreflector<T>
                 throw CannotDeserialize("Expected integer for enum, got different type {}", NAMEOF_TYPE(ValueType));
             },
             data->variant());
+    }
+};
+
+/// Reflector for pointer types
+template <typename T>
+requires std::is_pointer_v<T>
+struct Reflector<T>
+{
+    Reflected operator()(const T& data, const ReflectionContext& ctx) const
+    {
+        if (data == nullptr)
+        {
+            return Reflected{std::nullopt};
+        }
+        return ctx.reflect(*data);
     }
 };
 

--- a/nes-common/include/Util/Reflection/ReflectionCore.hpp
+++ b/nes-common/include/Util/Reflection/ReflectionCore.hpp
@@ -265,10 +265,10 @@ private:
     {
         using NamedTupleType = rfl::named_tuple_t<T>;
         constexpr size_t numFields = NamedTupleType::size();
-
+        const auto namedTuple = rfl::to_named_tuple(data);
         rfl::Generic::Object object;
-        [&]<size_t... Is>(std::index_sequence<Is...>) { (reflect_field<T, Is>(data, object), ...); }(std::make_index_sequence<numFields>{});
-
+        [&]<size_t... Is>(std::index_sequence<Is...>)
+        { (reflect_field<T, Is>(namedTuple, object), ...); }(std::make_index_sequence<numFields>{});
         return Reflected{rfl::Generic{std::move(object)}};
     }
 
@@ -370,14 +370,12 @@ private:
     }
 
     template <typename T, size_t Index>
-    void reflect_field(const T& data, rfl::Generic::Object& object) const
+    void reflect_field(const rfl::named_tuple_t<T>& namedTuple, rfl::Generic::Object& object) const
     {
         using NamedTupleType = rfl::named_tuple_t<T>;
         using FieldType = rfl::tuple_element_t<Index, typename NamedTupleType::Fields>;
         const auto fieldName = typename FieldType::Name().str();
 
-        /// Extract the field value from the aggregate via rfl::to_named_tuple
-        const auto namedTuple = rfl::to_named_tuple(data);
         const auto& fieldValue = rfl::get<Index>(namedTuple);
 
         /// Recursively reflect through the context so nested contextful reflectors get the context
@@ -411,19 +409,7 @@ private:
     }
 };
 
-namespace detail
-{
-/// Helper to reflect a single field at compile-time
-/// Implementation in Reflection.hpp to ensure all reflect() overloads are visible
-template <typename T, size_t Index>
-auto reflect_field_at_index(const T& data);
-
-/// Reflect an aggregate type field-by-field to build a Generic::Object
-/// Implementation in Reflection.hpp to ensure all reflect() overloads are visible
-
-}
-
-/// Core Unreflector specializations
+/// Core Reflector / Unreflector specializations
 
 template <>
 struct Reflector<Reflected>
@@ -516,6 +502,9 @@ struct Reflector<T>
 {
     Reflected operator()(const T& data, const ReflectionContext& ctx) const
     {
+        static_assert(
+            !std::is_same_v<std::remove_cv_t<std::remove_pointer_t<T>>, char>,
+            "Cannot reflect char*/const char* — use std::string instead");
         if (data == nullptr)
         {
             return Reflected{std::nullopt};

--- a/nes-common/include/Util/Reflection/StringViewReflection.hpp
+++ b/nes-common/include/Util/Reflection/StringViewReflection.hpp
@@ -23,7 +23,7 @@ namespace NES
 template <>
 struct Reflector<std::string_view>
 {
-    Reflected operator()(const std::string_view data) const { return reflect(std::string(data)); }
+    Reflected operator()(const std::string_view data, const ReflectionContext& context) const { return context.reflect(std::string(data)); }
 };
 
 /// No Unreflector so that we don't get a dangling reference

--- a/nes-common/include/Util/Reflection/UnorderedMapReflection.hpp
+++ b/nes-common/include/Util/Reflection/UnorderedMapReflection.hpp
@@ -33,7 +33,7 @@ template <typename K, typename V, typename Hash, typename KeyEqual, typename All
 requires(std::is_same_v<K, std::string> || std::is_arithmetic_v<K>)
 struct Reflector<std::unordered_map<K, V, Hash, KeyEqual, Allocator>>
 {
-    Reflected operator()(const std::unordered_map<K, V, Hash, KeyEqual, Allocator>& data) const
+    Reflected operator()(const std::unordered_map<K, V, Hash, KeyEqual, Allocator>& data, const ReflectionContext& context) const
     {
         rfl::Generic::Object obj;
         for (const auto& [key, value] : data)
@@ -52,7 +52,7 @@ struct Reflector<std::unordered_map<K, V, Hash, KeyEqual, Allocator>>
                 static_assert(
                     std::is_same_v<K, std::string> || std::is_arithmetic_v<K>, "Unsupported key type for std::unordered_map serialization");
             }
-            obj[keyStr] = *reflect(value);
+            obj[keyStr] = *context.reflect(value);
         }
         return Reflected{rfl::Generic::Object{std::move(obj)}};
     }

--- a/nes-common/include/Util/Reflection/UnorderedMapReflection.hpp
+++ b/nes-common/include/Util/Reflection/UnorderedMapReflection.hpp
@@ -117,9 +117,9 @@ template <typename K, typename V, typename Hash, typename KeyEqual, typename All
 requires(!std::is_same_v<K, std::string> && !std::is_arithmetic_v<K>)
 struct Reflector<std::unordered_map<K, V, Hash, KeyEqual, Allocator>>
 {
-    Reflected operator()(const std::unordered_map<K, V, Hash, KeyEqual, Allocator>& data) const
+    Reflected operator()(const std::unordered_map<K, V, Hash, KeyEqual, Allocator>& data, const ReflectionContext& context) const
     {
-        return reflect(data | std::ranges::to<std::vector>());
+        return context.reflect(data | std::ranges::to<std::vector>());
     }
 };
 

--- a/nes-common/include/Util/Reflection/VariantReflection.hpp
+++ b/nes-common/include/Util/Reflection/VariantReflection.hpp
@@ -33,11 +33,11 @@ namespace NES
 template <typename... Ts>
 struct Reflector<std::variant<Ts...>>
 {
-    Reflected operator()(const std::variant<Ts...>& data) const
+    Reflected operator()(const std::variant<Ts...>& data, const ReflectionContext& context) const
     {
         rfl::Generic::Object obj;
         obj["index"] = rfl::Generic{static_cast<int64_t>(data.index())};
-        std::visit([&obj](const auto& value) { obj["value"] = *reflect(value); }, data);
+        std::visit([&obj, &context](const auto& value) { obj["value"] = *context.reflect(value); }, data);
         return Reflected{rfl::Generic::Object{std::move(obj)}};
     }
 };

--- a/nes-common/include/Util/Reflection/VectorReflection.hpp
+++ b/nes-common/include/Util/Reflection/VectorReflection.hpp
@@ -28,13 +28,13 @@ namespace NES
 template <typename T>
 struct Reflector<std::vector<T>>
 {
-    Reflected operator()(const std::vector<T>& data) const
+    Reflected operator()(const std::vector<T>& data, const ReflectionContext& context) const
     {
         std::vector<rfl::Generic> result;
         result.reserve(data.size());
         for (const auto& element : data)
         {
-            auto reflected = reflect(element);
+            auto reflected = context.reflect(element);
             result.push_back(reflected);
         }
         return Reflected{rfl::Generic::Array{std::move(result)}};

--- a/nes-common/src/Identifiers/Identifier.cpp
+++ b/nes-common/src/Identifiers/Identifier.cpp
@@ -119,9 +119,9 @@ std::expected<Identifier, Exception> Identifier::tryParse(std::string value)
     return Identifier{std::move(value), caseSensitive.value()};
 }
 
-Reflected Reflector<Identifier>::operator()(const Identifier& identifier) const
+Reflected Reflector<Identifier>::operator()(const Identifier& identifier, const ReflectionContext& context) const
 {
-    return reflect(std::pair{identifier.getOriginalString(), identifier.isCaseSensitive()});
+    return context.reflect(std::pair{identifier.getOriginalString(), identifier.isCaseSensitive()});
 }
 
 Identifier Unreflector<Identifier>::operator()(const Reflected& reflectable, const ReflectionContext& context) const

--- a/nes-common/tests/UnitTests/Util/ReflectionTest.cpp
+++ b/nes-common/tests/UnitTests/Util/ReflectionTest.cpp
@@ -63,9 +63,9 @@ struct InnerDataDeserializationConfig
 template <>
 struct Reflector<InnerData>
 {
-    Reflected operator()(const InnerData& data) const
+    Reflected operator()(const InnerData& data, const ReflectionContext& context) const
     {
-        return reflect(detail::ReflectedInnerData{.value = data.value, .optionalField = data.optionalField});
+        return context.reflect(detail::ReflectedInnerData{.value = data.value, .optionalField = data.optionalField});
     }
 };
 
@@ -104,9 +104,9 @@ TEST(ReflectionTest, NestedContextPropagation)
 {
     const OuterData outer{.name = "outer", .inner = InnerData{.value = "inner", .optionalField = 99}, .count = 5};
 
-    auto reflected = reflect(outer);
-
     const ReflectionContext context{InnerDataDeserializationConfig{.includeOptionalField = true}};
+
+    auto reflected = context.reflect(outer);
 
     auto deserialized = context.unreflect<OuterData>(reflected);
 
@@ -121,9 +121,9 @@ TEST(ReflectionTest, NestedContextPropagationExcludesOptionalField)
 {
     const OuterData outer{.name = "outer", .inner = InnerData{.value = "inner", .optionalField = 99}, .count = 5};
 
-    auto reflected = reflect(outer);
-
     const ReflectionContext context{InnerDataDeserializationConfig{.includeOptionalField = false}};
+
+    auto reflected = context.reflect(outer);
 
     auto deserialized = context.unreflect<OuterData>(reflected);
 
@@ -140,9 +140,9 @@ TEST(ReflectionTest, VectorSerialization)
         InnerData{.value = "second", .optionalField = 2},
         InnerData{.value = "third", .optionalField = std::nullopt}};
 
-    auto reflected = reflect(vec);
-
     const ReflectionContext context{InnerDataDeserializationConfig{.includeOptionalField = true}};
+
+    auto reflected = context.reflect(vec);
 
     auto deserialized = context.unreflect<std::vector<InnerData>>(reflected);
 
@@ -159,9 +159,9 @@ TEST(ReflectionTest, OptionalSerialization)
 {
     const std::optional<InnerData> opt = InnerData{.value = "test", .optionalField = 42};
 
-    auto reflected = reflect(opt);
-
     const ReflectionContext context{InnerDataDeserializationConfig{.includeOptionalField = true}};
+
+    auto reflected = context.reflect(opt);
 
     auto deserialized = context.unreflect<std::optional<InnerData>>(reflected);
 
@@ -174,9 +174,9 @@ TEST(ReflectionTest, OptionalEmpty)
 {
     const std::optional<InnerData> opt = std::nullopt;
 
-    auto reflected = reflect(opt);
-
     const auto context = ReflectionContext{InnerDataDeserializationConfig{.includeOptionalField = true}};
+
+    auto reflected = context.reflect(opt);
 
     auto deserialized = context.unreflect<std::optional<InnerData>>(reflected);
 
@@ -186,8 +186,8 @@ TEST(ReflectionTest, OptionalEmpty)
 TEST(ReflectionTest, VariantSerialization)
 {
     const std::variant<InnerData, int> variant = InnerData{.value = "test", .optionalField = 42};
-    auto reflected = reflect(variant);
     const ReflectionContext context{InnerDataDeserializationConfig{.includeOptionalField = true}};
+    auto reflected = context.reflect(variant);
     auto deserialized = context.unreflect<std::variant<InnerData, int>>(reflected);
     ASSERT_TRUE(std::holds_alternative<InnerData>(deserialized));
     EXPECT_EQ(std::get<InnerData>(deserialized).value, "test");
@@ -197,8 +197,8 @@ TEST(ReflectionTest, VariantSerialization)
 TEST(ReflectionTest, PairSerialization)
 {
     const std::pair<InnerData, int> pair = std::pair{InnerData{.value = "test", .optionalField = 42}, 123};
-    auto reflected = reflect(pair);
     const ReflectionContext context{InnerDataDeserializationConfig{.includeOptionalField = true}};
+    auto reflected = context.reflect(pair);
     auto deserialized = context.unreflect<std::pair<InnerData, int>>(reflected);
     EXPECT_EQ(std::get<0>(deserialized).value, "test");
     EXPECT_EQ(std::get<0>(deserialized).optionalField.value(), 42);
@@ -211,8 +211,8 @@ TEST(ReflectionTest, MapSerialization)
         = {{"first", InnerData{.value = "first", .optionalField = 1}},
            {"second", InnerData{.value = "second", .optionalField = 2}},
            {"third", InnerData{.value = "third", .optionalField = std::nullopt}}};
-    auto reflected = reflect(map);
     const ReflectionContext context{InnerDataDeserializationConfig{.includeOptionalField = true}};
+    auto reflected = context.reflect(map);
     auto deserialized = context.unreflect<std::unordered_map<std::string, InnerData>>(reflected);
     ASSERT_EQ(deserialized.size(), 3);
     EXPECT_EQ(deserialized.at("first").value, "first");
@@ -232,8 +232,8 @@ TEST(ReflectionTest, EnumSerialization)
         Third
     };
     const TestEnum testEnum = TestEnum::Second;
-    auto reflected = reflect(testEnum);
     const ReflectionContext context{InnerDataDeserializationConfig{.includeOptionalField = true}};
+    auto reflected = context.reflect(testEnum);
     auto deserialized = context.unreflect<TestEnum>(reflected);
     EXPECT_EQ(deserialized, TestEnum::Second);
 }
@@ -242,9 +242,8 @@ TEST(ReflectionTest, MissingConfig)
 {
     const OuterData outer{.name = "outer", .inner = InnerData{.value = "inner", .optionalField = 99}, .count = 5};
 
-    auto reflected = reflect(outer);
-
     const ReflectionContext context{};
+    auto reflected = context.reflect(outer);
 
     EXPECT_ANY_THROW(context.unreflect<OuterData>(reflected));
 }
@@ -255,8 +254,8 @@ TEST(ReflectionTest, UnsignedConversion)
     /// C++ guarantees that for any uint64_t u static_cast<uint64_t>(static_cast<int64_t>(u)) == u ,
     /// but this test makes sure that no code of reflectcpp or us breaks this.
     constexpr uint64_t unsignedInput = std::dynamic_extent - 1;
-    const auto reflected = reflect(unsignedInput);
     const ReflectionContext context{};
+    const auto reflected = context.reflect(unsignedInput);
     const auto deserialized = context.unreflect<uint64_t>(reflected);
     EXPECT_EQ(deserialized, unsignedInput);
 }

--- a/nes-configurations/include/Configurations/Descriptor.hpp
+++ b/nes-configurations/include/Configurations/Descriptor.hpp
@@ -335,7 +335,7 @@ struct Descriptor
 
     [[nodiscard]] DescriptorConfig::Config getConfig() const { return config; }
 
-    [[nodiscard]] Reflected getReflectedConfig() const;
+    [[nodiscard]] Reflected getReflectedConfig(const ReflectionContext& context) const;
     static DescriptorConfig::Config unreflectConfig(const Reflected& rfl, const ReflectionContext& context);
 
 protected:

--- a/nes-configurations/include/Configurations/Enums/EnumWrapper.hpp
+++ b/nes-configurations/include/Configurations/Enums/EnumWrapper.hpp
@@ -57,7 +57,7 @@ private:
 template <>
 struct Reflector<EnumWrapper>
 {
-    Reflected operator()(const EnumWrapper& wrapper) const { return reflect(wrapper.getValue()); }
+    Reflected operator()(const EnumWrapper& wrapper, const ReflectionContext& context) const { return context.reflect(wrapper.getValue()); }
 };
 
 template <>

--- a/nes-configurations/src/Configurations/Descriptor.cpp
+++ b/nes-configurations/src/Configurations/Descriptor.cpp
@@ -178,7 +178,7 @@ struct ReflectedDescriptorConfig
     std::unordered_map<std::string, std::pair<std::string, Reflected>> config;
 };
 
-Reflected Descriptor::getReflectedConfig() const
+Reflected Descriptor::getReflectedConfig(const ReflectionContext& context) const
 {
     ReflectedDescriptorConfig reflectedConfig;
 
@@ -189,21 +189,21 @@ Reflected Descriptor::getReflectedConfig() const
     {
         std::visit(
             Overloaded{
-                [&](const int32_t val) { reflectedConfig.config[key] = std::make_pair("int32_t", reflect(val)); },
-                [&](const uint32_t val) { reflectedConfig.config[key] = std::make_pair("uint32_t", reflect(val)); },
-                [&](const int64_t val) { reflectedConfig.config[key] = std::make_pair("int64_t", reflect(val)); },
-                [&](const uint64_t val) { reflectedConfig.config[key] = std::make_pair("uint64_t", reflect(val)); },
-                [&](const bool val) { reflectedConfig.config[key] = std::make_pair("bool", reflect(val)); },
-                [&](const char val) { reflectedConfig.config[key] = std::make_pair("char", reflect(val)); },
-                [&](const float val) { reflectedConfig.config[key] = std::make_pair("float", reflect(val)); },
-                [&](const double val) { reflectedConfig.config[key] = std::make_pair("double", reflect(val)); },
-                [&](const std::string& val) { reflectedConfig.config[key] = std::make_pair("string", reflect(val)); },
-                [&](const EnumWrapper& val) { reflectedConfig.config[key] = std::make_pair("EnumWrapper", reflect(val)); }},
+                [&](const int32_t val) { reflectedConfig.config[key] = std::make_pair("int32_t", context.reflect(val)); },
+                [&](const uint32_t val) { reflectedConfig.config[key] = std::make_pair("uint32_t", context.reflect(val)); },
+                [&](const int64_t val) { reflectedConfig.config[key] = std::make_pair("int64_t", context.reflect(val)); },
+                [&](const uint64_t val) { reflectedConfig.config[key] = std::make_pair("uint64_t", context.reflect(val)); },
+                [&](const bool val) { reflectedConfig.config[key] = std::make_pair("bool", context.reflect(val)); },
+                [&](const char val) { reflectedConfig.config[key] = std::make_pair("char", context.reflect(val)); },
+                [&](const float val) { reflectedConfig.config[key] = std::make_pair("float", context.reflect(val)); },
+                [&](const double val) { reflectedConfig.config[key] = std::make_pair("double", context.reflect(val)); },
+                [&](const std::string& val) { reflectedConfig.config[key] = std::make_pair("string", context.reflect(val)); },
+                [&](const EnumWrapper& val) { reflectedConfig.config[key] = std::make_pair("EnumWrapper", context.reflect(val)); }},
             value);
     }
     ///NOLINTEND(clang-analyzer-core.CallAndMessage)
 
-    return reflect(reflectedConfig);
+    return context.reflect(reflectedConfig);
 }
 
 DescriptorConfig::Config Descriptor::unreflectConfig(const Reflected& rfl, const ReflectionContext& context)

--- a/nes-data-types/include/DataTypes/DataType.hpp
+++ b/nes-data-types/include/DataTypes/DataType.hpp
@@ -139,7 +139,7 @@ struct DataType final
 template <>
 struct Reflector<DataType>
 {
-    Reflected operator()(const DataType& field) const;
+    Reflected operator()(const DataType& field, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-data-types/include/DataTypes/Schema.hpp
+++ b/nes-data-types/include/DataTypes/Schema.hpp
@@ -349,7 +349,10 @@ auto Schema<FieldType, IsOrdered>::size() const -> decltype(std::declval<FieldCo
 template <typename FieldType, OrderType IsOrdered>
 struct Reflector<Schema<FieldType, IsOrdered>>
 {
-    Reflected operator()(const Schema<FieldType, IsOrdered>& schema) const { return reflect(schema | std::ranges::to<std::vector>()); }
+    Reflected operator()(const Schema<FieldType, IsOrdered>& schema, const ReflectionContext& context) const
+    {
+        return context.reflect(schema | std::ranges::to<std::vector>());
+    }
 };
 
 template <typename FieldType, OrderType IsOrdered>

--- a/nes-data-types/include/DataTypes/TimeUnit.hpp
+++ b/nes-data-types/include/DataTypes/TimeUnit.hpp
@@ -55,7 +55,7 @@ namespace NES
 template <>
 struct Reflector<Windowing::TimeUnit>
 {
-    Reflected operator()(const Windowing::TimeUnit& timeUnit) const;
+    Reflected operator()(const Windowing::TimeUnit& timeUnit, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-data-types/include/DataTypes/UnboundField.hpp
+++ b/nes-data-types/include/DataTypes/UnboundField.hpp
@@ -85,9 +85,9 @@ struct ReflectedUnboundFieldBase
 template <size_t IdListExtent>
 struct Reflector<UnboundFieldBase<IdListExtent>>
 {
-    Reflected operator()(const UnboundFieldBase<IdListExtent>& field) const
+    Reflected operator()(const UnboundFieldBase<IdListExtent>& field, const ReflectionContext& context) const
     {
-        return reflect(ReflectedUnboundFieldBase<IdListExtent>{field.getFullyQualifiedName(), field.getDataType()});
+        return context.reflect(ReflectedUnboundFieldBase<IdListExtent>{field.getFullyQualifiedName(), field.getDataType()});
     }
 };
 

--- a/nes-data-types/src/DataTypes/DataType.cpp
+++ b/nes-data-types/src/DataTypes/DataType.cpp
@@ -371,9 +371,9 @@ std::optional<DataType> DataType::join(const DataType& otherDataType) const
     return std::nullopt;
 }
 
-Reflected Reflector<DataType>::operator()(const DataType& field) const
+Reflected Reflector<DataType>::operator()(const DataType& field, const ReflectionContext& context) const
 {
-    return reflect(std::make_pair(field.type, field.nullable));
+    return context.reflect(std::make_pair(field.type, field.nullable));
 }
 
 DataType Unreflector<DataType>::operator()(const Reflected& rfl, const ReflectionContext& context) const

--- a/nes-data-types/src/DataTypes/TimeUnit.cpp
+++ b/nes-data-types/src/DataTypes/TimeUnit.cpp
@@ -71,9 +71,9 @@ TimeUnit TimeUnit::Days()
 
 namespace NES
 {
-Reflected Reflector<Windowing::TimeUnit>::operator()(const Windowing::TimeUnit& timeUnit) const
+Reflected Reflector<Windowing::TimeUnit>::operator()(const Windowing::TimeUnit& timeUnit, const ReflectionContext& context) const
 {
-    return reflect(timeUnit.getMillisecondsConversionMultiplier());
+    return context.reflect(timeUnit.getMillisecondsConversionMultiplier());
 }
 
 Windowing::TimeUnit Unreflector<Windowing::TimeUnit>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-frontend/apps/cli/CLIStarter.cpp
+++ b/nes-frontend/apps/cli/CLIStarter.cpp
@@ -653,7 +653,8 @@ void doStatus(
         {
             throw std::move(result.error());
         }
-        auto rows = NES::rowsToJsonArray(NES::StatementOutputAssembler<NES::WorkerStatusStatementResult>{}.convert(result.value()));
+        auto rows = NES::rowsToJsonArray(
+            NES::StatementOutputAssembler<NES::WorkerStatusStatementResult>{}.convert(result.value()), NES::ReflectionContext{});
         std::cout << rfl::json::write(rows, rfl::json::pretty) << '\n';
     }
     else
@@ -668,8 +669,9 @@ void doStatus(
                 throw std::move(statementResult.error());
             }
 
-            auto results
-                = NES::rowsToJsonArray(NES::StatementOutputAssembler<NES::ShowQueriesStatementResult>{}.convert(statementResult.value()));
+            auto results = NES::rowsToJsonArray(
+                NES::StatementOutputAssembler<NES::ShowQueriesStatementResult>{}.convert(statementResult.value()),
+                NES::ReflectionContext{});
             result.insert(result.end(), std::make_move_iterator(results.begin()), std::make_move_iterator(results.end()));
         }
 
@@ -688,8 +690,8 @@ void doStop(NES::QueryStatementHandler& queryStatementHandler, const std::vector
             throw std::move(statementResult.error());
         }
 
-        auto results
-            = NES::rowsToJsonArray(NES::StatementOutputAssembler<NES::DropQueryStatementResult>{}.convert(statementResult.value()));
+        auto results = NES::rowsToJsonArray(
+            NES::StatementOutputAssembler<NES::DropQueryStatementResult>{}.convert(statementResult.value()), NES::ReflectionContext{});
         result.insert(result.end(), std::make_move_iterator(results.begin()), std::make_move_iterator(results.end()));
     }
 

--- a/nes-frontend/apps/repl/Repl.cpp
+++ b/nes-frontend/apps/repl/Repl.cpp
@@ -442,7 +442,8 @@ struct Repl::Impl
                         [](const auto& statementResult)
                         {
                             return rfl::json::write(NES::rowsToJsonArray(
-                                NES::StatementOutputAssembler<std::remove_cvref_t<decltype(statementResult)>>{}.convert(statementResult)));
+                                NES::StatementOutputAssembler<std::remove_cvref_t<decltype(statementResult)>>{}.convert(statementResult),
+                                NES::ReflectionContext{}));
                         },
                         result.value())
                               << "\n";

--- a/nes-frontend/apps/repl/ReplStarter.cpp
+++ b/nes-frontend/apps/repl/ReplStarter.cpp
@@ -115,7 +115,7 @@ std::ostream& printStatementResult(std::ostream& os, NES::StatementOutputFormat 
         case NES::StatementOutputFormat::TEXT:
             return os << toText(result);
         case NES::StatementOutputFormat::JSON:
-            return os << rfl::json::write(NES::rowsToJsonArray(result)) << '\n';
+            return os << rfl::json::write(NES::rowsToJsonArray(result, NES::ReflectionContext{})) << '\n';
     }
     std::unreachable();
 }

--- a/nes-frontend/include/Statements/StatementJsonSerializers.hpp
+++ b/nes-frontend/include/Statements/StatementJsonSerializers.hpp
@@ -50,47 +50,48 @@
 namespace NES::detail
 {
 
-inline rfl::Generic toFrontendGeneric(const DataType& dataType)
+inline rfl::Generic toFrontendGeneric(const DataType& dataType, const ReflectionContext& context)
 {
-    return reflect(std::string(magic_enum::enum_name(dataType.type)));
+    return context.reflect(std::string(magic_enum::enum_name(dataType.type)));
 }
 
 /// reflectcpp's native handler for Identifier (via Reflector<Identifier>) emits `[original-string, case-sensitive-bool]`.
 /// The historical frontend JSON shape is the canonical (case-folded) string — override here.
-inline rfl::Generic toFrontendGeneric(const Identifier& identifier)
+inline rfl::Generic toFrontendGeneric(const Identifier& identifier, const ReflectionContext& context)
 {
-    return reflect(identifier.asCanonicalString());
+    return context.reflect(identifier.asCanonicalString());
 }
 
-inline rfl::Generic toFrontendGeneric(const UnqualifiedUnboundField& field)
+inline rfl::Generic toFrontendGeneric(const UnqualifiedUnboundField& field, const ReflectionContext& context)
 {
     rfl::Object<rfl::Generic> obj;
-    obj["name"] = reflect(field.getFullyQualifiedName());
+    obj["name"] = context.reflect(field.getFullyQualifiedName());
     obj["type"] = toFrontendGeneric(field.getDataType());
     return obj;
 }
 
-inline rfl::Generic toFrontendGeneric(const Schema<UnqualifiedUnboundField, Ordered>& schema)
+/// Historical shape: an outer array wrapping the array of fields.
+inline rfl::Generic toFrontendGeneric(const Schema<UnqualifiedUnboundField, Ordered>& schema, const ReflectionContext& context)
 {
     rfl::Generic::Array fields;
     fields.reserve(schema.size());
     for (const auto& field : schema)
     {
-        fields.emplace_back(toFrontendGeneric(field));
+        fields.emplace_back(toFrontendGeneric(field, context));
     }
     return fields;
 }
 
 /// reflectcpp's native std::unordered_map handler outputs a flat JSON object. The historical layout
 /// for DescriptorConfig::Config is a sorted array of single-key objects, so we override it here.
-inline rfl::Generic toFrontendGeneric(const DescriptorConfig::Config& config)
+inline rfl::Generic toFrontendGeneric(const DescriptorConfig::Config& config, const ReflectionContext& context)
 {
     rfl::Generic::Array entries;
     const auto ordered = config | std::ranges::to<std::map<std::string, DescriptorConfig::ConfigType>>();
     for (const auto& [key, val] : ordered)
     {
         rfl::Object<rfl::Generic> entry;
-        entry[key] = std::visit([](auto&& arg) -> rfl::Generic { return reflect(arg); }, val);
+        entry[key] = std::visit([&context](auto&& arg) -> rfl::Generic { return *context.reflect(arg); }, val);
         entries.emplace_back(std::move(entry));
     }
     return entries;
@@ -100,10 +101,10 @@ inline rfl::Generic toFrontendGeneric(const DescriptorConfig::Config& config)
 /// around DescriptorConfig::Config) into a doubly-nested, type-tagged object. The historical layout is a
 /// flat object: the formatter type under "type", then each remaining config parameter. char-typed
 /// delimiters become single-character strings, matching the previous nlohmann output.
-inline rfl::Generic toFrontendGeneric(const InputFormatterDescriptor& descriptor)
+inline rfl::Generic toFrontendGeneric(const InputFormatterDescriptor& descriptor, const ReflectionContext& context)
 {
     rfl::Object<rfl::Generic> obj;
-    obj["type"] = reflect(descriptor.getInputFormatterType());
+    obj["type"] = context.reflect(descriptor.getInputFormatterType());
     const auto ordered = descriptor.getConfig() | std::ranges::to<std::map<std::string, DescriptorConfig::ConfigType>>();
     for (const auto& [key, val] : ordered)
     {
@@ -112,15 +113,15 @@ inline rfl::Generic toFrontendGeneric(const InputFormatterDescriptor& descriptor
             continue;
         }
         obj[key] = std::visit(
-            [](auto&& arg) -> rfl::Generic
+            [&context](auto&& arg) -> rfl::Generic
             {
                 if constexpr (std::is_same_v<std::decay_t<decltype(arg)>, char>)
                 {
-                    return reflect(std::string(1, arg));
+                    return context.reflect(std::string(1, arg));
                 }
                 else
                 {
-                    return reflect(arg);
+                    return context.reflect(arg);
                 }
             },
             val);
@@ -129,12 +130,12 @@ inline rfl::Generic toFrontendGeneric(const InputFormatterDescriptor& descriptor
 }
 
 template <typename Clock, typename Duration>
-rfl::Generic toFrontendGeneric(const std::chrono::time_point<Clock, Duration>& timepoint)
+rfl::Generic toFrontendGeneric(const std::chrono::time_point<Clock, Duration>& timepoint, const ReflectionContext& context)
 {
     rfl::Object<rfl::Generic> obj;
-    obj["since_epoch"] = reflect(std::chrono::duration_cast<std::chrono::microseconds>(timepoint.time_since_epoch()).count());
-    obj["unit"] = reflect(std::string("microseconds"));
-    obj["formatted"] = reflect(fmt::format("{}", timepoint));
+    obj["since_epoch"] = context.reflect(std::chrono::duration_cast<std::chrono::microseconds>(timepoint.time_since_epoch()).count());
+    obj["unit"] = context.reflect(std::string("microseconds"));
+    obj["formatted"] = context.reflect(fmt::format("{}", timepoint));
     return obj;
 }
 
@@ -142,33 +143,33 @@ rfl::Generic toFrontendGeneric(const std::chrono::time_point<Clock, Duration>& t
 /// underlying integer value the default reflection chain would emit.
 template <typename T>
 requires std::is_enum_v<T>
-rfl::Generic toFrontendGeneric(const T& value)
+rfl::Generic toFrontendGeneric(const T& value, const ReflectionContext& context)
 {
-    return reflect(std::string(magic_enum::enum_name(value)));
+    return context.reflect(std::string(magic_enum::enum_name(value)));
 }
 
 /// Fallback for any type without a specific overload. Routes through the existing reflection chain
 /// (rfl::to_generic + NES::Reflector partial specialization), which already handles primitives,
 /// optionals, variants, maps, and NES strong-typed identifiers in a way compatible with the frontend output.
 template <typename T>
-rfl::Generic toFrontendGeneric(const T& value)
+rfl::Generic toFrontendGeneric(const T& value, const ReflectionContext& context)
 {
-    return reflect(value);
+    return context.reflect(value);
 }
 
 template <typename T>
-void appendField(rfl::Object<rfl::Generic>& target, std::string_view fieldName, const T& field)
+void appendField(rfl::Object<rfl::Generic>& target, std::string_view fieldName, const T& field, const ReflectionContext& context)
 {
     if constexpr (Optional<T>)
     {
         if (field.has_value())
         {
-            target[std::string(fieldName)] = toFrontendGeneric(*field);
+            target[std::string(fieldName)] = toFrontendGeneric(*field, context);
         }
     }
     else
     {
-        target[std::string(fieldName)] = toFrontendGeneric(field);
+        target[std::string(fieldName)] = toFrontendGeneric(field, context);
     }
 }
 
@@ -180,7 +181,8 @@ namespace NES
 /// Converts a (column-names, rows-of-tuples) pair as produced by StatementOutputAssembler into a
 /// JSON array of objects. Optional fields with no value are omitted.
 template <size_t N, typename... Ts>
-rfl::Generic::Array rowsToJsonArray(const std::pair<std::array<std::string_view, N>, std::vector<std::tuple<Ts...>>>& assembled)
+rfl::Generic::Array rowsToJsonArray(
+    const std::pair<std::array<std::string_view, N>, std::vector<std::tuple<Ts...>>>& assembled, const ReflectionContext& context)
 {
     rfl::Generic::Array rows;
     rows.reserve(assembled.second.size());
@@ -188,7 +190,7 @@ rfl::Generic::Array rowsToJsonArray(const std::pair<std::array<std::string_view,
     {
         rfl::Object<rfl::Generic> obj;
         [&]<size_t... Is>(std::index_sequence<Is...>)
-        { (detail::appendField(obj, assembled.first[Is], std::get<Is>(row)), ...); }(std::index_sequence_for<Ts...>{});
+        { (detail::appendField(obj, assembled.first[Is], std::get<Is>(row), context), ...); }(std::index_sequence_for<Ts...>{});
         rows.emplace_back(std::move(obj));
     }
     return rows;

--- a/nes-frontend/include/Statements/StatementJsonSerializers.hpp
+++ b/nes-frontend/include/Statements/StatementJsonSerializers.hpp
@@ -66,7 +66,7 @@ inline rfl::Generic toFrontendGeneric(const UnqualifiedUnboundField& field, cons
 {
     rfl::Object<rfl::Generic> obj;
     obj["name"] = context.reflect(field.getFullyQualifiedName());
-    obj["type"] = toFrontendGeneric(field.getDataType());
+    obj["type"] = toFrontendGeneric(field.getDataType(), context);
     return obj;
 }
 

--- a/nes-inference/include/Model.hpp
+++ b/nes-inference/include/Model.hpp
@@ -157,7 +157,7 @@ public:
 template <>
 struct Reflector<ImportedModel>
 {
-    Reflected operator()(const ImportedModel& model) const;
+    Reflected operator()(const ImportedModel& model, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-inference/include/ModelCatalog.hpp
+++ b/nes-inference/include/ModelCatalog.hpp
@@ -85,7 +85,7 @@ public:
 template <>
 struct Reflector<RegisteredModel>
 {
-    Reflected operator()(const RegisteredModel& model) const;
+    Reflected operator()(const RegisteredModel& model, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-inference/src/Model.cpp
+++ b/nes-inference/src/Model.cpp
@@ -49,12 +49,12 @@ struct
 };
 }
 
-Reflected Reflector<ImportedModel>::operator()(const ImportedModel& model) const
+Reflected Reflector<ImportedModel>::operator()(const ImportedModel& model, const ReflectionContext& context) const
 {
     const auto data = model.getData();
     /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) byte-to-char for textual MLIR serialization
     std::string mlir(reinterpret_cast<const char*>(data.data()), data.size());
-    return reflect(detail::ReflectedImportedModel{
+    return context.reflect(detail::ReflectedImportedModel{
         .mlir = std::make_optional(std::move(mlir)),
         .functionName = std::make_optional(model.getFunctionName()),
         .inputShape = std::make_optional(model.getInputShape()),
@@ -74,12 +74,12 @@ ImportedModel Unreflector<ImportedModel>::operator()(const Reflected& rfl, const
         reflected.outputShape.value_or(std::vector<size_t>{})};
 }
 
-Reflected Reflector<RegisteredModel>::operator()(const RegisteredModel& model) const
+Reflected Reflector<RegisteredModel>::operator()(const RegisteredModel& model, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedRegisteredModel{
+    return context.reflect(detail::ReflectedRegisteredModel{
         .name = std::make_optional(model.getName()),
         .path = std::make_optional(model.getPath().string()),
-        .imported = std::make_optional(Reflector<ImportedModel>{}(model.getImported())),
+        .imported = std::make_optional(Reflector<ImportedModel>{}(model.getImported(), context)),
         .inputs = std::make_optional(model.getSchema().inputs),
         .outputs = std::make_optional(model.getSchema().outputs)});
 }

--- a/nes-input-formatters/include/InputFormatterProvider/InputFormatterDescriptor.hpp
+++ b/nes-input-formatters/include/InputFormatterProvider/InputFormatterDescriptor.hpp
@@ -61,7 +61,7 @@ private:
 template <>
 struct Reflector<InputFormatterDescriptor>
 {
-    Reflected operator()(const InputFormatterDescriptor& inputFormatterDescriptor) const;
+    Reflected operator()(const InputFormatterDescriptor& inputFormatterDescriptor, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-input-formatters/src/InputFormatterDescriptor.cpp
+++ b/nes-input-formatters/src/InputFormatterDescriptor.cpp
@@ -40,12 +40,13 @@ std::ostream& operator<<(std::ostream& out, const InputFormatterDescriptor& inpu
     return out << fmt::format("InputFormatterDescriptor: (Config: {})", inputFormatterDescriptor.toStringConfig());
 }
 
-Reflected Reflector<InputFormatterDescriptor>::operator()(const InputFormatterDescriptor& inputFormatterDescriptor) const
+Reflected Reflector<InputFormatterDescriptor>::operator()(
+    const InputFormatterDescriptor& inputFormatterDescriptor, const ReflectionContext& context) const
 {
     const detail::ReflectedInputFormatterDescriptor descriptor{
-        .inputFormatterType = inputFormatterDescriptor.inputFormatterType, .config = inputFormatterDescriptor.getReflectedConfig()};
+        .inputFormatterType = inputFormatterDescriptor.inputFormatterType, .config = inputFormatterDescriptor.getReflectedConfig(context)};
 
-    return reflect(descriptor);
+    return context.reflect(descriptor);
 }
 
 InputFormatterDescriptor Unreflector<InputFormatterDescriptor>::operator()(const Reflected& rfl, const ReflectionContext& context) const

--- a/nes-logical-operators/include/Functions/ArithmeticalFunctions/AbsoluteLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/ArithmeticalFunctions/AbsoluteLogicalFunction.hpp
@@ -57,7 +57,7 @@ private:
 template <>
 struct Reflector<AbsoluteLogicalFunction>
 {
-    Reflected operator()(const AbsoluteLogicalFunction& function) const;
+    Reflected operator()(const AbsoluteLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/ArithmeticalFunctions/AddLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/ArithmeticalFunctions/AddLogicalFunction.hpp
@@ -57,7 +57,7 @@ private:
 template <>
 struct Reflector<AddLogicalFunction>
 {
-    Reflected operator()(const AddLogicalFunction& function) const;
+    Reflected operator()(const AddLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/ArithmeticalFunctions/CeilLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/ArithmeticalFunctions/CeilLogicalFunction.hpp
@@ -56,7 +56,7 @@ private:
 template <>
 struct Reflector<CeilLogicalFunction>
 {
-    Reflected operator()(const CeilLogicalFunction& function) const;
+    Reflected operator()(const CeilLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/ArithmeticalFunctions/DivLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/ArithmeticalFunctions/DivLogicalFunction.hpp
@@ -58,7 +58,7 @@ private:
 template <>
 struct Reflector<DivLogicalFunction>
 {
-    Reflected operator()(const DivLogicalFunction& function) const;
+    Reflected operator()(const DivLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/ArithmeticalFunctions/ExpLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/ArithmeticalFunctions/ExpLogicalFunction.hpp
@@ -57,7 +57,7 @@ private:
 template <>
 struct Reflector<ExpLogicalFunction>
 {
-    Reflected operator()(const ExpLogicalFunction& function) const;
+    Reflected operator()(const ExpLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/ArithmeticalFunctions/FloorLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/ArithmeticalFunctions/FloorLogicalFunction.hpp
@@ -57,7 +57,7 @@ private:
 template <>
 struct Reflector<FloorLogicalFunction>
 {
-    Reflected operator()(const FloorLogicalFunction& function) const;
+    Reflected operator()(const FloorLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/ArithmeticalFunctions/ModuloLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/ArithmeticalFunctions/ModuloLogicalFunction.hpp
@@ -57,7 +57,7 @@ private:
 template <>
 struct Reflector<ModuloLogicalFunction>
 {
-    Reflected operator()(const ModuloLogicalFunction& function) const;
+    Reflected operator()(const ModuloLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/ArithmeticalFunctions/MulLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/ArithmeticalFunctions/MulLogicalFunction.hpp
@@ -57,7 +57,7 @@ private:
 template <>
 struct Reflector<MulLogicalFunction>
 {
-    Reflected operator()(const MulLogicalFunction& function) const;
+    Reflected operator()(const MulLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/ArithmeticalFunctions/PowLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/ArithmeticalFunctions/PowLogicalFunction.hpp
@@ -57,7 +57,7 @@ private:
 template <>
 struct Reflector<PowLogicalFunction>
 {
-    Reflected operator()(const PowLogicalFunction& function) const;
+    Reflected operator()(const PowLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/ArithmeticalFunctions/RoundLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/ArithmeticalFunctions/RoundLogicalFunction.hpp
@@ -57,7 +57,7 @@ private:
 template <>
 struct Reflector<RoundLogicalFunction>
 {
-    Reflected operator()(const RoundLogicalFunction& function) const;
+    Reflected operator()(const RoundLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/ArithmeticalFunctions/SqrtLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/ArithmeticalFunctions/SqrtLogicalFunction.hpp
@@ -57,7 +57,7 @@ private:
 template <>
 struct Reflector<SqrtLogicalFunction>
 {
-    Reflected operator()(const SqrtLogicalFunction& function) const;
+    Reflected operator()(const SqrtLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/ArithmeticalFunctions/SubLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/ArithmeticalFunctions/SubLogicalFunction.hpp
@@ -57,7 +57,7 @@ private:
 template <>
 struct Reflector<SubLogicalFunction>
 {
-    Reflected operator()(const SubLogicalFunction& function) const;
+    Reflected operator()(const SubLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/BooleanFunctions/AndLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/BooleanFunctions/AndLogicalFunction.hpp
@@ -57,7 +57,7 @@ private:
 template <>
 struct Reflector<AndLogicalFunction>
 {
-    Reflected operator()(const AndLogicalFunction& function) const;
+    Reflected operator()(const AndLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/BooleanFunctions/EqualsLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/BooleanFunctions/EqualsLogicalFunction.hpp
@@ -57,7 +57,7 @@ private:
 template <>
 struct Reflector<EqualsLogicalFunction>
 {
-    Reflected operator()(const EqualsLogicalFunction& function) const;
+    Reflected operator()(const EqualsLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/BooleanFunctions/IsNullCheckLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/BooleanFunctions/IsNullCheckLogicalFunction.hpp
@@ -59,7 +59,7 @@ private:
 template <>
 struct Reflector<IsNullCheckLogicalFunction>
 {
-    Reflected operator()(const IsNullCheckLogicalFunction& function) const;
+    Reflected operator()(const IsNullCheckLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/BooleanFunctions/NegateLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/BooleanFunctions/NegateLogicalFunction.hpp
@@ -58,7 +58,7 @@ private:
 template <>
 struct Reflector<NegateLogicalFunction>
 {
-    Reflected operator()(const NegateLogicalFunction& function) const;
+    Reflected operator()(const NegateLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/BooleanFunctions/OrLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/BooleanFunctions/OrLogicalFunction.hpp
@@ -58,7 +58,7 @@ private:
 template <>
 struct Reflector<OrLogicalFunction>
 {
-    Reflected operator()(const OrLogicalFunction& function) const;
+    Reflected operator()(const OrLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/CastFromUnixTimestampLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/CastFromUnixTimestampLogicalFunction.hpp
@@ -62,7 +62,7 @@ private:
 template <>
 struct Reflector<CastFromUnixTimestampLogicalFunction>
 {
-    Reflected operator()(const CastFromUnixTimestampLogicalFunction& function) const;
+    Reflected operator()(const CastFromUnixTimestampLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/CastToTypeLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/CastToTypeLogicalFunction.hpp
@@ -67,7 +67,7 @@ struct ReflectedCastToTypeLogicalFunction
 template <>
 struct Reflector<CastToTypeLogicalFunction>
 {
-    Reflected operator()(const CastToTypeLogicalFunction& function) const;
+    Reflected operator()(const CastToTypeLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/CastToUnixTimestampLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/CastToUnixTimestampLogicalFunction.hpp
@@ -62,7 +62,7 @@ static_assert(LogicalFunctionConcept<CastToUnixTimestampLogicalFunction>);
 template <>
 struct Reflector<CastToUnixTimestampLogicalFunction>
 {
-    Reflected operator()(const CastToUnixTimestampLogicalFunction& function) const;
+    Reflected operator()(const CastToUnixTimestampLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/CastToUnixTimestampLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/CastToUnixTimestampLogicalFunction.hpp
@@ -57,8 +57,6 @@ private:
     friend Reflector<CastToUnixTimestampLogicalFunction>;
 };
 
-static_assert(LogicalFunctionConcept<CastToUnixTimestampLogicalFunction>);
-
 template <>
 struct Reflector<CastToUnixTimestampLogicalFunction>
 {

--- a/nes-logical-operators/include/Functions/CharLengthLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/CharLengthLogicalFunction.hpp
@@ -59,7 +59,7 @@ private:
 template <>
 struct Reflector<CharLengthLogicalFunction>
 {
-    Reflected operator()(const CharLengthLogicalFunction& function) const;
+    Reflected operator()(const CharLengthLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/ComparisonFunctions/GreaterEqualsLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/ComparisonFunctions/GreaterEqualsLogicalFunction.hpp
@@ -57,7 +57,7 @@ private:
 template <>
 struct Reflector<GreaterEqualsLogicalFunction>
 {
-    Reflected operator()(const GreaterEqualsLogicalFunction& function) const;
+    Reflected operator()(const GreaterEqualsLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/ComparisonFunctions/GreaterLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/ComparisonFunctions/GreaterLogicalFunction.hpp
@@ -57,7 +57,7 @@ private:
 template <>
 struct Reflector<GreaterLogicalFunction>
 {
-    Reflected operator()(const GreaterLogicalFunction& function) const;
+    Reflected operator()(const GreaterLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/ComparisonFunctions/LessEqualsLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/ComparisonFunctions/LessEqualsLogicalFunction.hpp
@@ -58,7 +58,7 @@ private:
 template <>
 struct Reflector<LessEqualsLogicalFunction>
 {
-    Reflected operator()(const LessEqualsLogicalFunction& function) const;
+    Reflected operator()(const LessEqualsLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/ComparisonFunctions/LessLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/ComparisonFunctions/LessLogicalFunction.hpp
@@ -58,7 +58,7 @@ private:
 template <>
 struct Reflector<LessLogicalFunction>
 {
-    Reflected operator()(const LessLogicalFunction& function) const;
+    Reflected operator()(const LessLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/ConcatLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/ConcatLogicalFunction.hpp
@@ -74,7 +74,7 @@ struct Unreflector<ConcatLogicalFunction>
 template <>
 struct Reflector<ConcatLogicalFunction>
 {
-    Reflected operator()(const ConcatLogicalFunction& function) const;
+    Reflected operator()(const ConcatLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 static_assert(LogicalFunctionConcept<ConcatLogicalFunction>);

--- a/nes-logical-operators/include/Functions/ConstantValueLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/ConstantValueLogicalFunction.hpp
@@ -75,7 +75,7 @@ private:
 template <>
 struct Reflector<ConstantValueLogicalFunction>
 {
-    Reflected operator()(const ConstantValueLogicalFunction& function) const;
+    Reflected operator()(const ConstantValueLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/ExtractFromTimestampLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/ExtractFromTimestampLogicalFunction.hpp
@@ -71,7 +71,7 @@ private:
 template <>
 struct Reflector<ExtractFromTimestampLogicalFunction>
 {
-    Reflected operator()(const ExtractFromTimestampLogicalFunction& function) const;
+    Reflected operator()(const ExtractFromTimestampLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/FieldAccessLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/FieldAccessLogicalFunction.hpp
@@ -67,7 +67,7 @@ private:
 template <>
 struct Reflector<FieldAccessLogicalFunction>
 {
-    Reflected operator()(const FieldAccessLogicalFunction& function) const;
+    Reflected operator()(const FieldAccessLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/FromBase64LogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/FromBase64LogicalFunction.hpp
@@ -63,7 +63,7 @@ private:
 template <>
 struct Reflector<FromBase64LogicalFunction>
 {
-    Reflected operator()(const FromBase64LogicalFunction& function) const;
+    Reflected operator()(const FromBase64LogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/LogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/LogicalFunction.hpp
@@ -71,6 +71,7 @@ concept LogicalFunctionConcept = requires(
     std::vector<LogicalFunction> children,
     DataType dataType,
     Schema<Field, Unordered> schema,
+    const ReflectionContext& context,
     const T& rhs) {
     /// Returns a string representation of the function
     { thisFunction.explain(verbosity) } -> std::convertible_to<std::string>;
@@ -91,7 +92,7 @@ concept LogicalFunctionConcept = requires(
     { thisFunction.getType() } -> std::convertible_to<std::string_view>;
 
     /// Serialize the function to a Reflected object
-    { NES::reflect(thisFunction) } -> std::same_as<Reflected>;
+    { context.reflect(thisFunction) } -> std::same_as<Reflected>;
 
     /// Compares this function with another for equality
     { thisFunction == rhs } -> std::convertible_to<bool>;
@@ -110,7 +111,7 @@ struct ErasedLogicalFunction
     [[nodiscard]] virtual std::vector<LogicalFunction> getChildren() const = 0;
     [[nodiscard]] virtual LogicalFunction withChildren(const std::vector<LogicalFunction>& children) const = 0;
     [[nodiscard]] virtual std::string_view getType() const = 0;
-    [[nodiscard]] virtual Reflected reflect() const = 0;
+    [[nodiscard]] virtual Reflected reflect(const ReflectionContext& context) const = 0;
     [[nodiscard]] virtual bool equals(const ErasedLogicalFunction& other) const = 0;
 
     friend bool operator==(const ErasedLogicalFunction& lhs, const ErasedLogicalFunction& rhs) { return lhs.equals(rhs); }
@@ -315,7 +316,7 @@ struct FunctionModel : ErasedLogicalFunction
         return impl.withChildren(children);
     }
 
-    [[nodiscard]] Reflected reflect() const override { return NES::Reflector<FunctionType>{}(impl); }
+    [[nodiscard]] Reflected reflect(const ReflectionContext& context) const override { return context.reflect(impl); }
 
     [[nodiscard]] std::string_view getType() const override { return impl.getType(); }
 

--- a/nes-logical-operators/include/Functions/OctetLengthLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/OctetLengthLogicalFunction.hpp
@@ -59,7 +59,7 @@ private:
 template <>
 struct Reflector<OctetLengthLogicalFunction>
 {
-    Reflected operator()(const OctetLengthLogicalFunction& function) const;
+    Reflected operator()(const OctetLengthLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/ToBase64LogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/ToBase64LogicalFunction.hpp
@@ -63,7 +63,7 @@ private:
 template <>
 struct Reflector<ToBase64LogicalFunction>
 {
-    Reflected operator()(const ToBase64LogicalFunction& function) const;
+    Reflected operator()(const ToBase64LogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Functions/UnboundFieldAccessLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/UnboundFieldAccessLogicalFunction.hpp
@@ -67,12 +67,10 @@ private:
 
 /// NOLINTEND(readability-convert-member-functions-to-static)
 
-static_assert(LogicalFunctionConcept<UnboundFieldAccessLogicalFunction>);
-
 template <>
 struct Reflector<UnboundFieldAccessLogicalFunction>
 {
-    Reflected operator()(const UnboundFieldAccessLogicalFunction& function) const;
+    Reflected operator()(const UnboundFieldAccessLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>
@@ -80,6 +78,8 @@ struct Unreflector<UnboundFieldAccessLogicalFunction>
 {
     UnboundFieldAccessLogicalFunction operator()(const Reflected& reflected, const ReflectionContext& context) const;
 };
+
+static_assert(LogicalFunctionConcept<UnboundFieldAccessLogicalFunction>);
 
 }
 

--- a/nes-logical-operators/include/Functions/VarSizedToNumericLogicalFunction.hpp
+++ b/nes-logical-operators/include/Functions/VarSizedToNumericLogicalFunction.hpp
@@ -69,7 +69,7 @@ struct ReflectedVarSizedToNumericLogicalFunction
 template <>
 struct Reflector<VarSizedToNumericLogicalFunction>
 {
-    Reflected operator()(const VarSizedToNumericLogicalFunction& function) const;
+    Reflected operator()(const VarSizedToNumericLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Operators/EventTimeWatermarkAssignerLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/EventTimeWatermarkAssignerLogicalOperator.hpp
@@ -106,7 +106,7 @@ struct ReflectedEventTimeWatermarkAssignerLogicalOperator
 template <>
 struct Reflector<TypedLogicalOperator<EventTimeWatermarkAssignerLogicalOperator>>
 {
-    Reflected operator()(const TypedLogicalOperator<EventTimeWatermarkAssignerLogicalOperator>& op) const;
+    Reflected operator()(const TypedLogicalOperator<EventTimeWatermarkAssignerLogicalOperator>& op, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Operators/InferModelLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/InferModelLogicalOperator.hpp
@@ -88,7 +88,7 @@ private:
 template <>
 struct Reflector<TypedLogicalOperator<InferModelLogicalOperator>>
 {
-    Reflected operator()(const TypedLogicalOperator<InferModelLogicalOperator>& op) const;
+    Reflected operator()(const TypedLogicalOperator<InferModelLogicalOperator>& op, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Operators/InferModelNameLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/InferModelNameLogicalOperator.hpp
@@ -83,7 +83,7 @@ private:
 template <>
 struct Reflector<TypedLogicalOperator<InferModelNameLogicalOperator>>
 {
-    Reflected operator()(const TypedLogicalOperator<InferModelNameLogicalOperator>& op) const;
+    Reflected operator()(const TypedLogicalOperator<InferModelNameLogicalOperator>& op, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Operators/IngestionTimeWatermarkAssignerLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/IngestionTimeWatermarkAssignerLogicalOperator.hpp
@@ -84,7 +84,8 @@ protected:
 template <>
 struct Reflector<TypedLogicalOperator<IngestionTimeWatermarkAssignerLogicalOperator>>
 {
-    Reflected operator()(const TypedLogicalOperator<IngestionTimeWatermarkAssignerLogicalOperator>& op) const;
+    Reflected
+    operator()(const TypedLogicalOperator<IngestionTimeWatermarkAssignerLogicalOperator>& op, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Operators/LogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/LogicalOperator.hpp
@@ -67,7 +67,7 @@ struct ErasedLogicalOperator : std::enable_shared_from_this<ErasedLogicalOperato
     [[nodiscard]] virtual LogicalOperator withChildren(std::vector<LogicalOperator> children) const = 0;
     [[nodiscard]] virtual LogicalOperator withTraitSet(TraitSet traitSet) const = 0;
     [[nodiscard]] virtual std::string_view getName() const noexcept = 0;
-    [[nodiscard]] virtual Reflected reflect() const = 0;
+    [[nodiscard]] virtual Reflected reflect(const ReflectionContext& context) const = 0;
     [[nodiscard]] virtual TraitSet getTraitSet() const = 0;
     [[nodiscard]] virtual Schema<Field, Unordered> getOutputSchema() const = 0;
     [[nodiscard]] virtual LogicalOperator withInferredSchema() const = 0;
@@ -493,9 +493,9 @@ struct OperatorModel : ErasedLogicalOperator
 
     [[nodiscard]] std::string_view getName() const noexcept override { return impl.getName(); }
 
-    [[nodiscard]] Reflected reflect() const override
+    [[nodiscard]] Reflected reflect(const ReflectionContext& context) const override
     {
-        return Reflector<TypedLogicalOperator<OperatorType>>{}(TypedLogicalOperator<OperatorType>{this->shared_from_this()});
+        return Reflector<TypedLogicalOperator<OperatorType>>{}(TypedLogicalOperator<OperatorType>{this->shared_from_this()}, context);
     }
 
     [[nodiscard]] TraitSet getTraitSet() const override { return impl.getTraitSet(); }
@@ -551,8 +551,16 @@ private:
         }
     }
 };
-
 }
+
+template <>
+struct Reflector<NES::detail::ErasedLogicalOperator>
+{
+    Reflected operator()(const NES::detail::ErasedLogicalOperator& op, const ReflectionContext& context) const
+    {
+        return op.reflect(context);
+    }
+};
 
 inline std::ostream& operator<<(std::ostream& os, const LogicalOperator& op)
 {

--- a/nes-logical-operators/include/Operators/ProjectionLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/ProjectionLogicalOperator.hpp
@@ -120,7 +120,7 @@ private:
 template <>
 struct Reflector<TypedLogicalOperator<ProjectionLogicalOperator>>
 {
-    Reflected operator()(const TypedLogicalOperator<ProjectionLogicalOperator>& op) const;
+    Reflected operator()(const TypedLogicalOperator<ProjectionLogicalOperator>& op, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Operators/SelectionLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/SelectionLogicalOperator.hpp
@@ -93,7 +93,7 @@ struct ReflectedSelectionLogicalOperator
 template <>
 struct Reflector<TypedLogicalOperator<SelectionLogicalOperator>>
 {
-    Reflected operator()(const TypedLogicalOperator<SelectionLogicalOperator>& op) const;
+    Reflected operator()(const TypedLogicalOperator<SelectionLogicalOperator>& op, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Operators/Sinks/InlineSinkLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Sinks/InlineSinkLogicalOperator.hpp
@@ -93,7 +93,7 @@ private:
 template <>
 struct Reflector<TypedLogicalOperator<InlineSinkLogicalOperator>>
 {
-    Reflected operator()(const TypedLogicalOperator<InlineSinkLogicalOperator>& op) const;
+    Reflected operator()(const TypedLogicalOperator<InlineSinkLogicalOperator>& op, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Operators/Sinks/SinkLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Sinks/SinkLogicalOperator.hpp
@@ -91,7 +91,7 @@ private:
 template <>
 struct Reflector<TypedLogicalOperator<SinkLogicalOperator>>
 {
-    Reflected operator()(const TypedLogicalOperator<SinkLogicalOperator>& op) const;
+    Reflected operator()(const TypedLogicalOperator<SinkLogicalOperator>& op, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Operators/Sources/InlineSourceLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Sources/InlineSourceLogicalOperator.hpp
@@ -97,7 +97,7 @@ private:
 template <>
 struct Reflector<TypedLogicalOperator<InlineSourceLogicalOperator>>
 {
-    Reflected operator()(const TypedLogicalOperator<InlineSourceLogicalOperator>&) const;
+    Reflected operator()(const TypedLogicalOperator<InlineSourceLogicalOperator>&, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Operators/Sources/SourceDescriptorLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Sources/SourceDescriptorLogicalOperator.hpp
@@ -100,7 +100,7 @@ struct ReflectedSourceDescriptorLogicalOperator
 template <>
 struct Reflector<TypedLogicalOperator<SourceDescriptorLogicalOperator>>
 {
-    Reflected operator()(const TypedLogicalOperator<SourceDescriptorLogicalOperator>& op) const;
+    Reflected operator()(const TypedLogicalOperator<SourceDescriptorLogicalOperator>& op, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Operators/Sources/SourceNameLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Sources/SourceNameLogicalOperator.hpp
@@ -81,7 +81,7 @@ private:
 template <>
 struct Reflector<TypedLogicalOperator<SourceNameLogicalOperator>>
 {
-    Reflected operator()(const TypedLogicalOperator<SourceNameLogicalOperator>& op) const;
+    Reflected operator()(const TypedLogicalOperator<SourceNameLogicalOperator>& op, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Operators/UnionLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/UnionLogicalOperator.hpp
@@ -86,7 +86,7 @@ private:
 template <>
 struct Reflector<TypedLogicalOperator<UnionLogicalOperator>>
 {
-    Reflected operator()(const TypedLogicalOperator<UnionLogicalOperator>&) const;
+    Reflected operator()(const TypedLogicalOperator<UnionLogicalOperator>&, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Operators/Windows/Aggregations/AvgAggregationLogicalFunction.hpp
+++ b/nes-logical-operators/include/Operators/Windows/Aggregations/AvgAggregationLogicalFunction.hpp
@@ -38,7 +38,6 @@ public:
     [[nodiscard]] AggregationFieldAccess getInputFunction() const;
     [[nodiscard]] AvgAggregationLogicalFunction withInferredType(const Schema<Field, Unordered>& schema) const;
     [[nodiscard]] static std::string_view getName() noexcept;
-    [[nodiscard]] Reflected reflect() const;
     [[nodiscard]] DataType getAggregateType() const;
     [[nodiscard]] std::string explain(ExplainVerbosity verbosity) const;
     [[nodiscard]] bool operator==(const AvgAggregationLogicalFunction& other) const;
@@ -54,7 +53,7 @@ private:
 template <>
 struct Reflector<AvgAggregationLogicalFunction>
 {
-    Reflected operator()(const AvgAggregationLogicalFunction& function) const;
+    Reflected operator()(const AvgAggregationLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Operators/Windows/Aggregations/CountAggregationLogicalFunction.hpp
+++ b/nes-logical-operators/include/Operators/Windows/Aggregations/CountAggregationLogicalFunction.hpp
@@ -41,7 +41,6 @@ public:
 
     [[nodiscard]] CountAggregationLogicalFunction withInferredType(const Schema<Field, Unordered>& schema) const;
     [[nodiscard]] std::string_view getName() const noexcept;
-    [[nodiscard]] Reflected reflect() const;
     [[nodiscard]] static DataType getAggregateType();
     [[nodiscard]] AggregationFieldAccess getInputFunction() const;
     [[nodiscard]] bool shallIncludeNullValues() const noexcept;
@@ -58,7 +57,7 @@ private:
 template <>
 struct Reflector<CountAggregationLogicalFunction>
 {
-    Reflected operator()(const CountAggregationLogicalFunction& function) const;
+    Reflected operator()(const CountAggregationLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Operators/Windows/Aggregations/MaxAggregationLogicalFunction.hpp
+++ b/nes-logical-operators/include/Operators/Windows/Aggregations/MaxAggregationLogicalFunction.hpp
@@ -40,7 +40,6 @@ public:
 
     [[nodiscard]] MaxAggregationLogicalFunction withInferredType(const Schema<Field, Unordered>& schema) const;
     [[nodiscard]] static std::string_view getName() noexcept;
-    [[nodiscard]] Reflected reflect() const;
     [[nodiscard]] DataType getAggregateType() const;
     [[nodiscard]] AggregationFieldAccess getInputFunction() const;
     [[nodiscard]] std::string explain(ExplainVerbosity verbosity) const;
@@ -56,7 +55,7 @@ private:
 template <>
 struct Reflector<MaxAggregationLogicalFunction>
 {
-    Reflected operator()(const MaxAggregationLogicalFunction& function) const;
+    Reflected operator()(const MaxAggregationLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Operators/Windows/Aggregations/MedianAggregationLogicalFunction.hpp
+++ b/nes-logical-operators/include/Operators/Windows/Aggregations/MedianAggregationLogicalFunction.hpp
@@ -40,7 +40,6 @@ public:
 
     [[nodiscard]] MedianAggregationLogicalFunction withInferredType(const Schema<Field, Unordered>& schema) const;
     [[nodiscard]] static std::string_view getName() noexcept;
-    [[nodiscard]] Reflected reflect() const;
     [[nodiscard]] DataType getAggregateType() const;
     [[nodiscard]] static bool shallIncludeNullValues() noexcept;
     [[nodiscard]] AggregationFieldAccess getInputFunction() const;
@@ -57,7 +56,7 @@ private:
 template <>
 struct Reflector<MedianAggregationLogicalFunction>
 {
-    Reflected operator()(const MedianAggregationLogicalFunction& function) const;
+    Reflected operator()(const MedianAggregationLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Operators/Windows/Aggregations/MinAggregationLogicalFunction.hpp
+++ b/nes-logical-operators/include/Operators/Windows/Aggregations/MinAggregationLogicalFunction.hpp
@@ -40,7 +40,6 @@ public:
 
     [[nodiscard]] MinAggregationLogicalFunction withInferredType(const Schema<Field, Unordered>& schema) const;
     [[nodiscard]] std::string_view getName() const noexcept;
-    [[nodiscard]] Reflected reflect() const;
     [[nodiscard]] DataType getAggregateType() const;
     [[nodiscard]] static bool shallIncludeNullValues() noexcept;
     [[nodiscard]] AggregationFieldAccess getInputFunction() const;
@@ -56,7 +55,7 @@ private:
 template <>
 struct Reflector<MinAggregationLogicalFunction>
 {
-    Reflected operator()(const MinAggregationLogicalFunction& function) const;
+    Reflected operator()(const MinAggregationLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Operators/Windows/Aggregations/SumAggregationLogicalFunction.hpp
+++ b/nes-logical-operators/include/Operators/Windows/Aggregations/SumAggregationLogicalFunction.hpp
@@ -41,7 +41,6 @@ public:
 
     [[nodiscard]] SumAggregationLogicalFunction withInferredType(const Schema<Field, Unordered>& schema) const;
     [[nodiscard]] std::string_view getName() const noexcept;
-    [[nodiscard]] Reflected reflect() const;
     [[nodiscard]] DataType getAggregateType() const;
     [[nodiscard]] static bool shallIncludeNullValues() noexcept;
     [[nodiscard]] AggregationFieldAccess getInputFunction() const;
@@ -59,7 +58,7 @@ private:
 template <>
 struct Reflector<SumAggregationLogicalFunction>
 {
-    Reflected operator()(const SumAggregationLogicalFunction& function) const;
+    Reflected operator()(const SumAggregationLogicalFunction& function, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Operators/Windows/Aggregations/WindowAggregationLogicalFunction.hpp
+++ b/nes-logical-operators/include/Operators/Windows/Aggregations/WindowAggregationLogicalFunction.hpp
@@ -62,6 +62,7 @@ concept WindowAggregationFunctionConcept = requires(
     DataType dataType,
     AggregationFieldAccess fieldAccessLogicalFunction,
     ExplainVerbosity verbosity,
+    const ReflectionContext& context,
     const T& rhs) {
     { thisFunction.getAggregateType() } -> std::convertible_to<DataType>;
 
@@ -73,7 +74,7 @@ concept WindowAggregationFunctionConcept = requires(
 
     { thisFunction.shallIncludeNullValues() } noexcept -> std::convertible_to<bool>;
 
-    { thisFunction.reflect() } -> std::convertible_to<Reflected>;
+    { context.reflect(thisFunction) } -> std::convertible_to<Reflected>;
 
     { thisFunction.getName() } noexcept -> std::convertible_to<std::string_view>;
 
@@ -91,7 +92,7 @@ struct ErasedWindowAggregationFunction
 
     [[nodiscard]] virtual std::string_view getName() const noexcept = 0;
     [[nodiscard]] virtual std::string explain(ExplainVerbosity verbosity) const = 0;
-    [[nodiscard]] virtual Reflected reflect() const = 0;
+    [[nodiscard]] virtual Reflected reflect(const ReflectionContext& context) const = 0;
     [[nodiscard]] virtual size_t hash() const = 0;
     [[nodiscard]] virtual bool equals(const ErasedWindowAggregationFunction& other) const = 0;
     [[nodiscard]] virtual DataType getAggregateType() const = 0;
@@ -264,7 +265,7 @@ struct TypedWindowAggregationLogicalFunction
 
     [[nodiscard]] std::string explain(const ExplainVerbosity verbosity) const { return self->explain(verbosity); }
 
-    [[nodiscard]] Reflected reflect() const { return self->reflect(); }
+    [[nodiscard]] Reflected reflect(const ReflectionContext& context) const { return self->reflect(context); }
 
     [[nodiscard]] bool shallIncludeNullValues() const noexcept { return self->shallIncludeNullValues(); }
 
@@ -301,7 +302,7 @@ struct WindowAggregationFunctionModel : ErasedWindowAggregationFunction
 
     [[nodiscard]] std::string explain(ExplainVerbosity verbosity) const override { return impl.explain(verbosity); }
 
-    [[nodiscard]] Reflected reflect() const override { return impl.reflect(); }
+    [[nodiscard]] Reflected reflect(const ReflectionContext& context) const override { return context.reflect(impl); }
 
     [[nodiscard]] bool shallIncludeNullValues() const noexcept override { return impl.shallIncludeNullValues(); }
 

--- a/nes-logical-operators/include/Operators/Windows/JoinLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Windows/JoinLogicalOperator.hpp
@@ -160,7 +160,7 @@ static_assert(LogicalOperatorConcept<JoinLogicalOperator>);
 template <>
 struct Reflector<TypedLogicalOperator<JoinLogicalOperator>>
 {
-    Reflected operator()(const TypedLogicalOperator<JoinLogicalOperator>& op) const;
+    Reflected operator()(const TypedLogicalOperator<JoinLogicalOperator>& op, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Operators/Windows/WindowedAggregationLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Windows/WindowedAggregationLogicalOperator.hpp
@@ -166,7 +166,7 @@ private:
 template <>
 struct Reflector<TypedLogicalOperator<WindowedAggregationLogicalOperator>>
 {
-    Reflected operator()(const TypedLogicalOperator<WindowedAggregationLogicalOperator>& op) const;
+    Reflected operator()(const TypedLogicalOperator<WindowedAggregationLogicalOperator>& op, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Schema/Field.hpp
+++ b/nes-logical-operators/include/Schema/Field.hpp
@@ -68,7 +68,7 @@ struct ReflectedField
 template <>
 struct Reflector<Field>
 {
-    Reflected operator()(const Field& field) const;
+    Reflected operator()(const Field& field, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/Serialization/LogicalFunctionReflection.hpp
+++ b/nes-logical-operators/include/Serialization/LogicalFunctionReflection.hpp
@@ -46,7 +46,7 @@ struct Reflector<TypedLogicalFunction<Checked>>
 {
     Reflected operator()(const TypedLogicalFunction<Checked>& function, const ReflectionContext& context) const
     {
-        return context.reflect(detail::ReflectedLogicalFunction{std::string{function.getType()}, Reflector<Checked>{}(*function)});
+        return context.reflect(detail::ReflectedLogicalFunction{std::string{function.getType()}, Reflector<Checked>{}(*function, context)});
     }
 };
 

--- a/nes-logical-operators/include/Serialization/LogicalFunctionReflection.hpp
+++ b/nes-logical-operators/include/Serialization/LogicalFunctionReflection.hpp
@@ -35,22 +35,25 @@ namespace NES
 template <>
 struct Reflector<detail::ErasedLogicalFunction>
 {
-    Reflected operator()(const detail::ErasedLogicalFunction& function) const { return function.reflect(); }
+    Reflected operator()(const detail::ErasedLogicalFunction& function, const ReflectionContext& context) const
+    {
+        return context.reflect(function);
+    }
 };
 
 template <LogicalFunctionConcept Checked>
 struct Reflector<TypedLogicalFunction<Checked>>
 {
-    Reflected operator()(const TypedLogicalFunction<Checked>& function) const
+    Reflected operator()(const TypedLogicalFunction<Checked>& function, const ReflectionContext& context) const
     {
-        return reflect(detail::ReflectedLogicalFunction{std::string{function.getType()}, Reflector<Checked>{}(*function)});
+        return context.reflect(detail::ReflectedLogicalFunction{std::string{function.getType()}, Reflector<Checked>{}(*function)});
     }
 };
 
 template <>
 struct Reflector<TypedLogicalFunction<detail::ErasedLogicalFunction>>
 {
-    Reflected operator()(const TypedLogicalFunction<detail::ErasedLogicalFunction>& function) const;
+    Reflected operator()(const TypedLogicalFunction<detail::ErasedLogicalFunction>& function, const ReflectionContext& context) const;
 };
 
 template <>
@@ -73,8 +76,8 @@ struct Unreflector<TypedLogicalFunction<Checked>>
     }
 };
 
-static_assert(requires(LogicalFunction logicalFunction) {
-    { reflect(logicalFunction) } -> std::same_as<Reflected>;
+static_assert(requires(LogicalFunction logicalFunction, ReflectionContext& context) {
+    { context.reflect(logicalFunction) } -> std::same_as<Reflected>;
 });
 
 }

--- a/nes-logical-operators/include/Serialization/LogicalFunctionReflection.hpp
+++ b/nes-logical-operators/include/Serialization/LogicalFunctionReflection.hpp
@@ -37,7 +37,7 @@ struct Reflector<detail::ErasedLogicalFunction>
 {
     Reflected operator()(const detail::ErasedLogicalFunction& function, const ReflectionContext& context) const
     {
-        return context.reflect(function);
+        return function.reflect(context);
     }
 };
 

--- a/nes-logical-operators/include/Serialization/WindowAggregationLogicalFunctionReflection.hpp
+++ b/nes-logical-operators/include/Serialization/WindowAggregationLogicalFunctionReflection.hpp
@@ -33,22 +33,28 @@ namespace NES
 template <>
 struct Reflector<detail::ErasedWindowAggregationFunction>
 {
-    Reflected operator()(const detail::ErasedWindowAggregationFunction& function) const { return function.reflect(); }
+    Reflected operator()(const detail::ErasedWindowAggregationFunction& function, const ReflectionContext& context) const
+    {
+        return function.reflect(context);
+    }
 };
 
 template <WindowAggregationFunctionConcept Checked>
 struct Reflector<TypedWindowAggregationLogicalFunction<Checked>>
 {
-    Reflected operator()(const TypedWindowAggregationLogicalFunction<Checked>& function) const
+    Reflected operator()(const TypedWindowAggregationLogicalFunction<Checked>& function, const ReflectionContext& context) const
     {
-        return reflect(detail::ReflectedWindowAggregationLogicalFunction{std::string{function.getName()}, Reflector<Checked>{}(*function)});
+        return context.reflect(
+            detail::ReflectedWindowAggregationLogicalFunction{std::string{function.getName()}, Reflector<Checked>{}(*function)});
     }
 };
 
 template <>
 struct Reflector<TypedWindowAggregationLogicalFunction<detail::ErasedWindowAggregationFunction>>
 {
-    Reflected operator()(const TypedWindowAggregationLogicalFunction<detail::ErasedWindowAggregationFunction>& function) const;
+    Reflected operator()(
+        const TypedWindowAggregationLogicalFunction<detail::ErasedWindowAggregationFunction>& function,
+        const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/WindowTypes/Measures/TimeMeasure.hpp
+++ b/nes-logical-operators/include/WindowTypes/Measures/TimeMeasure.hpp
@@ -50,7 +50,7 @@ namespace NES
 template <>
 struct Reflector<Windowing::TimeMeasure>
 {
-    Reflected operator()(const Windowing::TimeMeasure& measure) const;
+    Reflected operator()(const Windowing::TimeMeasure& measure, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/WindowTypes/Types/SlidingWindow.hpp
+++ b/nes-logical-operators/include/WindowTypes/Types/SlidingWindow.hpp
@@ -49,7 +49,7 @@ namespace NES
 template <>
 struct Reflector<Windowing::SlidingWindow>
 {
-    Reflected operator()(const Windowing::SlidingWindow& slidingWindow) const;
+    Reflected operator()(const Windowing::SlidingWindow& slidingWindow, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/WindowTypes/Types/TimeBasedWindowType.hpp
+++ b/nes-logical-operators/include/WindowTypes/Types/TimeBasedWindowType.hpp
@@ -55,7 +55,7 @@ namespace NES
 template <>
 struct Reflector<Windowing::TimeBasedWindowType>
 {
-    Reflected operator()(const Windowing::TimeBasedWindowType& window) const;
+    Reflected operator()(const Windowing::TimeBasedWindowType& window, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/include/WindowTypes/Types/TumblingWindow.hpp
+++ b/nes-logical-operators/include/WindowTypes/Types/TumblingWindow.hpp
@@ -52,7 +52,7 @@ namespace NES
 template <>
 struct Reflector<Windowing::TumblingWindow>
 {
-    Reflected operator()(const Windowing::TumblingWindow& tumblingWindow) const;
+    Reflected operator()(const Windowing::TumblingWindow& tumblingWindow, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-logical-operators/src/Functions/ArithmeticalFunctions/AbsoluteLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/ArithmeticalFunctions/AbsoluteLogicalFunction.cpp
@@ -90,9 +90,9 @@ std::string AbsoluteLogicalFunction::explain(ExplainVerbosity verbosity) const
     return fmt::format("ABS({})", child.explain(verbosity));
 }
 
-Reflected Reflector<AbsoluteLogicalFunction>::operator()(const AbsoluteLogicalFunction& function) const
+Reflected Reflector<AbsoluteLogicalFunction>::operator()(const AbsoluteLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedAbsoluteLogicalFunction{.child = function.child});
+    return context.reflect(detail::ReflectedAbsoluteLogicalFunction{.child = function.child});
 }
 
 AbsoluteLogicalFunction Unreflector<AbsoluteLogicalFunction>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-logical-operators/src/Functions/ArithmeticalFunctions/AddLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/ArithmeticalFunctions/AddLogicalFunction.cpp
@@ -100,9 +100,9 @@ std::string AddLogicalFunction::explain(ExplainVerbosity verbosity) const
     return fmt::format("{} + {}", left.explain(verbosity), right.explain(verbosity));
 }
 
-Reflected Reflector<AddLogicalFunction>::operator()(const AddLogicalFunction& function) const
+Reflected Reflector<AddLogicalFunction>::operator()(const AddLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedAddLogicalFunction{.left = function.left, .right = function.right});
+    return context.reflect(detail::ReflectedAddLogicalFunction{.left = function.left, .right = function.right});
 }
 
 AddLogicalFunction Unreflector<AddLogicalFunction>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-logical-operators/src/Functions/ArithmeticalFunctions/CeilLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/ArithmeticalFunctions/CeilLogicalFunction.cpp
@@ -89,9 +89,9 @@ std::string CeilLogicalFunction::explain(ExplainVerbosity verbosity) const
     return fmt::format("CEIL({})", child.explain(verbosity));
 }
 
-Reflected Reflector<CeilLogicalFunction>::operator()(const CeilLogicalFunction& function) const
+Reflected Reflector<CeilLogicalFunction>::operator()(const CeilLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedCeilLogicalFunction{.child = function.child});
+    return context.reflect(detail::ReflectedCeilLogicalFunction{.child = function.child});
 }
 
 CeilLogicalFunction Unreflector<CeilLogicalFunction>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-logical-operators/src/Functions/ArithmeticalFunctions/DivLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/ArithmeticalFunctions/DivLogicalFunction.cpp
@@ -100,9 +100,9 @@ std::string DivLogicalFunction::explain(ExplainVerbosity verbosity) const
     return fmt::format("{} / {}", left.explain(verbosity), right.explain(verbosity));
 }
 
-Reflected Reflector<DivLogicalFunction>::operator()(const DivLogicalFunction& function) const
+Reflected Reflector<DivLogicalFunction>::operator()(const DivLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedDivLogicalFunction{.left = function.left, .right = function.right});
+    return context.reflect(detail::ReflectedDivLogicalFunction{.left = function.left, .right = function.right});
 }
 
 DivLogicalFunction Unreflector<DivLogicalFunction>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-logical-operators/src/Functions/ArithmeticalFunctions/ExpLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/ArithmeticalFunctions/ExpLogicalFunction.cpp
@@ -88,9 +88,9 @@ std::string ExpLogicalFunction::explain(ExplainVerbosity verbosity) const
     return fmt::format("EXP({})", child.explain(verbosity));
 }
 
-Reflected Reflector<ExpLogicalFunction>::operator()(const ExpLogicalFunction& function) const
+Reflected Reflector<ExpLogicalFunction>::operator()(const ExpLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedExpLogicalFunction{.child = function.child});
+    return context.reflect(detail::ReflectedExpLogicalFunction{.child = function.child});
 }
 
 ExpLogicalFunction Unreflector<ExpLogicalFunction>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-logical-operators/src/Functions/ArithmeticalFunctions/FloorLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/ArithmeticalFunctions/FloorLogicalFunction.cpp
@@ -89,9 +89,9 @@ std::string FloorLogicalFunction::explain(ExplainVerbosity verbosity) const
     return fmt::format("FLOOR({})", child.explain(verbosity));
 }
 
-Reflected Reflector<FloorLogicalFunction>::operator()(const FloorLogicalFunction& function) const
+Reflected Reflector<FloorLogicalFunction>::operator()(const FloorLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedFloorLogicalFunction{.child = function.child});
+    return context.reflect(detail::ReflectedFloorLogicalFunction{.child = function.child});
 }
 
 FloorLogicalFunction Unreflector<FloorLogicalFunction>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-logical-operators/src/Functions/ArithmeticalFunctions/ModuloLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/ArithmeticalFunctions/ModuloLogicalFunction.cpp
@@ -96,9 +96,9 @@ std::string ModuloLogicalFunction::explain(ExplainVerbosity verbosity) const
     return fmt::format("{} % {}", left.explain(verbosity), right.explain(verbosity));
 }
 
-Reflected Reflector<ModuloLogicalFunction>::operator()(const ModuloLogicalFunction& function) const
+Reflected Reflector<ModuloLogicalFunction>::operator()(const ModuloLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedModuloLogicalFunction{.left = function.left, .right = function.right});
+    return context.reflect(detail::ReflectedModuloLogicalFunction{.left = function.left, .right = function.right});
 }
 
 ModuloLogicalFunction Unreflector<ModuloLogicalFunction>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-logical-operators/src/Functions/ArithmeticalFunctions/MulLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/ArithmeticalFunctions/MulLogicalFunction.cpp
@@ -98,9 +98,9 @@ std::string_view MulLogicalFunction::getType() const
     return NAME;
 }
 
-Reflected Reflector<MulLogicalFunction>::operator()(const MulLogicalFunction& function) const
+Reflected Reflector<MulLogicalFunction>::operator()(const MulLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedMulLogicalFunction{.left = function.left, .right = function.right});
+    return context.reflect(detail::ReflectedMulLogicalFunction{.left = function.left, .right = function.right});
 }
 
 MulLogicalFunction Unreflector<MulLogicalFunction>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-logical-operators/src/Functions/ArithmeticalFunctions/PowLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/ArithmeticalFunctions/PowLogicalFunction.cpp
@@ -89,9 +89,9 @@ std::string_view PowLogicalFunction::getType() const
     return NAME;
 }
 
-Reflected Reflector<PowLogicalFunction>::operator()(const PowLogicalFunction& function) const
+Reflected Reflector<PowLogicalFunction>::operator()(const PowLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedPowLogicalFunction{.left = function.left, .right = function.right});
+    return context.reflect(detail::ReflectedPowLogicalFunction{.left = function.left, .right = function.right});
 }
 
 PowLogicalFunction Unreflector<PowLogicalFunction>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-logical-operators/src/Functions/ArithmeticalFunctions/RoundLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/ArithmeticalFunctions/RoundLogicalFunction.cpp
@@ -90,9 +90,9 @@ std::string_view RoundLogicalFunction::getType() const
     return NAME;
 }
 
-Reflected Reflector<RoundLogicalFunction>::operator()(const RoundLogicalFunction& function) const
+Reflected Reflector<RoundLogicalFunction>::operator()(const RoundLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedRoundLogicalFunction{.child = function.child});
+    return context.reflect(detail::ReflectedRoundLogicalFunction{.child = function.child});
 }
 
 RoundLogicalFunction Unreflector<RoundLogicalFunction>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-logical-operators/src/Functions/ArithmeticalFunctions/SqrtLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/ArithmeticalFunctions/SqrtLogicalFunction.cpp
@@ -90,9 +90,9 @@ std::string_view SqrtLogicalFunction::getType() const
     return NAME;
 }
 
-Reflected Reflector<SqrtLogicalFunction>::operator()(const SqrtLogicalFunction& function) const
+Reflected Reflector<SqrtLogicalFunction>::operator()(const SqrtLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedSqrtLogicalFunction{.child = function.child});
+    return context.reflect(detail::ReflectedSqrtLogicalFunction{.child = function.child});
 }
 
 SqrtLogicalFunction Unreflector<SqrtLogicalFunction>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-logical-operators/src/Functions/ArithmeticalFunctions/SubLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/ArithmeticalFunctions/SubLogicalFunction.cpp
@@ -95,9 +95,9 @@ std::string_view SubLogicalFunction::getType() const
     return NAME;
 }
 
-Reflected Reflector<SubLogicalFunction>::operator()(const SubLogicalFunction& function) const
+Reflected Reflector<SubLogicalFunction>::operator()(const SubLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedSubLogicalFunction{.left = function.left, .right = function.right});
+    return context.reflect(detail::ReflectedSubLogicalFunction{.left = function.left, .right = function.right});
 }
 
 SubLogicalFunction Unreflector<SubLogicalFunction>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-logical-operators/src/Functions/BooleanFunctions/AndLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/BooleanFunctions/AndLogicalFunction.cpp
@@ -93,9 +93,9 @@ LogicalFunction AndLogicalFunction::withInferredDataType(const Schema<Field, Uno
     return copy;
 }
 
-Reflected Reflector<AndLogicalFunction>::operator()(const AndLogicalFunction& function) const
+Reflected Reflector<AndLogicalFunction>::operator()(const AndLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedAndLogicalFunction{.left = function.left, .right = function.right});
+    return context.reflect(detail::ReflectedAndLogicalFunction{.left = function.left, .right = function.right});
 }
 
 AndLogicalFunction Unreflector<AndLogicalFunction>::operator()(const Reflected& rfl, const ReflectionContext& context) const

--- a/nes-logical-operators/src/Functions/BooleanFunctions/EqualsLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/BooleanFunctions/EqualsLogicalFunction.cpp
@@ -95,9 +95,9 @@ std::string EqualsLogicalFunction::explain(ExplainVerbosity verbosity) const
     return fmt::format("{} = {}", left.explain(verbosity), right.explain(verbosity));
 }
 
-Reflected Reflector<EqualsLogicalFunction>::operator()(const EqualsLogicalFunction& function) const
+Reflected Reflector<EqualsLogicalFunction>::operator()(const EqualsLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedEqualsLogicalFunction{.left = function.left, .right = function.right});
+    return context.reflect(detail::ReflectedEqualsLogicalFunction{.left = function.left, .right = function.right});
 }
 
 EqualsLogicalFunction Unreflector<EqualsLogicalFunction>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-logical-operators/src/Functions/BooleanFunctions/IsNullCheckLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/BooleanFunctions/IsNullCheckLogicalFunction.cpp
@@ -86,9 +86,10 @@ std::string_view IsNullCheckLogicalFunction::getType()
     return NAME;
 }
 
-Reflected Reflector<IsNullCheckLogicalFunction>::operator()(const IsNullCheckLogicalFunction& function) const
+Reflected
+Reflector<IsNullCheckLogicalFunction>::operator()(const IsNullCheckLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedIsNullCheckLogicalFunction{.child = std::make_optional<LogicalFunction>(function.child)});
+    return context.reflect(detail::ReflectedIsNullCheckLogicalFunction{.child = std::make_optional<LogicalFunction>(function.child)});
 }
 
 IsNullCheckLogicalFunction

--- a/nes-logical-operators/src/Functions/BooleanFunctions/NegateLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/BooleanFunctions/NegateLogicalFunction.cpp
@@ -84,9 +84,9 @@ std::string_view NegateLogicalFunction::getType() const
     return NAME;
 }
 
-Reflected Reflector<NegateLogicalFunction>::operator()(const NegateLogicalFunction& function) const
+Reflected Reflector<NegateLogicalFunction>::operator()(const NegateLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedNegateLogicalFunction{.child = function.child});
+    return context.reflect(detail::ReflectedNegateLogicalFunction{.child = function.child});
 }
 
 NegateLogicalFunction Unreflector<NegateLogicalFunction>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-logical-operators/src/Functions/BooleanFunctions/OrLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/BooleanFunctions/OrLogicalFunction.cpp
@@ -90,9 +90,9 @@ LogicalFunction OrLogicalFunction::withInferredDataType(const Schema<Field, Unor
     return copy;
 }
 
-Reflected Reflector<OrLogicalFunction>::operator()(const OrLogicalFunction& function) const
+Reflected Reflector<OrLogicalFunction>::operator()(const OrLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedOrLogicalFunction{.left = function.left, .right = function.right});
+    return context.reflect(detail::ReflectedOrLogicalFunction{.left = function.left, .right = function.right});
 }
 
 OrLogicalFunction Unreflector<OrLogicalFunction>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-logical-operators/src/Functions/CastFromUnixTimestampLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/CastFromUnixTimestampLogicalFunction.cpp
@@ -99,9 +99,10 @@ std::string CastFromUnixTimestampLogicalFunction::explain(ExplainVerbosity) cons
     return fmt::format("Cast from unix timestamp (ms) to ISO-8601 UTC, outputType={}", outputType);
 }
 
-Reflected Reflector<CastFromUnixTimestampLogicalFunction>::operator()(const CastFromUnixTimestampLogicalFunction& function) const
+Reflected Reflector<CastFromUnixTimestampLogicalFunction>::operator()(
+    const CastFromUnixTimestampLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedCastFromUnixTimestampLogicalFunction{.child = function.child});
+    return context.reflect(detail::ReflectedCastFromUnixTimestampLogicalFunction{.child = function.child});
 }
 
 CastFromUnixTimestampLogicalFunction

--- a/nes-logical-operators/src/Functions/CastToTypeLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/CastToTypeLogicalFunction.cpp
@@ -107,7 +107,8 @@ LogicalFunctionGeneratedRegistrar::RegisterCastToTypeLogicalFunction(LogicalFunc
     std::unreachable();
 }
 
-Reflected Reflector<CastToTypeLogicalFunction>::operator()(const CastToTypeLogicalFunction& function, const ReflectionContext& context) const
+Reflected
+Reflector<CastToTypeLogicalFunction>::operator()(const CastToTypeLogicalFunction& function, const ReflectionContext& context) const
 {
     return context.reflect(detail::ReflectedCastToTypeLogicalFunction{
         .child = function.getChildren()[0],

--- a/nes-logical-operators/src/Functions/CastToTypeLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/CastToTypeLogicalFunction.cpp
@@ -107,9 +107,9 @@ LogicalFunctionGeneratedRegistrar::RegisterCastToTypeLogicalFunction(LogicalFunc
     std::unreachable();
 }
 
-Reflected Reflector<CastToTypeLogicalFunction>::operator()(const CastToTypeLogicalFunction& function) const
+Reflected Reflector<CastToTypeLogicalFunction>::operator()(const CastToTypeLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedCastToTypeLogicalFunction{
+    return context.reflect(detail::ReflectedCastToTypeLogicalFunction{
         .child = function.getChildren()[0],
         .castToType = function.getDataType(),
     });

--- a/nes-logical-operators/src/Functions/CastToUnixTimestampLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/CastToUnixTimestampLogicalFunction.cpp
@@ -99,9 +99,10 @@ std::string CastToUnixTimestampLogicalFunction::explain(ExplainVerbosity) const
     return fmt::format("Cast to unix timestamp (ms), outputType={}", outputType);
 }
 
-Reflected Reflector<CastToUnixTimestampLogicalFunction>::operator()(const CastToUnixTimestampLogicalFunction& function) const
+Reflected Reflector<CastToUnixTimestampLogicalFunction>::operator()(
+    const CastToUnixTimestampLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedCastToUnixTimestampLogicalFunction{.child = function.child});
+    return context.reflect(detail::ReflectedCastToUnixTimestampLogicalFunction{.child = function.child});
 }
 
 CastToUnixTimestampLogicalFunction

--- a/nes-logical-operators/src/Functions/CharLengthLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/CharLengthLogicalFunction.cpp
@@ -84,9 +84,10 @@ std::string_view CharLengthLogicalFunction::getType() const
     return NAME;
 }
 
-Reflected Reflector<CharLengthLogicalFunction>::operator()(const CharLengthLogicalFunction& function) const
+Reflected
+Reflector<CharLengthLogicalFunction>::operator()(const CharLengthLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedCharLengthLogicalFunction{.child = function.child});
+    return context.reflect(detail::ReflectedCharLengthLogicalFunction{.child = function.child});
 }
 
 CharLengthLogicalFunction

--- a/nes-logical-operators/src/Functions/ComparisonFunctions/GreaterEqualsLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/ComparisonFunctions/GreaterEqualsLogicalFunction.cpp
@@ -90,9 +90,10 @@ std::string_view GreaterEqualsLogicalFunction::getType() const
     return NAME;
 }
 
-Reflected Reflector<GreaterEqualsLogicalFunction>::operator()(const GreaterEqualsLogicalFunction& function) const
+Reflected
+Reflector<GreaterEqualsLogicalFunction>::operator()(const GreaterEqualsLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedGreaterEqualsLogicalFunction{.left = function.left, .right = function.right});
+    return context.reflect(detail::ReflectedGreaterEqualsLogicalFunction{.left = function.left, .right = function.right});
 }
 
 GreaterEqualsLogicalFunction

--- a/nes-logical-operators/src/Functions/ComparisonFunctions/GreaterLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/ComparisonFunctions/GreaterLogicalFunction.cpp
@@ -90,9 +90,9 @@ std::string_view GreaterLogicalFunction::getType() const
     return NAME;
 }
 
-Reflected Reflector<GreaterLogicalFunction>::operator()(const GreaterLogicalFunction& function) const
+Reflected Reflector<GreaterLogicalFunction>::operator()(const GreaterLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedGreaterLogicalFunction{.left = function.left, .right = function.right});
+    return context.reflect(detail::ReflectedGreaterLogicalFunction{.left = function.left, .right = function.right});
 }
 
 GreaterLogicalFunction Unreflector<GreaterLogicalFunction>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-logical-operators/src/Functions/ComparisonFunctions/LessEqualsLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/ComparisonFunctions/LessEqualsLogicalFunction.cpp
@@ -93,9 +93,10 @@ std::string_view LessEqualsLogicalFunction::getType() const
     return NAME;
 }
 
-Reflected Reflector<LessEqualsLogicalFunction>::operator()(const LessEqualsLogicalFunction& function) const
+Reflected
+Reflector<LessEqualsLogicalFunction>::operator()(const LessEqualsLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedLessEqualsLogicalFunction{.left = function.left, .right = function.right});
+    return context.reflect(detail::ReflectedLessEqualsLogicalFunction{.left = function.left, .right = function.right});
 }
 
 LessEqualsLogicalFunction

--- a/nes-logical-operators/src/Functions/ComparisonFunctions/LessLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/ComparisonFunctions/LessLogicalFunction.cpp
@@ -90,9 +90,9 @@ std::string_view LessLogicalFunction::getType() const
     return NAME;
 }
 
-Reflected Reflector<LessLogicalFunction>::operator()(const LessLogicalFunction& function) const
+Reflected Reflector<LessLogicalFunction>::operator()(const LessLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedLessLogicalFunction{.left = function.left, .right = function.right});
+    return context.reflect(detail::ReflectedLessLogicalFunction{.left = function.left, .right = function.right});
 }
 
 LessLogicalFunction Unreflector<LessLogicalFunction>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-logical-operators/src/Functions/ConcatLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/ConcatLogicalFunction.cpp
@@ -96,9 +96,9 @@ std::string_view ConcatLogicalFunction::getType() const
     return NAME;
 }
 
-Reflected Reflector<ConcatLogicalFunction>::operator()(const ConcatLogicalFunction& function) const
+Reflected Reflector<ConcatLogicalFunction>::operator()(const ConcatLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedConcatLogicalFunction{.left = function.left, .right = function.right});
+    return context.reflect(detail::ReflectedConcatLogicalFunction{.left = function.left, .right = function.right});
 }
 
 ConcatLogicalFunction Unreflector<ConcatLogicalFunction>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-logical-operators/src/Functions/ConstantValueLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/ConstantValueLogicalFunction.cpp
@@ -92,9 +92,11 @@ LogicalFunction ConstantValueLogicalFunction::withInferredDataType(const Schema<
     return *this;
 }
 
-Reflected Reflector<ConstantValueLogicalFunction>::operator()(const ConstantValueLogicalFunction& function) const
+Reflected
+Reflector<ConstantValueLogicalFunction>::operator()(const ConstantValueLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedConstantValueLogicalFunction{.value = function.getConstantValue(), .dataType = function.getDataType()});
+    return context.reflect(
+        detail::ReflectedConstantValueLogicalFunction{.value = function.getConstantValue(), .dataType = function.getDataType()});
 }
 
 ConstantValueLogicalFunction

--- a/nes-logical-operators/src/Functions/ExtractFromTimestampLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/ExtractFromTimestampLogicalFunction.cpp
@@ -120,9 +120,10 @@ std::string ExtractFromTimestampLogicalFunction::explain(ExplainVerbosity) const
     return fmt::format("{}: extract from unix timestamp (ms), outputType={}", getType(), outputType);
 }
 
-Reflected Reflector<ExtractFromTimestampLogicalFunction>::operator()(const ExtractFromTimestampLogicalFunction& function) const
+Reflected Reflector<ExtractFromTimestampLogicalFunction>::operator()(
+    const ExtractFromTimestampLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedExtractFromTimestampLogicalFunction{.unit = function.unit, .child = function.child});
+    return context.reflect(detail::ReflectedExtractFromTimestampLogicalFunction{.unit = function.unit, .child = function.child});
 }
 
 ExtractFromTimestampLogicalFunction

--- a/nes-logical-operators/src/Functions/FieldAccessLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/FieldAccessLogicalFunction.cpp
@@ -104,9 +104,10 @@ std::string_view FieldAccessLogicalFunction::getType() const
     return NAME;
 }
 
-Reflected Reflector<FieldAccessLogicalFunction>::operator()(const FieldAccessLogicalFunction& function) const
+Reflected
+Reflector<FieldAccessLogicalFunction>::operator()(const FieldAccessLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(function.getField());
+    return context.reflect(function.getField());
 }
 
 FieldAccessLogicalFunction

--- a/nes-logical-operators/src/Functions/FromBase64LogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/FromBase64LogicalFunction.cpp
@@ -99,9 +99,10 @@ std::string_view FromBase64LogicalFunction::getType() const
     return NAME;
 }
 
-Reflected Reflector<FromBase64LogicalFunction>::operator()(const FromBase64LogicalFunction& function) const
+Reflected
+Reflector<FromBase64LogicalFunction>::operator()(const FromBase64LogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedFromBase64LogicalFunction{.child = function.child});
+    return context.reflect(detail::ReflectedFromBase64LogicalFunction{.child = function.child});
 }
 
 FromBase64LogicalFunction

--- a/nes-logical-operators/src/Functions/OctetLengthLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/OctetLengthLogicalFunction.cpp
@@ -84,9 +84,10 @@ std::string_view OctetLengthLogicalFunction::getType() const
     return NAME;
 }
 
-Reflected Reflector<OctetLengthLogicalFunction>::operator()(const OctetLengthLogicalFunction& function) const
+Reflected
+Reflector<OctetLengthLogicalFunction>::operator()(const OctetLengthLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedOctetLengthLogicalFunction{.child = function.child});
+    return context.reflect(detail::ReflectedOctetLengthLogicalFunction{.child = function.child});
 }
 
 OctetLengthLogicalFunction

--- a/nes-logical-operators/src/Functions/ToBase64LogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/ToBase64LogicalFunction.cpp
@@ -99,9 +99,9 @@ std::string_view ToBase64LogicalFunction::getType() const
     return NAME;
 }
 
-Reflected Reflector<ToBase64LogicalFunction>::operator()(const ToBase64LogicalFunction& function) const
+Reflected Reflector<ToBase64LogicalFunction>::operator()(const ToBase64LogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedToBase64LogicalFunction{.child = function.child});
+    return context.reflect(detail::ReflectedToBase64LogicalFunction{.child = function.child});
 }
 
 ToBase64LogicalFunction Unreflector<ToBase64LogicalFunction>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-logical-operators/src/Functions/UnboundFieldAccessLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/UnboundFieldAccessLogicalFunction.cpp
@@ -100,7 +100,7 @@ std::string_view UnboundFieldAccessLogicalFunction::getType()
     return NAME;
 }
 
-Reflected Reflector<UnboundFieldAccessLogicalFunction>::operator()(const UnboundFieldAccessLogicalFunction&) const
+Reflected Reflector<UnboundFieldAccessLogicalFunction>::operator()(const UnboundFieldAccessLogicalFunction&, const ReflectionContext&) const
 {
     PRECONDITION(false, "UnboundFieldAccessLogicalFunction cannot be reflected, replace it with a FieldAccessLogicalFunction");
     std::unreachable();

--- a/nes-logical-operators/src/Functions/VarSizedToNumericLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/VarSizedToNumericLogicalFunction.cpp
@@ -123,9 +123,10 @@ std::string VarSizedToNumericLogicalFunction::explain(ExplainVerbosity verbosity
     return fmt::format("VarSizedToNumeric({}, {})", child.explain(verbosity), targetType);
 }
 
-Reflected Reflector<VarSizedToNumericLogicalFunction>::operator()(const VarSizedToNumericLogicalFunction& function) const
+Reflected Reflector<VarSizedToNumericLogicalFunction>::operator()(
+    const VarSizedToNumericLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedVarSizedToNumericLogicalFunction{
+    return context.reflect(detail::ReflectedVarSizedToNumericLogicalFunction{
         .child = function.getChildren()[0],
         .targetType = function.getDataType(),
     });

--- a/nes-logical-operators/src/Operators/EventTimeWatermarkAssignerLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/EventTimeWatermarkAssignerLogicalOperator.cpp
@@ -171,9 +171,9 @@ Windowing::TimeUnit EventTimeWatermarkAssignerLogicalOperator::getUnit() const
 }
 
 Reflected Reflector<TypedLogicalOperator<EventTimeWatermarkAssignerLogicalOperator>>::operator()(
-    const TypedLogicalOperator<EventTimeWatermarkAssignerLogicalOperator>& op) const
+    const TypedLogicalOperator<EventTimeWatermarkAssignerLogicalOperator>& op, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedEventTimeWatermarkAssignerLogicalOperator{
+    return context.reflect(detail::ReflectedEventTimeWatermarkAssignerLogicalOperator{
         .operatorId = op.getId(), .onField = op->getOnField(), .timeUnit = op->getUnit()});
 }
 

--- a/nes-logical-operators/src/Operators/InferModelLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/InferModelLogicalOperator.cpp
@@ -206,7 +206,7 @@ LogicalOperator InferModelLogicalOperator::getChild() const
 Reflected Reflector<TypedLogicalOperator<InferModelLogicalOperator>>::operator()(
     const TypedLogicalOperator<InferModelLogicalOperator>& op, const ReflectionContext& context) const
 {
-    return context.reflect(detail::ReflectedInferModelLogicalOperator{.operatorId = op.getId(), .model = reflect(op->getModel())});
+    return context.reflect(detail::ReflectedInferModelLogicalOperator{.operatorId = op.getId(), .model = context.reflect(op->getModel())});
 }
 
 Unreflector<TypedLogicalOperator<InferModelLogicalOperator>>::Unreflector(ContextType plan) : plan(std::move(plan))

--- a/nes-logical-operators/src/Operators/InferModelLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/InferModelLogicalOperator.cpp
@@ -203,10 +203,10 @@ LogicalOperator InferModelLogicalOperator::getChild() const
     return child.value();
 }
 
-Reflected
-Reflector<TypedLogicalOperator<InferModelLogicalOperator>>::operator()(const TypedLogicalOperator<InferModelLogicalOperator>& op) const
+Reflected Reflector<TypedLogicalOperator<InferModelLogicalOperator>>::operator()(
+    const TypedLogicalOperator<InferModelLogicalOperator>& op, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedInferModelLogicalOperator{.operatorId = op.getId(), .model = reflect(op->getModel())});
+    return context.reflect(detail::ReflectedInferModelLogicalOperator{.operatorId = op.getId(), .model = reflect(op->getModel())});
 }
 
 Unreflector<TypedLogicalOperator<InferModelLogicalOperator>>::Unreflector(ContextType plan) : plan(std::move(plan))

--- a/nes-logical-operators/src/Operators/InferModelNameLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/InferModelNameLogicalOperator.cpp
@@ -141,9 +141,9 @@ LogicalOperator InferModelNameLogicalOperator::getChild() const
 }
 
 Reflected Reflector<TypedLogicalOperator<InferModelNameLogicalOperator>>::operator()(
-    const TypedLogicalOperator<InferModelNameLogicalOperator>& op) const
+    const TypedLogicalOperator<InferModelNameLogicalOperator>& op, const ReflectionContext& context) const
 {
-    return reflect(
+    return context.reflect(
         detail::ReflectedInferModelNameLogicalOperator{.operatorId = op.getId(), .modelName = std::make_optional(op->getModelName())});
 }
 

--- a/nes-logical-operators/src/Operators/IngestionTimeWatermarkAssignerLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/IngestionTimeWatermarkAssignerLogicalOperator.cpp
@@ -146,9 +146,9 @@ std::vector<LogicalOperator> IngestionTimeWatermarkAssignerLogicalOperator::getC
 }
 
 Reflected Reflector<TypedLogicalOperator<IngestionTimeWatermarkAssignerLogicalOperator>>::operator()(
-    const TypedLogicalOperator<IngestionTimeWatermarkAssignerLogicalOperator>& op) const
+    const TypedLogicalOperator<IngestionTimeWatermarkAssignerLogicalOperator>& op, const ReflectionContext& context) const
 {
-    return reflect(op.getId());
+    return context.reflect(op.getId());
 }
 
 Unreflector<TypedLogicalOperator<IngestionTimeWatermarkAssignerLogicalOperator>>::Unreflector(ContextType operatorMapping)

--- a/nes-logical-operators/src/Operators/ProjectionLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/ProjectionLogicalOperator.cpp
@@ -319,13 +319,13 @@ bool ProjectionLogicalOperator::hasAsterisk() const
     return asterisk;
 }
 
-Reflected
-Reflector<TypedLogicalOperator<ProjectionLogicalOperator>>::operator()(const TypedLogicalOperator<ProjectionLogicalOperator>& op) const
+Reflected Reflector<TypedLogicalOperator<ProjectionLogicalOperator>>::operator()(
+    const TypedLogicalOperator<ProjectionLogicalOperator>& op, const ReflectionContext& context) const
 {
     auto projections = op->getProjections()
         | std::views::transform([](const auto& projection) { return std::pair{projection.first.getLastName(), projection.second}; })
         | std::ranges::to<std::vector>();
-    return reflect(
+    return context.reflect(
         detail::ReflectedProjectionLogicalOperator{.operatorId = op.getId(), .asterisk = op->hasAsterisk(), .projections = projections});
 }
 

--- a/nes-logical-operators/src/Operators/SelectionLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/SelectionLogicalOperator.cpp
@@ -162,10 +162,10 @@ LogicalOperator SelectionLogicalOperator::getChild() const
     return child.value();
 }
 
-Reflected
-Reflector<TypedLogicalOperator<SelectionLogicalOperator>>::operator()(const TypedLogicalOperator<SelectionLogicalOperator>& op) const
+Reflected Reflector<TypedLogicalOperator<SelectionLogicalOperator>>::operator()(
+    const TypedLogicalOperator<SelectionLogicalOperator>& op, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedSelectionLogicalOperator{.operatorId = op.getId(), .predicate = op->getPredicate()});
+    return context.reflect(detail::ReflectedSelectionLogicalOperator{.operatorId = op.getId(), .predicate = op->getPredicate()});
 }
 
 Unreflector<TypedLogicalOperator<SelectionLogicalOperator>>::Unreflector(ContextType operatorMapping) : plan(std::move(operatorMapping))

--- a/nes-logical-operators/src/Operators/Sinks/InlineSinkLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Sinks/InlineSinkLogicalOperator.cpp
@@ -154,7 +154,7 @@ std::vector<LogicalOperator> InlineSinkLogicalOperator::getChildren() const
 }
 
 Reflected
-Reflector<TypedLogicalOperator<InlineSinkLogicalOperator>>::operator()(const TypedLogicalOperator<InlineSinkLogicalOperator>&) const
+Reflector<TypedLogicalOperator<InlineSinkLogicalOperator>>::operator()(const TypedLogicalOperator<InlineSinkLogicalOperator>&, const ReflectionContext&) const
 {
     PRECONDITION(false, "no serialize for InlineSinkLogicalOperator defined. Serialization happens with SinkLogicalOperator");
     std::unreachable();

--- a/nes-logical-operators/src/Operators/Sinks/InlineSinkLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Sinks/InlineSinkLogicalOperator.cpp
@@ -153,8 +153,8 @@ std::vector<LogicalOperator> InlineSinkLogicalOperator::getChildren() const
     return children;
 }
 
-Reflected
-Reflector<TypedLogicalOperator<InlineSinkLogicalOperator>>::operator()(const TypedLogicalOperator<InlineSinkLogicalOperator>&, const ReflectionContext&) const
+Reflected Reflector<TypedLogicalOperator<InlineSinkLogicalOperator>>::operator()(
+    const TypedLogicalOperator<InlineSinkLogicalOperator>&, const ReflectionContext&) const
 {
     PRECONDITION(false, "no serialize for InlineSinkLogicalOperator defined. Serialization happens with SinkLogicalOperator");
     std::unreachable();

--- a/nes-logical-operators/src/Operators/Sinks/SinkLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Sinks/SinkLogicalOperator.cpp
@@ -258,9 +258,10 @@ SinkLogicalOperator SinkLogicalOperator::withSinkDescriptor(SinkDescriptor sinkD
     return newOperator;
 }
 
-Reflected Reflector<TypedLogicalOperator<SinkLogicalOperator>>::operator()(const TypedLogicalOperator<SinkLogicalOperator>& op) const
+Reflected Reflector<TypedLogicalOperator<SinkLogicalOperator>>::operator()(
+    const TypedLogicalOperator<SinkLogicalOperator>& op, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedSinkLogicalOperator{
+    return context.reflect(detail::ReflectedSinkLogicalOperator{
         .operatorId = op.getId(), .sinkDescriptor = op->getSinkDescriptor(), .sinkName = op->getSinkName()});
 }
 

--- a/nes-logical-operators/src/Operators/Sources/InlineSourceLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Sources/InlineSourceLogicalOperator.cpp
@@ -153,8 +153,8 @@ TypedLogicalOperator<InlineSourceLogicalOperator> InlineSourceLogicalOperator::c
         std::move(type), std::move(sourceSchema), std::move(sourceConfig), std::move(parserConfig)};
 }
 
-Reflected
-Reflector<TypedLogicalOperator<InlineSourceLogicalOperator>>::operator()(const TypedLogicalOperator<InlineSourceLogicalOperator>&, const ReflectionContext&) const
+Reflected Reflector<TypedLogicalOperator<InlineSourceLogicalOperator>>::operator()(
+    const TypedLogicalOperator<InlineSourceLogicalOperator>&, const ReflectionContext&) const
 {
     PRECONDITION(false, "no serialize for InlineSourceLogicalOperator defined. Serialization happens with SourceDescriptorLogicalOperator");
     std::unreachable();

--- a/nes-logical-operators/src/Operators/Sources/InlineSourceLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Sources/InlineSourceLogicalOperator.cpp
@@ -154,7 +154,7 @@ TypedLogicalOperator<InlineSourceLogicalOperator> InlineSourceLogicalOperator::c
 }
 
 Reflected
-Reflector<TypedLogicalOperator<InlineSourceLogicalOperator>>::operator()(const TypedLogicalOperator<InlineSourceLogicalOperator>&) const
+Reflector<TypedLogicalOperator<InlineSourceLogicalOperator>>::operator()(const TypedLogicalOperator<InlineSourceLogicalOperator>&, const ReflectionContext&) const
 {
     PRECONDITION(false, "no serialize for InlineSourceLogicalOperator defined. Serialization happens with SourceDescriptorLogicalOperator");
     std::unreachable();

--- a/nes-logical-operators/src/Operators/Sources/SourceDescriptorLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Sources/SourceDescriptorLogicalOperator.cpp
@@ -146,9 +146,9 @@ Unreflector<TypedLogicalOperator<SourceDescriptorLogicalOperator>>::Unreflector(
 }
 
 Reflected Reflector<TypedLogicalOperator<SourceDescriptorLogicalOperator>>::operator()(
-    const TypedLogicalOperator<SourceDescriptorLogicalOperator>& op) const
+    const TypedLogicalOperator<SourceDescriptorLogicalOperator>& op, const ReflectionContext& context) const
 {
-    return reflect(
+    return context.reflect(
         detail::ReflectedSourceDescriptorLogicalOperator{.operatorId = op.getId(), .sourceDescriptor = op->getSourceDescriptor()});
 }
 

--- a/nes-logical-operators/src/Operators/Sources/SourceNameLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Sources/SourceNameLogicalOperator.cpp
@@ -126,8 +126,8 @@ Identifier SourceNameLogicalOperator::getLogicalSourceName() const
     return logicalSourceName;
 }
 
-Reflected
-Reflector<TypedLogicalOperator<SourceNameLogicalOperator>>::operator()(const TypedLogicalOperator<SourceNameLogicalOperator>&) const
+Reflected Reflector<TypedLogicalOperator<SourceNameLogicalOperator>>::operator()(
+    const TypedLogicalOperator<SourceNameLogicalOperator>&, const ReflectionContext&) const
 {
     PRECONDITION(false, "no serialize for SourceNameLogicalOperator defined. Serialization happens with SourceDescriptorLogicalOperator");
     std::unreachable();

--- a/nes-logical-operators/src/Operators/UnionLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/UnionLogicalOperator.cpp
@@ -210,9 +210,9 @@ Schema<Field, Ordered> UnionLogicalOperator::getOrderedOutputSchema(ChildOutputO
     return bindToOperator(self.lock(), unbind(orderProvider(children.at(0))));
 }
 
-Reflected Reflector<TypedLogicalOperator<UnionLogicalOperator>>::operator()(const TypedLogicalOperator<UnionLogicalOperator>& op) const
+Reflected Reflector<TypedLogicalOperator<UnionLogicalOperator>>::operator()(const TypedLogicalOperator<UnionLogicalOperator>& op, const ReflectionContext& context) const
 {
-    return reflect(op.getId());
+    return context.reflect(op.getId());
 }
 
 Unreflector<TypedLogicalOperator<UnionLogicalOperator>>::Unreflector(ContextType operatorMapping) : plan(std::move(operatorMapping))

--- a/nes-logical-operators/src/Operators/UnionLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/UnionLogicalOperator.cpp
@@ -210,7 +210,8 @@ Schema<Field, Ordered> UnionLogicalOperator::getOrderedOutputSchema(ChildOutputO
     return bindToOperator(self.lock(), unbind(orderProvider(children.at(0))));
 }
 
-Reflected Reflector<TypedLogicalOperator<UnionLogicalOperator>>::operator()(const TypedLogicalOperator<UnionLogicalOperator>& op, const ReflectionContext& context) const
+Reflected Reflector<TypedLogicalOperator<UnionLogicalOperator>>::operator()(
+    const TypedLogicalOperator<UnionLogicalOperator>& op, const ReflectionContext& context) const
 {
     return context.reflect(op.getId());
 }

--- a/nes-logical-operators/src/Operators/Windows/Aggregations/AvgAggregationLogicalFunction.cpp
+++ b/nes-logical-operators/src/Operators/Windows/Aggregations/AvgAggregationLogicalFunction.cpp
@@ -92,14 +92,10 @@ AvgAggregationLogicalFunction AvgAggregationLogicalFunction::withInferredType(co
     return newAggFunction;
 }
 
-Reflected AvgAggregationLogicalFunction::reflect() const
+Reflected
+Reflector<AvgAggregationLogicalFunction>::operator()(const AvgAggregationLogicalFunction& function, const ReflectionContext& context) const
 {
-    return NES::reflect(this);
-}
-
-Reflected Reflector<AvgAggregationLogicalFunction>::operator()(const AvgAggregationLogicalFunction& function) const
-{
-    return reflect(function.getInputFunction());
+    return context.reflect(function.getInputFunction);
 }
 
 AvgAggregationLogicalFunction

--- a/nes-logical-operators/src/Operators/Windows/Aggregations/AvgAggregationLogicalFunction.cpp
+++ b/nes-logical-operators/src/Operators/Windows/Aggregations/AvgAggregationLogicalFunction.cpp
@@ -95,7 +95,7 @@ AvgAggregationLogicalFunction AvgAggregationLogicalFunction::withInferredType(co
 Reflected
 Reflector<AvgAggregationLogicalFunction>::operator()(const AvgAggregationLogicalFunction& function, const ReflectionContext& context) const
 {
-    return context.reflect(function.getInputFunction);
+    return context.reflect(function.getInputFunction());
 }
 
 AvgAggregationLogicalFunction

--- a/nes-logical-operators/src/Operators/Windows/Aggregations/CountAggregationLogicalFunction.cpp
+++ b/nes-logical-operators/src/Operators/Windows/Aggregations/CountAggregationLogicalFunction.cpp
@@ -80,11 +80,6 @@ bool CountAggregationLogicalFunction::operator==(const CountAggregationLogicalFu
     return inputFunction == other.inputFunction;
 }
 
-Reflected CountAggregationLogicalFunction::reflect() const
-{
-    return NES::reflect(this);
-}
-
 CountAggregationLogicalFunction CountAggregationLogicalFunction::withInferredType(const Schema<Field, Unordered>& schema) const
 {
     if (includeNullValues)
@@ -109,9 +104,10 @@ struct ReflectedCountAggregationLogicalFunction
 };
 }
 
-Reflected Reflector<CountAggregationLogicalFunction>::operator()(const CountAggregationLogicalFunction& function) const
+Reflected Reflector<CountAggregationLogicalFunction>::operator()(
+    const CountAggregationLogicalFunction& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedCountAggregationLogicalFunction{
+    return context.reflect(detail::ReflectedCountAggregationLogicalFunction{
         .inputFunction = function.getInputFunction(), .includeNullValues = function.shallIncludeNullValues()});
 }
 

--- a/nes-logical-operators/src/Operators/Windows/Aggregations/MaxAggregationLogicalFunction.cpp
+++ b/nes-logical-operators/src/Operators/Windows/Aggregations/MaxAggregationLogicalFunction.cpp
@@ -94,14 +94,10 @@ MaxAggregationLogicalFunction MaxAggregationLogicalFunction::withInferredType(co
     return MaxAggregationLogicalFunction{newInputFunction, newInputFunction->getDataType()};
 }
 
-Reflected MaxAggregationLogicalFunction::reflect() const
+Reflected
+Reflector<MaxAggregationLogicalFunction>::operator()(const MaxAggregationLogicalFunction& function, const ReflectionContext& context) const
 {
-    return NES::reflect(this);
-}
-
-Reflected Reflector<MaxAggregationLogicalFunction>::operator()(const MaxAggregationLogicalFunction& function) const
-{
-    return reflect(function.getInputFunction());
+    return context.reflect(function.getInputFunction());
 }
 
 MaxAggregationLogicalFunction

--- a/nes-logical-operators/src/Operators/Windows/Aggregations/MedianAggregationLogicalFunction.cpp
+++ b/nes-logical-operators/src/Operators/Windows/Aggregations/MedianAggregationLogicalFunction.cpp
@@ -93,14 +93,10 @@ MedianAggregationLogicalFunction MedianAggregationLogicalFunction::withInferredT
     return newAgg;
 }
 
-Reflected MedianAggregationLogicalFunction::reflect() const
+Reflected Reflector<MedianAggregationLogicalFunction>::operator()(
+    const MedianAggregationLogicalFunction& function, const ReflectionContext& context) const
 {
-    return NES::reflect(this);
-}
-
-Reflected Reflector<MedianAggregationLogicalFunction>::operator()(const MedianAggregationLogicalFunction& function) const
-{
-    return reflect(function.getInputFunction());
+    return context.reflect(function.getInputFunction());
 }
 
 MedianAggregationLogicalFunction

--- a/nes-logical-operators/src/Operators/Windows/Aggregations/MinAggregationLogicalFunction.cpp
+++ b/nes-logical-operators/src/Operators/Windows/Aggregations/MinAggregationLogicalFunction.cpp
@@ -93,14 +93,10 @@ MinAggregationLogicalFunction MinAggregationLogicalFunction::withInferredType(co
     return MinAggregationLogicalFunction{newInputFunction, newInputFunction->getDataType()};
 }
 
-Reflected MinAggregationLogicalFunction::reflect() const
+Reflected
+Reflector<MinAggregationLogicalFunction>::operator()(const MinAggregationLogicalFunction& function, const ReflectionContext& context) const
 {
-    return NES::reflect(this);
-}
-
-Reflected Reflector<MinAggregationLogicalFunction>::operator()(const MinAggregationLogicalFunction& function) const
-{
-    return reflect(function.getInputFunction());
+    return context.reflect(function.getInputFunction());
 }
 
 MinAggregationLogicalFunction

--- a/nes-logical-operators/src/Operators/Windows/Aggregations/SumAggregationLogicalFunction.cpp
+++ b/nes-logical-operators/src/Operators/Windows/Aggregations/SumAggregationLogicalFunction.cpp
@@ -118,14 +118,10 @@ bool SumAggregationLogicalFunction::operator==(const SumAggregationLogicalFuncti
     return inputFunction == other.inputFunction && aggregateType == other.aggregateType;
 }
 
-Reflected SumAggregationLogicalFunction::reflect() const
+Reflected
+Reflector<SumAggregationLogicalFunction>::operator()(const SumAggregationLogicalFunction& function, const ReflectionContext& context) const
 {
-    return NES::reflect(this);
-}
-
-Reflected Reflector<SumAggregationLogicalFunction>::operator()(const SumAggregationLogicalFunction& function) const
-{
-    return reflect(function.getInputFunction());
+    return context.reflect(function.getInputFunction());
 }
 
 SumAggregationLogicalFunction

--- a/nes-logical-operators/src/Operators/Windows/JoinLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Windows/JoinLogicalOperator.cpp
@@ -340,7 +340,8 @@ JoinTimeCharacteristic JoinLogicalOperator::getJoinTimeCharacteristics() const
     return timestampFields;
 }
 
-Reflected Reflector<TypedLogicalOperator<JoinLogicalOperator>>::operator()(const TypedLogicalOperator<JoinLogicalOperator>& op, const ReflectionContext& context) const
+Reflected Reflector<TypedLogicalOperator<JoinLogicalOperator>>::operator()(
+    const TypedLogicalOperator<JoinLogicalOperator>& op, const ReflectionContext& context) const
 {
     return context.reflect(detail::ReflectedJoinLogicalOperator{
         .operatorId = op.getId(),

--- a/nes-logical-operators/src/Operators/Windows/JoinLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Windows/JoinLogicalOperator.cpp
@@ -340,9 +340,9 @@ JoinTimeCharacteristic JoinLogicalOperator::getJoinTimeCharacteristics() const
     return timestampFields;
 }
 
-Reflected Reflector<TypedLogicalOperator<JoinLogicalOperator>>::operator()(const TypedLogicalOperator<JoinLogicalOperator>& op) const
+Reflected Reflector<TypedLogicalOperator<JoinLogicalOperator>>::operator()(const TypedLogicalOperator<JoinLogicalOperator>& op, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedJoinLogicalOperator{
+    return context.reflect(detail::ReflectedJoinLogicalOperator{
         .operatorId = op.getId(),
         .joinFunction = op->getJoinFunction(),
         .windowType = op->getWindowType(),

--- a/nes-logical-operators/src/Operators/Windows/WindowedAggregationLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Windows/WindowedAggregationLogicalOperator.cpp
@@ -421,9 +421,9 @@ WindowedAggregationLogicalOperator::getCharacteristic() const
 }
 
 Reflected Reflector<TypedLogicalOperator<WindowedAggregationLogicalOperator>>::operator()(
-    const TypedLogicalOperator<WindowedAggregationLogicalOperator>& op) const
+    const TypedLogicalOperator<WindowedAggregationLogicalOperator>& op, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedWindowAggregationLogicalOperator{
+    return context.reflect(detail::ReflectedWindowAggregationLogicalOperator{
         .operatorId = op.getId(),
         .windowType = op->getWindowType(),
         .groupingKeys = op->getGroupingKeysWithName(),

--- a/nes-logical-operators/src/Schema/Field.cpp
+++ b/nes-logical-operators/src/Schema/Field.cpp
@@ -57,9 +57,9 @@ Identifier Field::getLastName() const
     return name;
 }
 
-Reflected Reflector<Field>::operator()(const Field& field) const
+Reflected Reflector<Field>::operator()(const Field& field, const ReflectionContext& context) const
 {
-    return reflect(
+    return context.reflect(
         detail::ReflectedField{.producedBy = field.getProducedBy().getId(), .name = field.getLastName(), .dataType = field.getDataType()});
 }
 

--- a/nes-logical-operators/src/Serialization/LogicalFunctionReflection.cpp
+++ b/nes-logical-operators/src/Serialization/LogicalFunctionReflection.cpp
@@ -20,10 +20,10 @@
 
 namespace NES
 {
-Reflected Reflector<TypedLogicalFunction<>>::operator()(const TypedLogicalFunction<>& function) const
+Reflected Reflector<TypedLogicalFunction<>>::operator()(const TypedLogicalFunction<>& function, const ReflectionContext& context) const
 {
-    return reflect(
-        detail::ReflectedLogicalFunction{.functionType = std::string{function.getType()}, .functionConfig = function->reflect()});
+    return context.reflect(
+        detail::ReflectedLogicalFunction{.functionType = std::string{function.getType()}, .functionConfig = function->reflect(context)});
 }
 
 TypedLogicalFunction<> Unreflector<TypedLogicalFunction<>>::operator()(const Reflected& rfl, const ReflectionContext& context) const

--- a/nes-logical-operators/src/Serialization/QueryPlanSerializationUtil.cpp
+++ b/nes-logical-operators/src/Serialization/QueryPlanSerializationUtil.cpp
@@ -70,7 +70,7 @@ SerializableQueryPlan QueryPlanSerializationUtil::serializeQueryPlan(const Logic
             .type = std::string{itr->getName()},
             .operatorId = itr->getOperatorId(),
             .childrenIds = std::move(childrenIds),
-            .config = itr->reflect(),
+            .config = itr->reflect(ReflectionContext{}),
             .traitSet = itr->getTraitSet()};
 
         const auto serializedString = rfl::json::write(*ReflectionContext{}.reflect(reflectedOperator));

--- a/nes-logical-operators/src/Serialization/QueryPlanSerializationUtil.cpp
+++ b/nes-logical-operators/src/Serialization/QueryPlanSerializationUtil.cpp
@@ -73,7 +73,7 @@ SerializableQueryPlan QueryPlanSerializationUtil::serializeQueryPlan(const Logic
             .config = itr->reflect(),
             .traitSet = itr->getTraitSet()};
 
-        const auto serializedString = rfl::json::write(*reflect(reflectedOperator));
+        const auto serializedString = rfl::json::write(*ReflectionContext{}.reflect(reflectedOperator));
         serializableQueryPlan.add_reflectedoperators(serializedString);
     }
 

--- a/nes-logical-operators/src/Serialization/WindowAggregationLogicalFunctionReflection.cpp
+++ b/nes-logical-operators/src/Serialization/WindowAggregationLogicalFunctionReflection.cpp
@@ -20,10 +20,11 @@
 
 namespace NES
 {
-Reflected Reflector<TypedWindowAggregationLogicalFunction<>>::operator()(const TypedWindowAggregationLogicalFunction<>& function) const
+Reflected Reflector<TypedWindowAggregationLogicalFunction<>>::operator()(
+    const TypedWindowAggregationLogicalFunction<>& function, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedWindowAggregationLogicalFunction{
-        .functionType = std::string{function.getName()}, .functionConfig = function->reflect()});
+    return context.reflect(detail::ReflectedWindowAggregationLogicalFunction{
+        .functionType = std::string{function.getName()}, .functionConfig = function->reflect(context)});
 }
 
 TypedWindowAggregationLogicalFunction<>

--- a/nes-logical-operators/src/WindowTypes/Measures/TimeMeasure.cpp
+++ b/nes-logical-operators/src/WindowTypes/Measures/TimeMeasure.cpp
@@ -33,9 +33,9 @@ namespace NES::Windowing
 
 namespace NES
 {
-Reflected Reflector<Windowing::TimeMeasure>::operator()(const Windowing::TimeMeasure& measure) const
+Reflected Reflector<Windowing::TimeMeasure>::operator()(const Windowing::TimeMeasure& measure, const ReflectionContext& context) const
 {
-    return reflect(measure.getTime());
+    return context.reflect(measure.getTime());
 }
 
 Windowing::TimeMeasure Unreflector<Windowing::TimeMeasure>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-logical-operators/src/WindowTypes/Types/SlidingWindow.cpp
+++ b/nes-logical-operators/src/WindowTypes/Types/SlidingWindow.cpp
@@ -61,9 +61,10 @@ std::size_t std::hash<NES::Windowing::SlidingWindow>::operator()(const NES::Wind
 namespace NES
 {
 
-Reflected Reflector<Windowing::SlidingWindow>::operator()(const Windowing::SlidingWindow& slidingWindow) const
+Reflected
+Reflector<Windowing::SlidingWindow>::operator()(const Windowing::SlidingWindow& slidingWindow, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedSlidingWindow{.size = slidingWindow.getSize(), .slide = slidingWindow.getSlide()});
+    return context.reflect(detail::ReflectedSlidingWindow{.size = slidingWindow.getSize(), .slide = slidingWindow.getSlide()});
 }
 
 Windowing::SlidingWindow

--- a/nes-logical-operators/src/WindowTypes/Types/TimeBasedWindowType.cpp
+++ b/nes-logical-operators/src/WindowTypes/Types/TimeBasedWindowType.cpp
@@ -65,9 +65,10 @@ const std::variant<TumblingWindow, SlidingWindow>& TimeBasedWindowType::getUnder
 namespace NES
 {
 
-Reflected Reflector<Windowing::TimeBasedWindowType>::operator()(const Windowing::TimeBasedWindowType& window) const
+Reflected
+Reflector<Windowing::TimeBasedWindowType>::operator()(const Windowing::TimeBasedWindowType& window, const ReflectionContext& context) const
 {
-    return reflect(window.getUnderlying());
+    return context.reflect(window.getUnderlying());
 }
 
 Windowing::TimeBasedWindowType

--- a/nes-logical-operators/src/WindowTypes/Types/TumblingWindow.cpp
+++ b/nes-logical-operators/src/WindowTypes/Types/TumblingWindow.cpp
@@ -47,9 +47,10 @@ bool TumblingWindow::operator==(const TumblingWindow& otherWindowType) const = d
 namespace NES
 {
 
-Reflected Reflector<Windowing::TumblingWindow>::operator()(const Windowing::TumblingWindow& tumblingWindow) const
+Reflected
+Reflector<Windowing::TumblingWindow>::operator()(const Windowing::TumblingWindow& tumblingWindow, const ReflectionContext& context) const
 {
-    return reflect(tumblingWindow.getSize());
+    return context.reflect(tumblingWindow.getSize());
 }
 
 Windowing::TumblingWindow

--- a/nes-logical-operators/tests/LogicalPlanTest.cpp
+++ b/nes-logical-operators/tests/LogicalPlanTest.cpp
@@ -174,13 +174,13 @@ struct TestTrait final : DefaultTrait<TestTrait>
 template <>
 struct Reflector<TestTrait>
 {
-    Reflected operator()(const TestTrait&) const { return Reflected{}; };
+    Reflected operator()(const TestTrait&, const ReflectionContext&) const { return Reflected{}; };
 };
 
 template <>
 struct Unreflector<TestTrait>
 {
-    TestTrait operator()(const Reflected&) const { return TestTrait{}; };
+    TestTrait operator()(const Reflected&, const ReflectionContext&) const { return TestTrait{}; };
 };
 
 TEST_F(LogicalPlanTest, AddTraits)

--- a/nes-query-optimizer/include/Serialization/TraitReflection.hpp
+++ b/nes-query-optimizer/include/Serialization/TraitReflection.hpp
@@ -36,24 +36,24 @@ namespace NES
 template <>
 struct Reflector<detail::ErasedTrait>
 {
-    Reflected operator()(const detail::ErasedTrait& erased) const { return erased.reflect(); }
+    Reflected operator()(const detail::ErasedTrait& erased, const ReflectionContext& context) const { return erased.reflect(context); }
 };
 
 template <TraitConcept Checked>
 struct Reflector<TypedTrait<Checked>>
 {
-    Reflected operator()(const TypedTrait<Checked>& trait) const
+    Reflected operator()(const TypedTrait<Checked>& trait, const ReflectionContext& context) const
     {
-        return reflect(detail::ReflectedTrait{std::string{trait.getName()}, reflect(*trait)});
+        return context.reflect(detail::ReflectedTrait{std::string{trait.getName()}, context.reflect(*trait)});
     }
 };
 
 template <>
 struct Reflector<TypedTrait<detail::ErasedTrait>>
 {
-    Reflected operator()(const TypedTrait<detail::ErasedTrait>& trait) const
+    Reflected operator()(const TypedTrait<detail::ErasedTrait>& trait, const ReflectionContext& context) const
     {
-        return reflect(detail::ReflectedTrait{.type = std::string{trait.getName()}, .config = trait->reflect()});
+        return context.reflect(detail::ReflectedTrait{.type = std::string{trait.getName()}, .config = trait->reflect(context)});
     }
 };
 
@@ -73,8 +73,8 @@ struct Unreflector<TypedTrait<>>
     }
 };
 
-static_assert(requires(Trait trait) {
-    { reflect(trait) } -> std::same_as<Reflected>;
+static_assert(requires(Trait trait, const ReflectionContext& context) {
+    { context.reflect(trait) } -> std::same_as<Reflected>;
 });
 
 

--- a/nes-query-optimizer/include/Traits/FieldMappingTrait.hpp
+++ b/nes-query-optimizer/include/Traits/FieldMappingTrait.hpp
@@ -54,7 +54,7 @@ private:
 template <>
 struct Reflector<FieldMappingTrait>
 {
-    Reflected operator()(const FieldMappingTrait& trait) const;
+    Reflected operator()(const FieldMappingTrait& trait, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-query-optimizer/include/Traits/FieldOrderingTrait.hpp
+++ b/nes-query-optimizer/include/Traits/FieldOrderingTrait.hpp
@@ -55,7 +55,7 @@ private:
 template <>
 struct Reflector<FieldOrderingTrait>
 {
-    Reflected operator()(const FieldOrderingTrait& trait) const;
+    Reflected operator()(const FieldOrderingTrait& trait, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-query-optimizer/include/Traits/JoinImplementationTypeTrait.hpp
+++ b/nes-query-optimizer/include/Traits/JoinImplementationTypeTrait.hpp
@@ -56,7 +56,7 @@ struct JoinImplementationTypeTrait final
 template <>
 struct Reflector<JoinImplementationTypeTrait>
 {
-    Reflected operator()(const JoinImplementationTypeTrait& trait) const;
+    Reflected operator()(const JoinImplementationTypeTrait& trait, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-query-optimizer/include/Traits/MemoryLayoutTypeTrait.hpp
+++ b/nes-query-optimizer/include/Traits/MemoryLayoutTypeTrait.hpp
@@ -50,7 +50,7 @@ struct MemoryLayoutTypeTrait final
 template <>
 struct Reflector<MemoryLayoutTypeTrait>
 {
-    Reflected operator()(const MemoryLayoutTypeTrait& trait) const;
+    Reflected operator()(const MemoryLayoutTypeTrait& trait, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-query-optimizer/include/Traits/OutputOriginIdsTrait.hpp
+++ b/nes-query-optimizer/include/Traits/OutputOriginIdsTrait.hpp
@@ -57,7 +57,7 @@ private:
 template <>
 struct Reflector<OutputOriginIdsTrait>
 {
-    Reflected operator()(const OutputOriginIdsTrait& trait) const;
+    Reflected operator()(const OutputOriginIdsTrait& trait, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-query-optimizer/include/Traits/PlacementTrait.hpp
+++ b/nes-query-optimizer/include/Traits/PlacementTrait.hpp
@@ -50,7 +50,7 @@ struct PlacementTrait final
 template <>
 struct Reflector<PlacementTrait>
 {
-    Reflected operator()(const PlacementTrait& trait) const;
+    Reflected operator()(const PlacementTrait& trait, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-query-optimizer/include/Traits/Trait.hpp
+++ b/nes-query-optimizer/include/Traits/Trait.hpp
@@ -49,14 +49,14 @@ using Trait = TypedTrait<>;
 /// Traits are used to annotate logical operators with additional properties
 /// that can be used during query optimization.
 template <typename T>
-concept TraitConcept = requires(const T& thisTrait, ExplainVerbosity verbosity, const T& rhs) {
+concept TraitConcept = requires(const T& thisTrait, ExplainVerbosity verbosity, const ReflectionContext& context, const T& rhs) {
     /// Returns the type information of this trait.
     /// @return const std::type_info& The type information of this trait.
     { thisTrait.getType() } -> std::convertible_to<const std::type_info&>;
     { thisTrait.getName() } -> std::convertible_to<std::string_view>;
 
     /// Serialize the function to a Reflected object
-    { NES::reflect(thisTrait) } -> std::same_as<Reflected>;
+    { context.reflect(thisTrait) } -> std::same_as<Reflected>;
 
     /// Returns a string representation of the function
     { thisTrait.explain(verbosity) } -> std::convertible_to<std::string>;
@@ -80,7 +80,7 @@ struct ErasedTrait
 
     [[nodiscard]] virtual const std::type_info& getType() const = 0;
     [[nodiscard]] virtual std::string_view getName() const = 0;
-    [[nodiscard]] virtual Reflected reflect() const = 0;
+    [[nodiscard]] virtual Reflected reflect(const ReflectionContext& context) const = 0;
     [[nodiscard]] virtual std::string explain(ExplainVerbosity verbosity) const = 0;
     [[nodiscard]] virtual size_t hash() const = 0;
     [[nodiscard]] virtual bool equals(const ErasedTrait& other) const = 0;
@@ -310,7 +310,7 @@ struct TraitModel : ErasedTrait
 
     [[nodiscard]] std::string_view getName() const override { return impl.getName(); }
 
-    [[nodiscard]] Reflected reflect() const override { return NES::reflect(impl); }
+    [[nodiscard]] Reflected reflect(const ReflectionContext& context) const override { return context.reflect(impl); }
 
 private:
     template <typename T>

--- a/nes-query-optimizer/include/Traits/TraitSet.hpp
+++ b/nes-query-optimizer/include/Traits/TraitSet.hpp
@@ -136,7 +136,7 @@ bool tryInsert(TraitSet& traitset, TraitType trait)
 template <>
 struct Reflector<TraitSet>
 {
-    Reflected operator()(const TraitSet& traitSet) const;
+    Reflected operator()(const TraitSet& traitSet, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-query-optimizer/src/Traits/FieldMappingTrait.cpp
+++ b/nes-query-optimizer/src/Traits/FieldMappingTrait.cpp
@@ -67,9 +67,9 @@ std::string_view FieldMappingTrait::getName()
     return NAME;
 }
 
-Reflected Reflector<FieldMappingTrait>::operator()(const FieldMappingTrait& trait) const
+Reflected Reflector<FieldMappingTrait>::operator()(const FieldMappingTrait& trait, const ReflectionContext& context) const
 {
-    return reflect(trait.mapping);
+    return context.reflect(trait.mapping);
 }
 
 FieldMappingTrait Unreflector<FieldMappingTrait>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-query-optimizer/src/Traits/FieldOrderingTrait.cpp
+++ b/nes-query-optimizer/src/Traits/FieldOrderingTrait.cpp
@@ -53,9 +53,9 @@ std::string_view FieldOrderingTrait::getName()
     return NAME;
 }
 
-Reflected Reflector<FieldOrderingTrait>::operator()(const FieldOrderingTrait& trait) const
+Reflected Reflector<FieldOrderingTrait>::operator()(const FieldOrderingTrait& trait, const ReflectionContext& context) const
 {
-    return reflect(trait.orderedFields);
+    return context.reflect(trait.orderedFields);
 }
 
 FieldOrderingTrait Unreflector<FieldOrderingTrait>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-query-optimizer/src/Traits/JoinImplementationTypeTrait.cpp
+++ b/nes-query-optimizer/src/Traits/JoinImplementationTypeTrait.cpp
@@ -60,9 +60,10 @@ std::string_view JoinImplementationTypeTrait::getName() const
     return NAME;
 }
 
-Reflected Reflector<JoinImplementationTypeTrait>::operator()(const JoinImplementationTypeTrait& trait) const
+Reflected
+Reflector<JoinImplementationTypeTrait>::operator()(const JoinImplementationTypeTrait& trait, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedImplementationTypeTrait{trait.implementationType});
+    return context.reflect(detail::ReflectedImplementationTypeTrait{trait.implementationType});
 }
 
 JoinImplementationTypeTrait

--- a/nes-query-optimizer/src/Traits/MemoryLayoutTypeTrait.cpp
+++ b/nes-query-optimizer/src/Traits/MemoryLayoutTypeTrait.cpp
@@ -62,9 +62,9 @@ std::string_view MemoryLayoutTypeTrait::getName() const
     return NAME;
 }
 
-Reflected Reflector<MemoryLayoutTypeTrait>::operator()(const MemoryLayoutTypeTrait& trait) const
+Reflected Reflector<MemoryLayoutTypeTrait>::operator()(const MemoryLayoutTypeTrait& trait, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedMemoryLayoutTypeTrait{trait.memoryLayout});
+    return context.reflect(detail::ReflectedMemoryLayoutTypeTrait{trait.memoryLayout});
 }
 
 MemoryLayoutTypeTrait Unreflector<MemoryLayoutTypeTrait>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-query-optimizer/src/Traits/OutputOriginIdsTrait.cpp
+++ b/nes-query-optimizer/src/Traits/OutputOriginIdsTrait.cpp
@@ -92,7 +92,7 @@ size_t OutputOriginIdsTrait::size() const
     return originIds.size();
 }
 
-Reflected Reflector<OutputOriginIdsTrait>::operator()(const OutputOriginIdsTrait& trait) const
+Reflected Reflector<OutputOriginIdsTrait>::operator()(const OutputOriginIdsTrait& trait, const ReflectionContext& context) const
 {
     detail::ReflectedOutputOriginIdsTrait reflected;
     for (const auto& originId : trait.originIds)
@@ -100,7 +100,7 @@ Reflected Reflector<OutputOriginIdsTrait>::operator()(const OutputOriginIdsTrait
         reflected.originIds.emplace_back(originId.getRawValue());
     }
 
-    return reflect(reflected);
+    return context.reflect(reflected);
 }
 
 OutputOriginIdsTrait Unreflector<OutputOriginIdsTrait>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-query-optimizer/src/Traits/PlacementTrait.cpp
+++ b/nes-query-optimizer/src/Traits/PlacementTrait.cpp
@@ -51,9 +51,9 @@ std::string_view PlacementTrait::getName() const /// NOLINT(readability-convert-
     return NAME;
 }
 
-Reflected Reflector<PlacementTrait>::operator()(const PlacementTrait& trait) const
+Reflected Reflector<PlacementTrait>::operator()(const PlacementTrait& trait, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedPlacementTrait{trait.onNode});
+    return context.reflect(detail::ReflectedPlacementTrait{trait.onNode});
 }
 
 PlacementTrait Unreflector<PlacementTrait>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-query-optimizer/src/Traits/TraitSet.cpp
+++ b/nes-query-optimizer/src/Traits/TraitSet.cpp
@@ -51,7 +51,7 @@ std::string TraitSet::explain(ExplainVerbosity verbosity) const
             ", "));
 }
 
-Reflected Reflector<TraitSet>::operator()(const TraitSet& traitSet) const
+Reflected Reflector<TraitSet>::operator()(const TraitSet& traitSet, const ReflectionContext& context) const
 {
     detail::ReflectedTraitSet reflectedTraitSet;
 
@@ -60,7 +60,7 @@ Reflected Reflector<TraitSet>::operator()(const TraitSet& traitSet) const
         reflectedTraitSet.traits.emplace_back(trait);
     }
 
-    return reflect(reflectedTraitSet);
+    return context.reflect(reflectedTraitSet);
 }
 
 TraitSet Unreflector<TraitSet>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-sinks/include/Sinks/SinkDescriptor.hpp
+++ b/nes-sinks/include/Sinks/SinkDescriptor.hpp
@@ -239,7 +239,7 @@ struct ReflectedNamedSinkDescriptor
 template <>
 struct Reflector<NamedSinkDescriptor>
 {
-    Reflected operator()(const NamedSinkDescriptor& descriptor) const;
+    Reflected operator()(const NamedSinkDescriptor& descriptor, const ReflectionContext& context) const;
 };
 
 template <>
@@ -251,7 +251,7 @@ struct Unreflector<NamedSinkDescriptor>
 template <>
 struct Reflector<InlineSinkDescriptor>
 {
-    Reflected operator()(const InlineSinkDescriptor& descriptor) const;
+    Reflected operator()(const InlineSinkDescriptor& descriptor, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-sinks/include/Sinks/SinkDescriptor.hpp
+++ b/nes-sinks/include/Sinks/SinkDescriptor.hpp
@@ -204,7 +204,7 @@ public:
 template <>
 struct Reflector<SinkDescriptor>
 {
-    Reflected operator()(const SinkDescriptor& descriptor) const;
+    Reflected operator()(const SinkDescriptor& descriptor, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-sinks/src/SinkDescriptor.cpp
+++ b/nes-sinks/src/SinkDescriptor.cpp
@@ -303,15 +303,15 @@ bool operator==(const SinkDescriptor& lhs, const SinkDescriptor& rhs)
         rhs.underlying);
 }
 
-Reflected Reflector<NamedSinkDescriptor>::operator()(const NamedSinkDescriptor& descriptor) const
+Reflected Reflector<NamedSinkDescriptor>::operator()(const NamedSinkDescriptor& descriptor, const ReflectionContext& context) const
 {
-    return reflect(detail::ReflectedNamedSinkDescriptor{
+    return context.reflect(detail::ReflectedNamedSinkDescriptor{
         .name = descriptor.getSinkName(),
         .schema = *descriptor.getSchema(),
         .sinkType = descriptor.getSinkType(),
         .host = descriptor.getHost(),
-        .formatConfig = reflect(descriptor.getOutputFormatterConfig()),
-        .config = descriptor.getReflectedConfig()});
+        .formatConfig = context.reflect(descriptor.getOutputFormatterConfig()),
+        .config = descriptor.getReflectedConfig(context)});
 }
 
 NamedSinkDescriptor Unreflector<NamedSinkDescriptor>::operator()(const Reflected& reflected, const ReflectionContext& context) const
@@ -321,7 +321,7 @@ NamedSinkDescriptor Unreflector<NamedSinkDescriptor>::operator()(const Reflected
     return NamedSinkDescriptor{name, schema, sinkType, host, unreflectedFormatConfig, Descriptor::unreflectConfig(config, context)};
 }
 
-Reflected Reflector<InlineSinkDescriptor>::operator()(const InlineSinkDescriptor& descriptor) const
+Reflected Reflector<InlineSinkDescriptor>::operator()(const InlineSinkDescriptor& descriptor, const ReflectionContext& context) const
 {
     using SchemaType = decltype(std::declval<detail::ReflectedInlineSinkDescriptor>().schema);
     auto schema = std::visit(
@@ -330,13 +330,13 @@ Reflected Reflector<InlineSinkDescriptor>::operator()(const InlineSinkDescriptor
             [](const auto& schemaPtr) { return SchemaType{*schemaPtr}; }},
         descriptor.getSchema());
 
-    return reflect(detail::ReflectedInlineSinkDescriptor{
+    return context.reflect(detail::ReflectedInlineSinkDescriptor{
         .sinkId = descriptor.getSinkId(),
         .schema = std::move(schema),
         .sinkType = descriptor.getSinkType(),
         .host = descriptor.getHost(),
-        .formatConfig = reflect(descriptor.getOutputFormatterConfig()),
-        .config = descriptor.getReflectedConfig()});
+        .formatConfig = context.reflect(descriptor.getOutputFormatterConfig()),
+        .config = descriptor.getReflectedConfig(context)});
 }
 
 InlineSinkDescriptor Unreflector<InlineSinkDescriptor>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-sinks/src/SinkDescriptor.cpp
+++ b/nes-sinks/src/SinkDescriptor.cpp
@@ -346,9 +346,9 @@ InlineSinkDescriptor Unreflector<InlineSinkDescriptor>::operator()(const Reflect
     return InlineSinkDescriptor{sinkId, schema, sinkType, host, unreflectedFormatConfig, Descriptor::unreflectConfig(config, context)};
 }
 
-Reflected Reflector<SinkDescriptor>::operator()(const SinkDescriptor& descriptor) const
+Reflected Reflector<SinkDescriptor>::operator()(const SinkDescriptor& descriptor, const ReflectionContext& context) const
 {
-    return reflect(descriptor.underlying);
+    return context.reflect(descriptor.underlying);
 }
 
 SinkDescriptor Unreflector<SinkDescriptor>::operator()(const Reflected& reflected, const ReflectionContext& context) const

--- a/nes-sources/include/Sources/LogicalSource.hpp
+++ b/nes-sources/include/Sources/LogicalSource.hpp
@@ -57,7 +57,7 @@ private:
 template <>
 struct Reflector<LogicalSource>
 {
-    Reflected operator()(const LogicalSource& logicalSource) const;
+    Reflected operator()(const LogicalSource& logicalSource, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-sources/include/Sources/SourceDescriptor.hpp
+++ b/nes-sources/include/Sources/SourceDescriptor.hpp
@@ -108,7 +108,7 @@ public:
 template <>
 struct Reflector<SourceDescriptor>
 {
-    Reflected operator()(const SourceDescriptor& sourceDescriptor) const;
+    Reflected operator()(const SourceDescriptor& sourceDescriptor, const ReflectionContext& context) const;
 };
 
 template <>

--- a/nes-sources/src/LogicalSource.cpp
+++ b/nes-sources/src/LogicalSource.cpp
@@ -58,9 +58,9 @@ bool operator!=(const LogicalSource& lhs, const LogicalSource& rhs)
     return !(lhs == rhs);
 }
 
-Reflected Reflector<LogicalSource>::operator()(const LogicalSource& logicalSource) const
+Reflected Reflector<LogicalSource>::operator()(const LogicalSource& logicalSource, const ReflectionContext& context) const
 {
-    return reflect(std::pair{logicalSource.getLogicalSourceName(), *logicalSource.getSchema()});
+    return context.reflect(std::pair{logicalSource.getLogicalSourceName(), *logicalSource.getSchema()});
 }
 
 LogicalSource Unreflector<LogicalSource>::operator()(const Reflected& rfl, const ReflectionContext& context) const

--- a/nes-sources/src/SourceDescriptor.cpp
+++ b/nes-sources/src/SourceDescriptor.cpp
@@ -111,7 +111,7 @@ std::ostream& operator<<(std::ostream& out, const SourceDescriptor& descriptor)
                descriptor.getInputFormatterDescriptor());
 }
 
-Reflected Reflector<SourceDescriptor>::operator()(const SourceDescriptor& sourceDescriptor) const
+Reflected Reflector<SourceDescriptor>::operator()(const SourceDescriptor& sourceDescriptor, const ReflectionContext& context) const
 {
     const detail::ReflectedSourceDescriptor descriptor{
         .physicalSourceId = sourceDescriptor.physicalSourceId.getRawValue(),
@@ -119,9 +119,9 @@ Reflected Reflector<SourceDescriptor>::operator()(const SourceDescriptor& source
         .type = sourceDescriptor.sourceType,
         .host = sourceDescriptor.host,
         .inputFormatterDescriptor = sourceDescriptor.inputFormatterDescriptor,
-        .config = sourceDescriptor.getReflectedConfig()};
+        .config = sourceDescriptor.getReflectedConfig(context)};
 
-    return reflect(descriptor);
+    return context.reflect(descriptor);
 }
 
 SourceDescriptor Unreflector<SourceDescriptor>::operator()(const Reflected& rfl, const ReflectionContext& context) const


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

Following up on the recent `Unreflector` changes (#1412), this PR applies the same context-aware architecture to the serialization side (`Reflector`).

For a detailed explanation of why our IR requires a `ReflectionContext` and why we cannot rely on context-less `reflectcpp` calls, please refer to the previous `Unreflector` PR (#1412).

Changes in this PR:

* Replaced all global, context-less `reflect(...)` calls with `context.reflect(...)` across the entire codebase.
* Updated all `Reflector` specializations to mandate a `const ReflectionContext&` as their second argument.
* Moved template specializations for wrappers (like `TypedLogicalFunction`) strictly into headers to fix linker issues.
* Ensured that our custom context is correctly propagated through the entire serialization chain without falling back to default `reflectcpp` behavior.

## What components does this pull request potentially affect?

`nes-common`, `nes-logical-operators`, `nes-frontend`
