### PR TITLE
426 logical plan debug vis

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,0 +1,34 @@
+# NES project-level GDB init file
+# Lives at the repo root: nebulastream-public/.gdbinit
+#
+# GDB loads this automatically when you debug from the nebulastream-public
+# root directory — which is what CLion does.
+#
+# ONE-TIME SETUP per developer (only for native debugging on the host):
+#   Add this line to your ~/.gdbinit (create it if it doesn't exist):
+#
+#       add-auto-load-safe-path /path/to/nebulastream-public
+#
+#   This tells GDB it is safe to auto-load this project's .gdbinit.
+#   Without it GDB silently ignores this file for security reasons.
+#
+#   Inside the dev container this is already set up (the image trusts the
+#   mounted repo path), so no ~/.gdbinit change is needed there.
+
+# Load the NES pretty printer. This file only auto-loads from the repo root, so
+# the cwd is that root and the scripts/ path can be derived from it.
+python
+import os
+import sys
+sys.path.insert(0, os.path.join(os.getcwd(), 'scripts'))
+import pretty_print_logic_plans
+end
+
+# Make STL containers readable (vectors, strings etc.)
+set print pretty on
+
+# Show all characters in strings (plans can be long)
+set print elements 0
+
+# Follow shared_ptr and virtual dispatch automatically
+set print object on

--- a/docker/dependency/Development.dockerfile
+++ b/docker/dependency/Development.dockerfile
@@ -36,13 +36,25 @@ RUN git clone https://github.com/aras-p/ClangBuildAnalyzer.git \
 
 # Install GDB Libc++ Pretty Printer
 RUN wget -P /usr/share/libcxx/  https://raw.githubusercontent.com/llvm/llvm-project/refs/tags/llvmorg-19.1.7/libcxx/utils/gdb/libcxx/printers.py && \
-    cat <<EOF > /etc/gdb/gdbinit
-    python
-    import sys
-    sys.path.insert(0, '/usr/share/libcxx')
-    import printers
-    printers.register_libcxx_printer_loader()
-    end
+    cat << 'EOF' > /etc/gdb/gdbinit
+python
+import sys
+sys.path.insert(0, '/usr/share/libcxx')
+import printers
+printers.register_libcxx_printer_loader()
+end
+set auto-load safe-path /
+EOF
+
+# Same libc++ pretty printer for udb (UndoDB time-travel debugger)
+RUN cat << 'EOF' > /root/.udbinit
+python
+import sys
+sys.path.insert(0, '/usr/share/libcxx')
+import printers
+printers.register_libcxx_printer_loader()
+end
+set auto-load safe-path /
 EOF
 
 # Installing the stable and nightly rust toolchain

--- a/docker/dependency/DevelopmentLocal.dockerfile
+++ b/docker/dependency/DevelopmentLocal.dockerfile
@@ -21,4 +21,10 @@ RUN (${ROOTLESS} || (echo "uid: ${UID} gid ${GID} username ${USERNAME}" && \
 RUN mkdir -p /run/containerd && \
     chown -R ${UID}:${GID} /run/containerd
 
+# Mirror the root-level gdbinit trust setting for the non-root dev user: GDB reads
+# per-user config from ~/.config/gdb/gdbinit, and without this it refuses to
+# auto-load the repo-root .gdbinit (which loads the pretty-printer) when running
+# as ${USERNAME}.
+RUN mkdir -p /home/${USERNAME}/.config/gdb && \
+    echo "set auto-load safe-path /" > /home/${USERNAME}/.config/gdb/gdbinit
 USER ${USERNAME}

--- a/nes-logical-operators/include/Debug/DebugHelpers.hpp
+++ b/nes-logical-operators/include/Debug/DebugHelpers.hpp
@@ -1,0 +1,54 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+#include <string>
+#include <vector>
+#include <Operators/LogicalOperatorFwd.hpp>
+#include <Plans/LogicalPlan.hpp>
+
+namespace NES::Debug
+{
+
+/// Debugger-only helpers. Not used by production code paths.
+///
+/// Intended usage: while paused at a breakpoint in GDB/CLion, evaluate
+/// `NES::Debug::view(plan)` in the "Threads & Variables" expression box or the
+/// GDB console to get a shallow, expandable operator tree.
+///
+/// The *View structs are deliberately tiny (one label string + children) so
+/// the debugger renders them as a compact tree: operator -> children -> ...,
+/// without the self/get()/impl indirection of the real operator objects.
+/// One node of the shallow debug tree. `op` is the operator's short label and
+/// `children` recurse into the subtree.
+struct OperatorView
+{
+    std::string op;
+    std::vector<OperatorView> children;
+};
+
+/// Root of the shallow debug tree for a whole plan.
+struct PlanView
+{
+    std::string plan;
+    std::vector<OperatorView> roots;
+};
+
+/// Build a shallow debug tree for a single operator (recurses into children).
+[[nodiscard]] OperatorView view(const LogicalOperator& op);
+
+/// Build a shallow debug tree for a whole plan.
+[[nodiscard]] PlanView view(const LogicalPlan& plan);
+
+}

--- a/nes-logical-operators/src/Plans/LogicalPlan.cpp
+++ b/nes-logical-operators/src/Plans/LogicalPlan.cpp
@@ -26,6 +26,7 @@
 #include <utility>
 #include <vector>
 
+#include <Debug/DebugHelpers.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Iterators/BFSIterator.hpp>
 #include <Operators/LogicalOperator.hpp>
@@ -279,6 +280,35 @@ bool LogicalPlan::operator==(const LogicalPlan& other) const
 std::ostream& operator<<(std::ostream& os, const LogicalPlan& plan)
 {
     return os << explain(plan, ExplainVerbosity::Short);
+}
+
+namespace Debug
+{
+
+OperatorView view(const LogicalOperator& op) /// NOLINT(misc-no-recursion)
+{
+    OperatorView node;
+    node.op = op.explain(ExplainVerbosity::Short);
+    for (const auto& child : op.getChildren())
+    {
+        node.children.push_back(view(child));
+    }
+    return node;
+}
+
+PlanView view(const LogicalPlan& plan)
+{
+    PlanView result;
+    std::ostringstream planLabel;
+    planLabel << "LogicalPlan (queryId: " << plan.getQueryId() << ")";
+    result.plan = planLabel.str();
+    for (const auto& root : plan.getRootOperators())
+    {
+        result.roots.push_back(view(root));
+    }
+    return result;
+}
+
 }
 
 }

--- a/nes-logical-operators/tests/LogicalPlanTest.cpp
+++ b/nes-logical-operators/tests/LogicalPlanTest.cpp
@@ -32,6 +32,7 @@
 #include <DataTypes/Schema.hpp>
 #include <DataTypes/SchemaFwd.hpp>
 #include <DataTypes/UnboundField.hpp>
+#include <Debug/DebugHelpers.hpp>
 #include <Functions/FieldAccessLogicalFunction.hpp>
 #include <Functions/UnboundFieldAccessLogicalFunction.hpp>
 #include <Identifiers/Identifiers.hpp>
@@ -236,4 +237,22 @@ TEST_F(LogicalPlanTest, OutputOperator)
     std::stringstream ss;
     ss << plan;
     EXPECT_FALSE(ss.str().empty());
+}
+
+TEST_F(LogicalPlanTest, DebugViewBuildsLabeledTree)
+{
+    const auto source = SourceNameLogicalOperator::create(Identifier::parse("sensors"));
+    const auto filter = SelectionLogicalOperator::create(UnboundFieldAccessLogicalFunction{Identifier::parse("temperature")})
+                            .withChildrenUnsafe({source});
+    const auto sink = SinkLogicalOperator::create(Identifier::parse("ResultSink")).withChildrenUnsafe({filter});
+    const LogicalPlan plan(INVALID_QUERY_ID, {sink});
+
+    const auto planView = Debug::view(plan);
+    EXPECT_NE(planView.plan.find("LogicalPlan"), std::string::npos);
+    ASSERT_EQ(planView.roots.size(), 1);
+    EXPECT_EQ(planView.roots[0].op, "SINK(RESULTSINK)");
+    ASSERT_EQ(planView.roots[0].children.size(), 1);
+    EXPECT_EQ(planView.roots[0].children[0].op, "SELECTION(TEMPERATURE)");
+    ASSERT_EQ(planView.roots[0].children[0].children.size(), 1);
+    EXPECT_EQ(planView.roots[0].children[0].children[0].op, "SOURCE(SENSORS)");
 }

--- a/scripts/check_preamble.py
+++ b/scripts/check_preamble.py
@@ -58,6 +58,7 @@ INGORED_ENDINGS = {
     "dockerignore",
     "dummy",
     "env",
+    "gdbinit",
     "gitignore",
     "mailmap",
     "json",

--- a/scripts/pretty_print_logic_plans.py
+++ b/scripts/pretty_print_logic_plans.py
@@ -1,0 +1,360 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NES Query Plan Pretty Printers for GDB
+#
+# Two complementary features:
+#
+# 1) LABELS (automatic): LogicalPlan / LogicalOperator / LogicalFunction keep
+#    GDB's DEFAULT expandable structure completely unchanged; we only add an
+#    informative one-line label, e.g.
+#        sinkOp = {NES::LogicalOperator} Sink (id: 7, children: [Selection])
+#    Labels are computed by passive memory reading only (no C++ calls, no
+#    copies), so they cannot crash the inferior, even on half-built objects.
+#
+# 2) SHALLOW VIEW (manual): the C++ helper NES::Debug::view(plan) returns a
+#    lightweight PlanView/OperatorView tree. Type it in the Watches /
+#    Evaluate-expression box to get a compact operator tree without the
+#    self/get()/impl indirection. The printers below render those views as
+#    label + children directly.
+#
+# Setup: loaded automatically via the project .gdbinit. No setup needed.
+
+import gdb
+
+
+# ---------------------------------------------------------------------------
+# Safe, passive memory reads (never execute code in the inferior)
+# ---------------------------------------------------------------------------
+
+def _looks_like_heap_ptr(addr):
+    try:
+        return int(addr) >= 0x10000
+    except Exception:
+        return False
+
+
+def _name_from_type(erased):
+    """OperatorModel<NES::SourceNameLogicalOperator> -> SourceNameLogicalOperator"""
+    try:
+        tname = str(erased.dynamic_type)
+        inner = tname[tname.index('<') + 1: tname.rindex('>')]
+        return inner.split('::')[-1].strip()
+    except Exception:
+        return None
+
+
+def _read_name(impl, erased):
+    """Operator/function display name: static NAME if present, else type name."""
+    try:
+        name_sv = impl['NAME']
+        length = int(name_sv['_M_len'])
+        data = name_sv['_M_str']
+        if _looks_like_heap_ptr(data) and 0 < length < 256:
+            return data.string(length=length)
+    except Exception:
+        pass
+    return _name_from_type(erased)
+
+
+def _read_std_string(val):
+    """Read a std::string gdb.Value into a python str, or None.
+
+    Delegates to the registered std::string pretty-printer so it works under
+    both libc++ (local build) and libstdc++ (remote build), whose internal
+    layouts differ; falls back to raw libstdc++ field access."""
+    try:
+        vis = gdb.default_visualizer(val)
+        if vis is not None:
+            s = vis.to_string()
+            if hasattr(s, 'string'):
+                s = s.string()
+            if s is not None:
+                s = str(s)
+                # std::string visualizers hand back a gdb LazyString that
+                # stringifies with GDB's surrounding double quotes; strip one pair.
+                if len(s) >= 2 and s[0] == '"' and s[-1] == '"':
+                    s = s[1:-1]
+                return s
+    except Exception:
+        pass
+    try:
+        p = val['_M_dataplus']['_M_p']
+        if not _looks_like_heap_ptr(p):
+            return None
+        length = int(val['_M_string_length'])
+        if length < 0 or length > 4096:
+            return None
+        return p.string(length=length)
+    except Exception:
+        return None
+
+
+def _resolve_impl(handle_val):
+    """Follow handle.self (shared_ptr) to the concrete model. None if unsafe."""
+    try:
+        shared = handle_val['self']
+        ptr = shared['_M_ptr']
+        if not _looks_like_heap_ptr(ptr):
+            return None
+        erased = ptr.dereference()
+        concrete = erased.cast(erased.dynamic_type)
+        return (concrete['impl'], erased, concrete)
+    except Exception:
+        return None
+
+
+def _vector_range(vec_val, max_count=4096):
+    """Yield elements of a std::vector gdb.Value, with sanity checks.
+
+    Delegates to the registered std::vector pretty-printer (works under both
+    libc++ and libstdc++); falls back to raw libstdc++ field access."""
+    try:
+        vis = gdb.default_visualizer(vec_val)
+    except Exception:
+        vis = None
+    if vis is not None and hasattr(vis, 'children'):
+        count = 0
+        for _, elem in vis.children():
+            yield elem
+            count += 1
+            if count >= max_count:
+                return
+        return
+    try:
+        impl = vec_val['_M_impl']
+        start = impl['_M_start']
+        finish = impl['_M_finish']
+        if not _looks_like_heap_ptr(start):
+            return
+        start_i, finish_i = int(start), int(finish)
+        if finish_i < start_i:
+            return
+        elem_size = start.dereference().type.sizeof
+        count = (finish_i - start_i) // elem_size
+        if count < 0 or count > max_count:
+            return
+        for i in range(count):
+            yield start[i]
+    except Exception:
+        return
+
+
+def _child_names(impl, limit=4):
+    """Names of an operator's children, for the label. Empty list if none."""
+    names = []
+    try:
+        for child in _vector_range(impl['children'], max_count=64):
+            resolved = _resolve_impl(child)
+            if resolved is None:
+                names.append('?')
+            else:
+                c_impl, c_erased, _ = resolved
+                names.append(_read_name(c_impl, c_erased) or '?')
+            if len(names) >= limit:
+                names.append('...')
+                break
+    except Exception:
+        pass
+    return names
+
+
+def _yield_raw_fields(val):
+    """Yield every data member of val unchanged (default-like expansion)."""
+    try:
+        fields = val.type.strip_typedefs().fields()
+    except Exception:
+        return
+    for f in fields:
+        try:
+            if not f.name:
+                continue
+            if getattr(f, 'is_base_class', False):
+                continue
+            yield (f.name, val[f.name])
+        except Exception:
+            continue
+
+
+# ---------------------------------------------------------------------------
+# 1) Label printers: custom LABEL, default CHILDREN.
+# ---------------------------------------------------------------------------
+
+class LogicalOperatorPrinter:
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        resolved = _resolve_impl(self.val)
+        if resolved is None:
+            return None
+        impl, erased, concrete = resolved
+        name = _read_name(impl, erased)
+        if not name:
+            return None
+        parts = []
+        try:
+            parts.append(f'id: {int(concrete["id"]["value"])}')
+        except Exception:
+            pass
+        children = _child_names(impl)
+        if children:
+            parts.append('children: [' + ', '.join(children) + ']')
+        return f'{name} ({", ".join(parts)})' if parts else name
+
+    def children(self):
+        return _yield_raw_fields(self.val)
+
+    def display_hint(self):
+        return None
+
+
+class LogicalFunctionPrinter:
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        resolved = _resolve_impl(self.val)
+        if resolved is None:
+            return None
+        impl, erased, _ = resolved
+        return _read_name(impl, erased)
+
+    def children(self):
+        return _yield_raw_fields(self.val)
+
+    def display_hint(self):
+        return None
+
+
+class LogicalPlanPrinter:
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        label = 'LogicalPlan'
+        try:
+            qid = int(self.val['queryId']['value'])
+        except Exception:
+            return label
+        parts = [f'queryId: {qid}']
+        names = []
+        try:
+            for root in _vector_range(self.val['rootOperators'], max_count=64):
+                resolved = _resolve_impl(root)
+                if resolved is None:
+                    names.append('?')
+                else:
+                    impl, erased, _ = resolved
+                    names.append(_read_name(impl, erased) or '?')
+                if len(names) >= 4:
+                    names.append('...')
+                    break
+        except Exception:
+            pass
+        if names:
+            parts.append('roots: [' + ', '.join(names) + ']')
+        return f'{label} ({", ".join(parts)})'
+
+    def children(self):
+        return _yield_raw_fields(self.val)
+
+    def display_hint(self):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# 2) Shallow-view printers for NES::Debug::PlanView / OperatorView.
+#    These structs are produced by the C++ helper NES::Debug::view(...).
+#    Render: label string as the node text, children vector as the only rows.
+# ---------------------------------------------------------------------------
+
+class OperatorViewPrinter:
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        return _read_std_string(self.val['op']) or 'OperatorView'
+
+    def children(self):
+        idx = 0
+        try:
+            for child in _vector_range(self.val['children'], max_count=4096):
+                yield (f'[{idx}]', child)
+                idx += 1
+        except Exception:
+            return
+
+    def display_hint(self):
+        return None
+
+
+class PlanViewPrinter:
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        return _read_std_string(self.val['plan']) or 'PlanView'
+
+    def children(self):
+        idx = 0
+        try:
+            for root in _vector_range(self.val['roots'], max_count=4096):
+                yield (f'[root {idx}]', root)
+                idx += 1
+        except Exception:
+            return
+
+    def display_hint(self):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+def nes_pretty_printer_lookup(val):
+    try:
+        # unqualified() drops const/volatile: Type.name is None for a cv-qualified
+        # type, so a `const PlanView` (e.g. `const auto pv = ...`) would otherwise
+        # never match and print nothing.
+        type_name = val.type.strip_typedefs().unqualified().name
+    except Exception:
+        return None
+    if type_name is None:
+        return None
+    if type_name == 'NES::LogicalPlan':
+        return LogicalPlanPrinter(val)
+    if type_name == 'NES::Debug::PlanView':
+        return PlanViewPrinter(val)
+    if type_name == 'NES::Debug::OperatorView':
+        return OperatorViewPrinter(val)
+    if 'NES::TypedLogicalOperator<' in type_name:
+        return LogicalOperatorPrinter(val)
+    if 'NES::TypedLogicalFunction<' in type_name:
+        return LogicalFunctionPrinter(val)
+    return None
+
+
+def register_nes_printers(obj):
+    if obj is None:
+        obj = gdb
+    obj.pretty_printers = [
+        p for p in obj.pretty_printers
+        if p is not nes_pretty_printer_lookup
+    ]
+    obj.pretty_printers.append(nes_pretty_printer_lookup)
+
+
+register_nes_printers(None)
+print('[NES] Plan/operator labels loaded. '
+      'Shallow tree: evaluate NES::Debug::view(plan) in the Watches pane.')


### PR DESCRIPTION
### Purpose of the Change and Brief Change Log

 This is about how Logical plans are shown in the debugger. 

I have implemented two options for rendering the plan better. They are two separate commits so you can keep one, both, or drop either:

- Debug::view() — a small C++ helper. You type `NES::Debug::view(plan)` in the evaluate box and get a clean little tree with short labels like SINK(name), SELECTION(field), SOURCE(name). 
- GDB python pretty-printer — auto-adds a one-line label to every plan/operator variable, e.g. SinkLogicalOperator (id: 7, children: [Selection]), so you don't have to call anything. Loads automatically in the docker container; for native debugging you add two lines to your ~/.gdbinit.

### Verifying this change
With LogicalPlanTest
Just set a breakpoint on an EXPECT_EQ line in one of the DebugView_* tests and look at `NES::Debug::view(plan)`.

What components does this pull request potentially affect?

- nes-logical-operators — the new view() helper + tests (doesn't touch any real plan logic)
- Development.dockerfile / DevelopmentLocal.dockerfile — GDB setup so the printer loads
- .gdbinit — new file at repo root, loads the printer script for native debugging


## Issue Closed by this pull request:

This PR closes #426 
