### PR TITLE
  refactor(worker): queries are now directly started instead of requiring prior registration

### DIFF
--- a/grpc/SingleNodeWorkerRPCService.proto
+++ b/grpc/SingleNodeWorkerRPCService.proto
@@ -18,24 +18,18 @@ import "SerializableQueryPlan.proto";
 import "google/protobuf/empty.proto";
 
 service WorkerRPCService {
-  rpc RegisterQuery (RegisterQueryRequest) returns (RegisterQueryReply) {}
-
-  rpc StartQuery (StartQueryRequest) returns (google.protobuf.Empty) {}
+  rpc StartQuery (StartQueryRequest) returns (StartQueryReply) {}
   rpc StopQuery (StopQueryRequest) returns (google.protobuf.Empty) {}
 
   rpc RequestQueryStatus (QueryStatusRequest) returns (QueryStatusReply) {}
   rpc RequestStatus (WorkerStatusRequest) returns (WorkerStatusResponse) {}
 }
 
-message RegisterQueryRequest {
+message StartQueryRequest {
   NES.SerializableQueryPlan queryPlan = 1;
 }
 
-message RegisterQueryReply {
-  NES.SerializableQueryId queryId = 1;
-}
-
-message StartQueryRequest {
+message StartQueryReply {
   NES.SerializableQueryId queryId = 1;
 }
 

--- a/nes-common/include/ExceptionDefinitions.inc
+++ b/nes-common/include/ExceptionDefinitions.inc
@@ -95,7 +95,6 @@ EXCEPTION(CannotOpenSink, 4004, "failed to open a sink")
 
 /// 5XXX API errors
 EXCEPTION(QueryNotFound, 5000, "query is not registered")
-EXCEPTION(QueryRegistrationFailed, 5001, "query registration call failed")
 EXCEPTION(QueryStartFailed, 5002, "query start call failed")
 EXCEPTION(QueryStopFailed, 5003, "query stop call failed")
 EXCEPTION(QueryUnregistrationFailed, 5004, "query unregistration call failed")

--- a/nes-frontend/apps/cli/tests/distributed.bats
+++ b/nes-frontend/apps/cli/tests/distributed.bats
@@ -170,7 +170,7 @@ teardown()      { nes_distributed_teardown; }
   run docker_nes_cli -d start
 
   sync_workdir
-  grep "(5001) : query registration call failed; Status: UNAVAILABLE" nes-cli.log
+  grep "(5002) : query start call failed; Could not start query: query start call failed; Status: UNAVAILABLE" nes-cli.log
   [ "$status" -eq 1 ]
 
   docker compose up -d --wait worker-1

--- a/nes-frontend/include/QueryManager/EmbeddedWorkerQuerySubmissionBackend.hpp
+++ b/nes-frontend/include/QueryManager/EmbeddedWorkerQuerySubmissionBackend.hpp
@@ -21,6 +21,7 @@
 #include <Listeners/QueryLog.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <ErrorHandling.hpp>
+#include <QueryId.hpp>
 #include <QueryStatus.hpp>
 #include <SingleNodeWorker.hpp>
 #include <SingleNodeWorkerConfiguration.hpp>
@@ -32,8 +33,7 @@ class EmbeddedWorkerQuerySubmissionBackend final : public QuerySubmissionBackend
 {
 public:
     EmbeddedWorkerQuerySubmissionBackend(WorkerConfig config, SingleNodeWorkerConfiguration workerConfiguration);
-    [[nodiscard]] std::expected<QueryId, Exception> registerQuery(LogicalPlan) override;
-    std::expected<void, Exception> start(QueryId) override;
+    [[nodiscard]] std::expected<QueryId, Exception> start(LogicalPlan) override;
     std::expected<void, Exception> stop(QueryId) override;
     [[nodiscard]] std::expected<LocalQueryStatusSnapshot, Exception> status(QueryId) const override;
     [[nodiscard]] std::expected<WorkerStatus, Exception> workerStatus(std::chrono::system_clock::time_point after) const override;

--- a/nes-frontend/include/QueryManager/GRPCQuerySubmissionBackend.hpp
+++ b/nes-frontend/include/QueryManager/GRPCQuerySubmissionBackend.hpp
@@ -22,6 +22,7 @@
 #include <Listeners/QueryLog.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <ErrorHandling.hpp>
+#include <QueryId.hpp>
 #include <QueryStatus.hpp>
 #include <SingleNodeWorkerRPCService.grpc.pb.h>
 #include <WorkerStatus.hpp>
@@ -35,8 +36,7 @@ class GRPCQuerySubmissionBackend final : public QuerySubmissionBackend
 
 public:
     explicit GRPCQuerySubmissionBackend(WorkerConfig config);
-    [[nodiscard]] std::expected<QueryId, Exception> registerQuery(LogicalPlan) override;
-    std::expected<void, Exception> start(QueryId) override;
+    [[nodiscard]] std::expected<QueryId, Exception> start(LogicalPlan) override;
     std::expected<void, Exception> stop(QueryId) override;
     [[nodiscard]] std::expected<LocalQueryStatusSnapshot, Exception> status(QueryId) const override;
     [[nodiscard]] std::expected<WorkerStatus, Exception> workerStatus(std::chrono::system_clock::time_point after) const override;

--- a/nes-frontend/include/QueryManager/QueryManager.hpp
+++ b/nes-frontend/include/QueryManager/QueryManager.hpp
@@ -27,6 +27,7 @@
 #include <DistributedLogicalPlan.hpp>
 #include <DistributedQuery.hpp>
 #include <ErrorHandling.hpp>
+#include <QueryId.hpp>
 #include <QueryStatus.hpp>
 #include <WorkerCatalog.hpp>
 #include <WorkerConfig.hpp>
@@ -39,8 +40,7 @@ class QuerySubmissionBackend
 {
 public:
     virtual ~QuerySubmissionBackend() = default;
-    [[nodiscard]] virtual std::expected<QueryId, Exception> registerQuery(LogicalPlan) = 0;
-    virtual std::expected<void, Exception> start(QueryId) = 0;
+    [[nodiscard]] virtual std::expected<QueryId, Exception> start(LogicalPlan) = 0;
     virtual std::expected<void, Exception> stop(QueryId) = 0;
     [[nodiscard]] virtual std::expected<LocalQueryStatusSnapshot, Exception> status(QueryId) const = 0;
     [[nodiscard]] virtual std::expected<WorkerStatus, Exception> workerStatus(std::chrono::system_clock::time_point after) const = 0;
@@ -107,11 +107,9 @@ class QueryManager
 public:
     QueryManager(SharedPtr<WorkerCatalog> workerCatalog, BackendProvider provider, QueryManagerState state);
     QueryManager(SharedPtr<WorkerCatalog> workerCatalog, BackendProvider provider);
-    [[nodiscard]] std::expected<DistributedQueryId, Exception> registerQuery(const DistributedLogicalPlan& plan);
-    /// Starts a pre-registered query. Start may potentially block waiting for the query state to change (even if it fails).
-    std::expected<void, std::vector<Exception>> start(DistributedQueryId query);
+    /// Compiles and starts the distributed query on all assigned workers. Blocks until the query state has advanced past Registered.
+    [[nodiscard]] std::expected<DistributedQueryId, std::vector<Exception>> start(const DistributedLogicalPlan& plan);
     std::expected<void, std::vector<Exception>> stop(DistributedQueryId query);
-    std::expected<void, std::vector<Exception>> unregister(const DistributedQueryId& query);
     [[nodiscard]] std::expected<DistributedQueryStatusSnapshot, std::vector<Exception>> status(const DistributedQueryId& query) const;
     [[nodiscard]] std::vector<DistributedQueryId> getRunningQueries() const;
     [[nodiscard]] std::vector<DistributedQueryId> queries() const;

--- a/nes-frontend/src/QueryManager/EmbeddedWorkerQuerySubmissionBackend.cpp
+++ b/nes-frontend/src/QueryManager/EmbeddedWorkerQuerySubmissionBackend.cpp
@@ -16,6 +16,7 @@
 
 #include <chrono>
 #include <memory>
+#include <utility>
 #include <Identifiers/Identifiers.hpp>
 #include <Listeners/QueryLog.hpp>
 #include <Plans/LogicalPlan.hpp>
@@ -23,6 +24,7 @@
 
 #include <Util/Logger/impl/NesLogger.hpp>
 #include <ErrorHandling.hpp>
+#include <QueryId.hpp>
 #include <QueryStatus.hpp>
 #include <SingleNodeWorkerConfiguration.hpp>
 #include <WorkerStatus.hpp>
@@ -50,14 +52,9 @@ EmbeddedWorkerQuerySubmissionBackend::EmbeddedWorkerQuerySubmissionBackend(
 {
 }
 
-std::expected<QueryId, Exception> EmbeddedWorkerQuerySubmissionBackend::registerQuery(LogicalPlan plan)
+std::expected<QueryId, Exception> EmbeddedWorkerQuerySubmissionBackend::start(LogicalPlan plan)
 {
-    return worker.registerQuery(plan);
-}
-
-std::expected<void, Exception> EmbeddedWorkerQuerySubmissionBackend::start(QueryId queryId)
-{
-    return worker.startQuery(queryId);
+    return worker.startQuery(std::move(plan));
 }
 
 std::expected<void, Exception> EmbeddedWorkerQuerySubmissionBackend::stop(QueryId queryId)

--- a/nes-frontend/src/QueryManager/GRPCQuerySubmissionBackend.cpp
+++ b/nes-frontend/src/QueryManager/GRPCQuerySubmissionBackend.cpp
@@ -33,6 +33,7 @@
 #include <grpcpp/support/status.h>
 #include <magic_enum/magic_enum.hpp>
 #include <ErrorHandling.hpp>
+#include <QueryId.hpp>
 #include <QueryStatus.hpp>
 #include <SingleNodeWorkerRPCService.grpc.pb.h>
 #include <SingleNodeWorkerRPCService.pb.h>
@@ -53,16 +54,16 @@ GRPCQuerySubmissionBackend::GRPCQuerySubmissionBackend(WorkerConfig config)
     }
 }
 
-std::expected<QueryId, Exception> GRPCQuerySubmissionBackend::registerQuery(LogicalPlan localPlan)
+std::expected<QueryId, Exception> GRPCQuerySubmissionBackend::start(LogicalPlan localPlan)
 {
     grpc::ClientContext context;
-    RegisterQueryReply reply;
-    RegisterQueryRequest request;
+    StartQueryReply reply;
+    StartQueryRequest request;
     request.mutable_queryplan()->CopyFrom(QueryPlanSerializationUtil::serializeQueryPlan(localPlan));
-    const auto status = stub->RegisterQuery(&context, request, &reply);
+    const auto status = stub->StartQuery(&context, request, &reply);
     if (status.ok())
     {
-        NES_DEBUG("Registration of local query {} to node {} was successful.", localPlan.getQueryId(), workerConfig.host);
+        NES_DEBUG("Starting local query {} on node {} was successful.", localPlan.getQueryId(), workerConfig.host);
         /// The worker returns its assigned LocalQueryId, but we need to return the full QueryId
         /// which includes the DistributedQueryId from the plan
         auto workerQueryId = QueryPlanSerializationUtil::deserializeQueryId(reply.queryid());
@@ -72,23 +73,6 @@ std::expected<QueryId, Exception> GRPCQuerySubmissionBackend::registerQuery(Logi
         }
         return workerQueryId;
     }
-    return std::unexpected{QueryRegistrationFailed(
-        "Status: {}\nMessage: {}\nDetail: {}", magic_enum::enum_name(status.error_code()), status.error_message(), status.error_details())};
-}
-
-std::expected<void, Exception> GRPCQuerySubmissionBackend::start(QueryId queryId)
-{
-    grpc::ClientContext context;
-    StartQueryRequest request;
-    google::protobuf::Empty response;
-    *request.mutable_queryid() = QueryPlanSerializationUtil::serializeQueryId(queryId);
-    const auto status = stub->StartQuery(&context, request, &response);
-    if (status.ok())
-    {
-        NES_DEBUG("Starting query {} on node {} was successful.", queryId, workerConfig.host);
-        return {};
-    }
-
     return std::unexpected{QueryStartFailed(
         "Status: {}\nMessage: {}\nDetail: {}", magic_enum::enum_name(status.error_code()), status.error_message(), status.error_details())};
 }

--- a/nes-frontend/src/QueryManager/QueryManager.cpp
+++ b/nes-frontend/src/QueryManager/QueryManager.cpp
@@ -107,7 +107,7 @@ void QueryManager::QueryManagerBackends::rebuildBackendsIfNeeded() const
     }
 }
 
-[[nodiscard]] std::expected<DistributedQueryId, Exception> QueryManager::registerQuery(const DistributedLogicalPlan& plan)
+[[nodiscard]] std::expected<DistributedQueryId, std::vector<Exception>> QueryManager::start(const DistributedLogicalPlan& plan)
 {
     std::unordered_map<Host, std::vector<QueryId>> localQueries;
 
@@ -121,6 +121,9 @@ void QueryManager::QueryManagerBackends::rebuildBackendsIfNeeded() const
         throw QueryAlreadyRegistered("{}", plan.getQueryId());
     }
 
+    const std::chrono::steady_clock::time_point queryStartTimestamp = std::chrono::steady_clock::now();
+    std::vector<Exception> exceptions;
+
     for (const auto& [host, localPlans] : plan)
     {
         INVARIANT(backends.contains(host), "Plan was assigned to a node ({}) that is not part of the cluster", host);
@@ -130,72 +133,35 @@ void QueryManager::QueryManagerBackends::rebuildBackendsIfNeeded() const
             {
                 /// Set the distributed query ID on the local plan before sending to worker
                 localPlan.setQueryId(QueryId::createDistributed(id));
-                const auto result = backends.at(host).registerQuery(localPlan);
+                const auto result = backends.at(host).start(localPlan);
                 if (result)
                 {
-                    NES_DEBUG("Registration to node {} was successful.", host);
+                    NES_DEBUG("Starting query on node {} was successful.", host);
                     localQueries[host].emplace_back(*result);
                     continue;
                 }
-                return std::unexpected{result.error()};
+                exceptions.emplace_back(result.error());
             }
             catch (const std::exception& e)
             {
-                return std::unexpected{QueryRegistrationFailed("Message from external exception: {}", e.what())};
+                exceptions.emplace_back(QueryStartFailed("Message from external exception: {}", e.what()));
             }
         }
+    }
+
+    if (!exceptions.empty())
+    {
+        return std::unexpected(exceptions);
     }
 
     this->state.queries.emplace(id, std::move(localQueries));
-    return id;
-}
 
-std::expected<void, std::vector<Exception>> QueryManager::start(DistributedQueryId queryId)
-{
-    auto queryResult = getQuery(std::move(queryId));
-    if (!queryResult.has_value())
-    {
-        return std::unexpected(std::vector{queryResult.error()});
-    }
-    auto query = queryResult.value();
-    std::vector<Exception> exceptions;
-
-    const std::chrono::steady_clock::time_point queryStartTimestamp = std::chrono::steady_clock::now();
-    for (const auto& [host, localQueryId] : query.iterate())
-    {
-        try
-        {
-            INVARIANT(backends.contains(host), "Local query references node ({}) that is not part of the cluster", host);
-            const auto result = backends.at(host).start(localQueryId);
-            if (result)
-            {
-                NES_DEBUG("Starting query {} on node {} was successful.", localQueryId, host);
-                continue;
-            }
-
-            exceptions.emplace_back(result.error());
-        }
-        /// Worker backends return std::expected for normal errors; this catch is defensive
-        /// against unexpected exceptions from the underlying network layer (e.g., gRPC stubs).
-        catch (const std::exception& e)
-        {
-            exceptions.emplace_back(QueryStartFailed("Message from external exception: {} ", e.what()));
-        }
-    }
-
-    if (not exceptions.empty())
-    {
-        return std::unexpected{exceptions};
-    }
-
-    /// Poll all queries until there status has changed to something other than Registered.
-    /// We do this so the function can guarantee that the next call to status will guarantee that the query is not in the Registered
-    /// State anymore.
+    /// Poll until all local queries have advanced past Registered, so the caller can immediately
+    /// observe a meaningful status after this function returns.
+    auto query = this->state.queries.at(id);
     auto waitForStatusChange = query.iterate()
         | std::views::transform([](const auto& pair) { return std::pair{std::get<0>(pair), std::get<1>(pair)}; })
         | std::ranges::to<std::vector>();
-    /// The query is expected to be moved into the started state pretty quickly after lowering, it is very unlikely to even observe
-    /// the status not changing immediatly, so a rapid polling interval is appropriate.
     constexpr auto statusPollInterval = std::chrono::milliseconds(10);
     constexpr size_t statusRetries = 17;
     for (size_t i = 0; i < statusRetries; ++i)
@@ -211,9 +177,6 @@ std::expected<void, std::vector<Exception>> QueryManager::start(DistributedQuery
                     exceptions.emplace_back(QueryStartFailed("Waiting for query state to change: {}", result.error()));
                     return true;
                 }
-
-                /// Waiting until the query state changed. Even if the query status changes to failed we consider the start to be successful.
-                /// Subsequent status requests will find the query in a failed state.
                 return result->state != QueryStatus::Registered;
             });
 
@@ -242,9 +205,9 @@ std::expected<void, std::vector<Exception>> QueryManager::start(DistributedQuery
 
     NES_DEBUG(
         "Query {} started successfully after {}.",
-        queryId,
+        id,
         std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - queryStartTimestamp));
-    return {};
+    return id;
 }
 
 std::expected<DistributedQueryStatusSnapshot, std::vector<Exception>> QueryManager::status(const DistributedQueryId& queryId) const

--- a/nes-frontend/src/Statements/StatementHandler.cpp
+++ b/nes-frontend/src/Statements/StatementHandler.cpp
@@ -359,22 +359,15 @@ std::expected<QueryStatementResult, Exception> QueryStatementHandler::operator()
             distributedPlan.setQueryId(*statement.id);
         }
 
-        const auto queryResult = queryManager->registerQuery(distributedPlan);
-        return queryResult
-            .and_then(
-                [this](const auto& query)
+        return queryManager->start(distributedPlan)
+            .transform([](DistributedQueryId distQueryId) { return QueryStatementResult{std::move(distQueryId)}; })
+            .transform_error(
+                [](auto vecOfErrors)
                 {
-                    return queryManager->start(query)
-                        .transform([&query] { return query; })
-                        .transform_error(
-                            [](auto vecOfErrors)
-                            {
-                                return QueryStartFailed(
-                                    "Could not start query: {}",
-                                    fmt::join(std::views::transform(vecOfErrors, [](auto exception) { return exception.what(); }), ", "));
-                            });
-                })
-            .transform([](auto query) { return QueryStatementResult{std::move(query)}; });
+                    return QueryStartFailed(
+                        "Could not start query: {}",
+                        fmt::join(std::views::transform(vecOfErrors, [](auto exception) { return exception.what(); }), ", "));
+                });
     }
     CPPTRACE_CATCH(...)
     {

--- a/nes-runtime/include/Runtime/NodeEngine.hpp
+++ b/nes-runtime/include/Runtime/NodeEngine.hpp
@@ -22,15 +22,13 @@
 #include <Sources/SourceProvider.hpp>
 #include <CompiledQueryPlan.hpp>
 #include <QueryEngine.hpp>
+#include <QueryId.hpp>
 
 namespace NES
 {
-/// Forward declaration of QueryEngineTest, which includes Task, which includes SinkMedium, which includes NodeEngine
-class QueryTracker;
-
 /// @brief this class represents the interface and entrance point into the
 /// query processing part of NES. It provides basic functionality
-/// such as registering, starting, and stopping.
+/// such as starting and stopping.
 class NodeEngine
 {
     friend class NodeEngineBuilder;
@@ -48,8 +46,7 @@ public:
         std::unique_ptr<QueryEngine> queryEngine,
         std::unique_ptr<SourceProvider> sourceProvider);
 
-    void registerCompiledQueryPlan(QueryId queryId, std::unique_ptr<CompiledQueryPlan> compiledQueryPlan);
-    void startQuery(QueryId queryId);
+    void startQuery(QueryId queryId, std::unique_ptr<CompiledQueryPlan> compiledQueryPlan);
     /// Termination will happen asynchronously, thus the query might very well be running for an indeterminate time after this method has
     /// been called.
     void stopQuery(QueryId queryId);
@@ -66,7 +63,6 @@ private:
 
     std::shared_ptr<SystemEventListener> systemEventListener;
     std::unique_ptr<QueryEngine> queryEngine;
-    std::unique_ptr<QueryTracker> queryTracker;
     std::unique_ptr<SourceProvider> sourceProvider;
 };
 }

--- a/nes-runtime/src/Runtime/NodeEngine.cpp
+++ b/nes-runtime/src/Runtime/NodeEngine.cpp
@@ -16,73 +16,28 @@
 
 #include <chrono>
 #include <memory>
-#include <unordered_map>
 #include <utility>
 #include <Identifiers/Identifiers.hpp>
 #include <Listeners/QueryLog.hpp>
 #include <Listeners/SystemEventListener.hpp>
 #include <Runtime/BufferManager.hpp>
 
-#include <Util/AtomicState.hpp>
 #include <Util/Logger/Logger.hpp>
-#include <folly/Synchronized.h>
 #include <CompiledQueryPlan.hpp>
 #include <ErrorHandling.hpp>
 #include <ExecutableQueryPlan.hpp>
 #include <QueryEngine.hpp>
+#include <QueryId.hpp>
 #include <QueryStatus.hpp>
 
 namespace NES
 {
-
-class QueryTracker
-{
-    struct Idle
-    {
-        std::unique_ptr<CompiledQueryPlan> qep;
-    };
-
-    struct Executing
-    {
-    };
-
-    using QueryState = AtomicState<Idle, Executing>;
-    folly::Synchronized<std::unordered_map<QueryId, std::unique_ptr<QueryState>>> queries;
-
-public:
-    void registerQuery(std::unique_ptr<CompiledQueryPlan> qep, QueryId queryId)
-    {
-        auto locked = queries.wlock();
-        auto [it, inserted] = locked->emplace(queryId, std::make_unique<QueryState>(Idle{std::move(qep)}));
-        if (!inserted)
-        {
-            throw QueryAlreadyRegistered("Query with ID {} is already registered", queryId);
-        }
-    }
-
-    std::unique_ptr<CompiledQueryPlan> moveToExecuting(QueryId qid)
-    {
-        auto rlocked = queries.rlock();
-        std::unique_ptr<CompiledQueryPlan> qep;
-        if (auto it = rlocked->find(qid); it != rlocked->end())
-        {
-            it->second->transition(
-                [&](Idle&& idle)
-                {
-                    qep = std::move(idle).qep;
-                    return Executing{};
-                });
-        }
-        return qep;
-    }
-};
 
 NodeEngine::~NodeEngine()
 {
     NES_DEBUG("Shutting down NodeEngine");
     queryEngine.reset();
     sourceProvider.reset();
-    queryTracker.reset();
 
     bufferManager->destroy();
     bufferManager.reset();
@@ -98,30 +53,16 @@ NodeEngine::NodeEngine(
     , queryLog(std::move(queryLog))
     , systemEventListener(std::move(systemEventListener))
     , queryEngine(std::move(queryEngine))
-    , queryTracker(std::make_unique<QueryTracker>())
     , sourceProvider(std::move(sourceProvider))
 {
 }
 
-void NodeEngine::registerCompiledQueryPlan(QueryId queryId, std::unique_ptr<CompiledQueryPlan> compiledQueryPlan)
-{
-    queryTracker->registerQuery(std::move(compiledQueryPlan), queryId);
-    queryLog->logQueryStatusChange(queryId, QueryStatus::Registered, std::chrono::system_clock::now());
-}
-
-void NodeEngine::startQuery(QueryId queryId)
+void NodeEngine::startQuery(QueryId queryId, std::unique_ptr<CompiledQueryPlan> compiledQueryPlan)
 {
     PRECONDITION(queryId != INVALID_QUERY_ID, "QueryId must be not invalid!");
-
-    if (auto qep = queryTracker->moveToExecuting(queryId))
-    {
-        systemEventListener->onEvent(StartQuerySystemEvent(queryId));
-        queryEngine->start(ExecutableQueryPlan::instantiate(*qep, *sourceProvider));
-    }
-    else
-    {
-        throw QueryNotRegistered("Query with queryId {} is not currently idle", queryId);
-    }
+    queryLog->logQueryStatusChange(queryId, QueryStatus::Registered, std::chrono::system_clock::now());
+    systemEventListener->onEvent(StartQuerySystemEvent(std::move(queryId)));
+    queryEngine->start(ExecutableQueryPlan::instantiate(*compiledQueryPlan, *sourceProvider));
 }
 
 void NodeEngine::stopQuery(QueryId queryId)

--- a/nes-single-node-worker/include/GrpcService.hpp
+++ b/nes-single-node-worker/include/GrpcService.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 #include <utility>
+#include <grpcpp/server_context.h>
+#include <grpcpp/support/status.h>
 #include <SingleNodeWorker.hpp>
 #include <SingleNodeWorkerRPCService.grpc.pb.h>
 #include <SingleNodeWorkerRPCService.pb.h>
@@ -27,9 +29,7 @@ namespace NES
 class GRPCServer final : public WorkerRPCService::Service
 {
 public:
-    grpc::Status RegisterQuery(grpc::ServerContext*, const RegisterQueryRequest*, RegisterQueryReply*) override;
-
-    grpc::Status StartQuery(grpc::ServerContext*, const StartQueryRequest*, google::protobuf::Empty*) override;
+    grpc::Status StartQuery(grpc::ServerContext*, const StartQueryRequest*, StartQueryReply*) override;
 
     grpc::Status StopQuery(grpc::ServerContext*, const StopQueryRequest*, google::protobuf::Empty*) override;
 

--- a/nes-single-node-worker/include/SingleNodeWorker.hpp
+++ b/nes-single-node-worker/include/SingleNodeWorker.hpp
@@ -27,6 +27,7 @@
 #include <CompositeStatisticListener.hpp>
 #include <ErrorHandling.hpp>
 #include <QueryCompiler.hpp>
+#include <QueryId.hpp>
 #include <QueryStatus.hpp>
 #include <SingleNodeWorkerConfiguration.hpp>
 #include <WorkerStatus.hpp>
@@ -35,8 +36,7 @@ namespace NES
 {
 
 /// @brief The SingleNodeWorker is a compiling StreamProcessingEngine, working alone on local sources and sinks, without external
-/// coordination. The SingleNodeWorker can register LogicalQueryPlans which are lowered into an executable format, by the
-/// QueryCompiler. The user can manage the lifecycle of queries inside the NodeEngine using the SingleNodeWorkers interface.
+/// coordination. The SingleNodeWorker compiles and immediately starts LogicalQueryPlans via the QueryCompiler and NodeEngine.
 /// The Class itself is NonCopyable, but Movable, it owns the QueryCompiler and the NodeEngine.
 class SingleNodeWorker
 {
@@ -56,16 +56,11 @@ public:
     SingleNodeWorker(SingleNodeWorker&& other) noexcept;
     SingleNodeWorker& operator=(SingleNodeWorker&& other) noexcept;
 
-    /// Registers a DecomposedQueryPlan which internally triggers the QueryCompiler and registers the executable query plan. Once
-    /// returned the query can be started with the QueryId. The registered Query will be in the StoppedState
+    /// Compiles the LogicalPlan and immediately starts the query asynchronously. Query execution errors are only reported
+    /// during runtime of the query.
     /// @param plan Fully Specified LogicalQueryPlan.
-    /// @return QueryId which identifies the registered Query
-    [[nodiscard]] std::expected<QueryId, Exception> registerQuery(LogicalPlan plan) noexcept;
-
-    /// Starts the Query asynchronously and moves it into the RunningState. Query execution error are only reported during runtime
-    /// of the query.
-    /// @param queryId identifies the registered query
-    std::expected<void, Exception> startQuery(QueryId queryId) noexcept;
+    /// @return QueryId which identifies the started query
+    [[nodiscard]] std::expected<QueryId, Exception> startQuery(LogicalPlan plan) noexcept;
 
     /// Stops the Query and moves it into the StoppedState.
     /// @param queryId identifies the registered query

--- a/nes-single-node-worker/src/GrpcService.cpp
+++ b/nes-single-node-worker/src/GrpcService.cpp
@@ -122,31 +122,19 @@ grpc::Status tryWithDefaultHandling(const std::function<grpc::Status()>& f, grpc
 
 }
 
-grpc::Status GRPCServer::RegisterQuery(grpc::ServerContext* context, const RegisterQueryRequest* request, RegisterQueryReply* response)
+grpc::Status GRPCServer::StartQuery(grpc::ServerContext* context, const StartQueryRequest* request, StartQueryReply* response)
 {
-    auto fullySpecifiedQueryPlan = QueryPlanSerializationUtil::deserializeQueryPlan(request->queryplan());
+    auto queryPlan = QueryPlanSerializationUtil::deserializeQueryPlan(request->queryplan());
     return tryWithDefaultHandling(
         [&]
         {
-            auto result = delegate.registerQuery(std::move(fullySpecifiedQueryPlan));
+            auto result = delegate.startQuery(std::move(queryPlan));
             if (result.has_value())
             {
                 *response->mutable_queryid() = QueryPlanSerializationUtil::serializeQueryId(*result);
                 return grpc::Status::OK;
             }
             return handleError(result.error(), context);
-        },
-        context);
-}
-
-grpc::Status GRPCServer::StartQuery(grpc::ServerContext* context, const StartQueryRequest* request, google::protobuf::Empty*)
-{
-    const auto queryId = QueryPlanSerializationUtil::deserializeQueryId(request->queryid());
-    return tryWithDefaultHandling(
-        [&]
-        {
-            getValueOrThrow(delegate.startQuery(queryId));
-            return grpc::Status::OK;
         },
         context);
 }

--- a/nes-single-node-worker/src/SingleNodeWorker.cpp
+++ b/nes-single-node-worker/src/SingleNodeWorker.cpp
@@ -42,6 +42,7 @@
 #include <GoogleEventTracePrinter.hpp>
 #include <NetworkOptions.hpp>
 #include <QueryCompiler.hpp>
+#include <QueryId.hpp>
 #include <QueryStatus.hpp>
 #include <SingleNodeWorkerConfiguration.hpp>
 #include <WorkerStatus.hpp>
@@ -91,7 +92,7 @@ SingleNodeWorker::SingleNodeWorker(const SingleNodeWorkerConfiguration& configur
     }
 }
 
-std::expected<QueryId, Exception> SingleNodeWorker::registerQuery(LogicalPlan plan) noexcept
+std::expected<QueryId, Exception> SingleNodeWorker::startQuery(LogicalPlan plan) noexcept
 {
     CPPTRACE_TRY
     {
@@ -121,23 +122,8 @@ std::expected<QueryId, Exception> SingleNodeWorker::registerQuery(LogicalPlan pl
         request->dumpCompilationResult = dumpMode;
         auto result = compiler->compileQuery(std::move(request));
         INVARIANT(result, "expected successful query compilation or exception, but got nothing");
-        nodeEngine->registerCompiledQueryPlan(plan.getQueryId(), std::move(result));
+        nodeEngine->startQuery(plan.getQueryId(), std::move(result));
         return plan.getQueryId();
-    }
-    CPPTRACE_CATCH(...)
-    {
-        return std::unexpected(wrapExternalException());
-    }
-    std::unreachable();
-}
-
-std::expected<void, Exception> SingleNodeWorker::startQuery(QueryId queryId) noexcept
-{
-    CPPTRACE_TRY
-    {
-        PRECONDITION(queryId != INVALID_QUERY_ID, "QueryId must be not invalid!");
-        nodeEngine->startQuery(queryId);
-        return {};
     }
     CPPTRACE_CATCH(...)
     {

--- a/nes-systests/systest/include/QuerySubmitter.hpp
+++ b/nes-systests/systest/include/QuerySubmitter.hpp
@@ -31,8 +31,7 @@ class QuerySubmitter
 {
 public:
     explicit QuerySubmitter(std::unique_ptr<QueryManager> queryManager);
-    std::expected<DistributedQueryId, Exception> registerQuery(const DistributedLogicalPlan& plan);
-    void startQuery(const DistributedQueryId& query);
+    std::expected<DistributedQueryId, Exception> startQuery(const DistributedLogicalPlan& plan);
     void stopQuery(const DistributedQueryId& query);
     DistributedQueryStatusSnapshot waitForQueryTermination(const DistributedQueryId& query);
 

--- a/nes-systests/systest/src/QuerySubmitter.cpp
+++ b/nes-systests/systest/src/QuerySubmitter.cpp
@@ -40,7 +40,7 @@ QuerySubmitter::QuerySubmitter(std::unique_ptr<QueryManager> queryManager) : que
 {
 }
 
-std::expected<DistributedQueryId, Exception> QuerySubmitter::registerQuery(const DistributedLogicalPlan& plan)
+std::expected<DistributedQueryId, Exception> QuerySubmitter::startQuery(const DistributedLogicalPlan& plan)
 {
     /// Make sure the queryplan is passed through serialization logic.
     std::unordered_map<Host, std::vector<std::string>> serializationErrorsPerWorker;
@@ -61,22 +61,21 @@ std::expected<DistributedQueryId, Exception> QuerySubmitter::registerQuery(const
         }
     }
 
-    if (serializationErrorsPerWorker.empty())
+    if (!serializationErrorsPerWorker.empty())
     {
-        return queryManager->registerQuery(plan);
+        return std::unexpected(CannotSerialize("Encountered serialization errors: {}", serializationErrorsPerWorker));
     }
 
-    const auto exception = CannotSerialize("Encountered serialization errors: {}", serializationErrorsPerWorker);
-    return std::unexpected(exception);
-}
+    auto result = queryManager->start(plan);
 
-void QuerySubmitter::startQuery(const DistributedQueryId& query)
-{
-    if (auto started = queryManager->start(query); !started.has_value())
+
+    if (!result.has_value())
     {
-        throw std::move(started.error().at(0));
+        return std::unexpected(std::move(result.error().at(0)));
     }
-    ids.emplace(query);
+
+    ids.emplace(*result);
+    return result.value();
 }
 
 void QuerySubmitter::stopQuery(const DistributedQueryId& query)

--- a/nes-systests/systest/src/SystestRunner.cpp
+++ b/nes-systests/systest/src/SystestRunner.cpp
@@ -247,13 +247,11 @@ std::vector<RunningQuery> runQueries(
             if (nextQuery.differentialQueryPlan.has_value() and nextQuery.planInfoOrException.has_value())
             {
                 /// Start both differential queries
-                auto reg = querySubmitter.registerQuery(nextQuery.planInfoOrException.value().queryPlan);
-                auto regDiff = querySubmitter.registerQuery(nextQuery.differentialQueryPlan.value());
+                auto reg = querySubmitter.startQuery(nextQuery.planInfoOrException.value().queryPlan);
+                auto regDiff = querySubmitter.startQuery(nextQuery.differentialQueryPlan.value());
                 if (reg and regDiff)
                 {
                     hasOneMoreQueryToStart = true;
-                    querySubmitter.startQuery(*reg);
-                    querySubmitter.startQuery(*regDiff);
                     active.emplace(*reg, std::make_shared<RunningQuery>(nextQuery, *reg, *regDiff));
                     active.emplace(*regDiff, std::make_shared<RunningQuery>(nextQuery, *regDiff, *reg));
                 }
@@ -269,11 +267,9 @@ std::vector<RunningQuery> runQueries(
             }
             else if (nextQuery.planInfoOrException.has_value())
             {
-                /// Registration
-                if (auto reg = querySubmitter.registerQuery(nextQuery.planInfoOrException.value().queryPlan))
+                if (auto reg = querySubmitter.startQuery(nextQuery.planInfoOrException.value().queryPlan))
                 {
                     hasOneMoreQueryToStart = true;
-                    querySubmitter.startQuery(*reg);
                     active.emplace(*reg, std::make_shared<RunningQuery>(nextQuery, *reg));
                 }
                 else
@@ -452,18 +448,17 @@ std::vector<RunningQuery> runQueriesAndBenchmark(
             continue;
         }
 
-        const auto registrationResult = submitter.registerQuery(queryToRun.planInfoOrException.value().queryPlan);
-        if (not registrationResult.has_value())
+        const auto startResult = submitter.startQuery(queryToRun.planInfoOrException.value().queryPlan);
+        if (not startResult.has_value())
         {
             NES_ERROR("skip failing query: {}", queryToRun.testName);
             continue;
         }
-        auto queryId = registrationResult.value();
+        auto queryId = startResult.value();
 
         auto runningQueryPtr = std::make_shared<RunningQuery>(queryToRun, queryId);
         runningQueryPtr->passed = false;
         ranQueries.emplace_back(runningQueryPtr);
-        submitter.startQuery(queryId);
         const auto summary = submitter.finishedQueries().at(0);
 
         if (summary.getGlobalQueryStatus() == DistributedQueryStatus::Failed)

--- a/nes-systests/systest/tests/SystestRunnerTest.cpp
+++ b/nes-systests/systest/tests/SystestRunnerTest.cpp
@@ -137,8 +137,7 @@ public:
 class MockQuerySubmissionBackend final : public QuerySubmissionBackend
 {
 public:
-    MOCK_METHOD((std::expected<QueryId, Exception>), registerQuery, (LogicalPlan), (override));
-    MOCK_METHOD((std::expected<void, Exception>), start, (QueryId), (override));
+    MOCK_METHOD((std::expected<QueryId, Exception>), start, (LogicalPlan), (override));
     MOCK_METHOD((std::expected<void, Exception>), stop, (QueryId), (override));
     MOCK_METHOD((std::expected<LocalQueryStatusSnapshot, Exception>), status, (QueryId), (const, override));
     MOCK_METHOD((std::expected<WorkerStatus, Exception>), workerStatus, (std::chrono::system_clock::time_point), (const, override));
@@ -186,10 +185,8 @@ TEST_F(SystestRunnerTest, RuntimeFailureWithUnexpectedCode)
     const auto id = randomQueryId();
     const auto runtimeErr = std::make_shared<Exception>(Exception{"runtime boom", 10000});
     auto [submitter, mockBackend] = createQuerySubmitter();
-    EXPECT_CALL(*mockBackend, registerQuery(::testing::_)).WillOnce(testing::Return(std::expected<QueryId, Exception>{id}));
-    EXPECT_CALL(*mockBackend, start(id));
+    EXPECT_CALL(*mockBackend, start(::testing::_)).WillOnce(testing::Return(std::expected<QueryId, Exception>{id}));
     EXPECT_CALL(*mockBackend, status(id))
-        .WillOnce(testing::Return(makeSummary(id, QueryStatus::Registered, nullptr)))
         .WillOnce(testing::Return(makeSummary(id, QueryStatus::Started, nullptr)))
         .WillRepeatedly(testing::Return(makeSummary(id, QueryStatus::Failed, runtimeErr)));
     SystestProgressTracker progressTracker;
@@ -226,10 +223,8 @@ TEST_F(SystestRunnerTest, MissingExpectedRuntimeError)
     const auto id = randomQueryId();
 
     auto [submitter, mockBackend] = createQuerySubmitter();
-    EXPECT_CALL(*mockBackend, registerQuery(::testing::_)).WillOnce(testing::Return(std::expected<QueryId, Exception>{id}));
-    EXPECT_CALL(*mockBackend, start(id));
+    EXPECT_CALL(*mockBackend, start(::testing::_)).WillOnce(testing::Return(std::expected<QueryId, Exception>{id}));
     EXPECT_CALL(*mockBackend, status(id))
-        .WillOnce(testing::Return(makeSummary(id, QueryStatus::Registered, nullptr)))
         .WillOnce(testing::Return(makeSummary(id, QueryStatus::Running, nullptr)))
         .WillRepeatedly(testing::Return(makeSummary(id, QueryStatus::Stopped, nullptr)));
     SystestProgressTracker progressTracker;
@@ -306,22 +301,19 @@ TEST_F(SystestRunnerTest, SequentialExecutionOrderTest)
 
 
     auto [submitter, mockBackend] = createQuerySubmitter();
-    EXPECT_CALL(*mockBackend, registerQuery(::testing::_)).WillOnce(testing::Return(std::expected<QueryId, Exception>{queryId1}));
-    EXPECT_CALL(*mockBackend, start(queryId1));
+    EXPECT_CALL(*mockBackend, start(::testing::_)).WillOnce(testing::Return(std::expected<QueryId, Exception>{queryId1}));
 
     EXPECT_CALL(*mockBackend, status(queryId1))
         .WillOnce(testing::Return(makeSummary(queryId1, QueryStatus::Stopped, nullptr)))
         .WillRepeatedly(testing::Return(makeSummary(queryId1, QueryStatus::Stopped, nullptr)));
 
-    EXPECT_CALL(*mockBackend, registerQuery(::testing::_)).WillOnce(testing::Return(std::expected<QueryId, Exception>{queryId2}));
-    EXPECT_CALL(*mockBackend, start(queryId2));
+    EXPECT_CALL(*mockBackend, start(::testing::_)).WillOnce(testing::Return(std::expected<QueryId, Exception>{queryId2}));
 
     EXPECT_CALL(*mockBackend, status(queryId2))
         .WillOnce(testing::Return(makeSummary(queryId2, QueryStatus::Stopped, nullptr)))
         .WillRepeatedly(testing::Return(makeSummary(queryId2, QueryStatus::Stopped, nullptr)));
 
-    EXPECT_CALL(*mockBackend, registerQuery(::testing::_)).WillOnce(testing::Return(std::expected<QueryId, Exception>{queryId3}));
-    EXPECT_CALL(*mockBackend, start(queryId3));
+    EXPECT_CALL(*mockBackend, start(::testing::_)).WillOnce(testing::Return(std::expected<QueryId, Exception>{queryId3}));
 
     EXPECT_CALL(*mockBackend, status(queryId3))
         .WillOnce(testing::Return(makeSummary(queryId3, QueryStatus::Stopped, nullptr)))


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

Previously, submitting a query required two separate gRPC calls: registerQuery (compile and store), followed by startQuery (move to execution). Since the two were always called in immediate succession, this PR collapses them into one step.

`QueryStatus::Registered` stays the initial state of a query and is updated when the query successfully starts or fails to start. 


**IMPORTANT** We had internal discussions about this PR. The consensus agreed to add it because it simplifies a distinction that is nowhere actually used. Nevertheless, if there are major objections about this, please feel free to mention and argue them in the comments of the PR.  


## Verifying this change

All existing tests continue to run successfully

## What components does this pull request potentially affect?
- Worker (gRPC interface)
- NodeEngine
- Frontend (QueryManager, StatementHandler)


## Documentation
- Inline documentation was updated 
