### PR TITLE
Implement Median as Nautilus Function

### DIFF
--- a/nes-physical-operators/include/Aggregation/Function/MedianAggregationPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Aggregation/Function/MedianAggregationPhysicalFunction.hpp
@@ -15,6 +15,8 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
+#include <functional>
 #include <memory>
 #include <Aggregation/Function/AggregationPhysicalFunction.hpp>
 #include <DataTypes/DataType.hpp>
@@ -22,14 +24,54 @@
 #include <Interface/BufferRef/TupleBufferRef.hpp>
 #include <Interface/Record.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
+#include <nautilus/nautilus_function.hpp>
+#include <val_bool.hpp>
 #include <val_concepts.hpp>
+#include <val_ptr.hpp>
 
 namespace NES
 {
 
+/// Median aggregation.
+///
+/// The lift, combine, lower and reset bodies are extracted into dedicated nautilus functions
+/// (NautilusFunction, i.e. Pattern 2 cross-calls) so that they are compiled once and called from the
+/// pipeline rather than inlined at every aggregation. The functions live in a global, statically allocated,
+/// templated table (see the .cpp): one set per (input type, result type, nullability) with clear, type-derived
+/// names. As nautilus deduplicates functions by name, all medians of the same type in a pipeline share a
+/// single compiled instantiation. This object merely selects the matching set and forwards to it.
+///
+/// To keep the bodies type-parametric, the per-column work stays in the thin virtual wrappers: the wrapper
+/// computes the input value via inputFunction and hands it to the nautilus function through a scratch slot,
+/// and it reads the lowered result back from a scratch slot before writing it under the column-specific
+/// result field. Consequently the paged vector stores only the single aggregated value per row.
 class MedianAggregationPhysicalFunction : public AggregationPhysicalFunction
 {
 public:
+    /// Uniform signatures of the extracted nautilus functions. The concrete data type lives inside the body
+    /// (selected by template parameters), so these handle types are independent of it; values cross the
+    /// boundary through scratch memory (val<int8_t*>) because a Record/VarVal cannot.
+    using LiftFunction = nautilus::NautilusFunction<std::function<void(
+        nautilus::val<AggregationState*>,
+        nautilus::val<int8_t*>,
+        nautilus::val<bool>,
+        nautilus::val<AbstractBufferProvider*>)>>;
+    using CombineFunction
+        = nautilus::NautilusFunction<std::function<void(nautilus::val<AggregationState*>, nautilus::val<AggregationState*>)>>;
+    using LowerFunction = nautilus::NautilusFunction<
+        std::function<void(nautilus::val<AggregationState*>, nautilus::val<int8_t*>, nautilus::val<int8_t*>)>>;
+    using ResetFunction = nautilus::NautilusFunction<std::function<void(nautilus::val<AggregationState*>)>>;
+
+    /// The four extracted nautilus functions selected for this median's data types. Non-owning pointers into
+    /// the global static function table (see the .cpp).
+    struct MedianFunctions
+    {
+        LiftFunction* lift = nullptr;
+        CombineFunction* combine = nullptr;
+        LowerFunction* lower = nullptr;
+        ResetFunction* reset = nullptr;
+    };
+
     MedianAggregationPhysicalFunction(
         DataType inputType,
         DataType resultType,
@@ -51,7 +93,8 @@ public:
     ~MedianAggregationPhysicalFunction() override = default;
 
 private:
-    std::shared_ptr<TupleBufferRef> bufferRefPagedVector;
+    /// Selected from the global static function table by (input type, result type, nullability) in the constructor.
+    MedianFunctions functions;
 };
 
 }

--- a/nes-physical-operators/src/Aggregation/Function/MedianAggregationPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Aggregation/Function/MedianAggregationPhysicalFunction.cpp
@@ -16,16 +16,26 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
+#include <new>
+#include <string>
 #include <utility>
+#include <vector>
 #include <Aggregation/Function/AggregationPhysicalFunction.hpp>
 #include <DataTypes/DataType.hpp>
+#include <DataTypes/DataTypesUtil.hpp>
+#include <DataTypes/Schema.hpp>
+#include <DataTypes/VarVal.hpp>
 #include <Functions/PhysicalFunction.hpp>
+#include <Interface/BufferRef/LowerSchemaProvider.hpp>
 #include <Interface/BufferRef/TupleBufferRef.hpp>
 #include <Interface/PagedVector/PagedVector.hpp>
 #include <Interface/PagedVector/PagedVectorRef.hpp>
 #include <Interface/Record.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <nautilus/function.hpp>
+#include <nautilus/nautilus_function.hpp>
 #include <nautilus/std/cstring.h>
 #include <AggregationPhysicalFunctionRegistry.hpp>
 #include <ErrorHandling.hpp>
@@ -37,6 +47,288 @@
 
 namespace NES
 {
+namespace
+{
+/// The single field name under which the aggregated value is stored in / read from the paged vector.
+constexpr auto valueFieldName = "val";
+
+/// Maps a C++ type to its DataType::Type. Only the numeric types median accepts are provided.
+template <typename T>
+constexpr DataType::Type typeEnumOf();
+// clang-format off
+template <> constexpr DataType::Type typeEnumOf<int8_t>() { return DataType::Type::INT8; }
+template <> constexpr DataType::Type typeEnumOf<int16_t>() { return DataType::Type::INT16; }
+template <> constexpr DataType::Type typeEnumOf<int32_t>() { return DataType::Type::INT32; }
+template <> constexpr DataType::Type typeEnumOf<int64_t>() { return DataType::Type::INT64; }
+template <> constexpr DataType::Type typeEnumOf<uint8_t>() { return DataType::Type::UINT8; }
+template <> constexpr DataType::Type typeEnumOf<uint16_t>() { return DataType::Type::UINT16; }
+template <> constexpr DataType::Type typeEnumOf<uint32_t>() { return DataType::Type::UINT32; }
+template <> constexpr DataType::Type typeEnumOf<uint64_t>() { return DataType::Type::UINT64; }
+template <> constexpr DataType::Type typeEnumOf<float>() { return DataType::Type::FLOAT32; }
+template <> constexpr DataType::Type typeEnumOf<double>() { return DataType::Type::FLOAT64; }
+// clang-format on
+
+template <typename T>
+std::string typeName()
+{
+    return std::string(magic_enum::enum_name(typeEnumOf<T>()));
+}
+
+/// The non-nullable single-value DataType stored per row for the given C++ type.
+template <typename T>
+DataType valueDataType()
+{
+    return DataType{typeEnumOf<T>(), DataType::NULLABLE::NOT_NULLABLE};
+}
+
+/// Per-input-type, one-column buffer (the aggregated value) used to write/read stored values. It is fully
+/// determined by the input type, hence identical across all medians of the same type. Lazily and thread-safely
+/// initialized via a function-local static; selectMedianFunctions() initializes it with the query's page size
+/// before any tracing happens, so the default page size below is only a fallback.
+template <typename T>
+const std::shared_ptr<TupleBufferRef>& bufferRefFor(const uint64_t pageSize = 4096)
+{
+    static const std::shared_ptr<TupleBufferRef> bufferRef = LowerSchemaProvider::lowerSchema(
+        pageSize, Schema().addField(valueFieldName, valueDataType<T>()), MemoryLayoutType::ROW_LAYOUT);
+    return bufferRef;
+}
+
+/// --- The extracted nautilus function bodies. Free, type-parametric (no per-instance capture) so they can be
+/// global statics shared across all medians of the same type. ---
+
+template <typename InputT, bool Nullable>
+void medianLiftBody(
+    nautilus::val<AggregationState*> aggregationState,
+    nautilus::val<int8_t*> valueScratch,
+    [[maybe_unused]] nautilus::val<bool> isNull,
+    nautilus::val<AbstractBufferProvider*> bufferProvider)
+{
+    auto memArea = static_cast<nautilus::val<int8_t*>>(aggregationState);
+    if constexpr (Nullable)
+    {
+        /// Combine the incoming null information with the one stored so far in the first byte.
+        AggregationPhysicalFunction::storeNull(aggregationState, isNull or AggregationPhysicalFunction::readNull(aggregationState));
+        memArea += nautilus::val<uint64_t>{1};
+    }
+
+    const PagedVectorRef pagedVectorRef(static_cast<nautilus::val<PagedVector*>>(memArea), bufferRefFor<InputT>());
+    const auto value = VarVal::readNonNullableVarValFromMemory(valueScratch, valueDataType<InputT>());
+    Record record;
+    record.write(valueFieldName, value);
+    pagedVectorRef.writeRecord(record, bufferProvider);
+}
+
+template <bool Nullable>
+void medianCombineBody(nautilus::val<AggregationState*> aggregationState1, nautilus::val<AggregationState*> aggregationState2)
+{
+    auto memArea1 = static_cast<nautilus::val<int8_t*>>(aggregationState1);
+    auto memArea2 = static_cast<nautilus::val<int8_t*>>(aggregationState2);
+    if constexpr (Nullable)
+    {
+        AggregationPhysicalFunction::storeNull(
+            aggregationState1, AggregationPhysicalFunction::readNull(aggregationState1) or AggregationPhysicalFunction::readNull(aggregationState2));
+        memArea1 += nautilus::val<uint64_t>{1};
+        memArea2 += nautilus::val<uint64_t>{1};
+    }
+
+    /// Merge the two paged vectors by appending the content of the second to the first.
+    nautilus::invoke(
+        +[](PagedVector* vector1, const PagedVector* vector2) -> void { vector1->copyFrom(*vector2); }, memArea1, memArea2);
+}
+
+template <typename InputT, typename ResultT, bool Nullable>
+void medianLowerBody(
+    nautilus::val<AggregationState*> aggregationState, nautilus::val<int8_t*> resultScratch, nautilus::val<int8_t*> nullScratch)
+{
+    nautilus::val<bool> containsNull{false};
+    if constexpr (Nullable)
+    {
+        containsNull = AggregationPhysicalFunction::readNull(aggregationState);
+    }
+    VarVal{containsNull}.writeToMemory(nullScratch);
+
+    constexpr auto resultTypeEnum = typeEnumOf<ResultT>();
+    const VarVal zero(nautilus::val<uint64_t>(0));
+    VarVal medianValue = zero.castToType(resultTypeEnum);
+    /// Single exit: on null the result stays the (irrelevant) default and the caller returns null based on the
+    /// null flag written above. We deliberately avoid an early return inside the nautilus function body.
+    if (not containsNull)
+    {
+        const auto pagedVectorPtr = static_cast<nautilus::val<PagedVector*>>(
+            aggregationState + nautilus::val<uint64_t>{static_cast<uint64_t>(Nullable)});
+        const PagedVectorRef pagedVectorRef(pagedVectorPtr, bufferRefFor<InputT>());
+        const std::vector<Record::RecordFieldIdentifier> projections{valueFieldName};
+        const auto numberOfEntries = nautilus::invoke(
+            +[](const PagedVector* pagedVector)
+            {
+                const auto numberOfEntriesVal = pagedVector->getTotalNumberOfEntries();
+                INVARIANT(numberOfEntriesVal > 0, "The number of entries in the paged vector must be greater than 0");
+                return numberOfEntriesVal;
+            },
+            pagedVectorPtr);
+
+        /// Two nested loops over all stored values to find the median, identical in spirit to the original
+        /// implementation but reading the single stored value instead of re-applying the input function to a
+        /// full record.
+        const nautilus::val<int64_t> medianPos1 = (numberOfEntries - 1) / 2;
+        const nautilus::val<int64_t> medianPos2 = numberOfEntries / 2;
+        nautilus::val<uint64_t> medianItemPos1 = 0;
+        nautilus::val<uint64_t> medianItemPos2 = 0;
+        nautilus::val<bool> medianFound1(false);
+        nautilus::val<bool> medianFound2(false);
+
+        const auto endIt = pagedVectorRef.end(projections);
+        for (auto candidateIt = pagedVectorRef.begin(projections); candidateIt != endIt; ++candidateIt)
+        {
+            nautilus::val<int64_t> countLessThan = 0;
+            nautilus::val<int64_t> countEqual = 0;
+            const auto candidateRecord = *candidateIt;
+            const auto candidateValue = candidateRecord.read(valueFieldName);
+
+            for (auto itemIt = pagedVectorRef.begin(projections); itemIt != endIt; ++itemIt)
+            {
+                const auto itemRecord = *itemIt;
+                const auto itemValue = itemRecord.read(valueFieldName);
+                if (itemValue < candidateValue)
+                {
+                    countLessThan = countLessThan + 1;
+                }
+                if (itemValue == candidateValue)
+                {
+                    countEqual = countEqual + 1;
+                }
+            }
+
+            if (not medianFound1 && countLessThan <= medianPos1 && medianPos1 < countLessThan + countEqual)
+            {
+                medianItemPos1 = candidateIt - pagedVectorRef.begin(projections);
+                medianFound1 = true;
+            }
+            if (not medianFound2 && countLessThan <= medianPos2 && medianPos2 < countLessThan + countEqual)
+            {
+                medianItemPos2 = candidateIt - pagedVectorRef.begin(projections);
+                medianFound2 = true;
+            }
+        }
+
+        if (medianFound1 and medianFound2)
+        {
+            /// Regardless of an odd/even number of entries, the median is the average of the two middle values
+            /// (for odd counts both positions point at the same item).
+            const auto medianRecord1 = pagedVectorRef.readRecord(medianItemPos1, projections);
+            const auto medianRecord2 = pagedVectorRef.readRecord(medianItemPos2, projections);
+            const auto medianValue1 = medianRecord1.read(valueFieldName);
+            const auto medianValue2 = medianRecord2.read(valueFieldName);
+            const VarVal two = nautilus::val<uint64_t>(2);
+            medianValue
+                = (medianValue1.castToType(resultTypeEnum) + medianValue2.castToType(resultTypeEnum)) / two.castToType(resultTypeEnum);
+        }
+    }
+
+    medianValue.writeToMemory(resultScratch);
+}
+
+template <bool Nullable>
+void medianResetBody(nautilus::val<AggregationState*> aggregationState)
+{
+    nautilus::invoke(
+        +[](AggregationState* pagedVectorMemArea) -> void
+        {
+            /// Allocates a new PagedVector in the memory area provided by the pointer.
+            auto* pagedVector = reinterpret_cast<PagedVector*>(pagedVectorMemArea);
+            new (pagedVector) PagedVector();
+        },
+        aggregationState + nautilus::val<uint64_t>{static_cast<uint64_t>(Nullable)});
+
+    if constexpr (Nullable)
+    {
+        const auto memArea = static_cast<nautilus::val<int8_t*>>(aggregationState);
+        nautilus::memset(memArea, 0, 1);
+    }
+}
+
+/// Global static, statically allocated table of the four extracted nautilus functions for one (input type,
+/// result type, nullability) combination. Names are derived purely from the data types so that nautilus
+/// deduplicates same-typed medians to a single compiled function. combine and reset depend only on
+/// nullability and are named accordingly, so they are additionally shared across input types.
+template <typename InputT, typename ResultT, bool Nullable>
+struct MedianFunctionTable
+{
+    static inline MedianAggregationPhysicalFunction::LiftFunction lift{
+        "Median_lift_" + typeName<InputT>() + (Nullable ? "_N" : "_X"), std::function(medianLiftBody<InputT, Nullable>)};
+    static inline MedianAggregationPhysicalFunction::CombineFunction combine{
+        std::string("Median_combine_") + (Nullable ? "N" : "X"), std::function(medianCombineBody<Nullable>)};
+    static inline MedianAggregationPhysicalFunction::LowerFunction lower{
+        "Median_lower_" + typeName<InputT>() + "_" + typeName<ResultT>() + (Nullable ? "_N" : "_X"),
+        std::function(medianLowerBody<InputT, ResultT, Nullable>)};
+    static inline MedianAggregationPhysicalFunction::ResetFunction reset{
+        std::string("Median_reset_") + (Nullable ? "N" : "X"), std::function(medianResetBody<Nullable>)};
+};
+
+template <typename InputT, typename ResultT, bool Nullable>
+MedianAggregationPhysicalFunction::MedianFunctions makeSelected(const uint64_t pageSize)
+{
+    /// Initialize the per-type buffer ref from the query's page size before any tracing happens.
+    bufferRefFor<InputT>(pageSize);
+    return {
+        &MedianFunctionTable<InputT, ResultT, Nullable>::lift,
+        &MedianFunctionTable<InputT, ResultT, Nullable>::combine,
+        &MedianFunctionTable<InputT, ResultT, Nullable>::lower,
+        &MedianFunctionTable<InputT, ResultT, Nullable>::reset};
+}
+
+template <typename InputT, bool Nullable>
+MedianAggregationPhysicalFunction::MedianFunctions selectByResultType(const DataType::Type resultType, const uint64_t pageSize)
+{
+    /// Median's result type is always FLOAT64 (see MedianAggregationLogicalFunction), but we dispatch on it
+    /// explicitly to keep the result type a real template parameter.
+    switch (resultType)
+    {
+        case DataType::Type::FLOAT64:
+            return makeSelected<InputT, double, Nullable>(pageSize);
+        default:
+            throw UnknownAggregationType("MedianAggregation: unsupported result type {}", magic_enum::enum_name(resultType));
+    }
+}
+
+template <bool Nullable>
+MedianAggregationPhysicalFunction::MedianFunctions
+selectByInputType(const DataType::Type inputType, const DataType::Type resultType, const uint64_t pageSize)
+{
+    switch (inputType)
+    {
+        case DataType::Type::INT8:
+            return selectByResultType<int8_t, Nullable>(resultType, pageSize);
+        case DataType::Type::INT16:
+            return selectByResultType<int16_t, Nullable>(resultType, pageSize);
+        case DataType::Type::INT32:
+            return selectByResultType<int32_t, Nullable>(resultType, pageSize);
+        case DataType::Type::INT64:
+            return selectByResultType<int64_t, Nullable>(resultType, pageSize);
+        case DataType::Type::UINT8:
+            return selectByResultType<uint8_t, Nullable>(resultType, pageSize);
+        case DataType::Type::UINT16:
+            return selectByResultType<uint16_t, Nullable>(resultType, pageSize);
+        case DataType::Type::UINT32:
+            return selectByResultType<uint32_t, Nullable>(resultType, pageSize);
+        case DataType::Type::UINT64:
+            return selectByResultType<uint64_t, Nullable>(resultType, pageSize);
+        case DataType::Type::FLOAT32:
+            return selectByResultType<float, Nullable>(resultType, pageSize);
+        case DataType::Type::FLOAT64:
+            return selectByResultType<double, Nullable>(resultType, pageSize);
+        default:
+            throw UnknownAggregationType("MedianAggregation: unsupported input type {}", magic_enum::enum_name(inputType));
+    }
+}
+
+MedianAggregationPhysicalFunction::MedianFunctions
+selectMedianFunctions(const DataType& inputType, const DataType& resultType, const uint64_t pageSize)
+{
+    return inputType.nullable ? selectByInputType<true>(inputType.type, resultType.type, pageSize)
+                              : selectByInputType<false>(inputType.type, resultType.type, pageSize);
+}
+}
 
 MedianAggregationPhysicalFunction::MedianAggregationPhysicalFunction(
     DataType inputType,
@@ -45,28 +337,22 @@ MedianAggregationPhysicalFunction::MedianAggregationPhysicalFunction(
     Record::RecordFieldIdentifier resultFieldIdentifier,
     std::shared_ptr<TupleBufferRef> bufferRefPagedVector)
     : AggregationPhysicalFunction(std::move(inputType), std::move(resultType), std::move(inputFunction), std::move(resultFieldIdentifier))
-    , bufferRefPagedVector(std::move(bufferRefPagedVector))
 {
+    /// We only store the single aggregated value per row, so we only need the page size of the provided buffer
+    /// ref; the actual one-column buffer is derived from the input type inside the function table.
+    functions = selectMedianFunctions(this->inputType, this->resultType, bufferRefPagedVector->getBufferSize());
 }
 
 void MedianAggregationPhysicalFunction::lift(
     const nautilus::val<AggregationState*>& aggregationState, PipelineMemoryProvider& pipelineMemoryProvider, const Record& record)
 {
+    /// Column-specific work stays in the pipeline: compute the value and hand it to the nautilus function
+    /// through a scratch slot (a Record/VarVal cannot cross the function boundary).
     const auto value = inputFunction.execute(record, pipelineMemoryProvider.arena);
-    auto memArea = static_cast<nautilus::val<int8_t*>>(aggregationState);
-    if (inputType.nullable)
-    {
-        /// Reading the current null value and combining it with the one of the record
-        const auto oldContainsNull = readNull(aggregationState);
-        storeNull(aggregationState, value.isNull() or oldContainsNull);
-
-        /// Skipping the first byte (null)
-        memArea += nautilus::val<uint64_t>{1};
-    }
-
-    /// Adding the record to the paged vector. We are storing the full record in the paged vector for now.
-    const PagedVectorRef pagedVectorRef(memArea, bufferRefPagedVector);
-    pagedVectorRef.writeRecord(record, pipelineMemoryProvider.bufferProvider);
+    const auto valueScratch
+        = pipelineMemoryProvider.arena.allocateMemory(nautilus::val<size_t>(inputType.getSizeInBytesWithoutNull()));
+    value.writeToMemory(valueScratch);
+    (*functions.lift)(aggregationState, valueScratch, value.isNull(), pipelineMemoryProvider.bufferProvider);
 }
 
 void MedianAggregationPhysicalFunction::combine(
@@ -74,144 +360,27 @@ void MedianAggregationPhysicalFunction::combine(
     const nautilus::val<AggregationState*> aggregationState2,
     PipelineMemoryProvider&)
 {
-    /// Getting the paged vectors from the aggregation states
-    auto memArea1 = static_cast<nautilus::val<int8_t*>>(aggregationState1);
-    auto memArea2 = static_cast<nautilus::val<int8_t*>>(aggregationState2);
-
-    if (inputType.nullable)
-    {
-        /// Combining the null values
-        const auto containsNull1 = readNull(aggregationState1);
-        const auto containsNull2 = readNull(aggregationState2);
-        const auto newContainsNull = containsNull1 or containsNull2;
-        storeNull(aggregationState1, newContainsNull);
-
-        /// Skipping the first byte (null)
-        memArea1 += nautilus::val<uint64_t>{1};
-        memArea2 += nautilus::val<uint64_t>{1};
-    }
-
-    /// Calling the copyFrom function of the paged vector to combine the two paged vectors by copying the content of the second paged vector to the first paged vector
-    nautilus::invoke(+[](PagedVector* vector1, const PagedVector* vector2) -> void { vector1->copyFrom(*vector2); }, memArea1, memArea2);
+    (*functions.combine)(aggregationState1, aggregationState2);
 }
 
 Record MedianAggregationPhysicalFunction::lower(
     const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider& pipelineMemoryProvider)
 {
-    /// If it contains null values, we simply return a null value
-    const auto containsNull = inputType.nullable ? readNull(aggregationState) : nautilus::val<bool>{false};
-    if (containsNull)
-    {
-        const VarVal zero{nautilus::val<uint64_t>(0), true, true};
-        const VarVal medianValue = zero.castToType(resultType.type);
-        Record resultRecord;
-        resultRecord.write(resultFieldIdentifier, medianValue);
-        return resultRecord;
-    }
+    const auto resultScratch
+        = pipelineMemoryProvider.arena.allocateMemory(nautilus::val<size_t>(resultType.getSizeInBytesWithoutNull()));
+    const auto nullScratch = pipelineMemoryProvider.arena.allocateMemory(nautilus::val<size_t>(1));
+    (*functions.lower)(aggregationState, resultScratch, nullScratch);
 
-    /// Getting the paged vector from the aggregation state
-    const auto pagedVectorPtr
-        = static_cast<nautilus::val<PagedVector*>>(aggregationState + nautilus::val<uint64_t>{static_cast<uint64_t>(inputType.nullable)});
-    const PagedVectorRef pagedVectorRef(pagedVectorPtr, bufferRefPagedVector);
-    const auto allFieldNames = bufferRefPagedVector->getAllFieldNames();
-    const auto numberOfEntries = invoke(
-        +[](const PagedVector* pagedVector)
-        {
-            const auto numberOfEntriesVal = pagedVector->getTotalNumberOfEntries();
-            INVARIANT(numberOfEntriesVal > 0, "The number of entries in the paged vector must be greater than 0");
-            return numberOfEntriesVal;
-        },
-        pagedVectorPtr);
-
-    /// Iterating in two nested loops over all the records in the paged vector to get the median.
-    /// We pick a candidate and then count for each item, if the candidate is smaller and also if the candidate is less than the item.
-    const nautilus::val<int64_t> medianPos1 = (numberOfEntries - 1) / 2;
-    const nautilus::val<int64_t> medianPos2 = numberOfEntries / 2;
-    nautilus::val<uint64_t> medianItemPos1 = 0;
-    nautilus::val<uint64_t> medianItemPos2 = 0;
-    nautilus::val<bool> medianFound1(false);
-    nautilus::val<bool> medianFound2(false);
-
-
-    /// Picking a candidate and counting how many items are smaller or equal to the candidate
-    const auto endIt = pagedVectorRef.end(allFieldNames);
-    for (auto candidateIt = pagedVectorRef.begin(allFieldNames); candidateIt != endIt; ++candidateIt)
-    {
-        nautilus::val<int64_t> countLessThan = 0;
-        nautilus::val<int64_t> countEqual = 0;
-        const auto candidateRecord = *candidateIt;
-        const auto candidateValue = inputFunction.execute(candidateRecord, pipelineMemoryProvider.arena);
-
-        /// Counting how many items are smaller or equal for the current candidate
-        for (auto itemIt = pagedVectorRef.begin(allFieldNames); itemIt != endIt; ++itemIt)
-        {
-            const auto itemRecord = *itemIt;
-            const auto itemValue = inputFunction.execute(itemRecord, pipelineMemoryProvider.arena);
-            if (itemValue < candidateValue)
-            {
-                countLessThan = countLessThan + 1;
-            }
-            if (itemValue == candidateValue)
-            {
-                countEqual = countEqual + 1;
-            }
-        }
-
-        /// Checking if the current candidate is the median, and if so, storing the position of the median
-        /// The current candidate is the median if the number of items that are smaller or equal to the candidate is larger than the median position
-        if (not medianFound1 && countLessThan <= medianPos1 && medianPos1 < countLessThan + countEqual)
-        {
-            medianItemPos1 = candidateIt - pagedVectorRef.begin(allFieldNames);
-            medianFound1 = true;
-        }
-        if (not medianFound2 && countLessThan <= medianPos2 && medianPos2 < countLessThan + countEqual)
-        {
-            medianItemPos2 = candidateIt - pagedVectorRef.begin(allFieldNames);
-            medianFound2 = true;
-        }
-    }
-
-    /// Setting the default median value. If a median was found, the value will be overwritten
-    const VarVal zero(nautilus::val<uint64_t>(0));
-    VarVal medianValue = zero.castToType(resultType.type);
-    if (medianFound1 and medianFound2)
-    {
-        /// Calculating the median value. Regardless if the number of entries is odd or even, we calculate the median as the average of the two middle values.
-        /// For even numbers of entries, this is its natural definition.
-        /// For odd numbers of entries, both positions are pointing to the same item and thus, we are calculating the average of the same item, which is the item itself.
-        const auto medianRecord1 = pagedVectorRef.readRecord(medianItemPos1, allFieldNames);
-        const auto medianRecord2 = pagedVectorRef.readRecord(medianItemPos2, allFieldNames);
-
-        const auto medianValue1 = inputFunction.execute(medianRecord1, pipelineMemoryProvider.arena);
-        const auto medianValue2 = inputFunction.execute(medianRecord2, pipelineMemoryProvider.arena);
-        const VarVal two = nautilus::val<uint64_t>(2);
-        medianValue
-            = (medianValue1.castToType(resultType.type) + medianValue2.castToType(resultType.type)) / two.castToType(resultType.type);
-    }
-
-    /// Adding the median to the result record
+    const auto isNull = readValueFromMemRef<bool>(nullScratch);
+    const auto medianValue = VarVal::readVarValFromMemory(resultScratch, resultType, isNull);
     Record resultRecord;
     resultRecord.write(resultFieldIdentifier, medianValue);
-
     return resultRecord;
 }
 
 void MedianAggregationPhysicalFunction::reset(const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&)
 {
-    nautilus::invoke(
-        +[](AggregationState* pagedVectorMemArea) -> void
-        {
-            /// Allocates a new PagedVector in the memory area provided by the pointer to the pagedvector
-            auto* pagedVector = reinterpret_cast<PagedVector*>(pagedVectorMemArea);
-            new (pagedVector) PagedVector();
-        },
-        aggregationState + nautilus::val<uint64_t>{static_cast<uint64_t>(inputType.nullable)});
-
-    if (inputType.nullable)
-    {
-        const auto memArea = static_cast<nautilus::val<int8_t*>>(aggregationState);
-        nautilus::memset(memArea, 0, 1);
-    }
+    (*functions.reset)(aggregationState);
 }
 
 void MedianAggregationPhysicalFunction::cleanup(nautilus::val<AggregationState*> aggregationState)


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

The compilation of physical aggregation functions is expensive because each aggregation's `lift`/`combine`/`lower` body is traced and **inlined** into the build/probe pipeline functions. For median this is the worst case: its `lower` is a doubly-nested loop, and a query with many `MEDIAN` aggregations inlines that loop once per aggregation, blowing up the traced pipeline and slowing compilation.

This PR extracts the median bodies into dedicated **nautilus functions** (`NautilusFunction`, i.e. cross-calls compiled once and called from the pipeline) so they are no longer inlined. Since nautilus deduplicates functions by name, naming them purely by data type means all medians of the same type in a pipeline share a single compiled instantiation.

Change log:
- Added a global, statically-allocated templated table `MedianFunctionTable<InputT, ResultT, Nullable>` holding the four extracted nautilus functions (`lift`, `combine`, `lower`, `reset`) with clear, type-derived names (e.g. `Median_lower_INT64_FLOAT64_X`). `combine`/`reset` depend only on nullability and are named/shared accordingly.
- The bodies are free, type-parametric function templates (no per-instance capture) so they can be global statics shared across all medians of the same type.
- The virtual `lift`/`combine`/`lower`/`reset` are now thin wrappers that keep the column-specific work in the main pipeline trace (compute the input value via `inputFunction` into a scratch slot; read the lowered result from a scratch slot before writing the result field) and forward to the selected functions via a `MedianFunctions` pointer struct.
- The paged vector now stores **only the single aggregated value** per row (a one-column buffer derived from the input type) instead of the whole input record, so `lower` reads that value directly rather than re-applying `inputFunction`. `getSizeOfStateInBytes()` is unchanged, so the hash-map layout and the lowering rule are untouched.
- Scope is **median only**; the same pattern can be applied to Sum/Min/Max/Count/Avg later. The change is self-contained in `MedianAggregationPhysicalFunction.hpp/.cpp`.

## Verifying this change

This change should be covered by the existing aggregation systests (no behavior change intended):
- `nes-systests/operator/aggregation/WindowAggregationNull.test`, `WindowAggregationDifferentDataTypes*.test`, `WindowAggregationStackedAggregations.test`, `ExpressionInsideAggregation.test`, `ColumnNames.test`, `AggregationOfUnion.test`
- `nes-systests/differential/AggregationEquiValence.test`, `nes-systests/guide/guide8.test`

The intended win can be confirmed by compiling a query with many `MEDIAN`s and checking that the probe module emits a single `Median_lower_*` per distinct type instead of one inlined copy per aggregation.

## What components does this pull request potentially affect?

- ExecutionEngine (physical aggregation functions / nautilus code generation)
- QueryCompiler (only indirectly; the windowed-aggregation lowering rule is unchanged)

## Documentation

- The change is reflected in in-code documentation (class and helper comments in `MedianAggregationPhysicalFunction`).

## Issue Closed by this pull request:

This PR closes #<issue number>