### PR TITLE
Add rustc and cargo to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -643,6 +643,8 @@
           git
           ccache
           mold
+          rustc
+          cargo
         ];
 
         # LLVM toolchain with versioned symlinks for vcpkg


### PR DESCRIPTION
This PR adds rustc and cargo to the buildTools in the flake.nix. With the addition of rust into Nebulastream using the nix devshell to build ran into errors about rustc and cargo dependencies missing. 