### PR TITLE
feat(Format): Flag parent-relative and absolute path includes

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -188,6 +188,17 @@ do
     fi
 done
 
+# error: no parent-relative or absolute path includes
+#
+# Includes must use the configured include paths, not parent-directory traversal
+# (e.g. <../../foo.hpp> or "../../foo.hpp") or absolute paths (e.g. </home/user/foo.hpp>
+# or "/home/user/foo.hpp"). This applies to both angle-bracket and double-quote includes.
+INCLUDE_PATH_PATTERN='#include[[:space:]]+([<"]/|[<"][^>"]*\.\./)'
+if git grep -E "$INCLUDE_PATH_PATTERN" -- "*.hpp" "*.cpp" > /dev/null
+then
+    log_error "Found include(s) with parent-relative or absolute paths. Use proper include paths instead.\n$(git grep -n -E "$INCLUDE_PATH_PATTERN" -- "*.hpp" "*.cpp")"
+fi
+
 # no raw catch (...)
 #
 # We generally want to have cpptrace traces, thus we need to use the cpptrace try-catch wrapper.


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
`scripts/format.sh` had no guard against includes using parent-directory traversal (`#include <../../foo.hpp>`) or absolute paths. CLion adds these automatically when a target is not on the include path, and a few slipped into #1566.
- Added a whole-repo `git grep` check in `scripts/format.sh` that errors on any `#include` whose path is absolute (starts with `/`) or contains `../`, for both `<...>` and `"..."` forms.

## Verifying this change
- `scripts/format.sh` passes on the current tree.
- Confirmed it errors on `<../../x.hpp>`, `"../../x.hpp"`, `</abs/x.hpp>`, `"/abs/x.hpp"`, and `<a/../b.hpp>`, while leaving `<vector>` / `<folly/hash/Hash.h>` untouched.

## What components does this pull request potentially affect?
- Tooling only (`scripts/format.sh`); no source or runtime changes.

## Issue Closed by this pull request:
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)