### PR TITLE
Feature: Disk-backed state spilling for windowed aggregation and joins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ scripts/__pycache__
 .claude/
 .codex/
 [Cc][Ll][Aa][Uu][Dd][Ee].md
+
+# build directories
+/build*

--- a/nes-common/include/ExceptionDefinitions.inc
+++ b/nes-common/include/ExceptionDefinitions.inc
@@ -83,6 +83,7 @@ EXCEPTION(CannotAllocateBuffer, 3003, "cannot allocate buffer")
 EXCEPTION(SkippingDelayedTaskDuringShutdown, 3004, "skipping delayed task during shutdown")
 EXCEPTION(TuplesTooLargeForPipelineBufferSize, 3005, "tuples too large for pipeline buffer size")
 EXCEPTION(InferenceRuntimeFailure, 3006, "inference runtime failure")
+EXCEPTION(SpillIoFailure, 3007, "spill I/O failure")
 EXCEPTION(ArithmeticalError, 3013, "arithmetical error")
 EXCEPTION(WindowingError, 3014, "windowing error")
 

--- a/nes-executable/include/PipelineExecutionContext.hpp
+++ b/nes-executable/include/PipelineExecutionContext.hpp
@@ -25,6 +25,8 @@
 
 namespace NES
 {
+class SpillManager;
+
 class PipelineExecutionContext
 {
 public:
@@ -57,6 +59,11 @@ public:
     [[nodiscard]] virtual WorkerThreadId getWorkerThreadId() const = 0;
     [[nodiscard]] virtual uint64_t getNumberOfWorkerThreads() const = 0;
     [[nodiscard]] virtual std::shared_ptr<AbstractBufferProvider> getBufferManager() const = 0;
+
+    /// The process-wide state-spilling governor, or nullptr if state spilling is not configured. Window/aggregation
+    /// operator handlers obtain it here (in start()) to make their slices spillable.
+    [[nodiscard]] virtual std::shared_ptr<SpillManager> getSpillManager() const { return nullptr; }
+
     [[nodiscard]] virtual PipelineId getPipelineId() const = 0;
 
     /// TODO #30 Remove OperatorHandler from the pipeline execution context

--- a/nes-memory/ArenaMemoryResource.cpp
+++ b/nes-memory/ArenaMemoryResource.cpp
@@ -1,0 +1,259 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Runtime/Spill/ArenaMemoryResource.hpp>
+
+#include <cerrno>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory_resource>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <utility>
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+
+namespace
+{
+/// System page size; mmap regions and file offsets must be page-aligned (e.g. 4 KiB on x86-64, 16 KiB on arm64 macOS).
+size_t pageSize()
+{
+    static const auto CachedPageSize = static_cast<size_t>(::sysconf(_SC_PAGE_SIZE));
+    return CachedPageSize;
+}
+
+size_t roundUpToPage(size_t numberOfBytes)
+{
+    const size_t page = pageSize();
+    return (numberOfBytes + page - 1) & ~(page - 1);
+}
+
+/// Injects synthetic per-page storage latency so the storage-speed axis can be a controlled knob in experiments.
+void injectIoLatency(uint64_t ioLatencyUsPer4k, size_t bytes)
+{
+    if (ioLatencyUsPer4k == 0)
+    {
+        return;
+    }
+    const size_t pages = (bytes + pageSize() - 1) / pageSize();
+    std::this_thread::sleep_for(std::chrono::microseconds(ioLatencyUsPer4k * pages));
+}
+
+void fullPwrite(int fileDescriptor, const void* buf, size_t len, off_t off)
+{
+    const auto* ptr = static_cast<const char*>(buf);
+    size_t done = 0;
+    while (done < len)
+    {
+        /// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic): walking the caller's contiguous mmap buffer
+        const ssize_t written = ::pwrite(fileDescriptor, ptr + done, len - done, off + static_cast<off_t>(done));
+        if (written < 0)
+        {
+            if (errno == EINTR)
+            {
+                continue;
+            }
+            /// NOLINTNEXTLINE(concurrency-mt-unsafe): strerror used only on the fatal error path under the arena mutex
+            throw SpillIoFailure("pwrite failed: {}", std::strerror(errno));
+        }
+        done += static_cast<size_t>(written);
+    }
+}
+
+void fullPread(int fileDescriptor, void* buf, size_t len, off_t off)
+{
+    auto* ptr = static_cast<char*>(buf);
+    size_t done = 0;
+    while (done < len)
+    {
+        /// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic): walking the caller's contiguous mmap buffer
+        const ssize_t read = ::pread(fileDescriptor, ptr + done, len - done, off + static_cast<off_t>(done));
+        if (read < 0)
+        {
+            if (errno == EINTR)
+            {
+                continue;
+            }
+            /// NOLINTNEXTLINE(concurrency-mt-unsafe): strerror used only on the fatal error path under the arena mutex
+            throw SpillIoFailure("pread failed: {}", std::strerror(errno));
+        }
+        if (read == 0)
+        {
+            break; /// region was never written (e.g. untouched reserved space)
+        }
+        done += static_cast<size_t>(read);
+    }
+}
+}
+
+namespace
+{
+/// Backing spill file is owner read/write only (rw-------): it holds this query's private operator state.
+constexpr mode_t SPILL_FILE_MODE = 0600;
+}
+
+ArenaMemoryResource::ArenaMemoryResource(Mode mode, std::string backingFilePath) : mode(mode), backingPath(std::move(backingFilePath))
+{
+    /// open() is a variadic POSIX syscall; fd is computed (open() may fail and throw) so it cannot live in the member-init list.
+    /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,cppcoreguidelines-prefer-member-initializer)
+    fd = ::open(backingPath.c_str(), O_RDWR | O_CREAT | O_TRUNC, SPILL_FILE_MODE);
+    if (fd < 0)
+    {
+        /// NOLINTNEXTLINE(concurrency-mt-unsafe): strerror used only on the fatal error path during single-threaded construction
+        throw SpillIoFailure("could not open backing file {}: {}", backingPath, std::strerror(errno));
+    }
+}
+
+ArenaMemoryResource::~ArenaMemoryResource()
+{
+    for (auto& region : regions)
+    {
+        if (region.live && region.ptr != nullptr)
+        {
+            ::munmap(region.ptr, region.mapLen);
+        }
+    }
+    if (fd >= 0)
+    {
+        ::close(fd);
+        /// NOLINTNEXTLINE(concurrency-mt-unsafe): unlink runs only in the destructor, after all access to this arena has ceased
+        ::unlink(backingPath.c_str());
+    }
+}
+
+void* ArenaMemoryResource::do_allocate(size_t bytes, [[maybe_unused]] size_t alignment)
+{
+    PRECONDITION(alignment <= pageSize(), "ArenaMemoryResource: alignment {} larger than a page {} is unsupported", alignment, pageSize());
+    const std::lock_guard guard(mutex);
+    const size_t mapLen = roundUpToPage(bytes);
+    void* ptr = nullptr;
+    if (mode == Mode::Anon)
+    {
+        ptr = ::mmap(nullptr, mapLen, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+    }
+    else
+    {
+        if (::ftruncate(fd, static_cast<off_t>(fileCursor + mapLen)) != 0)
+        {
+            /// NOLINTNEXTLINE(concurrency-mt-unsafe): strerror used only on the fatal error path under the arena mutex
+            throw SpillIoFailure("ftruncate failed: {}", std::strerror(errno));
+        }
+        ptr = ::mmap(nullptr, mapLen, PROT_READ | PROT_WRITE, MAP_SHARED, fd, static_cast<off_t>(fileCursor));
+    }
+    if (ptr == MAP_FAILED)
+    {
+        /// NOLINTNEXTLINE(concurrency-mt-unsafe): strerror used only on the fatal error path under the arena mutex
+        throw CannotAllocateBuffer("ArenaMemoryResource: mmap of {} bytes failed: {}", mapLen, std::strerror(errno));
+    }
+    regions.push_back(Region{.ptr = ptr, .mapLen = mapLen, .spillOffset = fileCursor, .live = true});
+    fileCursor += mapLen;
+    liveByteCount += mapLen;
+    return ptr;
+}
+
+void ArenaMemoryResource::do_deallocate(void* ptr, size_t /*bytes*/, size_t /*alignment*/)
+{
+    const std::lock_guard guard(mutex);
+    for (auto& region : regions)
+    {
+        if (region.live && region.ptr == ptr)
+        {
+            ::munmap(region.ptr, region.mapLen);
+            region.live = false;
+            liveByteCount -= region.mapLen;
+            return;
+        }
+    }
+}
+
+bool ArenaMemoryResource::do_is_equal(const std::pmr::memory_resource& other) const noexcept
+{
+    return this == &other;
+}
+
+void ArenaMemoryResource::evict(uint64_t ioLatencyUsPer4k)
+{
+    const std::lock_guard guard(mutex);
+    if (evicted)
+    {
+        return;
+    }
+    for (auto& region : regions)
+    {
+        if (!region.live)
+        {
+            continue;
+        }
+        injectIoLatency(ioLatencyUsPer4k, region.mapLen);
+        if (mode == Mode::Anon)
+        {
+            fullPwrite(fd, region.ptr, region.mapLen, static_cast<off_t>(region.spillOffset));
+        }
+        else
+        {
+            ::msync(region.ptr, region.mapLen, MS_SYNC);
+        }
+        totalBytesWritten += region.mapLen;
+        ::madvise(region.ptr, region.mapLen, MADV_DONTNEED);
+    }
+    evicted = true;
+}
+
+void ArenaMemoryResource::reload(uint64_t ioLatencyUsPer4k)
+{
+    const std::lock_guard guard(mutex);
+    if (!evicted)
+    {
+        return;
+    }
+    for (auto& region : regions)
+    {
+        if (!region.live)
+        {
+            continue;
+        }
+        injectIoLatency(ioLatencyUsPer4k, region.mapLen);
+        if (mode == Mode::Anon)
+        {
+            fullPread(fd, region.ptr, region.mapLen, static_cast<off_t>(region.spillOffset));
+        }
+        else
+        {
+            ::madvise(region.ptr, region.mapLen, MADV_WILLNEED);
+            volatile unsigned char sink = 0;
+            for (size_t off = 0; off < region.mapLen; off += pageSize())
+            {
+                /// touch one byte per page to fault the mmap region back in
+                /// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+                sink = sink | static_cast<volatile unsigned char*>(region.ptr)[off];
+            }
+            (void)sink;
+        }
+        totalBytesRead += region.mapLen;
+    }
+    evicted = false;
+}
+
+}

--- a/nes-memory/CMakeLists.txt
+++ b/nes-memory/CMakeLists.txt
@@ -19,6 +19,8 @@ add_library(nes-memory
         UnpooledChunksManager.cpp
         VariableSizedAccess.cpp
         MemoryUtils.cpp
+        ArenaMemoryResource.cpp
+        SpillManager.cpp
         ${MEMORY_LAYOUT_SOURCES}
 )
 

--- a/nes-memory/SpillManager.cpp
+++ b/nes-memory/SpillManager.cpp
@@ -1,0 +1,188 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Runtime/Spill/SpillManager.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <utility>
+#include <vector>
+
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+
+SpillManager::SpillManager(SpillConfiguration configuration) : config(std::move(configuration))
+{
+    PRECONDITION(
+        config.lowWatermark <= config.highWatermark,
+        "SpillManager lowWatermark ({}) must not exceed highWatermark ({})",
+        config.lowWatermark,
+        config.highWatermark);
+}
+
+void SpillManager::registerState(const std::shared_ptr<SpillableState>& state)
+{
+    PRECONDITION(state != nullptr, "Cannot register a null SpillableState");
+    const std::unique_lock lock(registryMutex);
+    auto entry = std::make_shared<Entry>();
+    entry->state = state;
+    registry[state.get()] = std::move(entry);
+}
+
+void SpillManager::unregisterState(const SpillableState* state)
+{
+    const std::unique_lock lock(registryMutex);
+    registry.erase(state);
+}
+
+std::shared_ptr<SpillManager::Entry> SpillManager::lookup(const SpillableState* state) const
+{
+    const std::shared_lock lock(registryMutex);
+    if (const auto it = registry.find(state); it != registry.end())
+    {
+        return it->second;
+    }
+    return nullptr;
+}
+
+void SpillManager::pin(SpillableState& state)
+{
+    /// Unregistered states are not spillable (e.g. slices of operators that do not opt into spilling), so pinning them
+    /// is a no-op. The generic build path may call pin() on any slice.
+    const auto entry = lookup(&state);
+    if (entry == nullptr)
+    {
+        return;
+    }
+    const std::lock_guard guard(entry->residencyMutex);
+    /// Pin before any access: bump the count first (so a concurrent eviction sees it pinned), then reload if needed.
+    entry->pinCount.fetch_add(1);
+    if (state.isEvicted())
+    {
+        state.reloadState();
+    }
+}
+
+void SpillManager::unpin(SpillableState& state)
+{
+    const auto entry = lookup(&state);
+    if (entry == nullptr)
+    {
+        return;
+    }
+    USED_IN_DEBUG const auto previous = entry->pinCount.fetch_sub(1);
+    INVARIANT(previous > 0, "unpin() called more times than pin() for a SpillableState");
+}
+
+size_t SpillManager::residentBytes() const
+{
+    const std::shared_lock lock(registryMutex);
+    size_t total = 0;
+    for (const auto& [ptr, entry] : registry)
+    {
+        if (const auto state = entry->state.lock())
+        {
+            total += state->residentBytes();
+        }
+    }
+    return total;
+}
+
+size_t SpillManager::registeredCount() const
+{
+    const std::shared_lock lock(registryMutex);
+    return registry.size();
+}
+
+size_t SpillManager::maybeSpill()
+{
+    if (!config.enabled || config.stateMemoryBudgetBytes == 0)
+    {
+        return 0;
+    }
+    const auto highBytes = static_cast<size_t>(static_cast<double>(config.stateMemoryBudgetBytes) * config.highWatermark);
+    if (residentBytes() <= highBytes)
+    {
+        return 0;
+    }
+    const auto lowBytes = static_cast<size_t>(static_cast<double>(config.stateMemoryBudgetBytes) * config.lowWatermark);
+    return evictDownTo(lowBytes);
+}
+
+size_t SpillManager::evictDownTo(size_t targetBytes)
+{
+    /// Snapshot live candidates (entry + a strong ref + its coldness) under a brief read-lock, then do the actual evict
+    /// I/O outside it (under each unit's residency mutex) so disk I/O never serializes the whole registry. Holding the
+    /// strong ref keeps each unit alive across the evict I/O; units being concurrently destroyed fail to lock and are skipped.
+    struct Candidate
+    {
+        std::shared_ptr<Entry> entry;
+        std::shared_ptr<SpillableState> state;
+        uint64_t coldness;
+    };
+
+    std::vector<Candidate> candidates;
+    size_t resident = 0;
+    {
+        const std::shared_lock lock(registryMutex);
+        candidates.reserve(registry.size());
+        for (const auto& [ptr, entry] : registry)
+        {
+            if (auto state = entry->state.lock())
+            {
+                resident += state->residentBytes();
+                candidates.push_back({entry, std::move(state), 0});
+            }
+        }
+    }
+    if (resident <= targetBytes)
+    {
+        return 0;
+    }
+    for (auto& candidate : candidates)
+    {
+        candidate.coldness = candidate.state->coldnessKey();
+    }
+
+    /// Coldest first (smallest coldnessKey is evicted first).
+    std::ranges::sort(candidates, [](const auto& lhs, const auto& rhs) { return lhs.coldness < rhs.coldness; });
+
+    size_t freed = 0;
+    for (const auto& candidate : candidates)
+    {
+        if (resident - freed <= targetBytes)
+        {
+            break;
+        }
+        const std::lock_guard guard(candidate.entry->residencyMutex);
+        /// Re-check under the residency mutex: skip pinned or already-evicted units.
+        if (candidate.entry->pinCount.load() != 0 || candidate.state->isEvicted())
+        {
+            continue;
+        }
+        const auto bytes = candidate.state->residentBytes();
+        candidate.state->evictState();
+        freed += bytes;
+    }
+    return freed;
+}
+
+}

--- a/nes-memory/include/Runtime/Spill/ArenaMemoryResource.hpp
+++ b/nes-memory/include/Runtime/Spill/ArenaMemoryResource.hpp
@@ -1,0 +1,106 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory_resource>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace NES
+{
+
+/// A std::pmr::memory_resource that backs every allocation with its own page-aligned mmap region at a fixed virtual
+/// address. It is intended to be injected into NES::BufferManager::create() so that all buffers (and therefore all
+/// operator state allocated through that BufferManager, e.g. ChainedHashMap / PagedVector pages) land in this single
+/// resource without any changes to the allocating code. The whole resource then is one slice's resident set and the
+/// unit of spilling.
+///
+/// Spilling preserves virtual addresses, which is the key property that lets live pointers into the state (hashmap
+/// chains, paged-vector entries) survive an evict/reload cycle. Two modes:
+///   - Anon:       MAP_PRIVATE|ANON|NORESERVE; evict = pwrite the pages to a spill file + madvise(DONTNEED);
+///                 reload = pread them back to the same address. This is the explicit, vmcache-faithful path.
+///                 NOTE: after evict, the pages fault back as zero-fill, so a reload() MUST happen before any access.
+///   - FileBacked: MAP_SHARED on a backing file; evict = msync + madvise(DONTNEED); reload = madvise(WILLNEED) and
+///                 touch the pages so the OS pages them back in.
+///
+/// Allocation/deallocation are guarded by an internal mutex, so multiple worker threads may allocate from one arena
+/// concurrently (the page-boundary allocations are low frequency). evict/reload must not run concurrently with access
+/// to the backed memory; the SpillManager's pin protocol guarantees this (a slice is reloaded+pinned before access and
+/// only evicted while unpinned).
+class ArenaMemoryResource final : public std::pmr::memory_resource
+{
+public:
+    enum class Mode : uint8_t
+    {
+        Anon,
+        FileBacked
+    };
+
+    /// @param mode spilling strategy (see class comment)
+    /// @param backingFilePath path of the spill/backing file; created (O_TRUNC) on construction and unlinked on destruction
+    ArenaMemoryResource(Mode mode, std::string backingFilePath);
+    ~ArenaMemoryResource() override;
+
+    ArenaMemoryResource(const ArenaMemoryResource&) = delete;
+    ArenaMemoryResource& operator=(const ArenaMemoryResource&) = delete;
+    /// Deleted: this resource exclusively owns an fd and a set of mmap regions, which cannot be moved.
+    ArenaMemoryResource(ArenaMemoryResource&&) = delete;
+    ArenaMemoryResource& operator=(ArenaMemoryResource&&) = delete;
+
+    /// Move all resident pages out of DRAM. No-op if already evicted.
+    /// @param ioLatencyUsPer4k optional synthetic per-4KB I/O latency (storage-speed knob for experiments; 0 = off)
+    void evict(uint64_t ioLatencyUsPer4k = 0);
+    /// Bring all pages back to their exact original virtual addresses. No-op if not evicted.
+    void reload(uint64_t ioLatencyUsPer4k = 0);
+
+    [[nodiscard]] bool isEvicted() const noexcept { return evicted; }
+
+    /// Sum of the mapped (page-rounded) bytes of all live regions; i.e. this slice's resident-set size.
+    [[nodiscard]] size_t liveBytes() const noexcept { return liveByteCount; }
+
+    [[nodiscard]] uint64_t bytesWritten() const noexcept { return totalBytesWritten; }
+
+    [[nodiscard]] uint64_t bytesRead() const noexcept { return totalBytesRead; }
+
+protected:
+    void* do_allocate(size_t bytes, size_t alignment) override;
+    void do_deallocate(void* ptr, size_t bytes, size_t alignment) override;
+    [[nodiscard]] bool do_is_equal(const std::pmr::memory_resource& other) const noexcept override;
+
+private:
+    struct Region
+    {
+        void* ptr;
+        size_t mapLen;
+        size_t spillOffset; /// offset of this region in the spill/backing file
+        bool live;
+    };
+
+    mutable std::mutex mutex; /// guards regions/fileCursor/liveByteCount and evict/reload
+    Mode mode;
+    std::string backingPath;
+    int fd{-1};
+    size_t fileCursor{0}; /// next free offset in the backing file
+    std::vector<Region> regions;
+    size_t liveByteCount{0};
+    bool evicted{false};
+    uint64_t totalBytesWritten{0};
+    uint64_t totalBytesRead{0};
+};
+
+}

--- a/nes-memory/include/Runtime/Spill/SpillManager.hpp
+++ b/nes-memory/include/Runtime/Spill/SpillManager.hpp
@@ -1,0 +1,128 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <Runtime/Spill/ArenaMemoryResource.hpp>
+
+namespace NES
+{
+
+/// Interface a spillable unit of operator state (a window/aggregation/join slice) implements so the process-wide
+/// SpillManager can account for its DRAM footprint and evict/reload it under memory pressure. Implementations back
+/// their state with an ArenaMemoryResource so eviction preserves virtual addresses (see ArenaMemoryResource).
+class SpillableState
+{
+public:
+    virtual ~SpillableState() = default;
+
+    /// Physical DRAM footprint of this unit right now: its byte size when resident, 0 when evicted.
+    [[nodiscard]] virtual size_t residentBytes() const = 0;
+    [[nodiscard]] virtual bool isEvicted() const = 0;
+
+    /// Move this unit's state out of DRAM. Called by the SpillManager only while unpinned and resident.
+    virtual void evictState() = 0;
+    /// Bring this unit's state back into DRAM at its original addresses. Called before the unit is pinned for access.
+    virtual void reloadState() = 0;
+
+    /// Victim-selection ordering: a smaller key is colder and is evicted first. For time-based slices this is the
+    /// slice end (oldest slice = least likely to be written next under monotone event time).
+    [[nodiscard]] virtual uint64_t coldnessKey() const = 0;
+};
+
+/// Policy for the SpillManager. Budgets are in bytes; watermarks are fractions of the budget.
+struct SpillConfiguration
+{
+    static constexpr double DEFAULT_HIGH_WATERMARK = 0.9;
+    static constexpr double DEFAULT_LOW_WATERMARK = 0.7;
+
+    bool enabled = false;
+    /// Target ceiling for total resident state bytes across all registered units. 0 => no proactive eviction.
+    size_t stateMemoryBudgetBytes = 0;
+    /// Start evicting once resident bytes exceed highWatermark * budget ...
+    double highWatermark = DEFAULT_HIGH_WATERMARK;
+    /// ... and keep evicting the coldest unpinned units down to lowWatermark * budget.
+    double lowWatermark = DEFAULT_LOW_WATERMARK;
+    /// Directory under which per-slice arena backing files are created.
+    std::string spillDirectory = "/tmp";
+    /// Backend used by per-slice arenas (Anon = vmcache-faithful explicit pwrite/madvise/pread; the production default).
+    ArenaMemoryResource::Mode arenaMode = ArenaMemoryResource::Mode::Anon;
+};
+
+/// Process-wide governor that decides when and what to spill. Operators do not evict their own state; they only
+/// register/unregister their slices and pin/unpin them around access. The governor owns the eviction policy so the
+/// budget is global across operators (a join can evict an aggregation's cold slice and vice versa).
+///
+/// Thread-safety: the registry is guarded by a shared mutex; each unit has its own residency mutex. Eviction selects
+/// victims under a brief registry read-lock (copying shared_ptrs) and performs the actual evict I/O outside that lock,
+/// under the per-unit residency mutex, so disk I/O never serializes the whole registry.
+class SpillManager
+{
+public:
+    /// Non-copyable and non-movable (the std::shared_mutex member makes it so implicitly).
+    explicit SpillManager(SpillConfiguration configuration);
+
+    /// Register a unit so the governor accounts for and may evict it. Safe to call from any thread.
+    void registerState(const std::shared_ptr<SpillableState>& state);
+    /// Stop tracking a unit (e.g. on slice garbage collection). Idempotent.
+    void unregisterState(const SpillableState* state);
+
+    /// Reload-if-evicted and increment the unit's pin count. While pinned (>0) the unit is never evicted. Must be
+    /// called before a worker writes or probes the unit's state.
+    void pin(SpillableState& state);
+    /// Decrement the unit's pin count; the unit becomes evictable again when it reaches 0.
+    void unpin(SpillableState& state);
+
+    /// Proactive eviction: if resident bytes exceed the high watermark, evict the coldest unpinned units until resident
+    /// bytes drop to the low watermark (or no more evictable units remain). Returns the number of bytes evicted.
+    size_t maybeSpill();
+
+    /// Reactive backstop: evict coldest unpinned units until resident bytes <= targetBytes (or none remain). Returns
+    /// bytes evicted. Used to make room before an allocation that would otherwise breach the budget.
+    size_t evictDownTo(size_t targetBytes);
+
+    /// Sum of residentBytes() across all registered units.
+    [[nodiscard]] size_t residentBytes() const;
+    [[nodiscard]] size_t registeredCount() const;
+
+    [[nodiscard]] const SpillConfiguration& configuration() const noexcept { return config; }
+
+private:
+    /// Per-unit bookkeeping. Stored behind a shared_ptr so its address (and mutex) stay stable across registry rehash.
+    /// The state is held by weak_ptr: the SliceStore owns the slice's lifetime, so the governor must not keep it alive.
+    /// Eviction/pin lock the weak_ptr to a temporary shared_ptr, which keeps the unit alive for the duration of the I/O
+    /// and returns null (skip) if the unit is concurrently being destroyed.
+    struct Entry
+    {
+        std::weak_ptr<SpillableState> state;
+        std::atomic<uint32_t> pinCount{0};
+        std::mutex residencyMutex; /// serializes evict/reload and pin-reload for this unit
+    };
+
+    std::shared_ptr<Entry> lookup(const SpillableState* state) const;
+
+    SpillConfiguration config;
+    mutable std::shared_mutex registryMutex;
+    std::map<const SpillableState*, std::shared_ptr<Entry>> registry;
+};
+
+}

--- a/nes-memory/tests/ArenaMemoryResourceTest.cpp
+++ b/nes-memory/tests/ArenaMemoryResourceTest.cpp
@@ -1,0 +1,211 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <numeric>
+#include <span>
+#include <string>
+#include <vector>
+#include <Runtime/BufferManager.hpp>
+#include <Runtime/Spill/ArenaMemoryResource.hpp>
+#include <Runtime/TupleBuffer.hpp>
+#include <gtest/gtest.h>
+
+namespace NES
+{
+
+namespace
+{
+/// Common alignment used across the tests (one cache line); allocations are page-rounded internally anyway.
+constexpr size_t TestAlignment = 64;
+}
+
+/// Tests for ArenaMemoryResource, the per-slice spill unit. The core guarantees are:
+/// (1) after an evict/reload cycle the data is intact at the *same* virtual address (so live pointers survive), and
+/// (2) live-byte accounting reflects allocations/deallocations. Both the Anon (vmcache-faithful) and FileBacked modes
+/// are exercised.
+class ArenaMemoryResourceTest : public ::testing::TestWithParam<ArenaMemoryResource::Mode>
+{
+protected:
+    std::filesystem::path backingFile;
+
+    void SetUp() override
+    {
+        /// Unique backing file per test so parallel test execution does not collide. The parameterized suite/test
+        /// names contain '/' (e.g. "Modes/ArenaMemoryResourceTest"), so sanitize them into a flat file name.
+        const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+        std::string name = std::string("nes-arena-") + info->test_suite_name() + "-" + info->name() + ".spill";
+        std::ranges::replace(name, '/', '_');
+        backingFile = std::filesystem::temp_directory_path() / name;
+    }
+
+    void TearDown() override
+    {
+        std::error_code ec;
+        std::filesystem::remove(backingFile, ec);
+    }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    Modes,
+    ArenaMemoryResourceTest,
+    ::testing::Values(ArenaMemoryResource::Mode::Anon, ArenaMemoryResource::Mode::FileBacked),
+    [](const auto& info) { return info.param == ArenaMemoryResource::Mode::Anon ? "Anon" : "FileBacked"; });
+
+/// Data written into an allocation survives an evict/reload cycle and stays at the same address.
+TEST_P(ArenaMemoryResourceTest, DataAndAddressSurviveEvictReload)
+{
+    ArenaMemoryResource arena(GetParam(), backingFile.string());
+
+    constexpr size_t numBytes = size_t{64} * 1024;
+    constexpr uint8_t patternStride = 31;
+    constexpr uint8_t patternOffset = 7;
+    auto* region = static_cast<uint8_t*>(arena.allocate(numBytes, TestAlignment));
+    ASSERT_NE(region, nullptr);
+
+    /// Write a deterministic pattern.
+    for (size_t i = 0; i < numBytes; ++i)
+    {
+        region[i] = static_cast<uint8_t>((i * patternStride + patternOffset) & 0xFFU);
+    }
+
+    EXPECT_FALSE(arena.isEvicted());
+    arena.evict();
+    EXPECT_TRUE(arena.isEvicted());
+    arena.reload();
+    EXPECT_FALSE(arena.isEvicted());
+
+    /// Same virtual address, identical contents.
+    for (size_t i = 0; i < numBytes; ++i)
+    {
+        ASSERT_EQ(region[i], static_cast<uint8_t>((i * patternStride + patternOffset) & 0xFFU)) << "mismatch at byte " << i;
+    }
+    EXPECT_GT(arena.bytesWritten(), 0U);
+    EXPECT_GT(arena.bytesRead(), 0U);
+
+    arena.deallocate(region, numBytes, TestAlignment);
+}
+
+/// Multiple allocations all survive a single evict/reload, each at its own stable address.
+TEST_P(ArenaMemoryResourceTest, MultipleRegionsSurvive)
+{
+    ArenaMemoryResource arena(GetParam(), backingFile.string());
+    std::vector<uint8_t*> regions;
+    constexpr size_t numRegions = 5;
+    constexpr size_t regionBytes = size_t{8} * 1024;
+    for (size_t region = 0; region < numRegions; ++region)
+    {
+        auto* ptr = static_cast<uint8_t*>(arena.allocate(regionBytes, TestAlignment));
+        std::memset(ptr, static_cast<int>(region + 1), regionBytes);
+        regions.push_back(ptr);
+    }
+
+    arena.evict();
+    arena.reload();
+
+    for (size_t region = 0; region < numRegions; ++region)
+    {
+        for (size_t i = 0; i < regionBytes; ++i)
+        {
+            ASSERT_EQ(regions[region][i], static_cast<uint8_t>(region + 1)) << "region " << region << " byte " << i;
+        }
+    }
+    for (auto* ptr : regions)
+    {
+        arena.deallocate(ptr, regionBytes, TestAlignment);
+    }
+}
+
+/// Live-byte accounting tracks allocations and deallocations (page-rounded).
+TEST_P(ArenaMemoryResourceTest, LiveByteAccounting)
+{
+    ArenaMemoryResource arena(GetParam(), backingFile.string());
+    EXPECT_EQ(arena.liveBytes(), 0U);
+
+    constexpr size_t smallAllocBytes = 1000; /// rounds up to one page
+    constexpr size_t largeAllocBytes = 9000; /// spans more than one page
+
+    auto* first = arena.allocate(smallAllocBytes, TestAlignment);
+    const auto afterFirst = arena.liveBytes();
+    EXPECT_GE(afterFirst, smallAllocBytes);
+
+    auto* second = arena.allocate(largeAllocBytes, TestAlignment);
+    EXPECT_GT(arena.liveBytes(), afterFirst);
+
+    arena.deallocate(first, smallAllocBytes, TestAlignment);
+    arena.deallocate(second, largeAllocBytes, TestAlignment);
+    EXPECT_EQ(arena.liveBytes(), 0U);
+}
+
+/// evict()/reload() are idempotent: redundant calls are no-ops and do not corrupt state.
+TEST_P(ArenaMemoryResourceTest, EvictReloadIdempotent)
+{
+    ArenaMemoryResource arena(GetParam(), backingFile.string());
+    constexpr size_t allocBytes = 4096;
+    constexpr size_t patternLength = 256;
+    auto* ptr = static_cast<uint8_t*>(arena.allocate(allocBytes, TestAlignment));
+    std::iota(ptr, ptr + patternLength, uint8_t{0});
+
+    arena.evict();
+    arena.evict(); /// no-op
+    arena.reload();
+    arena.reload(); /// no-op
+
+    for (size_t i = 0; i < patternLength; ++i)
+    {
+        ASSERT_EQ(ptr[i], static_cast<uint8_t>(i));
+    }
+    arena.deallocate(ptr, allocBytes, TestAlignment);
+}
+
+/// A BufferManager backed by the arena keeps its buffers' contents and addresses across an evict/reload, proving the
+/// arena works as the per-slice allocation backend (the real integration path for spilling operator state).
+TEST_P(ArenaMemoryResourceTest, BufferManagerBackedByArenaSurvivesEvictReload)
+{
+    auto arena = std::make_shared<ArenaMemoryResource>(GetParam(), backingFile.string());
+    constexpr uint32_t bufferSize = 4096;
+    constexpr uint32_t numBuffers = 4;
+    constexpr uint8_t patternStride = 13;
+    constexpr uint8_t patternOffset = 5;
+    auto bm = BufferManager::create(bufferSize, numBuffers, arena, TestAlignment);
+
+    auto buffer = bm->getBufferBlocking();
+    auto* raw = buffer.getAvailableMemoryArea<uint8_t>().data();
+    auto mem = buffer.getAvailableMemoryArea<uint8_t>();
+    for (size_t i = 0; i < mem.size(); ++i)
+    {
+        mem[i] = static_cast<uint8_t>((i * patternStride + patternOffset) & 0xFFU);
+    }
+
+    arena->evict();
+    arena->reload();
+
+    /// Same backing address; contents intact.
+    EXPECT_EQ(buffer.getAvailableMemoryArea<uint8_t>().data(), raw);
+    auto memAfter = buffer.getAvailableMemoryArea<uint8_t>();
+    for (size_t i = 0; i < memAfter.size(); ++i)
+    {
+        ASSERT_EQ(memAfter[i], static_cast<uint8_t>((i * patternStride + patternOffset) & 0xFFU)) << "byte " << i;
+    }
+
+    /// Release before destroying the BufferManager (its destructor asserts no outstanding buffers).
+    buffer = TupleBuffer();
+    bm->destroy();
+}
+
+}

--- a/nes-memory/tests/CMakeLists.txt
+++ b/nes-memory/tests/CMakeLists.txt
@@ -19,5 +19,11 @@ target_link_libraries(tuple-buffer-memory-access-tests nes-memory)
 add_nes_test(buffer-manager-destroy-test BufferManagerDestroyTest.cpp)
 target_link_libraries(buffer-manager-destroy-test nes-memory)
 
+add_nes_test(arena-memory-resource-test ArenaMemoryResourceTest.cpp)
+target_link_libraries(arena-memory-resource-test nes-memory)
+
+add_nes_test(spill-manager-test SpillManagerTest.cpp)
+target_link_libraries(spill-manager-test nes-memory)
+
 add_nes_test(child-buffer-tests ChildBufferTests.cpp)
 target_link_libraries(child-buffer-tests nes-memory)

--- a/nes-memory/tests/SpillManagerTest.cpp
+++ b/nes-memory/tests/SpillManagerTest.cpp
@@ -1,0 +1,226 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+#include <Runtime/Spill/ArenaMemoryResource.hpp>
+#include <Runtime/Spill/SpillManager.hpp>
+#include <gtest/gtest.h>
+
+namespace NES
+{
+
+namespace
+{
+constexpr size_t KiB = 1024;
+constexpr size_t StateBytes = 64 * KiB;
+constexpr size_t Alignment = 64;
+constexpr uint64_t PatternStride = 7;
+constexpr uint64_t PatternMask = 0xFF;
+
+/// A test-double SpillableState backed by a real ArenaMemoryResource. residentBytes() reports the mapped bytes while
+/// resident and 0 once evicted, modelling actual DRAM pressure. A deterministic pattern lets us assert that data
+/// survives an evict/reload driven by the SpillManager.
+class FakeSpillableState final : public SpillableState
+{
+public:
+    FakeSpillableState(uint64_t coldness, size_t bytes, const std::string& backingFile)
+        : coldness(coldness)
+        , arena(ArenaMemoryResource::Mode::Anon, backingFile)
+        , region(static_cast<uint8_t*>(arena.allocate(bytes, Alignment)))
+        , sizeBytes(bytes)
+        , mappedBytes(arena.liveBytes())
+    {
+        for (size_t i = 0; i < bytes; ++i)
+        {
+            region[i] = patternByte(i);
+        }
+    }
+
+    [[nodiscard]] size_t residentBytes() const override { return arena.isEvicted() ? 0 : mappedBytes; }
+
+    [[nodiscard]] bool isEvicted() const override { return arena.isEvicted(); }
+
+    void evictState() override { arena.evict(); }
+
+    void reloadState() override { arena.reload(); }
+
+    [[nodiscard]] uint64_t coldnessKey() const override { return coldness; }
+
+    [[nodiscard]] bool patternIntact() const
+    {
+        for (size_t i = 0; i < sizeBytes; ++i)
+        {
+            if (region[i] != patternByte(i))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+private:
+    [[nodiscard]] uint8_t patternByte(size_t i) const { return static_cast<uint8_t>(((i * PatternStride) + coldness) & PatternMask); }
+
+    uint64_t coldness;
+    ArenaMemoryResource arena;
+    uint8_t* region{nullptr};
+    size_t sizeBytes{0};
+    size_t mappedBytes{0};
+};
+}
+
+class SpillManagerTest : public ::testing::Test
+{
+protected:
+    std::filesystem::path dir;
+
+    void SetUp() override
+    {
+        const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+        dir = std::filesystem::temp_directory_path() / (std::string("nes-spillmgr-") + info->name());
+        std::filesystem::create_directories(dir);
+    }
+
+    void TearDown() override
+    {
+        std::error_code ec;
+        std::filesystem::remove_all(dir, ec);
+    }
+
+    std::shared_ptr<FakeSpillableState> makeState(uint64_t coldness)
+    {
+        return std::make_shared<FakeSpillableState>(coldness, StateBytes, (dir / ("s" + std::to_string(coldness) + ".spill")).string());
+    }
+};
+
+/// residentBytes() sums the footprint of all registered units; unregister stops tracking.
+TEST_F(SpillManagerTest, AccountingAndRegistration)
+{
+    SpillManager mgr(SpillConfiguration{});
+    EXPECT_EQ(mgr.registeredCount(), 0U);
+    EXPECT_EQ(mgr.residentBytes(), 0U);
+
+    auto a = makeState(1);
+    auto b = makeState(2);
+    mgr.registerState(a);
+    mgr.registerState(b);
+    EXPECT_EQ(mgr.registeredCount(), 2U);
+    EXPECT_GE(mgr.residentBytes(), 2 * StateBytes);
+
+    mgr.unregisterState(a.get());
+    EXPECT_EQ(mgr.registeredCount(), 1U);
+    EXPECT_GE(mgr.residentBytes(), StateBytes);
+    EXPECT_FALSE(b->isEvicted());
+}
+
+/// Proactive eviction removes the coldest units (lowest key) down to the low watermark; survivors keep their data,
+/// and an evicted unit's data is restored on pin().
+TEST_F(SpillManagerTest, MaybeSpillEvictsColdestToLowWatermark)
+{
+    SpillConfiguration cfg;
+    cfg.enabled = true;
+    cfg.stateMemoryBudgetBytes = 5 * StateBytes;
+    cfg.highWatermark = 0.9; /// 4.5 units -> over budget at 5 units triggers
+    cfg.lowWatermark = 0.5; /// evict down to ~2.5 units
+    SpillManager mgr(cfg);
+
+    std::vector<std::shared_ptr<FakeSpillableState>> states;
+    for (uint64_t k = 1; k <= 5; ++k)
+    {
+        states.push_back(makeState(k));
+        mgr.registerState(states.back());
+    }
+
+    const auto freed = mgr.maybeSpill();
+    EXPECT_GT(freed, 0U);
+    EXPECT_LE(mgr.residentBytes(), static_cast<size_t>(cfg.stateMemoryBudgetBytes * cfg.lowWatermark));
+
+    /// Coldest (keys 1..3) evicted; warmest (4,5) resident with intact data.
+    EXPECT_TRUE(states[0]->isEvicted());
+    EXPECT_TRUE(states[1]->isEvicted());
+    EXPECT_TRUE(states[2]->isEvicted());
+    EXPECT_FALSE(states[3]->isEvicted());
+    EXPECT_FALSE(states[4]->isEvicted());
+    EXPECT_TRUE(states[3]->patternIntact());
+
+    /// Pin reloads an evicted unit and its data is restored.
+    mgr.pin(*states[0]);
+    EXPECT_FALSE(states[0]->isEvicted());
+    EXPECT_TRUE(states[0]->patternIntact());
+    mgr.unpin(*states[0]);
+}
+
+/// A pinned unit is never evicted, even when it is the coldest victim.
+TEST_F(SpillManagerTest, PinnedStateIsNotEvicted)
+{
+    SpillConfiguration cfg;
+    cfg.enabled = true;
+    cfg.stateMemoryBudgetBytes = 5 * StateBytes;
+    cfg.highWatermark = 0.9;
+    cfg.lowWatermark = 0.5;
+    SpillManager mgr(cfg);
+
+    std::vector<std::shared_ptr<FakeSpillableState>> states;
+    for (uint64_t k = 1; k <= 5; ++k)
+    {
+        states.push_back(makeState(k));
+        mgr.registerState(states.back());
+    }
+
+    mgr.pin(*states[0]); /// pin the coldest
+    mgr.maybeSpill();
+    EXPECT_FALSE(states[0]->isEvicted()) << "pinned coldest unit must not be evicted";
+    mgr.unpin(*states[0]);
+}
+
+/// Reactive backstop: evictDownTo evicts the coldest until resident <= target.
+TEST_F(SpillManagerTest, EvictDownToTarget)
+{
+    SpillManager mgr(SpillConfiguration{});
+    std::vector<std::shared_ptr<FakeSpillableState>> states;
+    for (uint64_t k = 1; k <= 4; ++k)
+    {
+        states.push_back(makeState(k));
+        mgr.registerState(states.back());
+    }
+    const auto freed = mgr.evictDownTo(2 * StateBytes);
+    EXPECT_GT(freed, 0U);
+    EXPECT_LE(mgr.residentBytes(), 2 * StateBytes);
+    EXPECT_TRUE(states[0]->isEvicted());
+}
+
+/// With spilling disabled, maybeSpill never evicts even when over budget.
+TEST_F(SpillManagerTest, DisabledDoesNotSpill)
+{
+    SpillConfiguration cfg;
+    cfg.enabled = false;
+    cfg.stateMemoryBudgetBytes = StateBytes; /// deliberately tiny
+    SpillManager mgr(cfg);
+
+    auto a = makeState(1);
+    auto b = makeState(2);
+    mgr.registerState(a);
+    mgr.registerState(b);
+
+    EXPECT_EQ(mgr.maybeSpill(), 0U);
+    EXPECT_FALSE(a->isEvicted());
+    EXPECT_FALSE(b->isEvicted());
+}
+
+}

--- a/nes-nautilus/include/Interface/HashMap/ChainedHashMap/ChainedHashMap.hpp
+++ b/nes-nautilus/include/Interface/HashMap/ChainedHashMap/ChainedHashMap.hpp
@@ -80,6 +80,13 @@ public:
     [[nodiscard]] ChainedHashMapEntry* findChain(HashFunction::HashValue::raw_type hash) const;
     std::span<std::byte> allocateSpaceForVarSized(AbstractBufferProvider* bufferProvider, size_t neededSize);
     AbstractHashMapEntry* insertEntry(HashFunction::HashValue::raw_type hash, AbstractBufferProvider* bufferProvider) override;
+
+    /// Pins this hash map's page allocations to a specific buffer provider, overriding the provider passed to
+    /// insertEntry/allocateSpaceForVarSized. Used by spillable slices so all of a slice's hash-map memory is allocated
+    /// from the slice's own (arena-backed) BufferManager and can therefore be evicted/reloaded as a unit. When left
+    /// unset (nullptr, the default), the provider passed at the call site is used, i.e. behaviour is unchanged.
+    void setOwnBufferProvider(AbstractBufferProvider* provider) { ownBufferProvider = provider; }
+
     [[nodiscard]] uint64_t getNumberOfTuples() const override;
     [[nodiscard]] const TupleBuffer& getPage(uint64_t pageIndex) const;
     [[nodiscard]] uint64_t getNumberOfPages() const;
@@ -99,8 +106,15 @@ public:
 private:
     friend class ChainedHashMapRef;
 
+    /// Returns the provider to allocate from: the pinned own provider when set, otherwise the one passed at the call site.
+    [[nodiscard]] AbstractBufferProvider* effectiveProvider(AbstractBufferProvider* passed) const
+    {
+        return ownBufferProvider != nullptr ? ownBufferProvider : passed;
+    }
+
     /// Specifies the number of pre-allocated var sized
     static constexpr auto NUMBER_OF_PRE_ALLOCATED_VAR_SIZED_ITEMS = 100;
+    AbstractBufferProvider* ownBufferProvider{nullptr};
     TupleBuffer entrySpace;
     std::vector<TupleBuffer> storageSpace;
     std::vector<TupleBuffer> varSizedSpace;

--- a/nes-nautilus/src/Interface/HashMap/ChainedHashMap/ChainedHashMap.cpp
+++ b/nes-nautilus/src/Interface/HashMap/ChainedHashMap/ChainedHashMap.cpp
@@ -134,7 +134,7 @@ std::span<std::byte> ChainedHashMap::allocateSpaceForVarSized(AbstractBufferProv
     if (varSizedSpace.empty() or varSizedSpace.back().getNumberOfTuples() + neededSize >= varSizedSpace.back().getBufferSize())
     {
         /// We allocate more space than currently necessary for the variable sized data to reduce the allocation overhead
-        auto varSizedBuffer = bufferProvider->getUnpooledBuffer(neededSize * NUMBER_OF_PRE_ALLOCATED_VAR_SIZED_ITEMS);
+        auto varSizedBuffer = effectiveProvider(bufferProvider)->getUnpooledBuffer(neededSize * NUMBER_OF_PRE_ALLOCATED_VAR_SIZED_ITEMS);
         if (not varSizedBuffer)
         {
             throw CannotAllocateBuffer(
@@ -161,7 +161,7 @@ AbstractHashMapEntry* ChainedHashMap::insertEntry(const HashFunction::HashValue:
         /// We add one more entry to the capacity, as we need to have a valid entry for the last entry in the entries array
         /// We will be using this entry for checking, if we are at the end of our hash map in our EntryIterator
         const auto totalSpace = (numberOfChains + 1) * sizeof(ChainedHashMapEntry*);
-        const auto entryBuffer = bufferProvider->getUnpooledBuffer(totalSpace);
+        const auto entryBuffer = effectiveProvider(bufferProvider)->getUnpooledBuffer(totalSpace);
         if (not entryBuffer)
         {
             throw CannotAllocateBuffer("Could not allocate memory for ChainedHashMap of size {}", std::to_string(totalSpace));
@@ -177,7 +177,7 @@ AbstractHashMapEntry* ChainedHashMap::insertEntry(const HashFunction::HashValue:
     /// 1. Check if we need to allocate a new page
     if (numberOfTuples % entriesPerPage == 0)
     {
-        auto newPage = bufferProvider->getUnpooledBuffer(pageSize);
+        auto newPage = effectiveProvider(bufferProvider)->getUnpooledBuffer(pageSize);
         if (not newPage)
         {
             throw CannotAllocateBuffer("Could not allocate memory for new page in ChainedHashMap of size {}", std::to_string(pageSize));

--- a/nes-physical-operators/include/Aggregation/AggregationSlice.hpp
+++ b/nes-physical-operators/include/Aggregation/AggregationSlice.hpp
@@ -15,8 +15,10 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <Identifiers/Identifiers.hpp>
 #include <Interface/HashMap/HashMap.hpp>
+#include <Runtime/Spill/SpillManager.hpp>
 #include <SliceStore/Slice.hpp>
 #include <HashMapSlice.hpp>
 
@@ -30,7 +32,11 @@ class AggregationSlice final : public HashMapSlice
 {
 public:
     AggregationSlice(
-        SliceStart sliceStart, SliceEnd sliceEnd, const CreateNewHashMapSliceArgs& createNewHashMapSliceArgs, uint64_t numberOfHashMaps);
+        SliceStart sliceStart,
+        SliceEnd sliceEnd,
+        const CreateNewHashMapSliceArgs& createNewHashMapSliceArgs,
+        uint64_t numberOfHashMaps,
+        std::shared_ptr<SpillManager> spillManager = nullptr);
 
     /// Returns the pointer to the underlying hashmap.
     /// IMPORTANT: This method should only be used for passing the hashmap to the nautilus executable.

--- a/nes-physical-operators/include/HashMapSlice.hpp
+++ b/nes-physical-operators/include/HashMapSlice.hpp
@@ -14,14 +14,21 @@
 
 #pragma once
 
+#include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <utility>
 #include <vector>
 #include <Identifiers/Identifiers.hpp>
 #include <Interface/HashMap/HashMap.hpp>
+#include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/BufferManager.hpp>
+#include <Runtime/Spill/ArenaMemoryResource.hpp>
+#include <Runtime/Spill/SpillManager.hpp>
 #include <SliceStore/Slice.hpp>
 #include <CompilationContext.hpp>
 
@@ -64,7 +71,10 @@ struct CreateNewHashMapSliceArgs : CreateNewSlicesArguments
 ///
 /// As the hashmap might need to clean up its state, we expect multiple clean up functions as part of the @struct CreateNewHashMapSliceArgs
 /// For each stream, we expect one cleanup function and once this HashMapSlice gets destroyed they are being called.
-class HashMapSlice : public Slice
+/// HashMapSlice is also a SpillableState: when a SpillManager with spilling enabled is supplied, the slice allocates
+/// all of its hash maps' memory from its own arena-backed BufferManager (see spillProviderOrNull), so the whole slice
+/// can be evicted to / reloaded from disk as a unit by the governor.
+class HashMapSlice : public Slice, public SpillableState
 {
 public:
     explicit HashMapSlice(
@@ -72,7 +82,8 @@ public:
         SliceEnd sliceEnd,
         const CreateNewHashMapSliceArgs& createNewHashMapSliceArgs,
         uint64_t numberOfHashMaps,
-        uint64_t numberOfInputStreams);
+        uint64_t numberOfInputStreams,
+        std::shared_ptr<SpillManager> spillManager = nullptr);
 
     ~HashMapSlice() override;
 
@@ -81,11 +92,34 @@ public:
 
     [[nodiscard]] uint64_t getNumberOfTuples() const;
 
+    /// SpillableState: the slice's resident footprint, eviction/reload, and victim-ordering key (the slice end, so the
+    /// oldest slice is evicted first).
+    [[nodiscard]] size_t residentBytes() const override;
+    [[nodiscard]] bool isEvicted() const override;
+    void evictState() override;
+    void reloadState() override;
+    [[nodiscard]] uint64_t coldnessKey() const override;
+
 protected:
+    /// Returns the slice's own arena-backed buffer provider when spilling is enabled (creating the arena lazily on
+    /// first use), or nullptr when spilling is disabled (in which case callers use the global pipeline provider, i.e.
+    /// behaviour is unchanged). Pinning the returned provider into a hash map makes that hash map spillable.
+    AbstractBufferProvider* spillProviderOrNull();
+
     std::vector<std::unique_ptr<HashMap>> hashMaps;
     CreateNewHashMapSliceArgs createNewHashMapSliceArgs;
     uint64_t numberOfHashMapsPerInputStream;
     uint64_t numberOfInputStreams;
+
+private:
+    /// Spilling state (only used when spillManager is set and spilling is enabled). One arena + BufferManager per slice;
+    /// all of the slice's hash maps allocate from it, so the slice is a single spill unit.
+    std::shared_ptr<SpillManager> spillManager;
+    std::shared_ptr<ArenaMemoryResource> spillArena;
+    std::shared_ptr<BufferManager> spillBufferManager;
+    bool spillEnabled{false};
+    std::atomic<bool> spillEvicted{false};
+    std::mutex spillMutex; /// guards lazy arena creation and the evicted flag
 };
 
 }

--- a/nes-physical-operators/include/Join/HashJoin/HJSlice.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJSlice.hpp
@@ -15,9 +15,11 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <Identifiers/Identifiers.hpp>
 #include <Interface/HashMap/HashMap.hpp>
 #include <Join/StreamJoinUtil.hpp>
+#include <Runtime/Spill/SpillManager.hpp>
 #include <SliceStore/Slice.hpp>
 #include <HashMapSlice.hpp>
 
@@ -47,7 +49,11 @@ class HJSlice final : public HashMapSlice
 {
 public:
     HJSlice(
-        SliceStart sliceStart, SliceEnd sliceEnd, const CreateNewHashMapSliceArgs& createNewHashMapSliceArgs, uint64_t numberOfHashMaps);
+        SliceStart sliceStart,
+        SliceEnd sliceEnd,
+        const CreateNewHashMapSliceArgs& createNewHashMapSliceArgs,
+        uint64_t numberOfHashMaps,
+        std::shared_ptr<SpillManager> spillManager = nullptr);
     [[nodiscard]] HashMap* getHashMapPtr(WorkerThreadId workerThreadId, const JoinBuildSideType& buildSide) const;
     [[nodiscard]] HashMap* getHashMapPtrOrCreate(WorkerThreadId workerThreadId, const JoinBuildSideType& buildSide);
     [[nodiscard]] uint64_t getNumberOfHashMapsForSide() const;

--- a/nes-physical-operators/include/Join/NestedLoopJoin/NLJSlice.hpp
+++ b/nes-physical-operators/include/Join/NestedLoopJoin/NLJSlice.hpp
@@ -14,13 +14,19 @@
 
 #pragma once
 
+#include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <vector>
 #include <Identifiers/Identifiers.hpp>
 #include <Interface/PagedVector/PagedVector.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/BufferManager.hpp>
+#include <Runtime/Spill/ArenaMemoryResource.hpp>
+#include <Runtime/Spill/SpillManager.hpp>
 #include <Runtime/TupleBuffer.hpp>
 #include <SliceStore/Slice.hpp>
 
@@ -44,7 +50,9 @@ struct CreateNewNLJSliceArgs final : CreateNewSlicesArguments
 };
 
 /// This class represents a single slice for the NestedLoopJoin. It stores all tuples for the left and right stream.
-class NLJSlice final : public Slice
+/// When state spilling is enabled it is also a SpillableState: all of its PagedVectors allocate from one per-slice
+/// arena-backed BufferManager, so the whole slice (both sides, all workers) is a single spill unit.
+class NLJSlice final : public Slice, public SpillableState
 {
 public:
     NLJSlice(
@@ -53,7 +61,9 @@ public:
         SliceEnd sliceEnd,
         uint64_t numberOfWorkerThreads,
         uint64_t tupleSizeLeft,
-        uint64_t tupleSizeRight);
+        uint64_t tupleSizeRight,
+        std::shared_ptr<SpillManager> spillManager = nullptr);
+    ~NLJSlice() override;
 
     /// Returns the number of tuples in this slice on either side.
     [[nodiscard]] uint64_t getNumberOfTuplesLeft() const;
@@ -67,9 +77,27 @@ public:
     /// Moves all tuples in this slice to the PagedVector at 0th index on both sides.
     void combinePagedVectors();
 
+    /// Returns the per-slice arena-backed BufferManager when spilling is enabled, else nullptr. The build operator uses
+    /// it to route PagedVector page allocations into this slice's arena so the whole slice is a single spill unit.
+    [[nodiscard]] AbstractBufferProvider* getSpillBufferProvider() const;
+
+    /// SpillableState
+    [[nodiscard]] size_t residentBytes() const override;
+    [[nodiscard]] bool isEvicted() const override;
+    void evictState() override;
+    void reloadState() override;
+    [[nodiscard]] uint64_t coldnessKey() const override;
+
 private:
     std::vector<TupleBuffer> leftPagedVectorBuffers;
     std::vector<TupleBuffer> rightPagedVectorBuffers;
     std::mutex combinePagedVectorsMutex;
+
+    /// Per-slice spill arena (only created when spilling is enabled); all PagedVectors are pinned to its BufferManager.
+    std::shared_ptr<SpillManager> spillManager;
+    std::shared_ptr<ArenaMemoryResource> spillArena;
+    std::shared_ptr<BufferManager> spillBufferManager;
+    bool spillEnabled{false};
+    std::atomic<bool> spillEvicted{false};
 };
 }

--- a/nes-physical-operators/include/SliceStore/SliceCache/SliceCache.hpp
+++ b/nes-physical-operators/include/SliceStore/SliceCache/SliceCache.hpp
@@ -71,6 +71,11 @@ public:
     /// Memory layout: [Thread0 entries][Thread1 entries]...[ThreadN entries]
     [[nodiscard]] virtual uint64_t getCacheMemorySize() const;
 
+    /// True if every access is a cache miss (i.e. always routes through the replace/cache-miss proxy). State spilling
+    /// requires this so that the proxy can pin/reload the slice on every access (a cached pointer could otherwise refer
+    /// to an evicted, discarded arena page). Only SliceCacheNone returns true.
+    [[nodiscard]] virtual bool alwaysMisses() const { return false; }
+
     /// Sets the number of worker threads so that per-thread cache memory can be allocated.
     void setNumberOfWorkerThreads(uint64_t numberOfWorkerThreads);
 

--- a/nes-physical-operators/include/SliceStore/SliceCache/SliceCacheNone.hpp
+++ b/nes-physical-operators/include/SliceStore/SliceCache/SliceCacheNone.hpp
@@ -33,6 +33,9 @@ public:
     SliceCacheNone();
     ~SliceCacheNone() override = default;
     [[nodiscard]] std::unique_ptr<SliceCache> clone() const override;
+
+    [[nodiscard]] bool alwaysMisses() const override { return true; }
+
     nautilus::val<SliceCacheEntry::DataStructure> getDataStructureRef(
         const nautilus::val<Timestamp>& timestamp,
         const nautilus::val<WorkerThreadId>& workerThreadId,

--- a/nes-physical-operators/include/WindowBasedOperatorHandler.hpp
+++ b/nes-physical-operators/include/WindowBasedOperatorHandler.hpp
@@ -22,6 +22,7 @@
 #include <Identifiers/Identifiers.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Runtime/QueryTerminationType.hpp>
+#include <Runtime/Spill/SpillManager.hpp>
 #include <Sequencing/SequenceData.hpp>
 #include <SliceStore/Slice.hpp>
 #include <SliceStore/WindowSlicesStoreInterface.hpp>
@@ -84,6 +85,20 @@ public:
     [[nodiscard]] virtual std::function<std::vector<std::shared_ptr<Slice>>(SliceStart, SliceEnd)>
     getCreateNewSlicesFunction(const CreateNewSlicesArguments& newSlicesArguments) const = 0;
 
+    [[nodiscard]] const std::shared_ptr<SpillManager>& getSpillManager() const { return spillManager; }
+
+    /// Called from the build cache-miss proxy on every record access (state spilling requires the no-op slice cache, so
+    /// every access misses). Pins the resolved slice for this worker -- reloading it if it was evicted -- and unpins the
+    /// slice this worker pinned previously, so eviction never targets a slice a worker is currently building into. A
+    /// shared_ptr to the pinned slice is held per worker so it cannot be destroyed while pinned. Triggers a proactive
+    /// spill when the worker moves to a new slice. No-op when spilling is disabled.
+    void pinSliceForBuild(WorkerThreadId workerThreadId, const std::shared_ptr<Slice>& slice);
+
+    /// Returns the slice this worker is currently building into (the one most recently pinned via pinSliceForBuild),
+    /// or nullptr when spilling is disabled / no slice is pinned yet. Used by build operators to route page allocations
+    /// into the slice's own spill arena. The returned pointer is valid while the worker keeps building this slice.
+    [[nodiscard]] Slice* getPinnedBuildSlice(WorkerThreadId workerThreadId) const;
+
 protected:
     /// Gets called if slices should be triggered once a window is ready to be emitted.
     /// Each window operator can be specific about what to do if the given slices are ready to be emitted
@@ -98,5 +113,11 @@ protected:
     uint64_t numberOfWorkerThreads;
     const OriginId outputOriginId;
     const std::vector<OriginId> inputOrigins;
+    /// Process-wide spill governor, obtained from the pipeline execution context in start(). Null when state spilling is
+    /// not configured; when set and enabled, slices created by this handler are registered with it and become spillable.
+    std::shared_ptr<SpillManager> spillManager;
+    /// The slice each worker is currently building into (and has pinned). Sized to the worker count in start(); only
+    /// used when spilling is enabled. Holding the shared_ptr keeps the slice alive (and registered) while pinned.
+    std::vector<std::shared_ptr<Slice>> pinnedBuildSlicePerWorker;
 };
 }

--- a/nes-physical-operators/src/Aggregation/AggregationOperatorHandler.cpp
+++ b/nes-physical-operators/src/Aggregation/AggregationOperatorHandler.cpp
@@ -59,11 +59,20 @@ AggregationOperatorHandler::getCreateNewSlicesFunction(const CreateNewSlicesArgu
     auto newHashMapArgs = dynamic_cast<const CreateNewHashMapSliceArgs&>(newSlicesArguments);
     newHashMapArgs.numberOfBuckets = std::clamp(rollingAverageNumberOfKeys.rlock()->getAverage(), 1UL, maxNumberOfBuckets);
     return std::function(
-        [outputOriginId = outputOriginId, numberOfWorkerThreads = numberOfWorkerThreads, copyOfNewHashMapArgs = newHashMapArgs](
-            SliceStart sliceStart, SliceEnd sliceEnd) -> std::vector<std::shared_ptr<Slice>>
+        [outputOriginId = outputOriginId,
+         numberOfWorkerThreads = numberOfWorkerThreads,
+         copyOfNewHashMapArgs = newHashMapArgs,
+         spillManager = spillManager](SliceStart sliceStart, SliceEnd sliceEnd) -> std::vector<std::shared_ptr<Slice>>
         {
             NES_TRACE("Creating new aggregation slice with for slice {}-{} for output origin {}", sliceStart, sliceEnd, outputOriginId);
-            return {std::make_shared<AggregationSlice>(sliceStart, sliceEnd, copyOfNewHashMapArgs, numberOfWorkerThreads)};
+            auto slice
+                = std::make_shared<AggregationSlice>(sliceStart, sliceEnd, copyOfNewHashMapArgs, numberOfWorkerThreads, spillManager);
+            /// Register the slice with the governor so it can be evicted/reloaded under memory pressure.
+            if (spillManager != nullptr && spillManager->configuration().enabled)
+            {
+                spillManager->registerState(slice);
+            }
+            return {slice};
         });
 }
 
@@ -73,6 +82,21 @@ void AggregationOperatorHandler::triggerSlices(
 {
     for (const auto& [windowInfo, allSlices] : slicesAndWindowInfo)
     {
+        /// This emits a buffer holding raw pointers into these slices' hash maps for the probe operator to read
+        /// asynchronously (later, in another task). Pin them (reloading any that were evicted) and keep them pinned: the
+        /// pin is intentionally not released here, so the governor cannot evict a triggered slice before the probe has
+        /// consumed it. The pin is dropped when the slice is destroyed (post-probe garbage collection unregisters it).
+        if (spillManager != nullptr && spillManager->configuration().enabled)
+        {
+            for (const auto& slice : allSlices)
+            {
+                if (auto* spillable = dynamic_cast<SpillableState*>(slice.get()))
+                {
+                    spillManager->pin(*spillable);
+                }
+            }
+        }
+
         /// Getting all hashmaps for each slice that has at least one tuple
         std::unique_ptr<ChainedHashMap> finalHashMap;
         std::vector<HashMap*> allHashMaps;

--- a/nes-physical-operators/src/Aggregation/AggregationSlice.cpp
+++ b/nes-physical-operators/src/Aggregation/AggregationSlice.cpp
@@ -19,6 +19,7 @@
 #include <Identifiers/Identifiers.hpp>
 #include <Interface/HashMap/ChainedHashMap/ChainedHashMap.hpp>
 #include <Interface/HashMap/HashMap.hpp>
+#include <Runtime/Spill/SpillManager.hpp>
 #include <SliceStore/Slice.hpp>
 #include <ErrorHandling.hpp>
 #include <HashMapSlice.hpp>
@@ -29,8 +30,9 @@ AggregationSlice::AggregationSlice(
     const SliceStart sliceStart,
     const SliceEnd sliceEnd,
     const CreateNewHashMapSliceArgs& createNewHashMapSliceArgs,
-    const uint64_t numberOfHashMaps)
-    : HashMapSlice(sliceStart, sliceEnd, createNewHashMapSliceArgs, numberOfHashMaps, 1)
+    const uint64_t numberOfHashMaps,
+    std::shared_ptr<SpillManager> spillManager)
+    : HashMapSlice(sliceStart, sliceEnd, createNewHashMapSliceArgs, numberOfHashMaps, 1, std::move(spillManager))
 {
 }
 
@@ -48,11 +50,19 @@ HashMap* AggregationSlice::getHashMapPtrOrCreate(const WorkerThreadId workerThre
 
     if (hashMaps.at(pos) == nullptr)
     {
-        hashMaps.at(pos) = std::make_unique<ChainedHashMap>(
+        auto hashMap = std::make_unique<ChainedHashMap>(
             createNewHashMapSliceArgs.keySize,
             createNewHashMapSliceArgs.valueSize,
             createNewHashMapSliceArgs.numberOfBuckets,
             createNewHashMapSliceArgs.pageSize);
+        /// When spilling is enabled, pin this hash map's allocations to the slice's own arena-backed provider so the
+        /// whole slice can be evicted/reloaded as a unit. When disabled, spillProviderOrNull() returns nullptr and the
+        /// hash map keeps using the provider passed at insert time (behaviour unchanged).
+        if (auto* sliceProvider = spillProviderOrNull())
+        {
+            hashMap->setOwnBufferProvider(sliceProvider);
+        }
+        hashMaps.at(pos) = std::move(hashMap);
     }
     return hashMaps[pos].get();
 }

--- a/nes-physical-operators/src/HashMapSlice.cpp
+++ b/nes-physical-operators/src/HashMapSlice.cpp
@@ -14,32 +14,49 @@
 #include <HashMapSlice.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
 #include <numeric>
+#include <string>
 #include <utility>
 #include <vector>
 #include <Identifiers/Identifiers.hpp>
 #include <Interface/HashMap/ChainedHashMap/ChainedHashMap.hpp>
 #include <Interface/HashMap/HashMap.hpp>
+#include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/BufferManager.hpp>
+#include <Runtime/Spill/ArenaMemoryResource.hpp>
 #include <SliceStore/Slice.hpp>
 #include <ErrorHandling.hpp>
 
 namespace NES
 {
 
+namespace
+{
+/// Process-wide counter to give each slice's arena backing file a unique name.
+std::atomic<uint64_t> spillSliceCounter{0};
+/// Small pooled count for the per-slice BufferManager: the hash maps allocate via getUnpooledBuffer (the unpooled path,
+/// which routes through the arena), so the pooled area is essentially unused and is kept tiny.
+constexpr uint32_t SLICE_POOL_BUFFERS = 2;
+}
+
 HashMapSlice::HashMapSlice(
     const SliceStart sliceStart,
     const SliceEnd sliceEnd,
     const CreateNewHashMapSliceArgs& createNewHashMapSliceArgs,
     const uint64_t numberOfHashMaps,
-    const uint64_t numberOfInputStreams)
+    const uint64_t numberOfInputStreams,
+    std::shared_ptr<SpillManager> spillManager)
     : Slice(sliceStart, sliceEnd)
     , createNewHashMapSliceArgs(createNewHashMapSliceArgs)
     , numberOfHashMapsPerInputStream(numberOfHashMaps)
     , numberOfInputStreams(numberOfInputStreams)
+    , spillManager(std::move(spillManager))
+    , spillEnabled(this->spillManager != nullptr && this->spillManager->configuration().enabled)
 {
     for (uint64_t i = 0; i < numberOfHashMaps * numberOfInputStreams; i++)
     {
@@ -50,6 +67,19 @@ HashMapSlice::HashMapSlice(
 HashMapSlice::~HashMapSlice()
 {
     INVARIANT(createNewHashMapSliceArgs.nautilusCleanup.size() == numberOfInputStreams, "We expect one cleanup function per input ");
+
+    /// Stop the governor from tracking this slice before we touch its state.
+    if (spillManager != nullptr)
+    {
+        spillManager->unregisterState(this);
+    }
+    /// The nautilus cleanup below dereferences the hash maps' entries, which live in the arena. If the slice is
+    /// currently evicted, reload it first so cleanup reads valid memory rather than discarded (zero-fill) pages.
+    if (spillEvicted.load() && spillArena != nullptr)
+    {
+        spillArena->reload();
+        spillEvicted.store(false);
+    }
 
     /// As we assume that each hashmap of an input stream lie one after the other.
     /// Thus, we need to call #numbnumberOfHashMaps times the same nautilusCleanup function and then move to the next one.
@@ -63,6 +93,61 @@ HashMapSlice::~HashMapSlice()
     }
 
     hashMaps.clear();
+}
+
+AbstractBufferProvider* HashMapSlice::spillProviderOrNull()
+{
+    if (!spillEnabled)
+    {
+        return nullptr;
+    }
+    const std::lock_guard guard(spillMutex);
+    if (spillArena == nullptr)
+    {
+        const auto& config = spillManager->configuration();
+        const auto backingFile = config.spillDirectory + "/nes-slice-" + std::to_string(spillSliceCounter.fetch_add(1)) + ".spill";
+        spillArena = std::make_shared<ArenaMemoryResource>(config.arenaMode, backingFile);
+        spillBufferManager
+            = BufferManager::create(static_cast<uint32_t>(createNewHashMapSliceArgs.pageSize), SLICE_POOL_BUFFERS, spillArena);
+    }
+    return spillBufferManager.get();
+}
+
+size_t HashMapSlice::residentBytes() const
+{
+    if (spillEvicted.load() || spillArena == nullptr)
+    {
+        return 0;
+    }
+    return spillArena->liveBytes();
+}
+
+bool HashMapSlice::isEvicted() const
+{
+    return spillEvicted.load();
+}
+
+void HashMapSlice::evictState()
+{
+    if (spillArena != nullptr && !spillEvicted.load())
+    {
+        spillArena->evict();
+        spillEvicted.store(true);
+    }
+}
+
+void HashMapSlice::reloadState()
+{
+    if (spillArena != nullptr && spillEvicted.load())
+    {
+        spillArena->reload();
+        spillEvicted.store(false);
+    }
+}
+
+uint64_t HashMapSlice::coldnessKey() const
+{
+    return sliceEnd.getRawValue();
 }
 
 uint64_t HashMapSlice::getNumberOfHashMaps() const

--- a/nes-physical-operators/src/Join/HashJoin/HJOperatorHandler.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJOperatorHandler.cpp
@@ -105,11 +105,18 @@ HJOperatorHandler::getCreateNewSlicesFunction(const CreateNewSlicesArguments& ne
     }
 
     return std::function(
-        [outputOriginId = outputOriginId, numberOfWorkerThreads = numberOfWorkerThreads, copyOfNewHashMapArgs = newHashMapArgs](
-            SliceStart sliceStart, SliceEnd sliceEnd) -> std::vector<std::shared_ptr<Slice>>
+        [outputOriginId = outputOriginId,
+         numberOfWorkerThreads = numberOfWorkerThreads,
+         copyOfNewHashMapArgs = newHashMapArgs,
+         spillManager = spillManager](SliceStart sliceStart, SliceEnd sliceEnd) -> std::vector<std::shared_ptr<Slice>>
         {
             NES_TRACE("Creating new hash-join slice for slice {}-{} for output origin {}", sliceStart, sliceEnd, outputOriginId);
-            return {std::make_shared<HJSlice>(sliceStart, sliceEnd, copyOfNewHashMapArgs, numberOfWorkerThreads)};
+            auto slice = std::make_shared<HJSlice>(sliceStart, sliceEnd, copyOfNewHashMapArgs, numberOfWorkerThreads, spillManager);
+            if (spillManager != nullptr && spillManager->configuration().enabled)
+            {
+                spillManager->registerState(slice);
+            }
+            return {slice};
         });
 }
 

--- a/nes-physical-operators/src/Join/HashJoin/HJSlice.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJSlice.cpp
@@ -21,6 +21,8 @@
 #include <Interface/HashMap/ChainedHashMap/ChainedHashMap.hpp>
 #include <Interface/HashMap/HashMap.hpp>
 #include <Join/StreamJoinUtil.hpp>
+#include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/Spill/SpillManager.hpp>
 #include <SliceStore/Slice.hpp>
 #include <ErrorHandling.hpp>
 #include <HashMapSlice.hpp>
@@ -28,8 +30,12 @@
 namespace NES
 {
 HJSlice::HJSlice(
-    SliceStart sliceStart, SliceEnd sliceEnd, const CreateNewHashMapSliceArgs& createNewHashMapSliceArgs, const uint64_t numberOfHashMaps)
-    : HashMapSlice(std::move(sliceStart), std::move(sliceEnd), createNewHashMapSliceArgs, numberOfHashMaps, 2)
+    SliceStart sliceStart,
+    SliceEnd sliceEnd,
+    const CreateNewHashMapSliceArgs& createNewHashMapSliceArgs,
+    const uint64_t numberOfHashMaps,
+    std::shared_ptr<SpillManager> spillManager)
+    : HashMapSlice(std::move(sliceStart), std::move(sliceEnd), createNewHashMapSliceArgs, numberOfHashMaps, 2, std::move(spillManager))
 {
 }
 
@@ -64,11 +70,18 @@ HashMap* HJSlice::getHashMapPtrOrCreate(const WorkerThreadId workerThreadId, con
     if (hashMaps.at(pos) == nullptr)
     {
         /// Hashmap at pos has not been initialized
-        hashMaps.at(pos) = std::make_unique<ChainedHashMap>(
+        auto hashMap = std::make_unique<ChainedHashMap>(
             createNewHashMapSliceArgs.keySize,
             createNewHashMapSliceArgs.valueSize,
             createNewHashMapSliceArgs.numberOfBuckets,
             createNewHashMapSliceArgs.pageSize);
+        /// Route this hash map's pages through the slice's arena when spilling is enabled, so the whole slice (both
+        /// build sides) is one spill unit. No-op (nullptr) when spilling is disabled -> behaviour unchanged.
+        if (auto* sliceProvider = spillProviderOrNull())
+        {
+            hashMap->setOwnBufferProvider(sliceProvider);
+        }
+        hashMaps.at(pos) = std::move(hashMap);
     }
     return hashMaps.at(pos).get();
 }

--- a/nes-physical-operators/src/Join/NestedLoopJoin/NLJBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/NestedLoopJoin/NLJBuildPhysicalOperator.cpp
@@ -15,6 +15,7 @@
 
 #include <memory>
 #include <utility>
+#include <Identifiers/Identifiers.hpp>
 #include <Interface/BufferRef/TupleBufferRef.hpp>
 #include <Interface/NautilusBuffer.hpp>
 #include <Interface/PagedVector/PagedVectorRef.hpp>
@@ -23,13 +24,17 @@
 #include <Join/NestedLoopJoin/NLJSlice.hpp>
 #include <Join/StreamJoinBuildPhysicalOperator.hpp>
 #include <Join/StreamJoinUtil.hpp>
+#include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <SliceStore/Slice.hpp>
 #include <Time/Timestamp.hpp>
 #include <Watermark/TimeFunction.hpp>
 #include <ErrorHandling.hpp>
 #include <ExecutionContext.hpp>
+#include <WindowBasedOperatorHandler.hpp>
 #include <WindowBuildPhysicalOperator.hpp>
+#include <function.hpp>
+#include <val_ptr.hpp>
 
 namespace NES
 {
@@ -43,6 +48,28 @@ SliceEnd getNLJSliceEndProxy(const NLJSlice* nljSlice)
 {
     PRECONDITION(nljSlice != nullptr, "nlj slice pointer should not be null!");
     return nljSlice->getSliceEnd();
+}
+
+/// Returns the provider that PagedVector page allocations should go through for the slice this worker is currently
+/// building into. When state spilling is enabled the slice owns an arena-backed BufferManager, and routing pages
+/// through it keeps the whole slice (main buffers + pages) in a single spill unit. When spilling is disabled (or the
+/// slice is not yet pinned), the pipeline's buffer provider is used instead, so behaviour is unchanged.
+AbstractBufferProvider*
+getNLJBuildBufferProviderProxy(OperatorHandler* ptrOpHandler, const WorkerThreadId workerThreadId, AbstractBufferProvider* fallbackProvider)
+{
+    PRECONDITION(ptrOpHandler != nullptr, "op handler context should not be null");
+    PRECONDITION(fallbackProvider != nullptr, "fallback buffer provider should not be null");
+    if (const auto* windowHandler = dynamic_cast<WindowBasedOperatorHandler*>(ptrOpHandler))
+    {
+        if (auto* slice = dynamic_cast<NLJSlice*>(windowHandler->getPinnedBuildSlice(workerThreadId)))
+        {
+            if (auto* spillProvider = slice->getSpillBufferProvider())
+            {
+                return spillProvider;
+            }
+        }
+    }
+    return fallbackProvider;
 }
 
 NLJBuildPhysicalOperator::NLJBuildPhysicalOperator(
@@ -66,8 +93,16 @@ void NLJBuildPhysicalOperator::execute(ExecutionContext& executionCtx, Record& r
     const auto timestamp = timeFunction->getTs(executionCtx, record);
     auto nljPagedVectorMemRef = sliceStoreRef->getDataStructureRef(
         timestamp, executionCtx.workerThreadId, operatorHandler, executionCtx.pipelineMemoryProvider.bufferProvider);
+
+    /// Determine which provider PagedVector pages are allocated from. With state spilling enabled, getDataStructureRef
+    /// has just pinned this worker's build slice, so we route page allocations through that slice's own arena-backed
+    /// provider (keeping the whole slice as a single spill unit). With spilling disabled the proxy returns the pipeline
+    /// provider, leaving behaviour unchanged.
+    const nautilus::val<AbstractBufferProvider*> pageProvider = nautilus::invoke(
+        getNLJBuildBufferProviderProxy, operatorHandler, executionCtx.workerThreadId, executionCtx.pipelineMemoryProvider.bufferProvider);
+
     /// Write record to the pagedVector
     PagedVectorRef pagedVectorRef{BorrowedNautilusBuffer::from(nljPagedVectorMemRef), tupleLayout};
-    pagedVectorRef.pushBack(record, executionCtx.pipelineMemoryProvider.bufferProvider);
+    pagedVectorRef.pushBack(record, pageProvider);
 }
 }

--- a/nes-physical-operators/src/Join/NestedLoopJoin/NLJOperatorHandler.cpp
+++ b/nes-physical-operators/src/Join/NestedLoopJoin/NLJOperatorHandler.cpp
@@ -55,8 +55,17 @@ NLJOperatorHandler::getCreateNewSlicesFunction(const CreateNewSlicesArguments& a
         [numberOfWorkerThreads = numberOfWorkerThreads,
          bufferProvider = nljArgs.bufferProvider,
          tupleSizeLeft = nljArgs.tupleSizeLeft,
-         tupleSizeRight = nljArgs.tupleSizeRight](SliceStart start, SliceEnd end) -> std::vector<std::shared_ptr<Slice>>
-        { return {std::make_shared<NLJSlice>(*bufferProvider, start, end, numberOfWorkerThreads, tupleSizeLeft, tupleSizeRight)}; });
+         tupleSizeRight = nljArgs.tupleSizeRight,
+         spillManager = spillManager](SliceStart start, SliceEnd end) -> std::vector<std::shared_ptr<Slice>>
+        {
+            auto slice = std::make_shared<NLJSlice>(
+                *bufferProvider, start, end, numberOfWorkerThreads, tupleSizeLeft, tupleSizeRight, spillManager);
+            if (spillManager != nullptr && spillManager->configuration().enabled)
+            {
+                spillManager->registerState(slice);
+            }
+            return {slice};
+        });
 }
 
 void NLJOperatorHandler::emitSlicesToProbe(

--- a/nes-physical-operators/src/Join/NestedLoopJoin/NLJSlice.cpp
+++ b/nes-physical-operators/src/Join/NestedLoopJoin/NLJSlice.cpp
@@ -14,20 +14,36 @@
 
 #include <Join/NestedLoopJoin/NLJSlice.hpp>
 
+#include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <mutex>
 #include <numeric>
+#include <string>
 #include <utility>
 #include <Identifiers/Identifiers.hpp>
 #include <Interface/PagedVector/PagedVector.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/BufferManager.hpp>
+#include <Runtime/Spill/ArenaMemoryResource.hpp>
+#include <Runtime/Spill/SpillManager.hpp>
 #include <SliceStore/Slice.hpp>
 #include <ErrorHandling.hpp>
 
 namespace NES
 {
+
+namespace
+{
+std::atomic<uint64_t> nljSpillSliceCounter{0};
+/// The per-slice BufferManager's pooled area is unused (PagedVector main buffers and pages are allocated via
+/// getUnpooledBuffer, which routes through the arena), so it is kept tiny; this page size only sizes that unused
+/// pooled area.
+constexpr uint32_t NLJ_SLICE_POOL_PAGE_SIZE = 4096;
+constexpr uint32_t NLJ_SLICE_POOL_BUFFERS = 2;
+}
 
 NLJSlice::NLJSlice(
     AbstractBufferProvider& bufferProvider,
@@ -35,14 +51,29 @@ NLJSlice::NLJSlice(
     const SliceEnd sliceEnd,
     const uint64_t numberOfWorkerThreads,
     const uint64_t tupleSizeLeft,
-    const uint64_t tupleSizeRight)
+    const uint64_t tupleSizeRight,
+    std::shared_ptr<SpillManager> spillManager)
     : Slice(sliceStart, sliceEnd)
+    , spillManager(std::move(spillManager))
+    , spillEnabled(this->spillManager != nullptr && this->spillManager->configuration().enabled)
 {
+    /// When spilling is enabled, create the slice's arena up front and allocate ALL the PagedVector main buffers (and,
+    /// via the build operator routing getSpillBufferProvider() into pushBack, all pages) from the per-slice
+    /// arena-backed BufferManager. This makes the whole slice (both sides, all workers) a single spill unit.
+    if (spillEnabled)
+    {
+        const auto& config = this->spillManager->configuration();
+        const auto backingFile = config.spillDirectory + "/nes-nljslice-" + std::to_string(nljSpillSliceCounter.fetch_add(1)) + ".spill";
+        spillArena = std::make_shared<ArenaMemoryResource>(config.arenaMode, backingFile);
+        spillBufferManager = BufferManager::create(NLJ_SLICE_POOL_PAGE_SIZE, NLJ_SLICE_POOL_BUFFERS, spillArena);
+    }
+    AbstractBufferProvider& effectiveProvider = spillEnabled ? *spillBufferManager : bufferProvider;
+
     const uint64_t pvMainBufferSize = PagedVector::getMainBufferSize();
-    const uint64_t pvPageBufferSize = bufferProvider.getBufferSize();
+    const uint64_t pvPageBufferSize = effectiveProvider.getBufferSize();
     for (uint64_t i = 0; i < numberOfWorkerThreads; ++i)
     {
-        if (auto pagedVectorBuffer = bufferProvider.getUnpooledBuffer(pvMainBufferSize))
+        if (auto pagedVectorBuffer = effectiveProvider.getUnpooledBuffer(pvMainBufferSize))
         {
             /// initialize the paged vector tuple buffer
             PagedVector::init(pagedVectorBuffer.value(), pvPageBufferSize, tupleSizeLeft);
@@ -56,7 +87,7 @@ NLJSlice::NLJSlice(
 
     for (uint64_t i = 0; i < numberOfWorkerThreads; ++i)
     {
-        if (auto pagedVectorBuffer = bufferProvider.getUnpooledBuffer(pvMainBufferSize))
+        if (auto pagedVectorBuffer = effectiveProvider.getUnpooledBuffer(pvMainBufferSize))
         {
             /// initialize the paged vector tuple buffer
             PagedVector::init(pagedVectorBuffer.value(), pvPageBufferSize, tupleSizeRight);
@@ -67,6 +98,58 @@ NLJSlice::NLJSlice(
             throw BufferAllocationFailure("No unpooled TupleBuffer available for NLJ right paged vector main buffer");
         }
     }
+}
+
+NLJSlice::~NLJSlice()
+{
+    if (spillManager != nullptr)
+    {
+        spillManager->unregisterState(this);
+    }
+    /// Releasing the PagedVectors' TupleBuffers touches buffer control blocks that live in the arena; reload first so
+    /// that memory is valid rather than discarded (zero-fill) pages.
+    if (spillEvicted.load() && spillArena != nullptr)
+    {
+        spillArena->reload();
+        spillEvicted.store(false);
+    }
+}
+
+size_t NLJSlice::residentBytes() const
+{
+    if (spillEvicted.load() || spillArena == nullptr)
+    {
+        return 0;
+    }
+    return spillArena->liveBytes();
+}
+
+bool NLJSlice::isEvicted() const
+{
+    return spillEvicted.load();
+}
+
+void NLJSlice::evictState()
+{
+    if (spillArena != nullptr && !spillEvicted.load())
+    {
+        spillArena->evict();
+        spillEvicted.store(true);
+    }
+}
+
+void NLJSlice::reloadState()
+{
+    if (spillArena != nullptr && spillEvicted.load())
+    {
+        spillArena->reload();
+        spillEvicted.store(false);
+    }
+}
+
+uint64_t NLJSlice::coldnessKey() const
+{
+    return sliceEnd.getRawValue();
 }
 
 uint64_t NLJSlice::getNumberOfTuplesLeft() const
@@ -150,5 +233,10 @@ void NLJSlice::combinePagedVectors()
         }
         rightPagedVectorBuffers.erase(rightPagedVectorBuffers.begin() + 1, rightPagedVectorBuffers.end());
     }
+}
+
+AbstractBufferProvider* NLJSlice::getSpillBufferProvider() const
+{
+    return spillEnabled ? spillBufferManager.get() : nullptr;
 }
 }

--- a/nes-physical-operators/src/Join/StreamJoinOperatorHandler.cpp
+++ b/nes-physical-operators/src/Join/StreamJoinOperatorHandler.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 #include <Identifiers/Identifiers.hpp>
 #include <Join/StreamJoinUtil.hpp>
+#include <Runtime/Spill/SpillManager.hpp>
 #include <Sequencing/SequenceData.hpp>
 #include <SliceStore/Slice.hpp>
 #include <SliceStore/WindowSlicesStoreInterface.hpp>
@@ -53,6 +54,20 @@ void StreamJoinOperatorHandler::triggerSlices(
 
     for (const auto& [windowInfo, allSlices] : slicesAndWindowInfo)
     {
+        /// The probe operator reads raw pointers into these slices' state asynchronously. Pin them (reloading any
+        /// evicted) and keep them pinned so the governor cannot evict a triggered slice before the probe consumes it;
+        /// the pin is released when the slice is garbage-collected.
+        if (spillManager != nullptr && spillManager->configuration().enabled)
+        {
+            for (const auto& slice : allSlices)
+            {
+                if (auto* spillable = dynamic_cast<SpillableState*>(slice.get()))
+                {
+                    spillManager->pin(*spillable);
+                }
+            }
+        }
+
         std::visit([&](const auto& strategy) { strategy.triggerWindow(allSlices, windowInfo, emitFn, pipelineCtx); }, triggerStrategy);
     }
 }

--- a/nes-physical-operators/src/SliceStore/DefaultTimeBasedSliceStoreRef.cpp
+++ b/nes-physical-operators/src/SliceStore/DefaultTimeBasedSliceStoreRef.cpp
@@ -21,6 +21,7 @@
 #include <Interface/TimestampRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
+#include <Runtime/Spill/SpillManager.hpp>
 #include <SliceStore/DefaultTimeBasedSliceStore.hpp>
 #include <SliceStore/SliceCache/SliceCache.hpp>
 #include <SliceStore/SliceStoreRef.hpp>
@@ -60,6 +61,10 @@ void defaultTimeBasedSliceStoreRefCacheMissProxy(
     /// Look up or create the slice in the slice store
     const auto slices = sliceStore->getSlicesOrCreate(timestamp, createFunction);
     INVARIANT(slices.size() == 1, "Expected exactly one slice for the given timestamp, but got {}", slices.size());
+
+    /// Pin (and reload if evicted) the resolved slice for this worker before handing out a pointer into its state, so a
+    /// concurrent eviction cannot discard the arena pages we are about to access. No-op when spilling is disabled.
+    windowHandler->pinSliceForBuild(workerThreadId, slices[0]);
 
     /// Use the data structure extractor to get the operator-specific data structure, then store its pointer for usage in nautilus
     entryToReplace->sliceStart = slices[0]->getSliceStart().getRawValue();
@@ -121,6 +126,16 @@ void setupSliceStoreProxy(
 {
     PRECONDITION(sliceStore != nullptr, "The slice store not be null");
     PRECONDITION(pipelineCtx->getBufferManager() != nullptr, "bufferProvider should not be null!");
+
+    /// State spilling relies on every slice access going through the cache-miss proxy (so the proxy can pin/reload the
+    /// slice). A caching slice cache would serve a hit with a raw pointer into a possibly-evicted arena -> corruption.
+    /// Therefore spilling requires the no-op slice cache (enable_slice_cache=false).
+    if (const auto& spillManager = pipelineCtx->getSpillManager(); spillManager != nullptr && spillManager->configuration().enabled)
+    {
+        PRECONDITION(
+            self->sliceCache->alwaysMisses(),
+            "State spilling (enable_state_spilling=true) requires the slice cache to be disabled (enable_slice_cache=false)");
+    }
 
     /// Creating new space for the slice cache of this pipeline
     /// The order is important. First, we need to set the number of worker threads, as the slice cache depends on it.

--- a/nes-physical-operators/src/WindowBasedOperatorHandler.cpp
+++ b/nes-physical-operators/src/WindowBasedOperatorHandler.cpp
@@ -21,6 +21,8 @@
 #include <Identifiers/Identifiers.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Runtime/QueryTerminationType.hpp>
+#include <Runtime/Spill/SpillManager.hpp>
+#include <SliceStore/Slice.hpp>
 #include <SliceStore/WindowSlicesStoreInterface.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <Watermark/MultiOriginWatermarkProcessor.hpp>
@@ -45,10 +47,70 @@ WindowBasedOperatorHandler::WindowBasedOperatorHandler(
 void WindowBasedOperatorHandler::start(PipelineExecutionContext& pipelineExecutionContext, uint32_t)
 {
     numberOfWorkerThreads = pipelineExecutionContext.getNumberOfWorkerThreads();
+    spillManager = pipelineExecutionContext.getSpillManager();
+    if (spillManager != nullptr && spillManager->configuration().enabled)
+    {
+        pinnedBuildSlicePerWorker.assign(numberOfWorkerThreads, nullptr);
+    }
 }
 
 void WindowBasedOperatorHandler::stop(QueryTerminationType, PipelineExecutionContext&)
 {
+    /// Release any slices still pinned by the build path so they can be evicted/destroyed.
+    if (spillManager != nullptr)
+    {
+        for (auto& pinned : pinnedBuildSlicePerWorker)
+        {
+            if (pinned != nullptr)
+            {
+                if (auto* spillable = dynamic_cast<SpillableState*>(pinned.get()))
+                {
+                    spillManager->unpin(*spillable);
+                }
+                pinned = nullptr;
+            }
+        }
+    }
+}
+
+void WindowBasedOperatorHandler::pinSliceForBuild(const WorkerThreadId workerThreadId, const std::shared_ptr<Slice>& slice)
+{
+    if (spillManager == nullptr || !spillManager->configuration().enabled || pinnedBuildSlicePerWorker.empty())
+    {
+        return;
+    }
+    auto* spillable = dynamic_cast<SpillableState*>(slice.get());
+    if (spillable == nullptr)
+    {
+        return;
+    }
+    auto& pinned = pinnedBuildSlicePerWorker[workerThreadId % pinnedBuildSlicePerWorker.size()];
+    if (pinned.get() == slice.get())
+    {
+        /// Same slice as the previous access: already pinned, nothing to do.
+        return;
+    }
+    /// Moving to a different slice: unpin the previous one, pin (and reload if evicted) the new one.
+    if (pinned != nullptr)
+    {
+        if (auto* previous = dynamic_cast<SpillableState*>(pinned.get()))
+        {
+            spillManager->unpin(*previous);
+        }
+    }
+    spillManager->pin(*spillable);
+    pinned = slice;
+    /// State grew (a new slice is in use): give the governor a chance to evict cold, unpinned slices.
+    spillManager->maybeSpill();
+}
+
+Slice* WindowBasedOperatorHandler::getPinnedBuildSlice(const WorkerThreadId workerThreadId) const
+{
+    if (pinnedBuildSlicePerWorker.empty())
+    {
+        return nullptr;
+    }
+    return pinnedBuildSlicePerWorker[workerThreadId % pinnedBuildSlicePerWorker.size()].get();
 }
 
 WindowSlicesStoreInterface& WindowBasedOperatorHandler::getSliceAndWindowStore() const

--- a/nes-query-engine/QueryEngine.cpp
+++ b/nes-query-engine/QueryEngine.cpp
@@ -206,6 +206,7 @@ struct DefaultPEC final : PipelineExecutionContext
     std::function<bool(const TupleBuffer& tb, ContinuationPolicy)> handler;
     std::function<void(const TupleBuffer& tb, std::chrono::milliseconds duration)> repeatHandler;
     std::shared_ptr<AbstractBufferProvider> bm;
+    std::shared_ptr<SpillManager> spillManager;
     size_t numberOfThreads;
     WorkerThreadId threadId;
     PipelineId pipelineId;
@@ -222,11 +223,13 @@ struct DefaultPEC final : PipelineExecutionContext
         WorkerThreadId threadId,
         PipelineId pipelineId,
         std::shared_ptr<AbstractBufferProvider> bm,
+        std::shared_ptr<SpillManager> spillManager,
         std::function<bool(const TupleBuffer& tb, ContinuationPolicy)> handler,
         std::function<void(const TupleBuffer& tb, std::chrono::milliseconds)> repeatHandler)
         : handler(std::move(handler))
         , repeatHandler(std::move(repeatHandler))
         , bm(std::move(bm))
+        , spillManager(std::move(spillManager))
         , numberOfThreads(numberOfThreads)
         , threadId(threadId)
         , pipelineId(pipelineId)
@@ -272,6 +275,12 @@ struct DefaultPEC final : PipelineExecutionContext
 #endif
 
         repeatHandler(buffer, duration);
+    }
+
+    [[nodiscard]] std::shared_ptr<SpillManager> getSpillManager() const override
+    {
+        PRECONDITION(!wasRepeated, "A task should terminate after repeating");
+        return spillManager;
     }
 
     [[nodiscard]] std::shared_ptr<AbstractBufferProvider> getBufferManager() const override
@@ -409,10 +418,12 @@ public:
         std::shared_ptr<AbstractQueryStatusListener> listener,
         std::shared_ptr<QueryEngineStatisticListener> stats,
         std::shared_ptr<AbstractBufferProvider> bufferProvider,
+        std::shared_ptr<SpillManager> spillManager,
         const size_t admissionQueueSize)
         : listener(std::move(listener))
         , statistic(std::move(stats))
         , bufferProvider(std::move(bufferProvider))
+        , spillManager(std::move(spillManager))
         , taskQueue(admissionQueueSize)
         , delayedTaskSubmitter([this](Task&& task) noexcept { taskQueue.addInternalTaskNonBlocking(std::move(task)); })
     {
@@ -458,6 +469,7 @@ private:
     std::shared_ptr<AbstractQueryStatusListener> listener;
     std::shared_ptr<QueryEngineStatisticListener> statistic;
     std::shared_ptr<AbstractBufferProvider> bufferProvider;
+    std::shared_ptr<SpillManager> spillManager;
     std::atomic<TaskId::Underlying> taskIdCounter;
 
     TaskQueue<Task> taskQueue;
@@ -493,6 +505,7 @@ bool ThreadPool::WorkerThread::operator()(WorkTask& task) const
             WorkerThread::id,
             pipeline->id,
             pool.bufferProvider,
+            pool.spillManager,
             [&](const TupleBuffer& tupleBuffer, PipelineExecutionContext::ContinuationPolicy continuationPolicy)
             {
                 ENGINE_LOG_DEBUG(
@@ -550,6 +563,7 @@ bool ThreadPool::WorkerThread::operator()(StartPipelineTask& startPipeline) cons
             WorkerThread::id,
             pipeline->id,
             pool.bufferProvider,
+            pool.spillManager,
             [](const TupleBuffer&, PipelineExecutionContext::ContinuationPolicy)
             {
                 /// Catch Emits, that are currently not supported during pipeline stage initialization.
@@ -628,6 +642,7 @@ bool ThreadPool::WorkerThread::operator()(StopPipelineTask& stopPipelineTask) co
         WorkerThread::id,
         stopPipelineTask.pipeline->id,
         pool.bufferProvider,
+        pool.spillManager,
         [&](const TupleBuffer& tupleBuffer, PipelineExecutionContext::ContinuationPolicy policy)
         {
             if (terminating)
@@ -771,12 +786,15 @@ QueryEngine::QueryEngine(
     std::shared_ptr<QueryEngineStatisticListener> statListener,
     std::shared_ptr<AbstractQueryStatusListener> listener,
     std::shared_ptr<BufferManager> bm,
+    std::shared_ptr<SpillManager> spillManager,
     const Host& host)
     : bufferManager(std::move(bm))
+    , spillManager(std::move(spillManager))
     , statusListener(std::move(listener))
     , statisticListener(std::move(statListener))
     , queryCatalog(std::make_shared<QueryCatalog>())
-    , threadPool(std::make_unique<ThreadPool>(statusListener, statisticListener, bufferManager, config.admissionQueueSize.getValue()))
+    , threadPool(std::make_unique<ThreadPool>(
+          statusListener, statisticListener, bufferManager, this->spillManager, config.admissionQueueSize.getValue()))
     , host(host)
 {
     for (size_t i = 0; i < config.numberOfWorkerThreads.getValue(); ++i)

--- a/nes-query-engine/include/QueryEngine.hpp
+++ b/nes-query-engine/include/QueryEngine.hpp
@@ -17,6 +17,7 @@
 #include <Identifiers/Identifiers.hpp>
 #include <Listeners/AbstractQueryStatusListener.hpp>
 #include <Runtime/BufferManager.hpp>
+#include <Runtime/Spill/SpillManager.hpp>
 #include <ExecutableQueryPlan.hpp>
 #include <QueryEngineConfiguration.hpp>
 #include <QueryEngineStatisticListener.hpp>
@@ -36,6 +37,7 @@ public:
         std::shared_ptr<QueryEngineStatisticListener> statListener,
         std::shared_ptr<AbstractQueryStatusListener> listener,
         std::shared_ptr<BufferManager> bm,
+        std::shared_ptr<SpillManager> spillManager,
         const Host& host);
     void stop(QueryId queryId);
     void start(std::unique_ptr<ExecutableQueryPlan> executableQueryPlan);
@@ -48,6 +50,7 @@ public:
     /// left over running queries. Dropping a RunningQueryPlan has to invoke a HardStop which must not emit
     /// further work into the TaskQueue.
     std::shared_ptr<BufferManager> bufferManager;
+    std::shared_ptr<SpillManager> spillManager;
     std::shared_ptr<AbstractQueryStatusListener> statusListener;
     std::shared_ptr<QueryEngineStatisticListener> statisticListener;
     std::shared_ptr<QueryCatalog> queryCatalog;

--- a/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.cpp
+++ b/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.cpp
@@ -372,7 +372,8 @@ void TestingHarness::start()
     }
     QueryEngineConfiguration configuration{};
     configuration.numberOfWorkerThreads.setValue(numberOfThreads);
-    qm = std::make_unique<QueryEngine>(configuration, this->statListener, this->status, this->bm, Host("test"));
+    auto spillManager = std::make_shared<SpillManager>(SpillConfiguration{});
+    qm = std::make_unique<QueryEngine>(configuration, this->statListener, this->status, this->bm, spillManager, Host("test"));
 }
 
 void TestingHarness::startQuery(std::unique_ptr<ExecutableQueryPlan> query) const

--- a/nes-runtime/interface/Configuration/WorkerConfiguration.hpp
+++ b/nes-runtime/interface/Configuration/WorkerConfiguration.hpp
@@ -57,6 +57,21 @@ public:
            "SourceDescriptor).",
            {std::make_shared<NumberValidation>()}};
 
+    /// Enables disk-backed spilling of stateful operator (window/aggregation) slices when memory pressure is high, so
+    /// queries can run with state larger than RAM. Off by default.
+    BoolOption enableStateSpilling = {"enable_state_spilling", "false", "Enable disk-backed spilling of operator state."};
+
+    /// Target ceiling (in bytes) for total resident operator-state across all slices before the governor starts
+    /// evicting the coldest slices to disk. 0 means no proactive eviction (only relevant when spilling is enabled).
+    UIntOption stateMemoryBudgetInBytes
+        = {"state_memory_budget_in_bytes",
+           "0",
+           "Resident operator-state budget in bytes that triggers spilling (0 = unbounded).",
+           {std::make_shared<NumberValidation>()}};
+
+    /// Directory under which per-slice spill (arena backing) files are created.
+    StringOption spillDirectory = {"spill_directory", "/tmp", "Directory for operator-state spill files."};
+
     EnumOption<DumpMode::Options> dumpQueryCompilationIR
         = {"dump_compilation_result",
            DumpMode::Options::NONE,
@@ -74,6 +89,9 @@ private:
             &network,
             &numberOfBuffersInGlobalBufferManager,
             &defaultMaxInflightBuffers,
+            &enableStateSpilling,
+            &stateMemoryBudgetInBytes,
+            &spillDirectory,
             &dumpQueryCompilationIR,
             &dumpGraph};
     }

--- a/nes-runtime/src/Runtime/NodeEngineBuilder.cpp
+++ b/nes-runtime/src/Runtime/NodeEngineBuilder.cpp
@@ -21,6 +21,7 @@
 #include <Listeners/QueryLog.hpp>
 #include <Runtime/BufferManager.hpp>
 #include <Runtime/NodeEngine.hpp>
+#include <Runtime/Spill/SpillManager.hpp>
 #include <Sources/SourceProvider.hpp>
 #include <QueryEngine.hpp>
 
@@ -40,7 +41,14 @@ std::unique_ptr<NodeEngine> NodeEngineBuilder::build(const Host& host)
         workerConfiguration.numberOfBuffersInGlobalBufferManager.getValue());
     auto queryLog = std::make_shared<QueryLog>();
 
-    auto queryEngine = std::make_unique<QueryEngine>(workerConfiguration.queryEngine, statisticsListener, queryLog, bufferManager, host);
+    SpillConfiguration spillConfiguration;
+    spillConfiguration.enabled = workerConfiguration.enableStateSpilling.getValue();
+    spillConfiguration.stateMemoryBudgetBytes = workerConfiguration.stateMemoryBudgetInBytes.getValue();
+    spillConfiguration.spillDirectory = workerConfiguration.spillDirectory.getValue();
+    auto spillManager = std::make_shared<SpillManager>(spillConfiguration);
+
+    auto queryEngine
+        = std::make_unique<QueryEngine>(workerConfiguration.queryEngine, statisticsListener, queryLog, bufferManager, spillManager, host);
 
     auto sourceProvider = std::make_unique<SourceProvider>(workerConfiguration.defaultMaxInflightBuffers.getValue(), bufferManager);
 

--- a/nes-systests/configs/spill-enabled-nlj.yaml
+++ b/nes-systests/configs/spill-enabled-nlj.yaml
@@ -1,0 +1,9 @@
+# Same as spill-enabled.yaml but forces the nested-loop join strategy, to exercise NLJSlice/PagedVector spilling.
+enable_state_spilling: true
+state_memory_budget_in_bytes: 16384
+spill_directory: /tmp
+default_query_execution:
+  slice_cache:
+    enable_slice_cache: false
+default_query_optimization:
+  join_strategy: NESTED_LOOP_JOIN

--- a/nes-systests/configs/spill-enabled.yaml
+++ b/nes-systests/configs/spill-enabled.yaml
@@ -1,0 +1,8 @@
+# Worker config that turns on disk-backed state spilling with a deliberately tiny memory budget, so the governor
+# evicts/reloads slices during the query. State spilling requires the slice cache to be disabled.
+enable_state_spilling: true
+state_memory_budget_in_bytes: 16384
+spill_directory: /tmp
+default_query_execution:
+  slice_cache:
+    enable_slice_cache: false


### PR DESCRIPTION
## Problem

Stateful streaming operators (windowed aggregation, hash join, nested-loop join) accumulate slice state in memory. With enough keys/windows this state exceeds RAM, and there is no way to run such queries. This PR lets the engine spill cold operator state to disk and reload it on access, so queries can run with state larger than a configured memory budget.

This is the **capacity** half of the spilling effort and is **independent of the liveness reserve (the deadlock fix), which ships separately**. Default-off, so it is behaviour-neutral until enabled.

## Design

A slice is the unit of spilling. When spilling is enabled, each slice allocates all of its state from its own **arena-backed `BufferManager`** (`ArenaMemoryResource`: an anonymous mmap region; evict = `pwrite` + `madvise(DONTNEED)`, reload = `pread` to the *same* virtual address, so live pointers into the state survive). A process-wide **`SpillManager`** governor tracks resident bytes and, above a high-watermark, evicts the coldest unpinned slices down to a low-watermark.

Eviction-vs-access safety: spilling requires the no-op slice cache (`enable_slice_cache=false`), so every slice access goes through the C++ cache-miss proxy, which reload+pins the slice a worker is about to touch (one pinned slice per worker; eviction skips pinned slices). Triggered slices are pinned until the probe consumes them. A setup-time precondition enforces the cache requirement, so it cannot be misconfigured into corruption.

## What's included

- `ArenaMemoryResource` + `SpillManager` (in `nes-memory`), with unit tests (15 cases): evict/reload pointer & data stability, byte accounting, coldest-first eviction, pinned-not-evicted.
- `ChainedHashMap` / `PagedVector` gain an optional pinned buffer provider (null ⇒ unchanged).
- Slices made spillable: `AggregationSlice`/`HJSlice` (via `HashMapSlice`) and `NLJSlice`.
- Governor threaded `NodeEngine` → `QueryEngine` → `PipelineExecutionContext` → operator handlers → slices.
- New worker config: `enable_state_spilling`, `state_memory_budget_in_bytes`, `spill_directory` (all default off/empty).

## Validation

With `enable_state_spilling=true` and a deliberately tiny 16 KB budget forcing continuous evict→disk→reload, these produce **byte-identical results to the in-memory baseline**:
- keyed / stacked / expression windowed aggregation
- multi-stream join under `HASH_JOIN` and `NESTED_LOOP_JOIN`

Spilling-off regressions and the spill unit tests pass. Example configs: `nes-systests/configs/spill-enabled.yaml`, `spill-enabled-nlj.yaml`.

## Notes / follow-ups

- When spilling is on, the no-op-cache requirement costs one JIT→C++ call per record (the documented tradeoff); a residency-token cache fast-path could remove it later.
- clang-tidy: clean on changed lines (flagged checks are disabled in the repo `.clang-tidy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)