### PR TITLE
Reuse a single Nautilus engine per worker across all pipelines

### DIFF
--- a/nes-input-formatters/tests/Util/InputFormatterTestUtil.cpp
+++ b/nes-input-formatters/tests/Util/InputFormatterTestUtil.cpp
@@ -184,8 +184,9 @@ std::shared_ptr<CompiledExecutablePipelineStage> createInputFormatter(
     nautilusOptions.setOption("engine.backend", std::string("mlir"));
     nautilusOptions.setOption("engine.compilationStrategy", std::string("legacy"));
     nautilusOptions.setOption("mlir.enableMultithreading", false);
+    auto engine = std::make_shared<const nautilus::engine::NautilusEngine>(nautilusOptions);
     return std::make_shared<CompiledExecutablePipelineStage>(
-        physicalScanPipeline, physicalScanPipeline->getOperatorHandlers(), nautilusOptions);
+        physicalScanPipeline, physicalScanPipeline->getOperatorHandlers(), std::move(engine), nautilus::engine::ModuleOptions{});
 }
 
 }

--- a/nes-physical-operators/tests/InferModelPhysicalOperatorTest.cpp
+++ b/nes-physical-operators/tests/InferModelPhysicalOperatorTest.cpp
@@ -197,6 +197,17 @@ public:
         return names;
     }
 
+    /// Builds a standalone Nautilus engine for a single pipeline stage. In production a single engine is shared across
+    /// all pipelines of a worker; these tests construct stages directly, so each builds its own engine here.
+    static std::shared_ptr<const nautilus::engine::NautilusEngine> makeEngine(bool compiled)
+    {
+        nautilus::engine::Options options;
+        options.setOption("engine.Compilation", compiled);
+        options.setOption("engine.backend", std::string("mlir"));
+        options.setOption("engine.compilationStrategy", std::string("legacy"));
+        return std::make_shared<const nautilus::engine::NautilusEngine>(options);
+    }
+
     using TestSchema = Schema<UnqualifiedUnboundField, Ordered>;
 
     static UnqualifiedUnboundField makeField(std::string_view name, DataType::Type type)
@@ -299,17 +310,7 @@ TEST_F(InferModelPhysicalOperatorTest, IdentityModelCorrectness)
     {
         auto [pipeline, handlers]
             = createInferencePipeline(*identityModel, inputSchema, outputSchema, {"input_blob"}, outputFieldNames, true, false);
-        CompiledExecutablePipelineStage stage(
-            pipeline,
-            handlers,
-            [&]
-            {
-                nautilus::engine::Options opt;
-                opt.setOption("engine.Compilation", compiled);
-                opt.setOption("engine.backend", std::string("mlir"));
-                opt.setOption("engine.compilationStrategy", std::string("legacy"));
-                return opt;
-            }());
+        CompiledExecutablePipelineStage stage(pipeline, handlers, makeEngine(compiled), nautilus::engine::ModuleOptions{});
 
         folly::Synchronized<std::vector<TupleBuffer>> emittedBuffers;
         emittedBuffers.wlock()->reserve(16);
@@ -353,17 +354,7 @@ TEST_F(InferModelPhysicalOperatorTest, ReductionModelCorrectness)
     {
         auto [pipeline, handlers]
             = createInferencePipeline(*reductionModel, inputSchema, outputSchema, {"input_blob"}, outputFieldNames, true, false);
-        CompiledExecutablePipelineStage stage(
-            pipeline,
-            handlers,
-            [&]
-            {
-                nautilus::engine::Options opt;
-                opt.setOption("engine.Compilation", compiled);
-                opt.setOption("engine.backend", std::string("mlir"));
-                opt.setOption("engine.compilationStrategy", std::string("legacy"));
-                return opt;
-            }());
+        CompiledExecutablePipelineStage stage(pipeline, handlers, makeEngine(compiled), nautilus::engine::ModuleOptions{});
 
         folly::Synchronized<std::vector<TupleBuffer>> emittedBuffers;
         emittedBuffers.wlock()->reserve(16);
@@ -407,17 +398,7 @@ TEST_F(InferModelPhysicalOperatorTest, ExpansionModelCorrectness)
     {
         auto [pipeline, handlers]
             = createInferencePipeline(*expansionModel, inputSchema, outputSchema, {"input_blob"}, outputFieldNames, true, false);
-        CompiledExecutablePipelineStage stage(
-            pipeline,
-            handlers,
-            [&]
-            {
-                nautilus::engine::Options opt;
-                opt.setOption("engine.Compilation", compiled);
-                opt.setOption("engine.backend", std::string("mlir"));
-                opt.setOption("engine.compilationStrategy", std::string("legacy"));
-                return opt;
-            }());
+        CompiledExecutablePipelineStage stage(pipeline, handlers, makeEngine(compiled), nautilus::engine::ModuleOptions{});
 
         folly::Synchronized<std::vector<TupleBuffer>> emittedBuffers;
         emittedBuffers.wlock()->reserve(16);
@@ -469,17 +450,7 @@ TEST_F(InferModelPhysicalOperatorTest, MultiRecordIdentity)
     {
         auto [pipeline, handlers]
             = createInferencePipeline(*identityModel, inputSchema, outputSchema, {"input_blob"}, outputFieldNames, true, false);
-        CompiledExecutablePipelineStage stage(
-            pipeline,
-            handlers,
-            [&]
-            {
-                nautilus::engine::Options opt;
-                opt.setOption("engine.Compilation", compiled);
-                opt.setOption("engine.backend", std::string("mlir"));
-                opt.setOption("engine.compilationStrategy", std::string("legacy"));
-                return opt;
-            }());
+        CompiledExecutablePipelineStage stage(pipeline, handlers, makeEngine(compiled), nautilus::engine::ModuleOptions{});
 
         folly::Synchronized<std::vector<TupleBuffer>> emittedBuffers;
         emittedBuffers.wlock()->reserve(16);
@@ -524,17 +495,7 @@ TEST_F(InferModelPhysicalOperatorTest, ZeroRecordBuffer)
     {
         auto [pipeline, handlers]
             = createInferencePipeline(*identityModel, inputSchema, outputSchema, {"input_blob"}, outputFieldNames, true, false);
-        CompiledExecutablePipelineStage stage(
-            pipeline,
-            handlers,
-            [&]
-            {
-                nautilus::engine::Options opt;
-                opt.setOption("engine.Compilation", compiled);
-                opt.setOption("engine.backend", std::string("mlir"));
-                opt.setOption("engine.compilationStrategy", std::string("legacy"));
-                return opt;
-            }());
+        CompiledExecutablePipelineStage stage(pipeline, handlers, makeEngine(compiled), nautilus::engine::ModuleOptions{});
 
         folly::Synchronized<std::vector<TupleBuffer>> emittedBuffers;
         emittedBuffers.wlock()->reserve(16);
@@ -571,11 +532,7 @@ TEST_F(InferModelPhysicalOperatorTest, ConcurrentStressTest)
     auto [pipeline, handlers]
         = createInferencePipeline(*identityModel, inputSchema, outputSchema, {"input_blob"}, outputFieldNames, true, false);
 
-    nautilus::engine::Options options;
-    options.setOption("engine.Compilation", true);
-    options.setOption("engine.backend", std::string("mlir"));
-    options.setOption("engine.compilationStrategy", std::string("legacy"));
-    CompiledExecutablePipelineStage stage(pipeline, handlers, options);
+    CompiledExecutablePipelineStage stage(pipeline, handlers, makeEngine(true), nautilus::engine::ModuleOptions{});
 
     folly::Synchronized<std::vector<TupleBuffer>> emittedBuffers;
     emittedBuffers.wlock()->reserve(numThreads * buffersPerThread * 2);
@@ -681,17 +638,7 @@ TEST_F(InferModelPhysicalOperatorTest, VarsizedOutputCorrectness)
     {
         auto [pipeline, handlers] = createInferencePipeline(
             *identityModel, inputSchema, outputSchema, {"input_blob"}, {"output_blob"}, /*varsizedInput=*/true, /*varsizedOutput=*/true);
-        CompiledExecutablePipelineStage stage(
-            pipeline,
-            handlers,
-            [&]
-            {
-                nautilus::engine::Options opt;
-                opt.setOption("engine.Compilation", compiled);
-                opt.setOption("engine.backend", std::string("mlir"));
-                opt.setOption("engine.compilationStrategy", std::string("legacy"));
-                return opt;
-            }());
+        CompiledExecutablePipelineStage stage(pipeline, handlers, makeEngine(compiled), nautilus::engine::ModuleOptions{});
 
         folly::Synchronized<std::vector<TupleBuffer>> emittedBuffers;
         emittedBuffers.wlock()->reserve(16);

--- a/nes-query-compiler/include/QueryCompiler.hpp
+++ b/nes-query-compiler/include/QueryCompiler.hpp
@@ -21,6 +21,11 @@
 #include <CompiledQueryPlan.hpp>
 #include <QueryExecutionConfiguration.hpp>
 
+namespace nautilus::engine
+{
+class NautilusEngine;
+}
+
 namespace NES::QueryCompilation
 {
 
@@ -39,12 +44,16 @@ struct QueryCompilationRequest
 class QueryCompiler
 {
 public:
-    explicit QueryCompiler(QueryExecutionConfiguration defaultQueryExecution) : defaultQueryExecution(std::move(defaultQueryExecution)) { };
+    explicit QueryCompiler(QueryExecutionConfiguration defaultQueryExecution);
 
     std::unique_ptr<CompiledQueryPlan> compileQuery(std::unique_ptr<QueryCompilationRequest> request);
 
 private:
     QueryExecutionConfiguration defaultQueryExecution;
+    /// A single Nautilus engine is built once per worker and reused across all pipelines. It carries the engine-scope
+    /// options (backend, compilation strategy, compiled/interpreted mode); per-request dump options are applied per
+    /// module. Shared rather than owned outright because the compiled pipeline stages that use it outlive this compiler.
+    std::shared_ptr<const nautilus::engine::NautilusEngine> engine;
 };
 
 }

--- a/nes-query-compiler/private/Phases/LowerToCompiledQueryPlanPhase.hpp
+++ b/nes-query-compiler/private/Phases/LowerToCompiledQueryPlanPhase.hpp
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <unordered_map>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -24,13 +25,19 @@
 #include <CompiledQueryPlan.hpp>
 #include <PipelinedQueryPlan.hpp>
 
+namespace nautilus::engine
+{
+class NautilusEngine;
+}
+
 namespace NES
 {
 class LowerToCompiledQueryPlanPhase
 {
 public:
-    explicit LowerToCompiledQueryPlanPhase(DumpMode dumpQueryCompilationIntermediateRepresentations)
-        : dumpQueryCompilationIR(dumpQueryCompilationIntermediateRepresentations)
+    LowerToCompiledQueryPlanPhase(
+        DumpMode dumpQueryCompilationIntermediateRepresentations, std::shared_ptr<const nautilus::engine::NautilusEngine> engine)
+        : dumpQueryCompilationIR(dumpQueryCompilationIntermediateRepresentations), engine(std::move(engine))
     {
     }
 
@@ -56,5 +63,7 @@ private:
 
     /// Config parameter
     DumpMode dumpQueryCompilationIR;
+    /// The worker-wide Nautilus engine, shared by every pipeline stage this phase produces.
+    std::shared_ptr<const nautilus::engine::NautilusEngine> engine;
 };
 }

--- a/nes-query-compiler/src/Phases/LowerToCompiledQueryPlanPhase.cpp
+++ b/nes-query-compiler/src/Phases/LowerToCompiledQueryPlanPhase.cpp
@@ -27,7 +27,6 @@
 #include <Pipelines/CompiledExecutablePipelineStage.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Util/DumpMode.hpp>
-#include <Util/ExecutionMode.hpp>
 #include <CompiledQueryPlan.hpp>
 #include <ErrorHandling.hpp>
 #include <ExecutablePipelineStage.hpp>
@@ -87,55 +86,36 @@ void LowerToCompiledQueryPlanPhase::processSink(const Predecessor& predecessor, 
 
 std::unique_ptr<ExecutablePipelineStage> LowerToCompiledQueryPlanPhase::getStage(const std::shared_ptr<Pipeline>& pipeline)
 {
-    nautilus::engine::Options options;
-    /// We disable multithreading in MLIR by default to not interfere with NebulaStream's thread model
-    options.setOption("mlir.enableMultithreading", false);
-    /// Use the single-tier LegacyCompiler with the MLIR backend. Otherwise nautilus defaults to its tiered JIT
-    /// (bytecode tier-0, MLIR tier-1 promoted on a background thread), whose bytecode backend is intentionally not
-    /// built into our nautilus package and which would also conflict with the thread model above. We set both the
-    /// strategy and the backend explicitly rather than relying on the "non-empty backend implies legacy" shortcut.
-    options.setOption("engine.compilationStrategy", std::string("legacy"));
-    options.setOption("engine.backend", std::string("mlir"));
-    switch (pipelineQueryPlan->getExecutionMode())
-    {
-        case ExecutionMode::COMPILER: {
-            options.setOption("engine.Compilation", true);
-            break;
-        }
-        case ExecutionMode::INTERPRETER: {
-            options.setOption("engine.Compilation", false);
-            break;
-        }
-        default: {
-            INVARIANT(false, "Invalid backend");
-        }
-    }
+    /// The engine-scope options (backend, compilation strategy, compiled/interpreted mode) live on the shared,
+    /// worker-wide engine. Here we only set the module-scope options that vary per compilation request: the dump
+    /// configuration. They are applied when the stage creates its module from the shared engine.
     /// See: https://github.com/nebulastream/nautilus/blob/main/docs/options.md
+    nautilus::engine::ModuleOptions moduleOptions;
     switch (dumpQueryCompilationIR.getDumpOption())
     {
         case DumpMode::Options::NONE:
-            options.setOption("dump.all", false);
-            options.setOption("dump.console", false);
-            options.setOption("dump.file", false);
+            moduleOptions.setOption("dump.all", false);
+            moduleOptions.setOption("dump.console", false);
+            moduleOptions.setOption("dump.file", false);
             break;
         case DumpMode::Options::CONSOLE:
-            options.setOption("dump.all", true);
-            options.setOption("dump.console", true);
-            options.setOption("dump.file", false);
+            moduleOptions.setOption("dump.all", true);
+            moduleOptions.setOption("dump.console", true);
+            moduleOptions.setOption("dump.file", false);
             break;
         case DumpMode::Options::FILE:
-            options.setOption("dump.all", true);
-            options.setOption("dump.console", false);
-            options.setOption("dump.file", true);
+            moduleOptions.setOption("dump.all", true);
+            moduleOptions.setOption("dump.console", false);
+            moduleOptions.setOption("dump.file", true);
             break;
         case DumpMode::Options::FILE_AND_CONSOLE:
-            options.setOption("dump.all", true);
-            options.setOption("dump.console", true);
-            options.setOption("dump.file", true);
+            moduleOptions.setOption("dump.all", true);
+            moduleOptions.setOption("dump.console", true);
+            moduleOptions.setOption("dump.file", true);
             break;
     }
-    options.setOption("dump.graph", dumpQueryCompilationIR.isDumpGraphEnabled());
-    return std::make_unique<CompiledExecutablePipelineStage>(pipeline, pipeline->getOperatorHandlers(), options);
+    moduleOptions.setOption("dump.graph", dumpQueryCompilationIR.isDumpGraphEnabled());
+    return std::make_unique<CompiledExecutablePipelineStage>(pipeline, pipeline->getOperatorHandlers(), engine, std::move(moduleOptions));
 }
 
 std::shared_ptr<ExecutablePipeline> LowerToCompiledQueryPlanPhase::processOperatorPipeline(const std::shared_ptr<Pipeline>& pipeline)

--- a/nes-query-compiler/src/QueryCompiler.cpp
+++ b/nes-query-compiler/src/QueryCompiler.cpp
@@ -16,21 +16,46 @@
 #include <QueryCompiler.hpp>
 
 #include <memory>
+#include <string>
+#include <utility>
 #include <Configuration/WorkerConfiguration.hpp>
 #include <Phases/LowerToCompiledQueryPlanPhase.hpp>
 #include <Phases/LowerToPhysicalOperators.hpp>
 #include <Phases/PipeliningPhase.hpp>
 #include <Util/DumpMode.hpp>
+#include <Util/ExecutionMode.hpp>
 #include <CompiledQueryPlan.hpp>
 #include <ErrorHandling.hpp>
+#include <nautilus/Engine.hpp>
+#include <options.hpp>
 
 namespace NES::QueryCompilation
 {
 
+QueryCompiler::QueryCompiler(QueryExecutionConfiguration defaultQueryExecution)
+    : defaultQueryExecution(std::move(defaultQueryExecution))
+{
+    /// Build the single Nautilus engine once and reuse it for every pipeline compiled by this worker.
+    /// These engine-scope options are fixed for the worker's lifetime: the execution mode comes from the worker
+    /// configuration and is applied uniformly to all pipelines; only the per-request dump options vary, and those
+    /// are module-scope and applied when each pipeline creates its module.
+    nautilus::engine::Options options;
+    /// We disable multithreading in MLIR by default to not interfere with NebulaStream's thread model
+    options.setOption("mlir.enableMultithreading", false);
+    /// Use the single-tier LegacyCompiler with the MLIR backend. Otherwise nautilus defaults to its tiered JIT
+    /// (bytecode tier-0, MLIR tier-1 promoted on a background thread), whose bytecode backend is intentionally not
+    /// built into our nautilus package and which would also conflict with the thread model above. We set both the
+    /// strategy and the backend explicitly rather than relying on the "non-empty backend implies legacy" shortcut.
+    options.setOption("engine.compilationStrategy", std::string("legacy"));
+    options.setOption("engine.backend", std::string("mlir"));
+    options.setOption("engine.Compilation", this->defaultQueryExecution.executionMode.getValue() == ExecutionMode::COMPILER);
+    engine = std::make_shared<const nautilus::engine::NautilusEngine>(options);
+}
+
 /// This phase should be as dumb as possible and not further decisions should be made here.
 std::unique_ptr<CompiledQueryPlan> QueryCompiler::compileQuery(std::unique_ptr<QueryCompilationRequest> request)
 {
-    auto lowerToCompiledQueryPlanPhase = LowerToCompiledQueryPlanPhase(request->dumpCompilationResult);
+    auto lowerToCompiledQueryPlanPhase = LowerToCompiledQueryPlanPhase(request->dumpCompilationResult, engine);
     auto queryPlan = LowerToPhysicalOperators::apply(request->queryPlan, defaultQueryExecution);
     auto pipelinedQueryPlan = PipeliningPhase::apply(queryPlan);
     return lowerToCompiledQueryPlanPhase.apply(pipelinedQueryPlan);

--- a/nes-runtime/include/Pipelines/CompiledExecutablePipelineStage.hpp
+++ b/nes-runtime/include/Pipelines/CompiledExecutablePipelineStage.hpp
@@ -23,6 +23,7 @@
 #include <Runtime/TupleBuffer.hpp>
 #include <nautilus/Engine.hpp>
 #include <nautilus/Module.hpp>
+#include <nautilus/options.hpp>
 #include <ExecutablePipelineStage.hpp>
 #include <ExecutionContext.hpp>
 #include <Pipeline.hpp>
@@ -40,7 +41,8 @@ public:
     CompiledExecutablePipelineStage(
         std::shared_ptr<Pipeline> pipeline,
         std::unordered_map<OperatorHandlerId, std::shared_ptr<OperatorHandler>> operatorHandler,
-        nautilus::engine::Options options);
+        std::shared_ptr<const nautilus::engine::NautilusEngine> engine,
+        nautilus::engine::ModuleOptions moduleOptions);
     void start(PipelineExecutionContext& pipelineExecutionContext) override;
     void execute(const TupleBuffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext) override;
     void stop(PipelineExecutionContext& pipelineExecutionContext) override;
@@ -55,7 +57,11 @@ private:
     /// Registers the pipeline's main traced function in the pipeline's module.
     void registerPipelineFunction(nautilus::engine::NautilusModule& module) const;
 
-    nautilus::engine::NautilusEngine engine;
+    /// A single Nautilus engine is shared across all pipeline stages of the worker; this stage only keeps it alive
+    /// and creates its module from it. The per-pipeline module-scope options (dump configuration) are applied when
+    /// the module is created in start().
+    std::shared_ptr<const nautilus::engine::NautilusEngine> engine;
+    nautilus::engine::ModuleOptions moduleOptions;
     /// Both are created lazily in start(); neither type is default-constructible.
     std::optional<nautilus::engine::CompiledModule> compiledModule;
     std::optional<nautilus::engine::ModuleFunction<PipelineSignature>> compiledPipelineFunction;

--- a/nes-runtime/src/Pipelines/CompiledExecutablePipelineStage.cpp
+++ b/nes-runtime/src/Pipelines/CompiledExecutablePipelineStage.cpp
@@ -43,9 +43,14 @@ namespace NES
 CompiledExecutablePipelineStage::CompiledExecutablePipelineStage(
     std::shared_ptr<Pipeline> pipeline,
     std::unordered_map<OperatorHandlerId, std::shared_ptr<OperatorHandler>> operatorHandlers,
-    nautilus::engine::Options options)
-    : engine(options), operatorHandlers(std::move(operatorHandlers)), pipeline(std::move(pipeline))
+    std::shared_ptr<const nautilus::engine::NautilusEngine> engine,
+    nautilus::engine::ModuleOptions moduleOptions)
+    : engine(std::move(engine))
+    , moduleOptions(std::move(moduleOptions))
+    , operatorHandlers(std::move(operatorHandlers))
+    , pipeline(std::move(pipeline))
 {
+    INVARIANT(this->engine != nullptr, "CompiledExecutablePipelineStage requires a non-null Nautilus engine");
 }
 
 void CompiledExecutablePipelineStage::execute(const TupleBuffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext)
@@ -119,7 +124,7 @@ void CompiledExecutablePipelineStage::start(PipelineExecutionContext& pipelineEx
     /// all of them together. Only afterwards do the handles handed out during setup() become invocable.
     CPPTRACE_TRY
     {
-        auto module = engine.createModule();
+        auto module = engine->createModule(moduleOptions);
         CompilationContext compilationCtx{module};
         pipeline->getRootOperator().setup(ctx, compilationCtx);
         registerPipelineFunction(module);
@@ -134,7 +139,7 @@ void CompiledExecutablePipelineStage::start(PipelineExecutionContext& pipelineEx
             NES_DEBUG(
                 "Nautilus compilation statistics for pipeline {}:\n{}",
                 pipeline->getPipelineId(),
-                statistics->formatReport(fmt::format("pipeline-{}", pipeline->getPipelineId()), engine.getNameOfBackend()));
+                statistics->formatReport(fmt::format("pipeline-{}", pipeline->getPipelineId()), engine->getNameOfBackend()));
         }
     }
     CPPTRACE_CATCH(...)


### PR DESCRIPTION
## What & why

Today every pipeline constructs its **own** `nautilus::engine::NautilusEngine`
(owned by value in `CompiledExecutablePipelineStage`), re-initializing the
MLIR/JIT backend for each pipeline of a query. This PR makes the worker build
**one** engine and reuse it across all pipelines.

## Approach

The change leans on Nautilus' option scoping (see `nautilus/docs/options.md`):

- **Engine-scope** options — `engine.backend`, `engine.compilationStrategy`,
  `engine.Compilation`, `mlir.enableMultithreading` — are set once on the shared
  engine. They are worker-global: backend/strategy are constants and the
  compiled-vs-interpreted mode comes from the worker's
  `QueryExecutionConfiguration` (applied uniformly to every pipeline).
- **Module-scope** options — the per-request `dump.*` configuration — are
  carried as a `nautilus::engine::ModuleOptions` and applied per pipeline when
  the stage creates its module via `engine->createModule(moduleOptions)`.

### Ownership
- `QueryCompiler` (one per worker) builds the engine in its constructor and
  holds a `std::shared_ptr<const nautilus::engine::NautilusEngine>`.
- `LowerToCompiledQueryPlanPhase` receives the shared engine and threads it into
  every `CompiledExecutablePipelineStage` it creates, alongside that pipeline's
  `ModuleOptions`.
- `CompiledExecutablePipelineStage` now holds the shared engine (not an owned
  one) plus its `ModuleOptions`.

`shared_ptr` rather than `unique_ptr`: the pipeline stages live inside the
`NodeEngine`'s compiled query plans, which (by `SingleNodeWorker`'s member
destruction order) outlive the `QueryCompiler` that owns the engine. Shared
ownership decouples the engine's lifetime from destruction order.

## Files
- `nes-query-compiler/{include,src}/QueryCompiler.*` — build & own the shared engine
- `nes-query-compiler/{private,src}/Phases/LowerToCompiledQueryPlanPhase.*` — thread engine through; emit only module-scope dump options
- `nes-runtime/{include,src}/Pipelines/CompiledExecutablePipelineStage.*` — hold shared engine + ModuleOptions; `createModule(moduleOptions)`
- test call sites (`InferModelPhysicalOperatorTest`, `InputFormatterTestUtil`) updated to build their own engine

## Verification / risk to validate in CI
- ⚠️ **Thread-safety:** pipeline `start()` can run concurrently across worker
  threads, so multiple threads may now call `createModule()`/`compile()` on the
  *same* engine. Please run the concurrent-query systests under TSan/ASan to
  confirm the shared `const` engine tolerates concurrent module
  creation/compilation (MLIR multithreading is already disabled). If unsafe, the
  fallback is to guard module creation with a mutex in the stage, or keep one
  engine per worker thread.
- Confirm dump modes (CONSOLE/FILE) still emit IR per request — proves the
  module-scope override path works on the shared engine.
- Confirm `execution_mode=INTERPRETER` is still honored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFp7DG7BnKbD4DozAoLC8N)_