### PR TITLE
feat(Cmake): Added cmake flag for setting the absolute timeout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ option(ENABLE_FTIME_TRACE "Enable ftime-trace as a compilation flag to profile t
 option(CODE_COVERAGE "Compute test coverage" OFF)
 option(NES_ENABLES_TESTS "Enable tests" ON)
 option(ENABLE_LARGE_TESTS "Runs testcases with larger input data" OFF)
+set(LARGE_TEST_DOWNLOAD_TIMEOUT 1200 CACHE STRING "Absolute timeout in seconds for downloading large test data files")
 option(ENABLE_DOCKER_TESTS "Runs testcases that require docker" ON)
 
 option(NES_ENABLE_PRECOMPILED_HEADERS "Enable precompiled headers (might improve compilation time)" OFF)

--- a/nes-systests/systest/CMakeLists.txt
+++ b/nes-systests/systest/CMakeLists.txt
@@ -29,7 +29,7 @@ else ()
     # By default this only includes small files located in testdata/small
     set(TEST_DATA_PATH DATA{../testdata/,RECURSE:,REGEX:small.*})
 endif ()
-set(ExternalData_TIMEOUT_ABSOLUTE 1200)
+set(ExternalData_TIMEOUT_ABSOLUTE ${LARGE_TEST_DOWNLOAD_TIMEOUT})
 ExternalData_Expand_Arguments(
         test-data
         EXPANDED_TEST_DATA_PATH


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Provides a CMake flag to set the absolute timeout for downloading external data, e.g., a large test file. Can be overridden with `-DLARGE_TEST_DOWNLOAD_TIMEOUT=<seconds>`. 