### PR TITLE
fix(nix): Fix Clion not be able to launch systests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ set(NES_WARNINGS "-Wall -Wconstant-conversion -Wbitwise-instead-of-logical -Wext
 set(CMAKE_CXX_FLAGS "${NES_WARNINGS} -fno-omit-frame-pointer ${NES_SPECIFIC_FLAGS}")
 
 # setup rpath for linker
-set(CMAKE_BUILD_RPATH "${CMAKE_BINARY_DIR}/nes-plugins")
+list(APPEND CMAKE_BUILD_RPATH "${CMAKE_BINARY_DIR}/nes-plugins")
 set(CMAKE_INSTALL_RPATH "$ORIGIN/nes-plugins")
 
 if (ENABLE_FTIME_TRACE)

--- a/flake.nix
+++ b/flake.nix
@@ -786,8 +786,25 @@
               ++ [
                 "-DCMAKE_PROJECT_INCLUDE=${devCmakePrelude}"
                 "-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON"
+                "-DCMAKE_BUILD_RPATH=${runtimeLibraryPathCMake}"
               ]
               ++ cmakeCommonFlags combo;
+            allBuildInputs =
+              cmakeCtx.thirdPartyDeps
+              ++ [ mlirBinary ]
+              ++ sanitizer.extraPackages
+              ++ stdlib.extraPackages;
+            transitiveRuntimeDeps = [
+              pkgs.icu
+              pkgs.zlib.out
+              pkgs.c-ares
+              pkgs.openssl.out
+              pkgs.libuuid.lib
+            ];
+            runtimeLibraryPath = lib.makeLibraryPath (allBuildInputs ++ transitiveRuntimeDeps);
+            runtimeLibraryPathCMake = lib.concatStringsSep ";" (
+              lib.unique (map (dep: "${dep}/lib") (allBuildInputs ++ transitiveRuntimeDeps))
+            );
             envVars =
               sanitizer.extraEnv
               // stdlib.extraEnv
@@ -805,11 +822,7 @@
             // envVars
             // {
               name = "nebula-stream-${sanitizer.name}-${stdlib.name}";
-              buildInputs =
-                cmakeCtx.thirdPartyDeps
-                ++ [ mlirBinary ]
-                ++ sanitizer.extraPackages
-                ++ stdlib.extraPackages;
+              buildInputs = allBuildInputs;
               nativeBuildInputs = buildTools ++ llvmToolsVariant;
               packages = devTools;
               LLVM_TOOLCHAIN_VERSION = llvmToolchainVersion;
@@ -818,9 +831,7 @@
               cmakeFlags = cmakeFlagsList;
               shellHook = ''
                 unset NES_PREBUILT_VCPKG_ROOT
-                if [ -n "''${CMAKE_LIBRARY_PATH:-}" ]; then
-                  export LD_LIBRARY_PATH="''${CMAKE_LIBRARY_PATH}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-                fi
+                export LD_BINARY_PATH="${runtimeLibraryPath}''${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH}"
               '' + ccacheShellHook;
             }
           );


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This pr fixs a bug in the nix toolchain where libraries weren't linked with the executable. This lead to CLion not being able to launch systests or any built executable, as it "lives" outside of the nix dev shell

