### PR TITLE
Feature(#1703): runtime buffer capacity for row-layout codegen

### DIFF
--- a/nes-nautilus/include/Interface/RecordBuffer.hpp
+++ b/nes-nautilus/include/Interface/RecordBuffer.hpp
@@ -38,6 +38,10 @@ public:
     void setNumRecords(const nautilus::val<uint64_t>& numRecordsValue);
     [[nodiscard]] nautilus::val<uint64_t> getNumRecords() const;
 
+    /// Runtime byte size of the underlying buffer. Read at execution time (not baked at compile time) so a single
+    /// compiled pipeline can process variable-sized (size-class) buffers; see #1703.
+    [[nodiscard]] nautilus::val<uint64_t> getBufferSize() const;
+
     /// Retrieve the reference to the underling memory area from the record buffer.
     [[nodiscard]] nautilus::val<int8_t*> getMemArea() const;
 

--- a/nes-nautilus/src/Interface/BufferRef/RowTupleBufferRef.cpp
+++ b/nes-nautilus/src/Interface/BufferRef/RowTupleBufferRef.cpp
@@ -77,8 +77,12 @@ TupleBufferRef::WriteRecordResult RowTupleBufferRef::writeRecord(
 {
     nautilus::val<bool> successful{false};
     nautilus::val<uint64_t> writtenRecords{0};
-    /// Check if index is in-bounds
-    if (recordIndex < capacity)
+    /// Check if index is in-bounds. #1703: derive the capacity from the buffer's actual size at runtime
+    /// (rather than the compile-time-baked bufferSize/tupleSize) so the same compiled pipeline can write into a
+    /// variable-sized (size-class) buffer. tupleSize is a schema-derived compile-time constant; for a default-size
+    /// buffer this runtime capacity equals the previous baked `capacity`, so fixed-size pipelines are unaffected.
+    const auto runtimeCapacity = recordBuffer.getBufferSize() / tupleSize;
+    if (recordIndex < runtimeCapacity)
     {
         const auto bufferAddress = recordBuffer.getMemArea();
         const auto recordOffset = bufferAddress + (tupleSize * recordIndex);

--- a/nes-nautilus/src/Interface/RecordBuffer.cpp
+++ b/nes-nautilus/src/Interface/RecordBuffer.cpp
@@ -36,6 +36,11 @@ nautilus::val<uint64_t> RecordBuffer::getNumRecords() const
     return invoke(ProxyFunctions::NES_Memory_TupleBuffer_getNumberOfTuples, tupleBufferRef);
 }
 
+nautilus::val<uint64_t> RecordBuffer::getBufferSize() const
+{
+    return invoke(ProxyFunctions::NES_Memory_TupleBuffer_getBufferSize, tupleBufferRef);
+}
+
 void RecordBuffer::setNumRecords(const nautilus::val<uint64_t>& numRecordsValue)
 {
     invoke(ProxyFunctions::NES_Memory_TupleBuffer_setNumberOfTuples, tupleBufferRef, numRecordsValue);


### PR DESCRIPTION
Part of EPIC #1714 (dynamic memory). Makes buffer capacity a runtime value in row-layout codegen (was a baked compile-time constant), so one generated pipeline can process buffers of any size — a prerequisite for variable-sized and size-class buffers. Independent; based on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)