### PR TITLE
Feature(#1713): adaptive in-flight source provisioning (InflightThrottle + AIMD)

### DIFF
--- a/nes-input-formatters/tests/Util/InputFormatterTestUtil.cpp
+++ b/nes-input-formatters/tests/Util/InputFormatterTestUtil.cpp
@@ -143,7 +143,7 @@ std::pair<BackpressureController, std::unique_ptr<SourceHandle>> createFileSourc
         {{Identifier::parse("type"), "CSV"}});
     INVARIANT(sourceDescriptor.has_value(), "Test File Source couldn't be created");
     auto [backpressureController, backpressureListener] = createBackpressureChannel();
-    const SourceProvider sourceProvider(numberOfRequiredSourceBuffers, std::move(sourceBufferPool));
+    const SourceProvider sourceProvider(numberOfRequiredSourceBuffers, /*enableAdaptiveInflight*/ false, std::move(sourceBufferPool));
     return {std::move(backpressureController), sourceProvider.lower(NES::OriginId(1), backpressureListener, sourceDescriptor.value())};
 }
 

--- a/nes-query-engine/InflightThrottle.hpp
+++ b/nes-query-engine/InflightThrottle.hpp
@@ -50,10 +50,10 @@ public:
         cv.wait(lock, [&] { return inUse < limit || token.stop_requested(); });
         if (token.stop_requested())
         {
-            return {false, wouldBlock};
+            return {.acquired = false, .waited = wouldBlock};
         }
         ++inUse;
-        return {true, wouldBlock};
+        return {.acquired = true, .waited = wouldBlock};
     }
 
     /// Returns one slot. Safe to call from any thread (e.g. the task-completion callback).

--- a/nes-query-engine/InflightThrottle.hpp
+++ b/nes-query-engine/InflightThrottle.hpp
@@ -1,0 +1,144 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <algorithm>
+#include <condition_variable>
+#include <cstddef>
+#include <mutex>
+#include <stop_token>
+
+namespace NES
+{
+
+/// #1713: bounded counter with a dynamically adjustable limit, replacing std::counting_semaphore as the per-source
+/// inflight-buffer throttle so the cap can grow/shrink at runtime (adaptive provisioning). With a fixed limit the
+/// behaviour is identical to a counting semaphore. condition_variable_any is required to compose with std::stop_callback
+/// (std::condition_variable cannot wait on a stop_token).
+class InflightThrottle
+{
+public:
+    /// Outcome of an acquire(): whether a slot was taken, and whether the caller had to wait for it (the saturation
+    /// signal the adaptive policy grows on).
+    struct AcquireResult
+    {
+        bool acquired;
+        bool waited;
+    };
+
+    explicit InflightThrottle(const std::size_t initialLimit) : limit(initialLimit) { }
+
+    /// Blocks until inUse < limit OR the stop_token is signalled. Returns {acquired,waited}: acquired=false (and no slot
+    /// taken, so the caller must not release()) when it returned due to stop; waited=true if it had to block.
+    [[nodiscard]] AcquireResult acquire(const std::stop_token& token)
+    {
+        std::unique_lock lock(mutex);
+        const bool wouldBlock = !(inUse < limit);
+        const std::stop_callback callback(token, [this] { cv.notify_all(); });
+        cv.wait(lock, [&] { return inUse < limit || token.stop_requested(); });
+        if (token.stop_requested())
+        {
+            return {false, wouldBlock};
+        }
+        ++inUse;
+        return {true, wouldBlock};
+    }
+
+    /// Returns one slot. Safe to call from any thread (e.g. the task-completion callback).
+    void release()
+    {
+        bool notify = false;
+        {
+            const std::lock_guard lock(mutex);
+            if (inUse > 0)
+            {
+                --inUse;
+            }
+            notify = inUse < limit;
+        }
+        if (notify)
+        {
+            cv.notify_one();
+        }
+    }
+
+    /// Adjust the cap. Growing wakes waiters; shrinking below inUse simply blocks new acquires until releases drain it
+    /// -- in-flight buffers are never forcibly reclaimed.
+    void setLimit(const std::size_t newLimit)
+    {
+        bool grew = false;
+        {
+            const std::lock_guard lock(mutex);
+            grew = newLimit > limit;
+            limit = newLimit;
+        }
+        if (grew)
+        {
+            cv.notify_all();
+        }
+    }
+
+    [[nodiscard]] std::size_t currentLimit() const
+    {
+        const std::lock_guard lock(mutex);
+        return limit;
+    }
+
+    [[nodiscard]] std::size_t currentInUse() const
+    {
+        const std::lock_guard lock(mutex);
+        return inUse;
+    }
+
+private:
+    mutable std::mutex mutex;
+    std::condition_variable_any cv;
+    std::size_t inUse = 0;
+    std::size_t limit;
+};
+
+/// #1713: AIMD policy for the per-source inflight cap. Additive-increase when the source stalls (acquire had to wait,
+/// i.e. it is saturated and could use more slots), multiplicative-decrease when it has been idle (slots unused), always
+/// clamped to [min, max]. max is the source's configured inflight limit, so the adaptive cap never exceeds today's
+/// static cap -- adaptive growth therefore cannot create buffer pressure beyond the non-adaptive baseline. The policy is
+/// a pure value object (no locking / no time source) so it can be unit-tested deterministically; the emit loop owns the
+/// timing and feeds it the stall signal and elapsed-idle.
+struct InflightPolicy
+{
+    std::size_t min;
+    std::size_t max;
+    std::size_t current;
+    std::size_t additiveStep = 4;
+    /// Numerator/denominator of the multiplicative decrease (1/2 by default).
+    std::size_t decayNum = 1;
+    std::size_t decayDen = 2;
+
+    /// Saturated this round: additively increase, clamped to max.
+    std::size_t onStall()
+    {
+        current = std::min(max, current + additiveStep);
+        return current;
+    }
+
+    /// Idle long enough: multiplicatively decrease, clamped to min.
+    std::size_t onIdleDecay()
+    {
+        const std::size_t decayed = (current * decayNum) / decayDen;
+        current = std::max(min, decayed);
+        return current;
+    }
+};
+
+}

--- a/nes-query-engine/InflightThrottle.hpp
+++ b/nes-query-engine/InflightThrottle.hpp
@@ -117,9 +117,9 @@ private:
 /// timing and feeds it the stall signal and elapsed-idle.
 struct InflightPolicy
 {
-    std::size_t min;
-    std::size_t max;
-    std::size_t current;
+    std::size_t min{};
+    std::size_t max{};
+    std::size_t current{};
     std::size_t additiveStep = 4;
     /// Numerator/denominator of the multiplicative decrease (1/2 by default).
     std::size_t decayNum = 1;

--- a/nes-query-engine/RunningSource.cpp
+++ b/nes-query-engine/RunningSource.cpp
@@ -16,7 +16,6 @@
 
 #include <algorithm>
 #include <chrono>
-#include <condition_variable>
 #include <cstdint>
 #include <functional>
 #include <limits>
@@ -41,6 +40,14 @@ namespace NES
 
 namespace
 {
+/// #1713: adaptive-throttle divisors. The throttle starts at maxLimit/ADAPTIVE_INITIAL_LIMIT_DIVISOR and the AIMD floor
+/// and additive step are maxLimit/ADAPTIVE_MIN_LIMIT_DIVISOR.
+constexpr size_t ADAPTIVE_INITIAL_LIMIT_DIVISOR = 4;
+constexpr size_t ADAPTIVE_MIN_LIMIT_DIVISOR = 8;
+/// Idle interval after which the adaptive cap decays one AIMD step.
+constexpr auto ADAPTIVE_IDLE_DECAY_INTERVAL = std::chrono::milliseconds(500);
+
+/// NOLINTNEXTLINE(readability-function-cognitive-complexity): the adaptive-inflight emit loop is inherently branchy.
 SourceReturnType::EmitFunction emitFunction(
     QueryId queryId,
     size_t numberOfInflightBuffers,
@@ -53,14 +60,15 @@ SourceReturnType::EmitFunction emitFunction(
     /// #1713: max = the configured inflight limit, so the adaptive cap never exceeds the non-adaptive baseline. When
     /// adaptive, the throttle starts low (max/4) and the AIMD policy grows it toward max on stall / decays it on idle.
     const auto maxLimit = std::min(numberOfInflightBuffers, static_cast<size_t>(std::numeric_limits<int32_t>::max()));
-    const auto initialLimit = adaptiveInflight ? std::max<size_t>(1, maxLimit / 4) : maxLimit;
+    const auto initialLimit = adaptiveInflight ? std::max<size_t>(1, maxLimit / ADAPTIVE_INITIAL_LIMIT_DIVISOR) : maxLimit;
     auto availableBuffer = std::make_shared<InflightThrottle>(initialLimit);
     auto policy = std::make_shared<InflightPolicy>(InflightPolicy{
-        .min = std::max<size_t>(1, maxLimit / 8),
+        .min = std::max<size_t>(1, maxLimit / ADAPTIVE_MIN_LIMIT_DIVISOR),
         .max = maxLimit,
         .current = initialLimit,
-        .additiveStep = std::max<size_t>(1, maxLimit / 8)});
+        .additiveStep = std::max<size_t>(1, maxLimit / ADAPTIVE_MIN_LIMIT_DIVISOR)});
     auto lastActivity = std::make_shared<std::chrono::steady_clock::time_point>(std::chrono::steady_clock::now());
+    /// NOLINTNEXTLINE(readability-function-cognitive-complexity): the per-event emit lambda mirrors the source state machine.
     return [&controller,
             successors = std::move(successors),
             source,
@@ -103,7 +111,7 @@ SourceReturnType::EmitFunction emitFunction(
                                 }
                                 *lastActivity = now;
                             }
-                            else if (now - *lastActivity > std::chrono::milliseconds(500))
+                            else if (now - *lastActivity > ADAPTIVE_IDLE_DECAY_INTERVAL)
                             {
                                 const auto prev = availableBuffer->currentLimit();
                                 const auto decayed = policy->onIdleDecay();
@@ -181,8 +189,8 @@ std::shared_ptr<RunningSource> RunningSource::create(
     ENGINE_LOG_DEBUG("Starting Running Source");
     {
         const std::scoped_lock lock(runningSource->mutex);
-        runningSource->source->start(
-            emitFunction(queryId, maxInflightBuffers, runningSource, std::move(successors), controller, emitter, adaptiveInflight));
+        runningSource->source->start(emitFunction(
+            std::move(queryId), maxInflightBuffers, runningSource, std::move(successors), controller, emitter, adaptiveInflight));
     }
     return runningSource;
 }

--- a/nes-query-engine/RunningSource.cpp
+++ b/nes-query-engine/RunningSource.cpp
@@ -32,6 +32,7 @@
 #include <EngineLogger.hpp>
 #include <ErrorHandling.hpp>
 #include <Interfaces.hpp>
+#include <InflightThrottle.hpp>
 #include <PipelineExecutionContext.hpp>
 #include <RunningQueryPlan.hpp>
 
@@ -40,77 +41,6 @@ namespace NES
 
 namespace
 {
-/// #1713: bounded counter with a dynamically adjustable limit, replacing std::counting_semaphore as the per-source
-/// inflight-buffer throttle so the cap can later grow/shrink at runtime (adaptive provisioning). Stage 1 keeps the
-/// limit fixed, so behaviour is identical to the semaphore. condition_variable_any is required to compose with
-/// std::stop_callback (std::condition_variable cannot).
-class InflightThrottle
-{
-public:
-    explicit InflightThrottle(const std::size_t initialLimit) : limit(initialLimit) { }
-
-    /// Blocks until inUse < limit OR the stop_token is signalled. Returns true if a slot was acquired (inUse
-    /// incremented); false if it returned due to stop (inUse NOT incremented -- the caller must not release()).
-    [[nodiscard]] bool acquire(const std::stop_token& token)
-    {
-        std::unique_lock lock(mutex);
-        const std::stop_callback callback(token, [this] { cv.notify_all(); });
-        cv.wait(lock, [&] { return inUse < limit || token.stop_requested(); });
-        if (token.stop_requested())
-        {
-            return false;
-        }
-        ++inUse;
-        return true;
-    }
-
-    /// Returns one slot. Safe to call from any thread (e.g. the task-completion callback).
-    void release()
-    {
-        bool notify = false;
-        {
-            const std::lock_guard lock(mutex);
-            if (inUse > 0)
-            {
-                --inUse;
-            }
-            notify = inUse < limit;
-        }
-        if (notify)
-        {
-            cv.notify_one();
-        }
-    }
-
-    /// Adjust the cap (Stage 2 AIMD will call this; Stage 1 never does). Growing wakes waiters; shrinking below inUse
-    /// simply blocks new acquires until releases drain it -- in-flight buffers are never forcibly reclaimed.
-    void setLimit(const std::size_t newLimit)
-    {
-        bool grew = false;
-        {
-            const std::lock_guard lock(mutex);
-            grew = newLimit > limit;
-            limit = newLimit;
-        }
-        if (grew)
-        {
-            cv.notify_all();
-        }
-    }
-
-    [[nodiscard]] std::size_t currentLimit() const
-    {
-        const std::lock_guard lock(mutex);
-        return limit;
-    }
-
-private:
-    mutable std::mutex mutex;
-    std::condition_variable_any cv;
-    std::size_t inUse = 0;
-    std::size_t limit;
-};
-
 SourceReturnType::EmitFunction emitFunction(
     QueryId queryId,
     size_t numberOfInflightBuffers,
@@ -134,7 +64,7 @@ SourceReturnType::EmitFunction emitFunction(
                     {
                         /// Acquire an inflight slot; acquire() returns false (without taking a slot) if the source is
                         /// asked to terminate while waiting, so there is no permit imbalance on the stop path.
-                        if (not availableBuffer->acquire(stopToken))
+                        if (not availableBuffer->acquire(stopToken).acquired)
                         {
                             return SourceReturnType::EmitResult::STOP_REQUESTED;
                         }

--- a/nes-query-engine/RunningSource.cpp
+++ b/nes-query-engine/RunningSource.cpp
@@ -47,11 +47,29 @@ SourceReturnType::EmitFunction emitFunction(
     std::weak_ptr<RunningSource> source,
     std::vector<std::shared_ptr<RunningQueryPlanNode>> successors,
     QueryLifetimeController& controller,
-    WorkEmitter& emitter)
+    WorkEmitter& emitter,
+    const bool adaptiveInflight)
 {
-    auto availableBuffer = std::make_shared<InflightThrottle>(
-        std::min(numberOfInflightBuffers, static_cast<size_t>(std::numeric_limits<int32_t>::max())));
-    return [&controller, successors = std::move(successors), source, &emitter, queryId, availableBuffer = std::move(availableBuffer)](
+    /// #1713: max = the configured inflight limit, so the adaptive cap never exceeds the non-adaptive baseline. When
+    /// adaptive, the throttle starts low (max/4) and the AIMD policy grows it toward max on stall / decays it on idle.
+    const auto maxLimit = std::min(numberOfInflightBuffers, static_cast<size_t>(std::numeric_limits<int32_t>::max()));
+    const auto initialLimit = adaptiveInflight ? std::max<size_t>(1, maxLimit / 4) : maxLimit;
+    auto availableBuffer = std::make_shared<InflightThrottle>(initialLimit);
+    auto policy = std::make_shared<InflightPolicy>(InflightPolicy{
+        .min = std::max<size_t>(1, maxLimit / 8),
+        .max = maxLimit,
+        .current = initialLimit,
+        .additiveStep = std::max<size_t>(1, maxLimit / 8)});
+    auto lastActivity = std::make_shared<std::chrono::steady_clock::time_point>(std::chrono::steady_clock::now());
+    return [&controller,
+            successors = std::move(successors),
+            source,
+            &emitter,
+            queryId,
+            adaptiveInflight,
+            availableBuffer = std::move(availableBuffer),
+            policy = std::move(policy),
+            lastActivity = std::move(lastActivity)](
                const OriginId sourceId,
                SourceReturnType::SourceReturnType event,
                const std::stop_token& stopToken) -> SourceReturnType::EmitResult
@@ -62,11 +80,27 @@ SourceReturnType::EmitFunction emitFunction(
                 {
                     for (const auto& successor : successors)
                     {
-                        /// Acquire an inflight slot; acquire() returns false (without taking a slot) if the source is
-                        /// asked to terminate while waiting, so there is no permit imbalance on the stop path.
-                        if (not availableBuffer->acquire(stopToken).acquired)
+                        /// Acquire an inflight slot; acquire() returns acquired=false (without taking a slot) if the
+                        /// source is asked to terminate while waiting, so there is no permit imbalance on the stop path.
+                        const auto acquireResult = availableBuffer->acquire(stopToken);
+                        if (not acquireResult.acquired)
                         {
                             return SourceReturnType::EmitResult::STOP_REQUESTED;
+                        }
+                        if (adaptiveInflight)
+                        {
+                            /// #1713 AIMD: grow the cap when we had to wait (saturated), decay it after an idle gap.
+                            const auto now = std::chrono::steady_clock::now();
+                            if (acquireResult.waited)
+                            {
+                                availableBuffer->setLimit(policy->onStall());
+                                *lastActivity = now;
+                            }
+                            else if (now - *lastActivity > std::chrono::milliseconds(500))
+                            {
+                                availableBuffer->setLimit(policy->onIdleDecay());
+                                *lastActivity = now;
+                            }
                         }
                         /// The admission queue might be full, we have to reattempt
                         while (not emitter.emitWork(
@@ -128,12 +162,14 @@ std::shared_ptr<RunningSource> RunningSource::create(
     WorkEmitter& emitter)
 {
     const auto maxInflightBuffers = source->getRuntimeConfiguration().inflightBufferLimit;
+    const auto adaptiveInflight = source->getRuntimeConfiguration().adaptiveInflight;
     auto runningSource = std::shared_ptr<RunningSource>(
         new RunningSource(successors, std::move(source), std::move(onSourceStopped), std::move(onSourceFailure)));
     ENGINE_LOG_DEBUG("Starting Running Source");
     {
         const std::scoped_lock lock(runningSource->mutex);
-        runningSource->source->start(emitFunction(queryId, maxInflightBuffers, runningSource, std::move(successors), controller, emitter));
+        runningSource->source->start(
+            emitFunction(queryId, maxInflightBuffers, runningSource, std::move(successors), controller, emitter, adaptiveInflight));
     }
     return runningSource;
 }

--- a/nes-query-engine/RunningSource.cpp
+++ b/nes-query-engine/RunningSource.cpp
@@ -20,8 +20,8 @@
 #include <functional>
 #include <limits>
 #include <memory>
+#include <condition_variable>
 #include <mutex>
-#include <semaphore>
 #include <stop_token>
 #include <utility>
 #include <variant>
@@ -40,6 +40,77 @@ namespace NES
 
 namespace
 {
+/// #1713: bounded counter with a dynamically adjustable limit, replacing std::counting_semaphore as the per-source
+/// inflight-buffer throttle so the cap can later grow/shrink at runtime (adaptive provisioning). Stage 1 keeps the
+/// limit fixed, so behaviour is identical to the semaphore. condition_variable_any is required to compose with
+/// std::stop_callback (std::condition_variable cannot).
+class InflightThrottle
+{
+public:
+    explicit InflightThrottle(const std::size_t initialLimit) : limit(initialLimit) { }
+
+    /// Blocks until inUse < limit OR the stop_token is signalled. Returns true if a slot was acquired (inUse
+    /// incremented); false if it returned due to stop (inUse NOT incremented -- the caller must not release()).
+    [[nodiscard]] bool acquire(const std::stop_token& token)
+    {
+        std::unique_lock lock(mutex);
+        const std::stop_callback callback(token, [this] { cv.notify_all(); });
+        cv.wait(lock, [&] { return inUse < limit || token.stop_requested(); });
+        if (token.stop_requested())
+        {
+            return false;
+        }
+        ++inUse;
+        return true;
+    }
+
+    /// Returns one slot. Safe to call from any thread (e.g. the task-completion callback).
+    void release()
+    {
+        bool notify = false;
+        {
+            const std::lock_guard lock(mutex);
+            if (inUse > 0)
+            {
+                --inUse;
+            }
+            notify = inUse < limit;
+        }
+        if (notify)
+        {
+            cv.notify_one();
+        }
+    }
+
+    /// Adjust the cap (Stage 2 AIMD will call this; Stage 1 never does). Growing wakes waiters; shrinking below inUse
+    /// simply blocks new acquires until releases drain it -- in-flight buffers are never forcibly reclaimed.
+    void setLimit(const std::size_t newLimit)
+    {
+        bool grew = false;
+        {
+            const std::lock_guard lock(mutex);
+            grew = newLimit > limit;
+            limit = newLimit;
+        }
+        if (grew)
+        {
+            cv.notify_all();
+        }
+    }
+
+    [[nodiscard]] std::size_t currentLimit() const
+    {
+        const std::lock_guard lock(mutex);
+        return limit;
+    }
+
+private:
+    mutable std::mutex mutex;
+    std::condition_variable_any cv;
+    std::size_t inUse = 0;
+    std::size_t limit;
+};
+
 SourceReturnType::EmitFunction emitFunction(
     QueryId queryId,
     size_t numberOfInflightBuffers,
@@ -48,7 +119,7 @@ SourceReturnType::EmitFunction emitFunction(
     QueryLifetimeController& controller,
     WorkEmitter& emitter)
 {
-    auto availableBuffer = std::make_shared<std::counting_semaphore<>>(
+    auto availableBuffer = std::make_shared<InflightThrottle>(
         std::min(numberOfInflightBuffers, static_cast<size_t>(std::numeric_limits<int32_t>::max())));
     return [&controller, successors = std::move(successors), source, &emitter, queryId, availableBuffer = std::move(availableBuffer)](
                const OriginId sourceId,
@@ -61,14 +132,11 @@ SourceReturnType::EmitFunction emitFunction(
                 {
                     for (const auto& successor : successors)
                     {
+                        /// Acquire an inflight slot; acquire() returns false (without taking a slot) if the source is
+                        /// asked to terminate while waiting, so there is no permit imbalance on the stop path.
+                        if (not availableBuffer->acquire(stopToken))
                         {
-                            /// release the semaphore in case the source wants to terminate
-                            const std::stop_callback callback(stopToken, [&]() { availableBuffer->release(); });
-                            availableBuffer->acquire();
-                            if (stopToken.stop_requested())
-                            {
-                                return SourceReturnType::EmitResult::STOP_REQUESTED;
-                            }
+                            return SourceReturnType::EmitResult::STOP_REQUESTED;
                         }
                         /// The admission queue might be full, we have to reattempt
                         while (not emitter.emitWork(

--- a/nes-query-engine/RunningSource.cpp
+++ b/nes-query-engine/RunningSource.cpp
@@ -90,15 +90,28 @@ SourceReturnType::EmitFunction emitFunction(
                         if (adaptiveInflight)
                         {
                             /// #1713 AIMD: grow the cap when we had to wait (saturated), decay it after an idle gap.
+                            /// Log only on an actual change -- this doubles as the per-source grant/decay instrumentation.
                             const auto now = std::chrono::steady_clock::now();
                             if (acquireResult.waited)
                             {
-                                availableBuffer->setLimit(policy->onStall());
+                                const auto prev = availableBuffer->currentLimit();
+                                const auto grown = policy->onStall();
+                                availableBuffer->setLimit(grown);
+                                if (grown != prev)
+                                {
+                                    ENGINE_LOG_DEBUG("#1713 adaptive inflight grew {} -> {} (query {})", prev, grown, queryId);
+                                }
                                 *lastActivity = now;
                             }
                             else if (now - *lastActivity > std::chrono::milliseconds(500))
                             {
-                                availableBuffer->setLimit(policy->onIdleDecay());
+                                const auto prev = availableBuffer->currentLimit();
+                                const auto decayed = policy->onIdleDecay();
+                                availableBuffer->setLimit(decayed);
+                                if (decayed != prev)
+                                {
+                                    ENGINE_LOG_DEBUG("#1713 adaptive inflight decayed {} -> {} (query {})", prev, decayed, queryId);
+                                }
                                 *lastActivity = now;
                             }
                         }

--- a/nes-query-engine/RunningSource.cpp
+++ b/nes-query-engine/RunningSource.cpp
@@ -16,11 +16,11 @@
 
 #include <algorithm>
 #include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <functional>
 #include <limits>
 #include <memory>
-#include <condition_variable>
 #include <mutex>
 #include <stop_token>
 #include <utility>
@@ -31,8 +31,8 @@
 #include <Util/Overloaded.hpp>
 #include <EngineLogger.hpp>
 #include <ErrorHandling.hpp>
-#include <Interfaces.hpp>
 #include <InflightThrottle.hpp>
+#include <Interfaces.hpp>
 #include <PipelineExecutionContext.hpp>
 #include <RunningQueryPlan.hpp>
 

--- a/nes-query-engine/tests/CMakeLists.txt
+++ b/nes-query-engine/tests/CMakeLists.txt
@@ -23,5 +23,6 @@ add_query_engine_test(query-engine-task-queue-test TaskQueueTest.cpp)
 add_query_engine_test(running-query-plan-test QueryPlanTest.cpp)
 add_query_engine_test(query-engine-configuration-test QueryEngineConfigurationTest.cpp)
 add_query_engine_test(callback-test CallbackTest.cpp)
+add_query_engine_test(inflight-throttle-test InflightThrottleTest.cpp)
 
 add_subdirectory(Util)

--- a/nes-query-engine/tests/InflightThrottleTest.cpp
+++ b/nes-query-engine/tests/InflightThrottleTest.cpp
@@ -12,6 +12,8 @@
     limitations under the License.
 */
 
+/// Unit test: intentional magic literals and test-local using-directives.
+/// NOLINTBEGIN(readability-magic-numbers,google-build-using-namespace,misc-include-cleaner)
 #include <atomic>
 #include <chrono>
 #include <cstddef>
@@ -51,7 +53,7 @@ TEST_F(InflightThrottleTest, PolicyMultiplicativeDecreaseClampedToMin)
 TEST_F(InflightThrottleTest, AcquireReleaseAndWaitSignal)
 {
     InflightThrottle throttle(2);
-    std::stop_source stop;
+    const std::stop_source stop;
     const auto first = throttle.acquire(stop.get_token());
     EXPECT_TRUE(first.acquired);
     EXPECT_FALSE(first.waited);
@@ -118,3 +120,5 @@ TEST_F(InflightThrottleTest, SetLimitGrowWakesWaiter)
     EXPECT_TRUE(acquired.load());
     EXPECT_EQ(throttle.currentInUse(), 2U);
 }
+
+/// NOLINTEND(readability-magic-numbers,google-build-using-namespace,misc-include-cleaner)

--- a/nes-query-engine/tests/InflightThrottleTest.cpp
+++ b/nes-query-engine/tests/InflightThrottleTest.cpp
@@ -1,0 +1,120 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <stop_token>
+#include <thread>
+#include <gtest/gtest.h>
+#include <InflightThrottle.hpp>
+
+using namespace NES;
+using namespace std::chrono_literals;
+
+class InflightThrottleTest : public ::testing::Test
+{
+};
+
+/// AIMD policy is a pure value object -- additive-increase on stall, clamped to max.
+TEST_F(InflightThrottleTest, PolicyAdditiveIncreaseClampedToMax)
+{
+    InflightPolicy policy{.min = 2, .max = 16, .current = 4, .additiveStep = 4};
+    EXPECT_EQ(policy.onStall(), 8U);
+    EXPECT_EQ(policy.onStall(), 12U);
+    EXPECT_EQ(policy.onStall(), 16U);
+    EXPECT_EQ(policy.onStall(), 16U); /// clamp at max
+}
+
+/// Multiplicative-decrease on idle, clamped to min.
+TEST_F(InflightThrottleTest, PolicyMultiplicativeDecreaseClampedToMin)
+{
+    InflightPolicy policy{.min = 2, .max = 16, .current = 16};
+    EXPECT_EQ(policy.onIdleDecay(), 8U);
+    EXPECT_EQ(policy.onIdleDecay(), 4U);
+    EXPECT_EQ(policy.onIdleDecay(), 2U);
+    EXPECT_EQ(policy.onIdleDecay(), 2U); /// clamp at min
+}
+
+/// Acquire reports whether it had to wait (the saturation signal), and release frees a slot.
+TEST_F(InflightThrottleTest, AcquireReleaseAndWaitSignal)
+{
+    InflightThrottle throttle(2);
+    std::stop_source stop;
+    const auto first = throttle.acquire(stop.get_token());
+    EXPECT_TRUE(first.acquired);
+    EXPECT_FALSE(first.waited);
+    const auto second = throttle.acquire(stop.get_token());
+    EXPECT_TRUE(second.acquired);
+    EXPECT_FALSE(second.waited);
+    EXPECT_EQ(throttle.currentInUse(), 2U);
+
+    throttle.release();
+    EXPECT_EQ(throttle.currentInUse(), 1U);
+    const auto third = throttle.acquire(stop.get_token());
+    EXPECT_TRUE(third.acquired);
+    EXPECT_EQ(throttle.currentInUse(), 2U);
+}
+
+/// A blocked acquire returns (without taking a slot) when the source is asked to stop.
+TEST_F(InflightThrottleTest, StopUnblocksBlockedAcquire)
+{
+    InflightThrottle throttle(1);
+    std::stop_source stop;
+    ASSERT_TRUE(throttle.acquire(stop.get_token()).acquired); /// take the only slot
+
+    std::atomic<bool> finished{false};
+    InflightThrottle::AcquireResult result{};
+    std::thread worker(
+        [&]
+        {
+            result = throttle.acquire(stop.get_token());
+            finished = true;
+        });
+
+    std::this_thread::sleep_for(50ms);
+    EXPECT_FALSE(finished.load()); /// blocked: no slot available
+
+    stop.request_stop();
+    worker.join();
+    EXPECT_FALSE(result.acquired); /// returned due to stop, no slot taken
+    EXPECT_TRUE(result.waited);
+    EXPECT_EQ(throttle.currentInUse(), 1U); /// still only the first slot
+}
+
+/// Growing the limit wakes a waiter (the adaptive-increase path).
+TEST_F(InflightThrottleTest, SetLimitGrowWakesWaiter)
+{
+    InflightThrottle throttle(1);
+    std::stop_source stop;
+    ASSERT_TRUE(throttle.acquire(stop.get_token()).acquired); /// take the only slot
+
+    std::atomic<bool> acquired{false};
+    std::thread worker(
+        [&]
+        {
+            if (throttle.acquire(stop.get_token()).acquired)
+            {
+                acquired = true;
+            }
+        });
+
+    std::this_thread::sleep_for(50ms);
+    EXPECT_FALSE(acquired.load()); /// blocked at limit 1
+
+    throttle.setLimit(2); /// grow -> waiter wakes and acquires
+    worker.join();
+    EXPECT_TRUE(acquired.load());
+    EXPECT_EQ(throttle.currentInUse(), 2U);
+}

--- a/nes-runtime/interface/Configuration/WorkerConfiguration.hpp
+++ b/nes-runtime/interface/Configuration/WorkerConfiguration.hpp
@@ -77,6 +77,11 @@ public:
            "SourceDescriptor).",
            {std::make_shared<NumberValidation>()}};
 
+    /// #1713: enables adaptive (AIMD) per-source inflight-buffer provisioning -- the inflight cap starts low and grows
+    /// toward default_max_inflight_buffers under load, decaying when idle. Off by default (fixed cap).
+    BoolOption enableAdaptiveInflightBuffers
+        = {"enable_adaptive_inflight_buffers", "false", "Enable adaptive (AIMD) per-source inflight-buffer provisioning."};
+
     EnumOption<DumpMode::Options> dumpQueryCompilationIR
         = {"dump_compilation_result",
            DumpMode::Options::NONE,
@@ -96,6 +101,7 @@ private:
             &unpooledMemoryFraction,
             &bufferAlignmentInBytes,
             &defaultMaxInflightBuffers,
+            &enableAdaptiveInflightBuffers,
             &dumpQueryCompilationIR,
             &dumpGraph};
     }

--- a/nes-runtime/src/Runtime/NodeEngineBuilder.cpp
+++ b/nes-runtime/src/Runtime/NodeEngineBuilder.cpp
@@ -47,7 +47,10 @@ std::unique_ptr<NodeEngine> NodeEngineBuilder::build(const Host& host)
 
     auto queryEngine = std::make_unique<QueryEngine>(workerConfiguration.queryEngine, statisticsListener, queryLog, bufferManager, host);
 
-    auto sourceProvider = std::make_unique<SourceProvider>(workerConfiguration.defaultMaxInflightBuffers.getValue(), bufferManager);
+    auto sourceProvider = std::make_unique<SourceProvider>(
+        workerConfiguration.defaultMaxInflightBuffers.getValue(),
+        workerConfiguration.enableAdaptiveInflightBuffers.getValue(),
+        bufferManager);
 
     return std::make_unique<NodeEngine>(
         std::move(bufferManager), statisticsListener, std::move(queryLog), std::move(queryEngine), std::move(sourceProvider));

--- a/nes-sources/include/Sources/SourceHandle.hpp
+++ b/nes-sources/include/Sources/SourceHandle.hpp
@@ -34,6 +34,8 @@ class SourceThread;
 struct SourceRuntimeConfiguration
 {
     size_t inflightBufferLimit;
+    /// #1713: when true, the per-source inflight cap adapts (AIMD) within [.., inflightBufferLimit] instead of staying fixed.
+    bool adaptiveInflight = false;
 };
 
 /// Interface class to handle sources.

--- a/nes-sources/include/Sources/SourceProvider.hpp
+++ b/nes-sources/include/Sources/SourceProvider.hpp
@@ -31,11 +31,12 @@ namespace NES
 class SourceProvider
 {
     size_t defaultMaxInflightBuffers;
+    bool enableAdaptiveInflight;
     std::shared_ptr<AbstractBufferProvider> bufferPool;
 
 public:
     /// Constructor that can be configured with various options
-    SourceProvider(size_t defaultMaxInflightBuffers, std::shared_ptr<AbstractBufferProvider> bufferPool);
+    SourceProvider(size_t defaultMaxInflightBuffers, bool enableAdaptiveInflight, std::shared_ptr<AbstractBufferProvider> bufferPool);
 
     /// Returning a shared pointer, because sources may be shared by multiple executable query plans (qeps).
     [[nodiscard]] std::unique_ptr<SourceHandle>

--- a/nes-sources/src/SourceProvider.cpp
+++ b/nes-sources/src/SourceProvider.cpp
@@ -28,8 +28,11 @@
 namespace NES
 {
 
-SourceProvider::SourceProvider(size_t defaultMaxInflightBuffers, std::shared_ptr<AbstractBufferProvider> bufferPool)
-    : defaultMaxInflightBuffers(defaultMaxInflightBuffers), bufferPool(std::move(bufferPool))
+SourceProvider::SourceProvider(
+    size_t defaultMaxInflightBuffers, bool enableAdaptiveInflight, std::shared_ptr<AbstractBufferProvider> bufferPool)
+    : defaultMaxInflightBuffers(defaultMaxInflightBuffers)
+    , enableAdaptiveInflight(enableAdaptiveInflight)
+    , bufferPool(std::move(bufferPool))
 {
 }
 
@@ -45,7 +48,7 @@ SourceProvider::lower(OriginId originId, BackpressureListener backpressureListen
         const auto maxInflightBuffers = (sourceDescriptor.getFromConfig(SourceDescriptor::MAX_INFLIGHT_BUFFERS) > 0)
             ? sourceDescriptor.getFromConfig(SourceDescriptor::MAX_INFLIGHT_BUFFERS)
             : defaultMaxInflightBuffers;
-        SourceRuntimeConfiguration runtimeConfig{maxInflightBuffers};
+        SourceRuntimeConfiguration runtimeConfig{maxInflightBuffers, enableAdaptiveInflight};
 
         return std::make_unique<SourceHandle>(
             std::move(backpressureListener), std::move(originId), std::move(runtimeConfig), bufferPool, std::move(source.value()));

--- a/nes-sources/src/SourceProvider.cpp
+++ b/nes-sources/src/SourceProvider.cpp
@@ -48,7 +48,7 @@ SourceProvider::lower(OriginId originId, BackpressureListener backpressureListen
         const auto maxInflightBuffers = (sourceDescriptor.getFromConfig(SourceDescriptor::MAX_INFLIGHT_BUFFERS) > 0)
             ? sourceDescriptor.getFromConfig(SourceDescriptor::MAX_INFLIGHT_BUFFERS)
             : defaultMaxInflightBuffers;
-        SourceRuntimeConfiguration runtimeConfig{maxInflightBuffers, enableAdaptiveInflight};
+        SourceRuntimeConfiguration runtimeConfig{.inflightBufferLimit = maxInflightBuffers, .adaptiveInflight = enableAdaptiveInflight};
 
         return std::make_unique<SourceHandle>(
             std::move(backpressureListener), std::move(originId), std::move(runtimeConfig), bufferPool, std::move(source.value()));

--- a/nes-systests/differential/AdaptiveInflightSaturation.test
+++ b/nes-systests/differential/AdaptiveInflightSaturation.test
@@ -1,0 +1,22 @@
+# name: differential/AdaptiveInflightSaturation.test
+# description: High-volume (flood-rate) generator exercising #1713 adaptive inflight provisioning under load. Run with
+#   --workerConfig enable_adaptive_inflight_buffers=true to drive the adaptive path; the differential form asserts the
+#   two equivalent filters still agree, guarding correctness of the adaptive path under high volume.
+#   NOTE: for a *cheap* filter the source is the bottleneck, so the per-source cap does not grow (no backpressure). To
+#   observe the AIMD cap climbing, pair adaptive mode with a downstream-bound query (heavy join/aggregation or a slow
+#   sink) so the source's in-flight slots actually fill -- see the #1713 AIMD unit test for the policy's grow/decay math.
+# groups: [Differential]
+
+CREATE LOGICAL SOURCE stream(id UINT64 NOT NULL, value UINT64 NOT NULL, timestamp UINT64 NOT NULL);
+CREATE PHYSICAL SOURCE FOR stream TYPE Generator SET(
+    1 AS "SOURCE".SEED,
+    'ALL' as "SOURCE".STOP_GENERATOR_WHEN_SEQUENCE_FINISHES,
+    'emit_rate 1000000000' AS "SOURCE".GENERATOR_RATE_CONFIG,
+    'SEQUENCE UINT64 0 100000 1, SEQUENCE UINT64 0 100000 1, SEQUENCE UINT64 0 100000 1' AS "SOURCE".GENERATOR_SCHEMA
+);
+
+CREATE SINK saturationSink(out_id UINT64 NOT NULL, out_value UINT64 NOT NULL, out_timestamp UINT64 NOT NULL) TYPE File;
+
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp FROM stream WHERE value >= UINT64(50000) INTO saturationSink;
+====
+SELECT id AS out_id, value AS out_value, timestamp AS out_timestamp FROM stream WHERE NOT (value < UINT64(50000)) INTO saturationSink;


### PR DESCRIPTION
Part of EPIC #1714. Replaces the static per-source in-flight `counting_semaphore` with a resizable `InflightThrottle` + AIMD `InflightPolicy` (grow under load, decay when idle, bounded by the old cap), gated by `enable_adaptive_inflight_buffers`. Uses `condition_variable_any` to compose with `stop_token`. Unit + differential test included. Independent; based on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)