### PR TITLE
Feature(#1705): route operator-state pages through pooled size classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ scripts/__pycache__
 .claude/
 .codex/
 [Cc][Ll][Aa][Uu][Dd][Ee].md
+/build-bench*

--- a/nes-configurations/include/Configurations/Validation/PowerOfTwoValidation.hpp
+++ b/nes-configurations/include/Configurations/Validation/PowerOfTwoValidation.hpp
@@ -1,0 +1,29 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <string>
+#include <Configurations/Validation/ConfigurationValidation.hpp>
+
+namespace NES
+{
+
+/// @brief Validates that a parameter is a positive power of two (e.g. buffer size class bounds).
+class PowerOfTwoValidation : public ConfigurationValidation
+{
+public:
+    bool isValid(const std::string& parameter) const override;
+};
+}

--- a/nes-configurations/src/Configurations/Validation/PowerOfTwoValidation.cpp
+++ b/nes-configurations/src/Configurations/Validation/PowerOfTwoValidation.cpp
@@ -1,0 +1,39 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Configurations/Validation/PowerOfTwoValidation.hpp>
+
+#include <bit>
+#include <charconv>
+#include <cstdint>
+#include <string>
+#include <system_error>
+
+namespace NES
+{
+
+bool PowerOfTwoValidation::isValid(const std::string& parameter) const
+{
+    uint64_t value = 0;
+    const char* begin = parameter.data();
+    const char* end = begin + parameter.size();
+    /// from_chars does not throw: it rejects non-numeric input, partial parses, and overflow via the error code.
+    const auto [ptr, errorCode] = std::from_chars(begin, end, value);
+    if (errorCode != std::errc{} || ptr != end)
+    {
+        return false;
+    }
+    return value > 0 && std::has_single_bit(value);
+}
+}

--- a/nes-configurations/tests/CMakeLists.txt
+++ b/nes-configurations/tests/CMakeLists.txt
@@ -13,5 +13,5 @@
 # Google Testing Framework ----------------------------------------------------
 include(ExternalProject)
 ### Config Tests ###
-add_nes_unit_test(configuration-help-message-tests "UnitTests/Configurations/ConfigurationHelpMessageTests.cpp" "UnitTests/Validation/EndpointValidationTest.cpp" "UnitTests/Configurations/ExplicitlySetTrackingTests.cpp")
+add_nes_unit_test(configuration-help-message-tests "UnitTests/Configurations/ConfigurationHelpMessageTests.cpp" "UnitTests/Validation/EndpointValidationTest.cpp" "UnitTests/Validation/PowerOfTwoValidationTest.cpp" "UnitTests/Configurations/ExplicitlySetTrackingTests.cpp")
 set_tests_properties(${Tests} PROPERTIES TIMEOUT 35)

--- a/nes-configurations/tests/UnitTests/Validation/PowerOfTwoValidationTest.cpp
+++ b/nes-configurations/tests/UnitTests/Validation/PowerOfTwoValidationTest.cpp
@@ -1,0 +1,49 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <string>
+#include <Configurations/Validation/PowerOfTwoValidation.hpp>
+#include <gtest/gtest.h>
+
+GTEST_TEST(PowerOfTwoValidationTest, AcceptsPowersOfTwo)
+{
+    const NES::PowerOfTwoValidation validation;
+    auto assertValid = [&](const std::string& value) { EXPECT_TRUE(validation.isValid(value)) << value; };
+
+    assertValid("1");
+    assertValid("2");
+    assertValid("4");
+    assertValid("8");
+    assertValid("64");
+    assertValid("4096");
+    assertValid("1048576");
+    assertValid("9223372036854775808"); /// 2^63
+}
+
+GTEST_TEST(PowerOfTwoValidationTest, RejectsNonPowersOfTwoAndGarbage)
+{
+    const NES::PowerOfTwoValidation validation;
+    auto assertInvalid = [&](const std::string& value) { EXPECT_FALSE(validation.isValid(value)) << value; };
+
+    assertInvalid("0"); /// zero is not a positive power of two
+    assertInvalid("3");
+    assertInvalid("6");
+    assertInvalid("1000");
+    assertInvalid(""); /// empty
+    assertInvalid("abc"); /// non-numeric
+    assertInvalid("-4"); /// negative / leading sign
+    assertInvalid("4096 "); /// trailing characters -> partial parse
+    assertInvalid("0x10"); /// hex literal not accepted
+    assertInvalid("18446744073709551616"); /// 2^64 -> overflows uint64
+}

--- a/nes-memory/BufferManager.cpp
+++ b/nes-memory/BufferManager.cpp
@@ -14,17 +14,13 @@
 #include <Runtime/BufferManager.hpp>
 
 #include <algorithm>
-#include <array>
 #include <atomic>
 #include <bit>
 #include <chrono>
 #include <cstdint>
-#include <cstdio>
-#include <cstring>
-#include <deque>
+#include <map>
 #include <memory>
 #include <memory_resource>
-#include <mutex>
 #include <optional>
 #include <utility>
 #include <unistd.h>
@@ -33,8 +29,8 @@
 #include <Runtime/MemoryUtils.hpp>
 #include <Runtime/TupleBuffer.hpp>
 #include <Util/Logger/Logger.hpp>
-#include <folly/MPMCQueue.h>
 #include <ErrorHandling.hpp>
+#include <FixedSizeClassPool.hpp>
 #include <TupleBufferImpl.hpp>
 
 namespace NES
@@ -45,21 +41,25 @@ BufferManager::BufferManager(
     const uint32_t bufferSize,
     const uint32_t numOfBuffers,
     std::shared_ptr<std::pmr::memory_resource> memoryResource,
-    const uint32_t withAlignment)
-    : availableBuffers(numOfBuffers)
-    , unpooledChunksManager(std::make_shared<UnpooledChunksManager>(memoryResource))
+    const uint32_t withAlignment,
+    std::optional<SizeClassConfig> sizeClasses)
+    : unpooledChunksManager(std::make_shared<UnpooledChunksManager>(memoryResource))
     , bufferSize(bufferSize)
     , numOfBuffers(numOfBuffers)
     , memoryResource(std::move(memoryResource))
 {
     ((void)withAlignment);
-    initialize(DEFAULT_ALIGNMENT);
+    initialize(DEFAULT_ALIGNMENT, sizeClasses);
 }
 
 std::shared_ptr<BufferManager> BufferManager::create(
-    uint32_t bufferSize, uint32_t numOfBuffers, const std::shared_ptr<std::pmr::memory_resource>& memoryResource, uint32_t withAlignment)
+    uint32_t bufferSize,
+    uint32_t numOfBuffers,
+    const std::shared_ptr<std::pmr::memory_resource>& memoryResource,
+    uint32_t withAlignment,
+    std::optional<SizeClassConfig> sizeClasses)
 {
-    return std::make_shared<BufferManager>(Private{}, bufferSize, numOfBuffers, memoryResource, withAlignment);
+    return std::make_shared<BufferManager>(Private{}, bufferSize, numOfBuffers, memoryResource, withAlignment, std::move(sizeClasses));
 }
 
 BufferManager::~BufferManager()
@@ -74,114 +74,209 @@ void BufferManager::destroy()
     if (isDestroyed.compare_exchange_strong(expected, true))
     {
         bool success = true;
-        if (allBuffers.size() != getNumberOfAvailableBuffers())
+        size_t totalBuffers = 0;
+        size_t availableBuffers = 0;
+        for (const auto& pool : pools)
         {
-            NES_ERROR("[BufferManager] total buffers {} :: available buffers {}", allBuffers.size(), getNumberOfAvailableBuffers());
+            totalBuffers += pool->numTotal();
+            availableBuffers += pool->numAvailable();
+        }
+        if (totalBuffers != availableBuffers)
+        {
+            NES_ERROR("[BufferManager] total buffers {} :: available buffers {}", totalBuffers, availableBuffers);
             success = false;
         }
-        for (auto& buffer : allBuffers)
+        for (const auto& pool : pools)
         {
-            if (!buffer.isAvailable())
+            for (auto& buffer : pool->segments())
             {
+                if (!buffer.isAvailable())
+                {
 #ifdef NES_DEBUG_TUPLE_BUFFER_LEAKS
-                buffer.controlBlock->dumpOwningThreadInfo();
+                    buffer.controlBlock->dumpOwningThreadInfo();
 #endif
-                NES_ERROR("[BufferManager] leaked buffer detected: segment at {}", fmt::ptr(buffer.ptr));
-                success = false;
+                    NES_ERROR("[BufferManager] leaked buffer detected: segment at {}", fmt::ptr(buffer.ptr));
+                    success = false;
+                }
             }
         }
         INVARIANT(
             success,
             "Requested buffer manager shutdown but a buffer is still used allBuffers={} available={}",
-            allBuffers.size(),
-            getNumberOfAvailableBuffers());
-        /// RAII takes care of deallocating memory here
-        allBuffers.clear();
+            totalBuffers,
+            availableBuffers);
 
-        availableBuffers = decltype(availableBuffers)();
+        /// Destroy the MemorySegments (and their placed control blocks) before freeing the backing regions.
+        for (const auto& pool : pools)
+        {
+            pool->teardown();
+        }
+        pools.clear();
         NES_DEBUG("Shutting down Buffer Manager completed");
-        memoryResource->deallocate(basePointer, allocatedAreaSize, DEFAULT_ALIGNMENT);
-        allocatedAreaSize = 0;
 
         /// Destroying the unpooled chunks
         unpooledChunksManager.reset();
     }
 }
 
-void BufferManager::initialize(uint32_t withAlignment)
+namespace
+{
+/// Per-pool provisioning derived from the SizeClassConfig before any memory is allocated.
+struct PoolSpec
+{
+    size_t initialCount;
+    size_t capacity;
+    bool elastic;
+    size_t growthChunkBuffers;
+};
+}
+
+void BufferManager::initialize(uint32_t withAlignment, const std::optional<SizeClassConfig>& sizeClasses)
 {
     const size_t pages = sysconf(_SC_PHYS_PAGES);
-    size_t page_size = sysconf(_SC_PAGE_SIZE);
-    auto memorySizeInBytes = pages * page_size;
+    const size_t pageSize = sysconf(_SC_PAGE_SIZE);
+    const auto memorySizeInBytes = pages * pageSize;
 
-    uint64_t requiredMemorySpace = this->bufferSize * this->numOfBuffers;
-    double percentage = (100.0 * requiredMemorySpace) / memorySizeInBytes;
-    NES_DEBUG("NES memory allocation requires {} out of {} (so {}%) available bytes", requiredMemorySpace, memorySizeInBytes, percentage);
-
-    INVARIANT(
-        requiredMemorySpace < memorySizeInBytes,
-        "NES tries to allocate more memory than physically available requested={} available={}",
-        requiredMemorySpace,
-        memorySizeInBytes);
     if (withAlignment > 0)
     {
         PRECONDITION(
             !(withAlignment & (withAlignment - 1)), "NES tries to align memory but alignment={} is not a pow of two", withAlignment);
     }
-    PRECONDITION(withAlignment <= page_size, "NES tries to align memory but alignment is invalid: {} <= {}", withAlignment, page_size);
-
+    PRECONDITION(withAlignment <= pageSize, "NES tries to align memory but alignment is invalid: {} <= {}", withAlignment, pageSize);
     PRECONDITION(
         alignof(detail::BufferControlBlock) <= withAlignment,
         "Requested alignment is too small, must be at least {}",
         alignof(detail::BufferControlBlock));
+    this->alignment = withAlignment;
 
-    allBuffers.reserve(numOfBuffers);
-    auto controlBlockSize = alignBufferSize(sizeof(detail::BufferControlBlock), withAlignment);
-    auto alignedBufferSize = alignBufferSize(bufferSize, withAlignment);
-    allocatedAreaSize = alignBufferSize(controlBlockSize + alignedBufferSize, withAlignment);
-    const size_t offsetBetweenBuffers = allocatedAreaSize;
-    allocatedAreaSize *= numOfBuffers;
-    basePointer = static_cast<uint8_t*>(memoryResource->allocate(allocatedAreaSize, withAlignment));
+    /// std::map keeps the size classes sorted ascending and deduplicates a configured class that
+    /// coincides with the default buffer size (the default class' provisioning wins for that size).
+    std::map<size_t, PoolSpec> specs;
+    specs[bufferSize] = PoolSpec{.initialCount = numOfBuffers, .capacity = numOfBuffers, .elastic = false, .growthChunkBuffers = 0};
 
-#ifndef NDEBUG
-    constexpr std::array marker{'N', 'E', 'B', 'U', 'S', 'T', 'R', 'M'};
-    /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): basePointer is freshly allocated raw storage aligned to >= alignof(uint64_t).
-    std::fill_n(reinterpret_cast<uint64_t*>(basePointer), allocatedAreaSize / sizeof(uint64_t), std::bit_cast<uint64_t>(marker));
-#endif
-
-    NES_TRACE(
-        "Allocated {} bytes with alignment {} buffer size {} num buffer {} controlBlockSize {} {}",
-        allocatedAreaSize,
-        withAlignment,
-        alignedBufferSize,
-        numOfBuffers,
-        controlBlockSize,
-        alignof(detail::BufferControlBlock));
-
-    INVARIANT(basePointer, "memory allocation failed, because 'basePointer' was a nullptr");
-    uint8_t* ptr = basePointer;
-    for (size_t i = 0; i < numOfBuffers; ++i)
+    if (sizeClasses.has_value())
     {
-        uint8_t* controlBlock = ptr;
-        uint8_t* payload = ptr + controlBlockSize;
-        allBuffers.emplace_back(
-            payload,
-            bufferSize,
-            [](detail::MemorySegment* segment, BufferRecycler* recycler) { recycler->recyclePooledBuffer(segment); },
-            controlBlock);
+        const auto& sc = sizeClasses.value();
+        PRECONDITION(
+            std::has_single_bit(sc.minClassSize) && std::has_single_bit(sc.maxClassSize),
+            "Size class bounds must be powers of two, got min={} max={}",
+            sc.minClassSize,
+            sc.maxClassSize);
+        PRECONDITION(sc.minClassSize <= sc.maxClassSize, "minClassSize={} must be <= maxClassSize={}", sc.minClassSize, sc.maxClassSize);
 
-        availableBuffers.write(&allBuffers.back());
-        ptr += offsetBetweenBuffers;
+        std::vector<size_t> classSizes;
+        for (size_t classSize = sc.minClassSize; classSize <= sc.maxClassSize; classSize *= 2)
+        {
+            classSizes.push_back(classSize);
+        }
+        const size_t numClasses = classSizes.size();
+        const size_t budget = (sc.totalBudgetBytes != 0) ? sc.totalBudgetBytes : (static_cast<size_t>(bufferSize) * numOfBuffers);
+
+        for (const size_t classSize : classSizes)
+        {
+            if (specs.contains(classSize))
+            {
+                continue; /// already provided by the default class
+            }
+            PoolSpec spec{};
+            switch (sc.policy)
+            {
+                case BufferProvisioningPolicy::TotalBudgetSplit: {
+                    const size_t perClassBytes = budget / numClasses;
+                    spec.initialCount = std::max<size_t>(1, perClassBytes / classSize);
+                    spec.capacity = spec.initialCount;
+                    spec.elastic = false;
+                    spec.growthChunkBuffers = 0;
+                    break;
+                }
+                case BufferProvisioningPolicy::EagerPerClass: {
+                    spec.initialCount = std::max<size_t>(1, sc.buffersPerClass);
+                    spec.capacity = spec.initialCount;
+                    spec.elastic = false;
+                    spec.growthChunkBuffers = 0;
+                    break;
+                }
+                case BufferProvisioningPolicy::LazyElastic: {
+                    spec.growthChunkBuffers = std::max<size_t>(1, sc.growthChunkBuffers);
+                    spec.initialCount = sc.floorBuffersPerClass;
+                    spec.capacity = std::max({sc.maxBuffersPerClass, spec.initialCount, spec.growthChunkBuffers});
+                    spec.elastic = true;
+                    break;
+                }
+            }
+            specs[classSize] = spec;
+        }
     }
-    NES_DEBUG("BufferManager configuration bufferSize={} numOfBuffers={}", this->bufferSize, this->numOfBuffers);
+
+    /// Verify the eager preallocation fits into physical memory.
+    const size_t controlBlockSize = alignBufferSize(sizeof(detail::BufferControlBlock), withAlignment);
+    uint64_t requiredMemorySpace = 0;
+    for (const auto& [classSize, spec] : specs)
+    {
+        const size_t alignedBufferSize = alignBufferSize(classSize, withAlignment);
+        const size_t stride = alignBufferSize(controlBlockSize + alignedBufferSize, withAlignment);
+        requiredMemorySpace += stride * spec.initialCount;
+    }
+    const double percentage = (100.0 * requiredMemorySpace) / memorySizeInBytes;
+    NES_DEBUG("NES memory allocation requires {} out of {} (so {}%) available bytes", requiredMemorySpace, memorySizeInBytes, percentage);
+    INVARIANT(
+        requiredMemorySpace < memorySizeInBytes,
+        "NES tries to allocate more memory than physically available requested={} available={}",
+        requiredMemorySpace,
+        memorySizeInBytes);
+
+    /// Build the pools (std::map iterates ascending by class size).
+    pools.reserve(specs.size());
+    size_t index = 0;
+    for (const auto& [classSize, spec] : specs)
+    {
+        auto pool = std::make_unique<detail::FixedSizeClassPool>(
+            static_cast<uint32_t>(classSize),
+            std::max<size_t>(1, spec.capacity),
+            withAlignment,
+            memoryResource,
+            spec.elastic,
+            spec.growthChunkBuffers);
+        if (spec.initialCount > 0)
+        {
+            pool->addRegion(spec.initialCount);
+        }
+        if (classSize == bufferSize)
+        {
+            defaultPoolIndex = index;
+        }
+        pools.push_back(std::move(pool));
+        ++index;
+    }
+    NES_DEBUG("BufferManager configured with {} size class(es), default class bufferSize={}", pools.size(), bufferSize);
+}
+
+size_t BufferManager::classIndexForSize(const size_t size) const noexcept
+{
+    for (size_t i = 0; i < pools.size(); ++i)
+    {
+        if (pools[i]->getBufferSize() >= size)
+        {
+            return i;
+        }
+    }
+    return pools.size();
+}
+
+TupleBuffer BufferManager::wrapSegment(detail::MemorySegment* segment)
+{
+    if (segment->controlBlock->prepare(shared_from_this()))
+    {
+        return TupleBuffer(segment->controlBlock.get(), segment->ptr, segment->size);
+    }
+    throw InvalidRefCountForBuffer("[BufferManager] got buffer with invalid reference counter");
 }
 
 TupleBuffer BufferManager::getBufferBlocking()
 {
-    auto buffer = getBufferWithTimeout(GET_BUFFER_TIMEOUT);
-    if (buffer.has_value())
+    if (auto* segment = pools[defaultPoolIndex]->popUntil(std::chrono::steady_clock::now() + GET_BUFFER_TIMEOUT))
     {
-        return buffer.value();
+        return wrapSegment(segment);
     }
     /// Throw exception if no buffer was returned allocated after timeout.
     throw BufferAllocationFailure("Global buffer pool could not allocate buffer before timeout({})", GET_BUFFER_TIMEOUT);
@@ -189,31 +284,71 @@ TupleBuffer BufferManager::getBufferBlocking()
 
 std::optional<TupleBuffer> BufferManager::getBufferNoBlocking()
 {
-    detail::MemorySegment* memSegment = nullptr;
-    if (!availableBuffers.read(memSegment))
+    if (auto* segment = pools[defaultPoolIndex]->tryPop())
     {
-        return std::nullopt;
+        return wrapSegment(segment);
     }
-    if (memSegment->controlBlock->prepare(shared_from_this()))
-    {
-        return TupleBuffer(memSegment->controlBlock.get(), memSegment->ptr, memSegment->size);
-    }
-    throw InvalidRefCountForBuffer("[BufferManager] got buffer with invalid reference counter");
+    return std::nullopt;
 }
 
 std::optional<TupleBuffer> BufferManager::getBufferWithTimeout(const std::chrono::milliseconds timeoutMs)
 {
-    detail::MemorySegment* memSegment = nullptr;
-    const auto deadline = std::chrono::steady_clock::now() + timeoutMs;
-    if (!availableBuffers.tryReadUntil(deadline, memSegment))
+    if (auto* segment = pools[defaultPoolIndex]->popUntil(std::chrono::steady_clock::now() + timeoutMs))
     {
-        return std::nullopt;
+        return wrapSegment(segment);
     }
-    if (memSegment->controlBlock->prepare(shared_from_this()))
+    return std::nullopt;
+}
+
+std::optional<TupleBuffer> BufferManager::getBufferNoBlocking(const size_t size)
+{
+    const size_t index = classIndexForSize(size);
+    if (index >= pools.size())
     {
-        return TupleBuffer(memSegment->controlBlock.get(), memSegment->ptr, memSegment->size);
+        /// Larger than any size class -> serve from the unpooled path.
+        return getUnpooledBuffer(size);
     }
-    throw InvalidRefCountForBuffer("[BufferManager] got buffer with invalid reference counter");
+    /// Best-fit class first, then promote to larger classes if it is momentarily exhausted.
+    for (size_t i = index; i < pools.size(); ++i)
+    {
+        if (auto* segment = pools[i]->tryPop())
+        {
+            return wrapSegment(segment);
+        }
+    }
+    return std::nullopt;
+}
+
+TupleBuffer BufferManager::getBuffer(const size_t size)
+{
+    const size_t index = classIndexForSize(size);
+    if (index >= pools.size())
+    {
+        if (auto unpooled = getUnpooledBuffer(size))
+        {
+            return std::move(unpooled.value());
+        }
+        throw BufferAllocationFailure("Buffer manager could not allocate an unpooled buffer of size {}", size);
+    }
+
+    /// Fast path: best-fit or any larger class without blocking.
+    if (auto nonBlocking = getBufferNoBlocking(size))
+    {
+        return std::move(nonBlocking.value());
+    }
+
+    /// Slow path: block on the best-fit class until the timeout elapses.
+    if (auto* segment = pools[index]->popUntil(std::chrono::steady_clock::now() + GET_BUFFER_TIMEOUT))
+    {
+        return wrapSegment(segment);
+    }
+
+    /// Last resort: fall back to the unpooled path rather than failing.
+    if (auto unpooled = getUnpooledBuffer(size))
+    {
+        return std::move(unpooled.value());
+    }
+    throw BufferAllocationFailure("Buffer manager could not allocate a buffer of size {} before timeout({})", size, GET_BUFFER_TIMEOUT);
 }
 
 std::optional<TupleBuffer> BufferManager::getUnpooledBuffer(const size_t bufferSize)
@@ -226,8 +361,16 @@ void BufferManager::recyclePooledBuffer(detail::MemorySegment* segment)
     INVARIANT(segment->isAvailable(), "Recycling buffer callback invoked on used memory segment");
     INVARIANT(
         segment->controlBlock->owningBufferRecycler == nullptr, "Buffer should not retain a reference to its parent while not in use");
-    USED_IN_DEBUG const auto couldRecycleBuffer = availableBuffers.writeIfNotFull(segment);
-    INVARIANT(couldRecycleBuffer, "should always succeed");
+    const uint32_t size = segment->size;
+    for (const auto& pool : pools)
+    {
+        if (pool->getBufferSize() == size)
+        {
+            pool->recycle(segment);
+            return;
+        }
+    }
+    INVARIANT(false, "Recycled a pooled buffer whose size {} matches no size class", size);
 }
 
 void BufferManager::recycleUnpooledBuffer(detail::MemorySegment*, const AllocationThreadInfo&)
@@ -242,7 +385,12 @@ size_t BufferManager::getBufferSize() const
 
 size_t BufferManager::getNumOfPooledBuffers() const
 {
-    return numOfBuffers;
+    size_t total = 0;
+    for (const auto& pool : pools)
+    {
+        total += pool->numTotal();
+    }
+    return total;
 }
 
 size_t BufferManager::getNumOfUnpooledBuffers() const
@@ -252,8 +400,12 @@ size_t BufferManager::getNumOfUnpooledBuffers() const
 
 size_t BufferManager::getNumberOfAvailableBuffers() const
 {
-    /// If there are pending reads the queue may report negative values. This effectivly means its empty.
-    return static_cast<size_t>(std::max(availableBuffers.size(), static_cast<ssize_t>(0)));
+    size_t available = 0;
+    for (const auto& pool : pools)
+    {
+        available += pool->numAvailable();
+    }
+    return available;
 }
 
 BufferManagerType BufferManager::getBufferManagerType() const

--- a/nes-memory/BufferManager.cpp
+++ b/nes-memory/BufferManager.cpp
@@ -378,6 +378,12 @@ void BufferManager::recycleUnpooledBuffer(detail::MemorySegment*, const Allocati
     INVARIANT(false, "This method should not be called!");
 }
 
+bool BufferManager::servesSizeClasses() const
+{
+    /// More than the single default class means power-of-two size classes were configured.
+    return pools.size() > 1;
+}
+
 size_t BufferManager::getBufferSize() const
 {
     return bufferSize;

--- a/nes-memory/CMakeLists.txt
+++ b/nes-memory/CMakeLists.txt
@@ -32,3 +32,10 @@ target_include_directories(nes-memory
 find_package(folly REQUIRED)
 target_link_libraries(nes-memory PUBLIC nes-common nes-data-types PRIVATE folly::folly)
 add_tests_if_enabled(tests)
+
+# Optional microbenchmarks comparing the fixed-pooled, size-class-pooled, and unpooled allocation paths.
+# Off by default so normal builds do not pull in google-benchmark; enable with -DNES_BUILD_MEMORY_BENCHMARKS=ON.
+option(NES_BUILD_MEMORY_BENCHMARKS "Build nes-memory microbenchmarks" OFF)
+if (NES_BUILD_MEMORY_BENCHMARKS)
+    add_subdirectory(benchmarks)
+endif ()

--- a/nes-memory/FixedSizeClassPool.hpp
+++ b/nes-memory/FixedSizeClassPool.hpp
@@ -1,0 +1,217 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <array>
+#include <bit>
+#include <chrono>
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <memory_resource>
+#include <mutex>
+#include <utility>
+#include <vector>
+#include <Runtime/BufferRecycler.hpp>
+#include <Runtime/MemoryUtils.hpp>
+#include <folly/MPMCQueue.h>
+#include <ErrorHandling.hpp>
+#include <TupleBufferImpl.hpp>
+
+namespace NES::detail
+{
+
+/// A pool of preallocated, fixed-size pooled buffers for a single size class.
+///
+/// This encapsulates exactly the machinery the BufferManager used to have for its single global
+/// buffer size: a contiguous memory region whose buffers each carry a placement-new'd (Native)
+/// BufferControlBlock, plus a lock-free folly::MPMCQueue of the currently available segments. The
+/// multi-class BufferManager owns one FixedSizeClassPool per size class.
+///
+/// Memory is owned in `regions`: one region per (eager) preallocation or per (lazy) growth step.
+/// Buffers are stored in a std::deque so their addresses stay stable as the pool grows -- the
+/// availableBuffers queue and every handed-out TupleBuffer hold raw MemorySegment* into it.
+class FixedSizeClassPool
+{
+public:
+    FixedSizeClassPool(
+        const uint32_t bufferSize,
+        const size_t queueCapacity,
+        const uint32_t alignment,
+        std::shared_ptr<std::pmr::memory_resource> memoryResource,
+        const bool elastic,
+        const size_t growthChunkBuffers)
+        : bufferSize(bufferSize)
+        , alignment(alignment)
+        , queueCapacity(queueCapacity)
+        , elastic(elastic)
+        , growthChunkBuffers(growthChunkBuffers)
+        , memoryResource(std::move(memoryResource))
+        , availableBuffers(queueCapacity)
+    {
+        PRECONDITION(queueCapacity > 0, "A size class pool needs a positive queue capacity");
+        PRECONDITION(bufferSize > 0, "A size class pool needs a positive buffer size");
+    }
+
+    FixedSizeClassPool(const FixedSizeClassPool&) = delete;
+    FixedSizeClassPool& operator=(const FixedSizeClassPool&) = delete;
+
+    [[nodiscard]] uint32_t getBufferSize() const noexcept { return bufferSize; }
+
+    /// Preallocate `count` buffers (clamped to the remaining queue capacity) as a single region.
+    void addRegion(const size_t count)
+    {
+        const std::lock_guard lock(mutex);
+        addRegionLocked(count);
+    }
+
+    /// Non-blocking pop of an available segment. If the pool is elastic and currently empty, it
+    /// grows by one region and retries once. Returns nullptr if no buffer could be obtained.
+    MemorySegment* tryPop()
+    {
+        MemorySegment* segment = nullptr;
+        if (availableBuffers.read(segment))
+        {
+            return segment;
+        }
+        if (elastic)
+        {
+            const std::lock_guard lock(mutex);
+            /// Only grow if still empty and below the capacity ceiling -- another thread may have grown already.
+            if (allBuffers.size() < queueCapacity)
+            {
+                addRegionLocked(growthChunkBuffers);
+            }
+            if (availableBuffers.read(segment))
+            {
+                return segment;
+            }
+        }
+        return nullptr;
+    }
+
+    /// Pop blocking until `deadline`. Elastic pools grow once up-front if empty so the wait can
+    /// succeed immediately on the freshly added buffers.
+    MemorySegment* popUntil(const std::chrono::steady_clock::time_point deadline)
+    {
+        if (elastic && numAvailable() == 0)
+        {
+            const std::lock_guard lock(mutex);
+            if (allBuffers.size() < queueCapacity)
+            {
+                addRegionLocked(growthChunkBuffers);
+            }
+        }
+        MemorySegment* segment = nullptr;
+        if (availableBuffers.tryReadUntil(deadline, segment))
+        {
+            return segment;
+        }
+        return nullptr;
+    }
+
+    void recycle(MemorySegment* segment)
+    {
+        USED_IN_DEBUG const auto recycled = availableBuffers.writeIfNotFull(segment);
+        INVARIANT(recycled, "recycling a pooled buffer should always succeed; the queue cannot be full");
+    }
+
+    [[nodiscard]] size_t numAvailable() const { return static_cast<size_t>(std::max(availableBuffers.size(), static_cast<ssize_t>(0))); }
+
+    [[nodiscard]] size_t numTotal() const
+    {
+        const std::lock_guard lock(mutex);
+        return allBuffers.size();
+    }
+
+    /// Direct access to the segments for leak inspection at shutdown. Not thread-safe; only call
+    /// during destroy() when no buffers are being handed out.
+    std::deque<MemorySegment>& segments() { return allBuffers; }
+
+    /// Tear down: destroy all MemorySegments (which destroys the placement-new'd control blocks)
+    /// and only then free the backing regions, matching the original BufferManager teardown order.
+    void teardown()
+    {
+        allBuffers.clear();
+        availableBuffers = folly::MPMCQueue<MemorySegment*>(1);
+        for (auto& [base, size] : regions)
+        {
+            memoryResource->deallocate(base, size, alignment);
+        }
+        regions.clear();
+    }
+
+private:
+    void addRegionLocked(size_t count)
+    {
+        if (count == 0)
+        {
+            return;
+        }
+        const size_t currentTotal = allBuffers.size();
+        if (currentTotal + count > queueCapacity)
+        {
+            count = queueCapacity - currentTotal;
+        }
+        if (count == 0)
+        {
+            return;
+        }
+
+        const size_t controlBlockSize = alignBufferSize(sizeof(BufferControlBlock), alignment);
+        const size_t alignedBufferSize = alignBufferSize(bufferSize, alignment);
+        const size_t stride = alignBufferSize(controlBlockSize + alignedBufferSize, alignment);
+        const size_t regionSize = stride * count;
+
+        auto* base = static_cast<uint8_t*>(memoryResource->allocate(regionSize, alignment));
+        INVARIANT(base, "memory allocation failed for a size class region");
+
+#ifndef NDEBUG
+        constexpr std::array marker{'N', 'E', 'B', 'U', 'S', 'T', 'R', 'M'};
+        /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): freshly allocated raw storage aligned to >= alignof(uint64_t).
+        std::fill_n(reinterpret_cast<uint64_t*>(base), regionSize / sizeof(uint64_t), std::bit_cast<uint64_t>(marker));
+#endif
+
+        regions.emplace_back(base, regionSize);
+        uint8_t* ptr = base;
+        for (size_t i = 0; i < count; ++i)
+        {
+            uint8_t* controlBlock = ptr;
+            uint8_t* payload = ptr + controlBlockSize;
+            allBuffers.emplace_back(
+                payload,
+                bufferSize,
+                [](MemorySegment* segment, BufferRecycler* recycler) { recycler->recyclePooledBuffer(segment); },
+                controlBlock);
+            USED_IN_DEBUG const auto enqueued = availableBuffers.writeIfNotFull(&allBuffers.back());
+            INVARIANT(enqueued, "queue unexpectedly full while initializing a size class region");
+            ptr += stride;
+        }
+    }
+
+    uint32_t bufferSize;
+    uint32_t alignment;
+    size_t queueCapacity;
+    bool elastic;
+    size_t growthChunkBuffers;
+    std::shared_ptr<std::pmr::memory_resource> memoryResource;
+
+    folly::MPMCQueue<MemorySegment*> availableBuffers;
+    std::deque<MemorySegment> allBuffers;
+    std::vector<std::pair<uint8_t*, size_t>> regions;
+    mutable std::mutex mutex;
+};
+
+}

--- a/nes-memory/MemoryUtils.cpp
+++ b/nes-memory/MemoryUtils.cpp
@@ -28,17 +28,9 @@ namespace NES
 
 TupleBuffer getBuffer(const uint64_t size, AbstractBufferProvider& provider)
 {
-    if (size == provider.getBufferSize())
-    {
-        return provider.getBufferBlocking();
-    }
-
-    auto bufferOpt = provider.getUnpooledBuffer(size);
-    if (bufferOpt.has_value())
-    {
-        return bufferOpt.value();
-    }
-    throw BufferAllocationFailure("No unpooled TupleBuffer of size {} available!", size);
+    /// Route through the provider's size-aware allocation: a fitting pooled size class when one
+    /// exists, otherwise the unpooled fallback. The returned buffer is guaranteed to be >= size.
+    return provider.getBuffer(size);
 }
 
 TupleBuffer deepCopyBuffer(const TupleBuffer& buffer, AbstractBufferProvider& provider)

--- a/nes-memory/benchmarks/BufferManagerBenchmark.cpp
+++ b/nes-memory/benchmarks/BufferManagerBenchmark.cpp
@@ -1,0 +1,150 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/// Self-contained microbenchmark (no google-benchmark dependency, which is not part of the vcpkg
+/// manifest) comparing the three allocation paths of the buffer manager. It is the performance gate
+/// for the size-class work: the size-class pooled path must be on par with the legacy fixed pooled
+/// path and clearly faster than the unpooled path, and must scale across threads via the lock-free
+/// per-class queues.
+///
+/// Each iteration allocates one buffer and immediately releases it (RAII), so a pool of N buffers is
+/// never exhausted by up to N concurrent threads.
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+#include <Runtime/BufferManager.hpp>
+#include <Runtime/TupleBuffer.hpp>
+
+namespace
+{
+using namespace NES;
+
+constexpr uint32_t DEFAULT_SIZE = 8192;
+constexpr uint32_t NUM_BUFFERS = 16384;
+/// Maps to a dedicated power-of-two size class (not the default class) and is a valid unpooled size.
+constexpr size_t VARIABLE_SIZE = 1024;
+constexpr size_t ITERATIONS_PER_THREAD = 2'000'000;
+
+SizeClassConfig eagerSizeClasses()
+{
+    SizeClassConfig config{.minClassSize = 512, .maxClassSize = 65536};
+    config.policy = BufferProvisioningPolicy::EagerPerClass;
+    config.buffersPerClass = NUM_BUFFERS;
+    return config;
+}
+
+/// Runs `work` (one alloc+free) ITERATIONS_PER_THREAD times on each of `numThreads` threads that all
+/// start together, and returns the achieved nanoseconds per operation (lower is better).
+double runStrategy(const size_t numThreads, const std::function<void()>& work)
+{
+    std::atomic<size_t> ready{0};
+    std::atomic<bool> go{false};
+    std::vector<std::thread> threads;
+    threads.reserve(numThreads);
+    for (size_t t = 0; t < numThreads; ++t)
+    {
+        threads.emplace_back(
+            [&]
+            {
+                ready.fetch_add(1);
+                while (!go.load())
+                {
+                    /// spin until all threads are ready
+                }
+                for (size_t i = 0; i < ITERATIONS_PER_THREAD; ++i)
+                {
+                    work();
+                }
+            });
+    }
+    while (ready.load() < numThreads)
+    {
+        /// wait for all threads to be spun up
+    }
+    const auto start = std::chrono::steady_clock::now();
+    go.store(true);
+    for (auto& thread : threads)
+    {
+        thread.join();
+    }
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+    const auto totalOps = static_cast<double>(numThreads * ITERATIONS_PER_THREAD);
+    return static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(elapsed).count()) / totalOps;
+}
+
+void report(const std::string& name, const size_t threads, const double nsPerOp)
+{
+    const double opsPerSec = 1e9 / nsPerOp;
+    std::cout << "  " << name << "  threads=" << threads << "  " << nsPerOp << " ns/op  " << (opsPerSec * threads / 1e6)
+              << " Mops/s (aggregate)\n";
+}
+}
+
+int main()
+{
+    std::cout << "BufferManager allocation microbenchmark (" << ITERATIONS_PER_THREAD << " alloc+free per thread)\n";
+
+    for (const size_t threads : {size_t{1}, size_t{2}, size_t{4}, size_t{8}})
+    {
+        auto fixed = BufferManager::create(DEFAULT_SIZE, NUM_BUFFERS);
+        report(
+            "FixedPooled    ",
+            threads,
+            runStrategy(
+                threads,
+                [&]
+                {
+                    auto buffer = fixed->getBufferBlocking();
+                    (void)buffer;
+                }));
+        fixed.reset();
+
+        auto sizeClass
+            = BufferManager::create(DEFAULT_SIZE, NUM_BUFFERS, std::make_shared<NesDefaultMemoryAllocator>(), 64, eagerSizeClasses());
+        report(
+            "SizeClassPooled",
+            threads,
+            runStrategy(
+                threads,
+                [&]
+                {
+                    auto buffer = sizeClass->getBuffer(VARIABLE_SIZE);
+                    (void)buffer;
+                }));
+        sizeClass.reset();
+
+        auto unpooled = BufferManager::create(DEFAULT_SIZE, NUM_BUFFERS);
+        report(
+            "Unpooled       ",
+            threads,
+            runStrategy(
+                threads,
+                [&]
+                {
+                    auto buffer = unpooled->getUnpooledBuffer(VARIABLE_SIZE);
+                    (void)buffer;
+                }));
+        unpooled.reset();
+        std::cout << "\n";
+    }
+    return 0;
+}

--- a/nes-memory/benchmarks/CMakeLists.txt
+++ b/nes-memory/benchmarks/CMakeLists.txt
@@ -10,12 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_source_files(nes-configurations
-        IpValidation.cpp
-        NumberValidation.cpp
-        PowerOfTwoValidation.cpp
-        NonZeroValidation.cpp
-        EndpointValidation.cpp
-        FloatValidation.cpp
-        BooleanValidation.cpp
-)
+# Self-contained timing harness (no google-benchmark dependency, which is not in the vcpkg manifest).
+add_executable(buffer-manager-benchmark BufferManagerBenchmark.cpp)
+target_link_libraries(buffer-manager-benchmark PRIVATE nes-memory)

--- a/nes-memory/include/Runtime/AbstractBufferProvider.hpp
+++ b/nes-memory/include/Runtime/AbstractBufferProvider.hpp
@@ -61,6 +61,25 @@ public:
 
     /// Non-blocking variant of getBuffer(size). Returns an invalid optional if no buffer is currently available.
     virtual std::optional<TupleBuffer> getBufferNoBlocking(size_t size) = 0;
+
+    /// #1705: true if this provider serves multiple power-of-two size classes (size-class pooling enabled), so
+    /// operator-state pages should be drawn from a fitting class rather than the unpooled path.
+    [[nodiscard]] virtual bool servesSizeClasses() const { return false; }
 };
+
+/// #1705: allocate an operator-state page of at least `size` bytes. Prefers a pooled size-class buffer when the
+/// provider has size classes (avoids the slow, fragmenting unpooled path); otherwise uses the unpooled path so we
+/// never consume the default data pool for state. Returns nullopt only on a genuine budget breach (clean failure).
+inline std::optional<TupleBuffer> getPagedBuffer(const size_t size, AbstractBufferProvider& provider)
+{
+    if (provider.servesSizeClasses())
+    {
+        if (auto pooled = provider.getBufferNoBlocking(size); pooled.has_value())
+        {
+            return pooled;
+        }
+    }
+    return provider.getUnpooledBuffer(size);
+}
 
 }

--- a/nes-memory/include/Runtime/AbstractBufferProvider.hpp
+++ b/nes-memory/include/Runtime/AbstractBufferProvider.hpp
@@ -16,10 +16,8 @@
 #include <chrono>
 #include <cstddef>
 #include <optional>
-#include <utility>
 #include <vector>
 #include <Runtime/TupleBuffer.hpp>
-#include <ErrorHandling.hpp>
 
 /// This enum reflects the different types of buffer managers in the system
 /// global: overall buffer manager
@@ -59,28 +57,10 @@ public:
     /// Providers that support multiple size classes serve this from the smallest fitting class; otherwise
     /// it falls back to the default pooled buffer (for `size <= getBufferSize()`) or an unpooled buffer.
     /// Callers must always read the returned buffer's own getBufferSize(); it may exceed `size`.
-    virtual TupleBuffer getBuffer(size_t size)
-    {
-        if (size <= getBufferSize())
-        {
-            return getBufferBlocking();
-        }
-        if (auto unpooled = getUnpooledBuffer(size))
-        {
-            return std::move(unpooled.value());
-        }
-        throw BufferAllocationFailure("Could not allocate a buffer of size {}", size);
-    }
+    virtual TupleBuffer getBuffer(size_t size) = 0;
 
     /// Non-blocking variant of getBuffer(size). Returns an invalid optional if no buffer is currently available.
-    virtual std::optional<TupleBuffer> getBufferNoBlocking(size_t size)
-    {
-        if (size <= getBufferSize())
-        {
-            return getBufferNoBlocking();
-        }
-        return getUnpooledBuffer(size);
-    }
+    virtual std::optional<TupleBuffer> getBufferNoBlocking(size_t size) = 0;
 };
 
 }

--- a/nes-memory/include/Runtime/AbstractBufferProvider.hpp
+++ b/nes-memory/include/Runtime/AbstractBufferProvider.hpp
@@ -16,8 +16,10 @@
 #include <chrono>
 #include <cstddef>
 #include <optional>
+#include <utility>
 #include <vector>
 #include <Runtime/TupleBuffer.hpp>
+#include <ErrorHandling.hpp>
 
 /// This enum reflects the different types of buffer managers in the system
 /// global: overall buffer manager
@@ -52,6 +54,33 @@ public:
 
     /// Returns an unpooled buffer of size bufferSize wrapped in an optional or an invalid option if an error
     virtual std::optional<TupleBuffer> getUnpooledBuffer(size_t bufferSize) = 0;
+
+    /// Returns a pooled buffer whose capacity is at least `size` bytes, blocking until one is available.
+    /// Providers that support multiple size classes serve this from the smallest fitting class; otherwise
+    /// it falls back to the default pooled buffer (for `size <= getBufferSize()`) or an unpooled buffer.
+    /// Callers must always read the returned buffer's own getBufferSize(); it may exceed `size`.
+    virtual TupleBuffer getBuffer(size_t size)
+    {
+        if (size <= getBufferSize())
+        {
+            return getBufferBlocking();
+        }
+        if (auto unpooled = getUnpooledBuffer(size))
+        {
+            return std::move(unpooled.value());
+        }
+        throw BufferAllocationFailure("Could not allocate a buffer of size {}", size);
+    }
+
+    /// Non-blocking variant of getBuffer(size). Returns an invalid optional if no buffer is currently available.
+    virtual std::optional<TupleBuffer> getBufferNoBlocking(size_t size)
+    {
+        if (size <= getBufferSize())
+        {
+            return getBufferNoBlocking();
+        }
+        return getUnpooledBuffer(size);
+    }
 };
 
 }

--- a/nes-memory/include/Runtime/BufferManager.hpp
+++ b/nes-memory/include/Runtime/BufferManager.hpp
@@ -15,21 +15,53 @@
 #pragma once
 
 #include <atomic>
-#include <condition_variable>
-#include <deque>
+#include <cstdint>
 #include <memory>
 #include <memory_resource>
-#include <mutex>
 #include <optional>
 #include <vector>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/Allocator/NesDefaultMemoryAllocator.hpp>
 #include <Runtime/BufferRecycler.hpp>
 #include <Runtime/UnpooledChunksManager.hpp>
-#include <folly/MPMCQueue.h>
+
+namespace NES::detail
+{
+class FixedSizeClassPool;
+}
 
 namespace NES
 {
+
+/// How the buffers of the additional (power-of-two) size classes are provisioned. The default
+/// class (of exactly the configured bufferSize) is always eagerly preallocated for backward
+/// compatibility; this policy only governs the extra size classes.
+enum class BufferProvisioningPolicy : uint8_t
+{
+    /// Distribute one overall byte budget equally across all size classes (counts derived per class).
+    TotalBudgetSplit,
+    /// Eagerly preallocate a fixed number of buffers per size class.
+    EagerPerClass,
+    /// Preallocate a small floor per class and grow it by a region on demand, up to a ceiling.
+    LazyElastic
+};
+
+/// Opt-in configuration enabling additional power-of-two size classes alongside the default buffer
+/// size. Classes are minClassSize, 2*minClassSize, ... up to maxClassSize (both powers of two).
+struct SizeClassConfig
+{
+    size_t minClassSize;
+    size_t maxClassSize;
+    BufferProvisioningPolicy policy = BufferProvisioningPolicy::TotalBudgetSplit;
+    /// TotalBudgetSplit: total bytes distributed (equal share) across the size classes.
+    size_t totalBudgetBytes = 0;
+    /// EagerPerClass: buffers preallocated per size class.
+    size_t buffersPerClass = 0;
+    /// LazyElastic: floor preallocated per class, region growth step, and per-class ceiling.
+    size_t floorBuffersPerClass = 0;
+    size_t growthChunkBuffers = 64;
+    size_t maxBuffersPerClass = 4096;
+};
 
 /**
  * @brief The BufferManager is responsible for:
@@ -68,28 +100,31 @@ class BufferManager final : public std::enable_shared_from_this<BufferManager>, 
         explicit Private() = default;
     };
 
+public:
     static constexpr auto DEFAULT_BUFFER_SIZE = 8 * 1024;
     static constexpr auto DEFAULT_NUMBER_OF_BUFFERS = 1024;
     static constexpr auto DEFAULT_ALIGNMENT = 64;
 
-public:
     explicit BufferManager(
         Private,
         uint32_t bufferSize,
         uint32_t numOfBuffers,
         std::shared_ptr<std::pmr::memory_resource> memoryResource,
-        uint32_t withAlignment);
+        uint32_t withAlignment,
+        std::optional<SizeClassConfig> sizeClasses);
 
     /// Creates a new global buffer manager
-    /// @param bufferSize the size of each buffer in bytes
-    /// @param numOfBuffers the total number of buffers in the pool
+    /// @param bufferSize the size of each default-class buffer in bytes
+    /// @param numOfBuffers the total number of default-class buffers in the pool
     /// @param withAlignment the alignment of each buffer, default is 64 so ony cache line aligned buffers, This value must be a pow of two and smaller than page size
     /// @param memoryResource resource for allocating and deallocating memory
+    /// @param sizeClasses optional configuration enabling additional power-of-two size classes for variable-sized pooled buffers
     static std::shared_ptr<BufferManager> create(
         uint32_t bufferSize = DEFAULT_BUFFER_SIZE,
         uint32_t numOfBuffers = DEFAULT_NUMBER_OF_BUFFERS,
         const std::shared_ptr<std::pmr::memory_resource>& memoryResource = std::make_shared<NesDefaultMemoryAllocator>(),
-        uint32_t withAlignment = DEFAULT_ALIGNMENT);
+        uint32_t withAlignment = DEFAULT_ALIGNMENT,
+        std::optional<SizeClassConfig> sizeClasses = std::nullopt);
 
     BufferManager(const BufferManager&) = delete;
     BufferManager& operator=(const BufferManager&) = delete;
@@ -99,11 +134,16 @@ public:
 
 private:
     /**
-     * @brief Configure the BufferManager to use numOfBuffers buffers of size bufferSize bytes.
-     * This is a one shot call. A second invocation of this call will fail
-     * @param withAlignment
+     * @brief Build the size class pools (the default class plus any configured power-of-two classes)
+     * and preallocate their buffers according to the provisioning policy. One shot call.
      */
-    void initialize(uint32_t withAlignment);
+    void initialize(uint32_t withAlignment, const std::optional<SizeClassConfig>& sizeClasses);
+
+    /// Index of the smallest size class whose buffers are >= size, or pools.size() if none fits (too large).
+    [[nodiscard]] size_t classIndexForSize(size_t size) const noexcept;
+
+    /// Prepares the segment's control block (reference count 0 -> 1) and wraps it in a TupleBuffer.
+    TupleBuffer wrapSegment(NES::detail::MemorySegment* segment);
 
 public:
     /// This blocks until a buffer is available.
@@ -111,6 +151,13 @@ public:
 
     /// invalid optional if there is no buffer.
     std::optional<TupleBuffer> getBufferNoBlocking() override;
+
+    /// Blocks until a pooled buffer of at least `size` bytes is available, served from the smallest
+    /// fitting size class. Requests larger than the largest class fall back to an unpooled buffer.
+    TupleBuffer getBuffer(size_t size) override;
+
+    /// Non-blocking variant of getBuffer(size).
+    std::optional<TupleBuffer> getBufferNoBlocking(size_t size) override;
 
     /**
      * @brief Returns a new Buffer wrapped in an optional or an invalid option if there is no buffer available within
@@ -146,17 +193,16 @@ public:
     void recycleUnpooledBuffer(NES::detail::MemorySegment* segment, const AllocationThreadInfo&) override;
 
 private:
-    std::vector<NES::detail::MemorySegment> allBuffers;
-
-    folly::MPMCQueue<NES::detail::MemorySegment*> availableBuffers;
+    /// One pool per size class, sorted ascending by buffer size. pools[defaultPoolIndex] is the
+    /// class of exactly `bufferSize` that backs the no-arg getBufferBlocking()/getBufferSize().
+    std::vector<std::unique_ptr<NES::detail::FixedSizeClassPool>> pools;
+    size_t defaultPoolIndex{0};
 
     std::shared_ptr<NES::UnpooledChunksManager> unpooledChunksManager;
 
     size_t bufferSize;
     size_t numOfBuffers;
-
-    uint8_t* basePointer{nullptr};
-    size_t allocatedAreaSize;
+    uint32_t alignment{DEFAULT_ALIGNMENT};
 
     std::shared_ptr<std::pmr::memory_resource> memoryResource;
     std::atomic<bool> isDestroyed{false};

--- a/nes-memory/include/Runtime/BufferManager.hpp
+++ b/nes-memory/include/Runtime/BufferManager.hpp
@@ -174,6 +174,7 @@ public:
     size_t getNumOfPooledBuffers() const override;
     size_t getNumOfUnpooledBuffers() const override;
     size_t getNumberOfAvailableBuffers() const;
+    bool servesSizeClasses() const override;
 
     /// Explicitly shuts down the buffer manager: checks for leaked buffers (fires INVARIANT on leaks),
     /// deallocates all memory, and marks the manager as destroyed. The destructor calls this automatically

--- a/nes-memory/tests/CMakeLists.txt
+++ b/nes-memory/tests/CMakeLists.txt
@@ -21,3 +21,6 @@ target_link_libraries(buffer-manager-destroy-test nes-memory)
 
 add_nes_test(child-buffer-tests ChildBufferTests.cpp)
 target_link_libraries(child-buffer-tests nes-memory)
+
+add_nes_test(size-class-buffer-tests SizeClassBufferTests.cpp)
+target_link_libraries(size-class-buffer-tests nes-memory)

--- a/nes-memory/tests/SizeClassBufferTests.cpp
+++ b/nes-memory/tests/SizeClassBufferTests.cpp
@@ -1,0 +1,226 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <thread>
+#include <vector>
+#include <Runtime/BufferManager.hpp>
+#include <Runtime/TupleBuffer.hpp>
+#include <gtest/gtest.h> /// NOLINT(misc-include-cleaner): consumed via macros expanded from rapidcheck/gtest.h
+#include <rapidcheck/gtest.h>
+
+namespace NES
+{
+
+namespace
+{
+SizeClassConfig eagerConfig(const size_t minClass, const size_t maxClass, const size_t buffersPerClass)
+{
+    SizeClassConfig config{.minClassSize = minClass, .maxClassSize = maxClass};
+    config.policy = BufferProvisioningPolicy::EagerPerClass;
+    config.buffersPerClass = buffersPerClass;
+    return config;
+}
+
+SizeClassConfig budgetConfig(const size_t minClass, const size_t maxClass, const size_t totalBudgetBytes)
+{
+    SizeClassConfig config{.minClassSize = minClass, .maxClassSize = maxClass};
+    config.policy = BufferProvisioningPolicy::TotalBudgetSplit;
+    config.totalBudgetBytes = totalBudgetBytes;
+    return config;
+}
+
+SizeClassConfig lazyConfig(const size_t minClass, const size_t maxClass, const size_t floor, const size_t growth, const size_t ceiling)
+{
+    SizeClassConfig config{.minClassSize = minClass, .maxClassSize = maxClass};
+    config.policy = BufferProvisioningPolicy::LazyElastic;
+    config.floorBuffersPerClass = floor;
+    config.growthChunkBuffers = growth;
+    config.maxBuffersPerClass = ceiling;
+    return config;
+}
+}
+
+class SizeClassBufferTest : public ::testing::Test
+{
+};
+
+/// getBuffer(size) rounds the request up to the smallest fitting power-of-two size class.
+TEST_F(SizeClassBufferTest, RoundsUpToSmallestFittingClass)
+{
+    auto bm = BufferManager::create(4096, 8, std::make_shared<NesDefaultMemoryAllocator>(), 64, eagerConfig(1024, 16384, 4));
+
+    EXPECT_EQ(bm->getBuffer(1).getBufferSize(), 1024u);
+    EXPECT_EQ(bm->getBuffer(1024).getBufferSize(), 1024u);
+    EXPECT_EQ(bm->getBuffer(1025).getBufferSize(), 2048u);
+    EXPECT_EQ(bm->getBuffer(4096).getBufferSize(), 4096u); /// the default class
+    EXPECT_EQ(bm->getBuffer(5000).getBufferSize(), 8192u);
+    EXPECT_EQ(bm->getBuffer(16384).getBufferSize(), 16384u);
+
+    /// Larger than the largest class -> unpooled buffer that still satisfies the >= contract.
+    auto unpooled = bm->getBuffer(20000);
+    EXPECT_GE(unpooled.getBufferSize(), 20000u);
+}
+
+/// Without a SizeClassConfig the manager has exactly one class (the default), preserving legacy behavior,
+/// but getBuffer(size) still serves small requests from the pooled default class and large ones unpooled.
+TEST_F(SizeClassBufferTest, BackwardCompatibleSingleClass)
+{
+    auto bm = BufferManager::create(4096, 8);
+
+    EXPECT_EQ(bm->getBufferSize(), 4096u);
+    EXPECT_EQ(bm->getNumOfPooledBuffers(), 8u);
+    EXPECT_EQ(bm->getBuffer(2000).getBufferSize(), 4096u);
+    EXPECT_EQ(bm->getBuffer(4096).getBufferSize(), 4096u);
+    EXPECT_GE(bm->getBuffer(9000).getBufferSize(), 9000u); /// unpooled
+}
+
+/// EagerPerClass preallocates the configured number of buffers per class up front.
+TEST_F(SizeClassBufferTest, EagerPerClassPreallocatesCounts)
+{
+    /// Classes: 1024, 2048, 4096(default,8), 8192 -> 3 extra classes * 4 + default 8 = 20.
+    auto bm = BufferManager::create(4096, 8, std::make_shared<NesDefaultMemoryAllocator>(), 64, eagerConfig(1024, 8192, 4));
+    EXPECT_EQ(bm->getNumOfPooledBuffers(), 20u);
+    EXPECT_EQ(bm->getNumberOfAvailableBuffers(), 20u);
+}
+
+/// TotalBudgetSplit distributes a byte budget across the classes; each class gets at least one buffer.
+TEST_F(SizeClassBufferTest, TotalBudgetSplitDistributesBudget)
+{
+    auto bm = BufferManager::create(4096, 8, std::make_shared<NesDefaultMemoryAllocator>(), 64, budgetConfig(1024, 8192, 1U << 20U));
+    /// Default class (8) plus a positive number of buffers in each extra class.
+    EXPECT_GT(bm->getNumOfPooledBuffers(), 8u);
+    EXPECT_EQ(bm->getNumberOfAvailableBuffers(), bm->getNumOfPooledBuffers());
+}
+
+/// A released pooled buffer is recycled back into its own size class and can be obtained again.
+TEST_F(SizeClassBufferTest, RecyclesBackIntoCorrectClass)
+{
+    auto bm = BufferManager::create(4096, 8, std::make_shared<NesDefaultMemoryAllocator>(), 64, eagerConfig(1024, 8192, 2));
+    const auto totalAvailable = bm->getNumberOfAvailableBuffers();
+
+    {
+        auto buffer = bm->getBuffer(1500); /// 2048 class
+        EXPECT_EQ(buffer.getBufferSize(), 2048u);
+        EXPECT_EQ(bm->getNumberOfAvailableBuffers(), totalAvailable - 1);
+    }
+    /// After release the buffer is back, and a new same-sized request reuses the 2048 class.
+    EXPECT_EQ(bm->getNumberOfAvailableBuffers(), totalAvailable);
+    EXPECT_EQ(bm->getBuffer(1500).getBufferSize(), 2048u);
+}
+
+/// When the best-fit class is momentarily exhausted, getBuffer promotes to a larger pooled class.
+TEST_F(SizeClassBufferTest, PromotesToLargerClassWhenExhausted)
+{
+    auto bm = BufferManager::create(4096, 8, std::make_shared<NesDefaultMemoryAllocator>(), 64, eagerConfig(1024, 8192, 1));
+
+    auto first = bm->getBuffer(1000); /// drains the single 1024-class buffer
+    EXPECT_EQ(first.getBufferSize(), 1024u);
+    auto promoted = bm->getBuffer(1000); /// 1024 empty -> next class
+    EXPECT_GE(promoted.getBufferSize(), 1024u);
+    EXPECT_GT(promoted.getBufferSize(), 1024u);
+}
+
+/// LazyElastic starts near-empty and grows a class on demand up to its ceiling.
+TEST_F(SizeClassBufferTest, LazyElasticGrowsOnDemand)
+{
+    auto bm = BufferManager::create(4096, 8, std::make_shared<NesDefaultMemoryAllocator>(), 64, lazyConfig(2048, 8192, 0, 4, 64));
+
+    /// The lazy classes contribute nothing until first use.
+    EXPECT_EQ(bm->getNumberOfAvailableBuffers(), 8u);
+
+    std::vector<TupleBuffer> held;
+    held.reserve(10);
+    for (int i = 0; i < 10; ++i)
+    {
+        auto buffer = bm->getBuffer(2048);
+        EXPECT_EQ(buffer.getBufferSize(), 2048u);
+        held.push_back(std::move(buffer));
+    }
+    /// Grew past the initial growth chunk of 4 to satisfy 10 concurrent live buffers.
+    held.clear();
+    EXPECT_NO_FATAL_FAILURE(bm->destroy());
+}
+
+/// Requests larger than the largest size class are served from the unpooled path.
+TEST_F(SizeClassBufferTest, LargerThanMaxClassUsesUnpooled)
+{
+    auto bm = BufferManager::create(4096, 8, std::make_shared<NesDefaultMemoryAllocator>(), 64, eagerConfig(1024, 4096, 2));
+    const auto pooledBefore = bm->getNumberOfAvailableBuffers();
+
+    auto buffer = bm->getBuffer(100000);
+    EXPECT_GE(buffer.getBufferSize(), 100000u);
+    /// Pooled availability is untouched; the buffer came from the unpooled manager.
+    EXPECT_EQ(bm->getNumberOfAvailableBuffers(), pooledBefore);
+    EXPECT_GE(bm->getNumOfUnpooledBuffers(), 1u);
+}
+
+/// Many threads hammering mixed sizes across all classes must never leak: after everyone returns
+/// their buffers, every pooled buffer is available again and destroy() finds no live buffer.
+TEST_F(SizeClassBufferTest, ConcurrentMixedSizeAllocationsAreLeakFree)
+{
+    auto bm = BufferManager::create(8192, 64, std::make_shared<NesDefaultMemoryAllocator>(), 64, eagerConfig(512, 65536, 64));
+    const auto totalPooled = bm->getNumOfPooledBuffers();
+
+    constexpr size_t numThreads = 8;
+    constexpr size_t iterationsPerThread = 2000;
+    std::vector<std::thread> threads;
+    threads.reserve(numThreads);
+    for (size_t t = 0; t < numThreads; ++t)
+    {
+        threads.emplace_back(
+            [&bm, t]
+            {
+                std::mt19937 generator(static_cast<unsigned>(t + 1));
+                std::uniform_int_distribution<size_t> distribution(1, 70000);
+                for (size_t i = 0; i < iterationsPerThread; ++i)
+                {
+                    const size_t size = distribution(generator);
+                    auto buffer = bm->getBuffer(size);
+                    ASSERT_GE(buffer.getBufferSize(), size);
+                    /// buffer released at end of iteration
+                }
+            });
+    }
+    for (auto& thread : threads)
+    {
+        thread.join();
+    }
+
+    EXPECT_EQ(bm->getNumberOfAvailableBuffers(), totalPooled);
+    EXPECT_NO_FATAL_FAILURE(bm->destroy());
+}
+
+/// Property: every getBuffer(size) returns a buffer of at least the requested size, and once the
+/// buffer is released the pool returns to full availability (no buffers lost or duplicated).
+RC_GTEST_FIXTURE_PROP(SizeClassBufferTest, ReturnedBufferFitsAndRecycles, (const std::vector<uint32_t>& rawSizes))
+{
+    auto bm = BufferManager::create(4096, 16, std::make_shared<NesDefaultMemoryAllocator>(), 64, eagerConfig(512, 16384, 8));
+    const auto totalPooled = bm->getNumOfPooledBuffers();
+
+    for (const auto rawSize : rawSizes)
+    {
+        const size_t size = (rawSize % 32768U) + 1U; /// 1 .. 32768
+        auto buffer = bm->getBuffer(size);
+        RC_ASSERT(buffer.getBufferSize() >= size);
+        /// buffer released here, so at most one buffer is ever live -> no class can be exhausted
+    }
+
+    RC_ASSERT(bm->getNumberOfAvailableBuffers() == totalPooled);
+}
+
+}

--- a/nes-memory/tests/SizeClassBufferTests.cpp
+++ b/nes-memory/tests/SizeClassBufferTests.cpp
@@ -19,6 +19,7 @@
 #include <thread>
 #include <vector>
 #include <Runtime/BufferManager.hpp>
+#include <Runtime/MemoryUtils.hpp>
 #include <Runtime/TupleBuffer.hpp>
 #include <gtest/gtest.h> /// NOLINT(misc-include-cleaner): consumed via macros expanded from rapidcheck/gtest.h
 #include <rapidcheck/gtest.h>
@@ -167,6 +168,75 @@ TEST_F(SizeClassBufferTest, LargerThanMaxClassUsesUnpooled)
     /// Pooled availability is untouched; the buffer came from the unpooled manager.
     EXPECT_EQ(bm->getNumberOfAvailableBuffers(), pooledBefore);
     EXPECT_GE(bm->getNumOfUnpooledBuffers(), 1u);
+}
+
+/// getBufferNoBlocking(size) returns an empty optional once the best-fit class and every larger
+/// class are drained (so it cannot promote), without blocking.
+TEST_F(SizeClassBufferTest, NoBlockingReturnsNulloptWhenExhausted)
+{
+    /// Classes >= 1000 bytes are 1024(1), 2048(1) and the 4096 default(1) -> three buffers total.
+    auto bm = BufferManager::create(4096, 1, std::make_shared<NesDefaultMemoryAllocator>(), 64, eagerConfig(1024, 2048, 1));
+    std::vector<TupleBuffer> held;
+    held.push_back(bm->getBuffer(1000));
+    held.push_back(bm->getBuffer(1000));
+    held.push_back(bm->getBuffer(1000));
+    EXPECT_FALSE(bm->getBufferNoBlocking(1000).has_value());
+    held.clear();
+    EXPECT_TRUE(bm->getBufferNoBlocking(1000).has_value());
+}
+
+/// TotalBudgetSplit provisions every class and serves the exact class for a request.
+TEST_F(SizeClassBufferTest, BudgetPolicyServesEveryClass)
+{
+    auto bm = BufferManager::create(4096, 8, std::make_shared<NesDefaultMemoryAllocator>(), 64, budgetConfig(1024, 8192, 1U << 20U));
+    EXPECT_EQ(bm->getBuffer(1024).getBufferSize(), 1024u);
+    EXPECT_EQ(bm->getBuffer(8192).getBufferSize(), 8192u);
+}
+
+/// LazyElastic grows to its ceiling and then promotes / falls back for further demand, leak-free.
+TEST_F(SizeClassBufferTest, LazyElasticPastCeiling)
+{
+    auto bm = BufferManager::create(4096, 8, std::make_shared<NesDefaultMemoryAllocator>(), 64, lazyConfig(2048, 4096, 0, 2, 4));
+    std::vector<TupleBuffer> held;
+    held.reserve(12);
+    for (int i = 0; i < 12; ++i)
+    {
+        auto buffer = bm->getBuffer(2048);
+        EXPECT_GE(buffer.getBufferSize(), 2048u);
+        held.push_back(std::move(buffer));
+    }
+    held.clear();
+    EXPECT_NO_FATAL_FAILURE(bm->destroy());
+}
+
+/// deepCopyBuffer replicates the raw bytes, size and metadata into a fresh buffer.
+TEST_F(SizeClassBufferTest, DeepCopyReplicatesDataAndMetadata)
+{
+    auto bm = BufferManager::create(4096, 8, std::make_shared<NesDefaultMemoryAllocator>(), 64, eagerConfig(1024, 8192, 4));
+    auto source = bm->getBuffer(2000); /// 2048 class
+    auto bytes = source.getAvailableMemoryArea<uint8_t>();
+    for (size_t i = 0; i < bytes.size(); ++i)
+    {
+        bytes[i] = static_cast<uint8_t>(i & 0xFFU);
+    }
+    source.setNumberOfTuples(7);
+
+    auto copy = deepCopyBuffer(source, *bm);
+    EXPECT_GE(copy.getBufferSize(), source.getBufferSize());
+    EXPECT_EQ(copy.getNumberOfTuples(), 7u);
+    const auto copyBytes = copy.getAvailableMemoryArea<uint8_t>();
+    for (size_t i = 0; i < source.getBufferSize(); ++i)
+    {
+        EXPECT_EQ(copyBytes[i], static_cast<uint8_t>(i & 0xFFU));
+    }
+}
+
+/// Exhausting the default pool makes the blocking no-arg path throw after the timeout.
+TEST_F(SizeClassBufferTest, BlockingThrowsWhenDefaultPoolExhausted)
+{
+    auto bm = BufferManager::create(4096, 1);
+    auto held = bm->getBufferBlocking();
+    EXPECT_ANY_THROW([[maybe_unused]] auto buffer = bm->getBufferBlocking());
 }
 
 /// Many threads hammering mixed sizes across all classes must never leak: after everyone returns

--- a/nes-nautilus/src/Arena.cpp
+++ b/nes-nautilus/src/Arena.cpp
@@ -31,15 +31,12 @@ namespace NES
 
 std::span<std::byte> Arena::allocateMemory(const size_t sizeInBytes)
 {
-    /// Case 1
+    /// Case 1: the request does not fit into a default-size buffer. Serve it from the smallest
+    /// fitting pooled size class (falling back to an unpooled buffer for very large requests).
     if (bufferProvider->getBufferSize() < sizeInBytes)
     {
-        const auto unpooledBufferOpt = bufferProvider->getUnpooledBuffer(sizeInBytes);
-        if (not unpooledBufferOpt.has_value())
-        {
-            throw CannotAllocateBuffer("Cannot allocate unpooled buffer of size " + std::to_string(sizeInBytes));
-        }
-        unpooledBuffers.emplace_back(unpooledBufferOpt.value());
+        auto oversizedBuffer = bufferProvider->getBuffer(sizeInBytes);
+        unpooledBuffers.emplace_back(oversizedBuffer);
         lastAllocationSize = sizeInBytes;
         return unpooledBuffers.back().getAvailableMemoryArea().subspan(0, sizeInBytes);
     }

--- a/nes-nautilus/src/Interface/HashMap/ChainedHashMap/ChainedHashMap.cpp
+++ b/nes-nautilus/src/Interface/HashMap/ChainedHashMap/ChainedHashMap.cpp
@@ -134,7 +134,7 @@ std::span<std::byte> ChainedHashMap::allocateSpaceForVarSized(AbstractBufferProv
     if (varSizedSpace.empty() or varSizedSpace.back().getNumberOfTuples() + neededSize >= varSizedSpace.back().getBufferSize())
     {
         /// We allocate more space than currently necessary for the variable sized data to reduce the allocation overhead
-        auto varSizedBuffer = bufferProvider->getUnpooledBuffer(neededSize * NUMBER_OF_PRE_ALLOCATED_VAR_SIZED_ITEMS);
+        auto varSizedBuffer = getPagedBuffer(neededSize * NUMBER_OF_PRE_ALLOCATED_VAR_SIZED_ITEMS, *bufferProvider);
         if (not varSizedBuffer)
         {
             throw CannotAllocateBuffer(
@@ -161,7 +161,7 @@ AbstractHashMapEntry* ChainedHashMap::insertEntry(const HashFunction::HashValue:
         /// We add one more entry to the capacity, as we need to have a valid entry for the last entry in the entries array
         /// We will be using this entry for checking, if we are at the end of our hash map in our EntryIterator
         const auto totalSpace = (numberOfChains + 1) * sizeof(ChainedHashMapEntry*);
-        const auto entryBuffer = bufferProvider->getUnpooledBuffer(totalSpace);
+        const auto entryBuffer = getPagedBuffer(totalSpace, *bufferProvider);
         if (not entryBuffer)
         {
             throw CannotAllocateBuffer("Could not allocate memory for ChainedHashMap of size {}", std::to_string(totalSpace));
@@ -177,7 +177,7 @@ AbstractHashMapEntry* ChainedHashMap::insertEntry(const HashFunction::HashValue:
     /// 1. Check if we need to allocate a new page
     if (numberOfTuples % entriesPerPage == 0)
     {
-        auto newPage = bufferProvider->getUnpooledBuffer(pageSize);
+        auto newPage = getPagedBuffer(pageSize, *bufferProvider);
         if (not newPage)
         {
             throw CannotAllocateBuffer("Could not allocate memory for new page in ChainedHashMap of size {}", std::to_string(pageSize));

--- a/nes-nautilus/src/Interface/PagedVector/PagedVector.cpp
+++ b/nes-nautilus/src/Interface/PagedVector/PagedVector.cpp
@@ -155,7 +155,7 @@ uint64_t PagedVector::getMainBufferSize()
 void PagedVector::addNewPage(AbstractBufferProvider* bufferProvider, const uint64_t bufferSize)
 {
     /// Either no pages exist, or the last page is full so allocate a new one
-    if (auto page = bufferProvider->getUnpooledBuffer(bufferSize); page.has_value())
+    if (auto page = getPagedBuffer(bufferSize, *bufferProvider); page.has_value())
     {
         updateCumulativeSumLastItem();
         Page::init(page.value());

--- a/nes-nautilus/tests/UnitTests/PagedVectorTest.cpp
+++ b/nes-nautilus/tests/UnitTests/PagedVectorTest.cpp
@@ -154,6 +154,29 @@ struct DirtyBufferProvider : AbstractBufferProvider
         return buffer;
     }
 
+    TupleBuffer getBuffer(size_t size) override
+    {
+        auto buffer = bm->getBuffer(size);
+        for (uint32_t& availableMemoryArea : buffer.getAvailableMemoryArea<uint32_t>())
+        {
+            availableMemoryArea = DIRTY_FILL_PATTERN;
+        }
+        return buffer;
+    }
+
+    std::optional<TupleBuffer> getBufferNoBlocking(size_t size) override
+    {
+        auto buffer = bm->getBufferNoBlocking(size);
+        if (buffer)
+        {
+            for (uint32_t& availableMemoryArea : buffer->getAvailableMemoryArea<uint32_t>())
+            {
+                availableMemoryArea = DIRTY_FILL_PATTERN;
+            }
+        }
+        return buffer;
+    }
+
     std::shared_ptr<BufferManager> bm;
 };
 

--- a/nes-network/nes-rust-bindings/network/src/NetworkBindings.cpp
+++ b/nes-network/nes-rust-bindings/network/src/NetworkBindings.cpp
@@ -65,21 +65,18 @@ void TupleBufferBuilder::setData(rust::Slice<const uint8_t> data)
 
 void TupleBufferBuilder::addChildBuffer(const rust::Slice<const uint8_t> child)
 {
-    auto childBuffer = bufferProvider.getUnpooledBuffer(child.size());
-    if (!childBuffer)
-    {
-        throw NES::CannotAllocateBuffer("allocating child buffer");
-    }
+    /// Serve the child buffer from the smallest fitting pooled size class (falling back to unpooled
+    /// for very large children). The returned buffer is guaranteed to be >= child.size().
+    auto childBuffer = bufferProvider.getBuffer(child.size());
 
     INVARIANT(
-        childBuffer->getBufferSize() >= child.length(),
-        "Unpooled Buffer size mismatch. Internal BufferSize: {} vs. External {}",
-        childBuffer->getBufferSize(),
+        childBuffer.getBufferSize() >= child.length(),
+        "Child buffer size mismatch. Internal BufferSize: {} vs. External {}",
+        childBuffer.getBufferSize(),
         child.length());
 
-    std::ranges::copy(child, childBuffer->getAvailableMemoryArea<uint8_t>().begin());
-    [[maybe_unused]] auto childIndex
-        = buffer.storeChildBuffer(*childBuffer); /// index should already be present in the owning parent buffer
+    std::ranges::copy(child, childBuffer.getAvailableMemoryArea<uint8_t>().begin());
+    [[maybe_unused]] auto childIndex = buffer.storeChildBuffer(childBuffer); /// index should already be present in the owning parent buffer
 }
 
 void identifyThread(const rust::str threadName, const rust::str host) /// NOLINT(misc-use-internal-linkage)

--- a/nes-runtime/include/Runtime/NodeEngineBuilder.hpp
+++ b/nes-runtime/include/Runtime/NodeEngineBuilder.hpp
@@ -14,9 +14,11 @@
 
 #pragma once
 #include <memory>
+#include <optional>
 #include <Configuration/WorkerConfiguration.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Listeners/StatisticListener.hpp>
+#include <Runtime/BufferManager.hpp>
 #include <Runtime/NodeEngine.hpp>
 
 namespace NES
@@ -30,6 +32,10 @@ public:
     explicit NodeEngineBuilder(const WorkerConfiguration& workerConfiguration, std::shared_ptr<StatisticListener> statisticListener);
 
     std::unique_ptr<NodeEngine> build(const Host& host);
+
+    /// Translates the buffer-size-class worker options into a SizeClassConfig, or std::nullopt when
+    /// size classes are disabled. Throws InvalidConfigParameter if min > max. Exposed for testing.
+    static std::optional<SizeClassConfig> makeSizeClassConfig(const WorkerConfiguration& workerConfiguration);
 
 private:
     WorkerConfiguration workerConfiguration;

--- a/nes-runtime/interface/Configuration/WorkerConfiguration.hpp
+++ b/nes-runtime/interface/Configuration/WorkerConfiguration.hpp
@@ -22,6 +22,8 @@
 #include <Configurations/Enums/EnumOption.hpp>
 #include <Configurations/ScalarOption.hpp>
 #include <Configurations/Validation/NumberValidation.hpp>
+#include <Configurations/Validation/PowerOfTwoValidation.hpp>
+#include <Runtime/BufferManager.hpp>
 #include <Util/DumpMode.hpp>
 #include <fmt/format.h>
 #include <QueryEngineConfiguration.hpp>
@@ -64,6 +66,43 @@ public:
 
     BoolOption dumpGraph = {"dump_graph", "false", "If to dump graph of the compilation results"};
 
+    /// Enables variable-sized pooled buffers served from additional power-of-two size classes (alongside
+    /// the default operator_buffer_size class). When disabled the global buffer manager behaves exactly as
+    /// before: a single fixed-size pooled class plus the unpooled fallback.
+    BoolOption enableBufferSizeClasses
+        = {"enable_buffer_size_classes", "false", "Enable variable-sized pooled buffers via power-of-two size classes."};
+
+    UIntOption bufferSizeClassMinBytes
+        = {"buffer_size_class_min_bytes",
+           "4096",
+           "Smallest power-of-two size class in bytes (only used when enable_buffer_size_classes is true).",
+           {std::make_shared<PowerOfTwoValidation>()}};
+
+    UIntOption bufferSizeClassMaxBytes
+        = {"buffer_size_class_max_bytes",
+           "1048576",
+           "Largest power-of-two size class in bytes (only used when enable_buffer_size_classes is true).",
+           {std::make_shared<PowerOfTwoValidation>()}};
+
+    EnumOption<BufferProvisioningPolicy> bufferSizeClassProvisioning
+        = {"buffer_size_class_provisioning",
+           BufferProvisioningPolicy::TotalBudgetSplit,
+           fmt::format("How the size classes are provisioned: {}", enumPipeList<BufferProvisioningPolicy>())};
+
+    /// TotalBudgetSplit: total bytes distributed across the size classes (0 -> derive from the default pool size).
+    UIntOption bufferSizeClassBudgetBytes
+        = {"buffer_size_class_budget_bytes",
+           "0",
+           "Total bytes distributed across size classes for the TotalBudgetSplit policy (0 = derive).",
+           {std::make_shared<NumberValidation>()}};
+
+    /// EagerPerClass: buffers preallocated per size class.
+    UIntOption bufferSizeClassBuffersPerClass
+        = {"buffer_size_class_buffers_per_class",
+           "256",
+           "Buffers preallocated per size class for the EagerPerClass policy.",
+           {std::make_shared<NumberValidation>()}};
+
 private:
     std::vector<BaseOption*> getOptions() override
     {
@@ -75,7 +114,13 @@ private:
             &numberOfBuffersInGlobalBufferManager,
             &defaultMaxInflightBuffers,
             &dumpQueryCompilationIR,
-            &dumpGraph};
+            &dumpGraph,
+            &enableBufferSizeClasses,
+            &bufferSizeClassMinBytes,
+            &bufferSizeClassMaxBytes,
+            &bufferSizeClassProvisioning,
+            &bufferSizeClassBudgetBytes,
+            &bufferSizeClassBuffersPerClass};
     }
 };
 }

--- a/nes-runtime/src/Runtime/NodeEngineBuilder.cpp
+++ b/nes-runtime/src/Runtime/NodeEngineBuilder.cpp
@@ -35,31 +35,34 @@ NodeEngineBuilder::NodeEngineBuilder(const WorkerConfiguration& workerConfigurat
 {
 }
 
+std::optional<SizeClassConfig> NodeEngineBuilder::makeSizeClassConfig(const WorkerConfiguration& workerConfiguration)
+{
+    if (!workerConfiguration.enableBufferSizeClasses.getValue())
+    {
+        return std::nullopt;
+    }
+    const auto minClassSize = workerConfiguration.bufferSizeClassMinBytes.getValue();
+    const auto maxClassSize = workerConfiguration.bufferSizeClassMaxBytes.getValue();
+    if (minClassSize > maxClassSize)
+    {
+        throw InvalidConfigParameter(
+            "buffer_size_class_min_bytes ({}) must be <= buffer_size_class_max_bytes ({})", minClassSize, maxClassSize);
+    }
+    SizeClassConfig config{.minClassSize = minClassSize, .maxClassSize = maxClassSize};
+    config.policy = workerConfiguration.bufferSizeClassProvisioning.getValue();
+    config.totalBudgetBytes = workerConfiguration.bufferSizeClassBudgetBytes.getValue();
+    config.buffersPerClass = workerConfiguration.bufferSizeClassBuffersPerClass.getValue();
+    return config;
+}
+
 std::unique_ptr<NodeEngine> NodeEngineBuilder::build(const Host& host)
 {
-    std::optional<SizeClassConfig> sizeClasses;
-    if (workerConfiguration.enableBufferSizeClasses.getValue())
-    {
-        const auto minClassSize = workerConfiguration.bufferSizeClassMinBytes.getValue();
-        const auto maxClassSize = workerConfiguration.bufferSizeClassMaxBytes.getValue();
-        if (minClassSize > maxClassSize)
-        {
-            throw InvalidConfigParameter(
-                "buffer_size_class_min_bytes ({}) must be <= buffer_size_class_max_bytes ({})", minClassSize, maxClassSize);
-        }
-        SizeClassConfig config{.minClassSize = minClassSize, .maxClassSize = maxClassSize};
-        config.policy = workerConfiguration.bufferSizeClassProvisioning.getValue();
-        config.totalBudgetBytes = workerConfiguration.bufferSizeClassBudgetBytes.getValue();
-        config.buffersPerClass = workerConfiguration.bufferSizeClassBuffersPerClass.getValue();
-        sizeClasses = config;
-    }
-
     auto bufferManager = BufferManager::create(
         workerConfiguration.defaultQueryExecution.operatorBufferSize.getValue(),
         workerConfiguration.numberOfBuffersInGlobalBufferManager.getValue(),
         std::make_shared<NesDefaultMemoryAllocator>(),
         BufferManager::DEFAULT_ALIGNMENT,
-        std::move(sizeClasses));
+        makeSizeClassConfig(workerConfiguration));
     auto queryLog = std::make_shared<QueryLog>();
 
     auto queryEngine = std::make_unique<QueryEngine>(workerConfiguration.queryEngine, statisticsListener, queryLog, bufferManager, host);

--- a/nes-runtime/src/Runtime/NodeEngineBuilder.cpp
+++ b/nes-runtime/src/Runtime/NodeEngineBuilder.cpp
@@ -15,6 +15,7 @@
 #include <Runtime/NodeEngineBuilder.hpp>
 
 #include <memory>
+#include <optional>
 #include <utility>
 #include <Configuration/WorkerConfiguration.hpp>
 #include <Identifiers/Identifiers.hpp>
@@ -22,6 +23,7 @@
 #include <Runtime/BufferManager.hpp>
 #include <Runtime/NodeEngine.hpp>
 #include <Sources/SourceProvider.hpp>
+#include <ErrorHandling.hpp>
 #include <QueryEngine.hpp>
 
 namespace NES
@@ -35,9 +37,29 @@ NodeEngineBuilder::NodeEngineBuilder(const WorkerConfiguration& workerConfigurat
 
 std::unique_ptr<NodeEngine> NodeEngineBuilder::build(const Host& host)
 {
+    std::optional<SizeClassConfig> sizeClasses;
+    if (workerConfiguration.enableBufferSizeClasses.getValue())
+    {
+        const auto minClassSize = workerConfiguration.bufferSizeClassMinBytes.getValue();
+        const auto maxClassSize = workerConfiguration.bufferSizeClassMaxBytes.getValue();
+        if (minClassSize > maxClassSize)
+        {
+            throw InvalidConfigParameter(
+                "buffer_size_class_min_bytes ({}) must be <= buffer_size_class_max_bytes ({})", minClassSize, maxClassSize);
+        }
+        SizeClassConfig config{.minClassSize = minClassSize, .maxClassSize = maxClassSize};
+        config.policy = workerConfiguration.bufferSizeClassProvisioning.getValue();
+        config.totalBudgetBytes = workerConfiguration.bufferSizeClassBudgetBytes.getValue();
+        config.buffersPerClass = workerConfiguration.bufferSizeClassBuffersPerClass.getValue();
+        sizeClasses = config;
+    }
+
     auto bufferManager = BufferManager::create(
         workerConfiguration.defaultQueryExecution.operatorBufferSize.getValue(),
-        workerConfiguration.numberOfBuffersInGlobalBufferManager.getValue());
+        workerConfiguration.numberOfBuffersInGlobalBufferManager.getValue(),
+        std::make_shared<NesDefaultMemoryAllocator>(),
+        BufferManager::DEFAULT_ALIGNMENT,
+        std::move(sizeClasses));
     auto queryLog = std::make_shared<QueryLog>();
 
     auto queryEngine = std::make_unique<QueryEngine>(workerConfiguration.queryEngine, statisticsListener, queryLog, bufferManager, host);

--- a/nes-runtime/tests/UnitTests/Runtime/CMakeLists.txt
+++ b/nes-runtime/tests/UnitTests/Runtime/CMakeLists.txt
@@ -11,3 +11,4 @@
 # limitations under the License.
 
 add_nes_runtime_test(query-log-test "QueryLogTest.cpp")
+add_nes_runtime_test(node-engine-builder-test "NodeEngineBuilderTest.cpp")

--- a/nes-runtime/tests/UnitTests/Runtime/NodeEngineBuilderTest.cpp
+++ b/nes-runtime/tests/UnitTests/Runtime/NodeEngineBuilderTest.cpp
@@ -1,0 +1,60 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Configuration/WorkerConfiguration.hpp>
+#include <Runtime/BufferManager.hpp>
+#include <Runtime/NodeEngineBuilder.hpp>
+#include <gtest/gtest.h>
+
+namespace NES
+{
+
+/// Size classes are off by default -> no SizeClassConfig is produced.
+GTEST_TEST(NodeEngineBuilderTest, SizeClassesDisabledByDefault)
+{
+    const WorkerConfiguration config;
+    EXPECT_FALSE(NodeEngineBuilder::makeSizeClassConfig(config).has_value());
+}
+
+/// When enabled, the worker options are translated 1:1 into the SizeClassConfig.
+GTEST_TEST(NodeEngineBuilderTest, SizeClassesEnabledTranslatesOptions)
+{
+    WorkerConfiguration config;
+    config.enableBufferSizeClasses.setValue(true);
+    config.bufferSizeClassMinBytes.setValue(512);
+    config.bufferSizeClassMaxBytes.setValue(65536);
+    config.bufferSizeClassProvisioning.setValue(BufferProvisioningPolicy::EagerPerClass);
+    config.bufferSizeClassBudgetBytes.setValue(0);
+    config.bufferSizeClassBuffersPerClass.setValue(128);
+
+    const auto result = NodeEngineBuilder::makeSizeClassConfig(config);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->minClassSize, 512U);
+    EXPECT_EQ(result->maxClassSize, 65536U);
+    EXPECT_EQ(result->policy, BufferProvisioningPolicy::EagerPerClass);
+    EXPECT_EQ(result->buffersPerClass, 128U);
+}
+
+/// A min class size larger than the max is rejected with a clear configuration error.
+GTEST_TEST(NodeEngineBuilderTest, MinGreaterThanMaxThrows)
+{
+    WorkerConfiguration config;
+    config.enableBufferSizeClasses.setValue(true);
+    config.bufferSizeClassMinBytes.setValue(65536);
+    config.bufferSizeClassMaxBytes.setValue(512);
+
+    EXPECT_ANY_THROW([[maybe_unused]] auto result = NodeEngineBuilder::makeSizeClassConfig(config));
+}
+
+}


### PR DESCRIPTION
Part of EPIC #1714. Routes operator-state pages (PagedVector, ChainedHashMap) through `getPagedBuffer` + `servesSizeClasses()` so state is served from fitting size classes under the unified budget instead of the unpooled heap. Stacked on #1706 (base: `feature/variable-size-buffer-size-classes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)