### PR TITLE
chore(Clang-Tidy): Fixed misc-misplaced-const from nightly clang-tidy

### DIFF
--- a/nes-physical-operators/tests/SliceCacheTest.cpp
+++ b/nes-physical-operators/tests/SliceCacheTest.cpp
@@ -407,7 +407,7 @@ TEST_P(SliceCacheSecondChanceTest, testSliceCacheSecondChance)
             op.timestamp.getRawValue(), op.sliceStart.getRawValue(), op.sliceEnd.getRawValue(), op.expectedResult, &callbackCalled);
 
         /// Perform the same lookup in the reference cache
-        const auto [refHit, refPtr] = referenceCache.lookup(Timestamp{op.timestamp}, op.sliceStart, op.sliceEnd, op.expectedResult);
+        auto [refHit, refPtr] = referenceCache.lookup(Timestamp{op.timestamp}, op.sliceStart, op.sliceEnd, op.expectedResult);
 
         /// Verify hit/miss agreement between the Nautilus implementation and the reference cache
         if (refHit)


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR fixes the `misc-misplaced-const` from the nightly clang-tidy full run

## Verifying this change
This change is tested by running our CI tests.