### PR TITLE
Chore: drop the dead withAlignment parameter from BufferManager

### DIFF
--- a/nes-memory/BufferManager.cpp
+++ b/nes-memory/BufferManager.cpp
@@ -41,25 +41,20 @@ namespace NES
 {
 
 BufferManager::BufferManager(
-    Private,
-    const uint32_t bufferSize,
-    const uint32_t numOfBuffers,
-    std::shared_ptr<std::pmr::memory_resource> memoryResource,
-    const uint32_t withAlignment)
+    Private, const uint32_t bufferSize, const uint32_t numOfBuffers, std::shared_ptr<std::pmr::memory_resource> memoryResource)
     : availableBuffers(numOfBuffers)
     , unpooledChunksManager(std::make_shared<UnpooledChunksManager>(memoryResource))
     , bufferSize(bufferSize)
     , numOfBuffers(numOfBuffers)
     , memoryResource(std::move(memoryResource))
 {
-    ((void)withAlignment);
-    initialize(DEFAULT_ALIGNMENT);
+    initialize();
 }
 
-std::shared_ptr<BufferManager> BufferManager::create(
-    uint32_t bufferSize, uint32_t numOfBuffers, const std::shared_ptr<std::pmr::memory_resource>& memoryResource, uint32_t withAlignment)
+std::shared_ptr<BufferManager>
+BufferManager::create(uint32_t bufferSize, uint32_t numOfBuffers, const std::shared_ptr<std::pmr::memory_resource>& memoryResource)
 {
-    return std::make_shared<BufferManager>(Private{}, bufferSize, numOfBuffers, memoryResource, withAlignment);
+    return std::make_shared<BufferManager>(Private{}, bufferSize, numOfBuffers, memoryResource);
 }
 
 BufferManager::~BufferManager()
@@ -108,8 +103,10 @@ void BufferManager::destroy()
     }
 }
 
-void BufferManager::initialize(uint32_t withAlignment)
+void BufferManager::initialize()
 {
+    /// Buffers are always aligned to a cache line; the alignment is no longer configurable.
+    constexpr uint32_t withAlignment = DEFAULT_ALIGNMENT;
     const size_t pages = sysconf(_SC_PHYS_PAGES);
     size_t page_size = sysconf(_SC_PAGE_SIZE);
     auto memorySizeInBytes = pages * page_size;

--- a/nes-memory/include/Runtime/BufferManager.hpp
+++ b/nes-memory/include/Runtime/BufferManager.hpp
@@ -73,23 +73,16 @@ class BufferManager final : public std::enable_shared_from_this<BufferManager>, 
     static constexpr auto DEFAULT_ALIGNMENT = 64;
 
 public:
-    explicit BufferManager(
-        Private,
-        uint32_t bufferSize,
-        uint32_t numOfBuffers,
-        std::shared_ptr<std::pmr::memory_resource> memoryResource,
-        uint32_t withAlignment);
+    explicit BufferManager(Private, uint32_t bufferSize, uint32_t numOfBuffers, std::shared_ptr<std::pmr::memory_resource> memoryResource);
 
-    /// Creates a new global buffer manager
+    /// Creates a new global buffer manager. Buffers are always aligned to DEFAULT_ALIGNMENT (a cache line).
     /// @param bufferSize the size of each buffer in bytes
     /// @param numOfBuffers the total number of buffers in the pool
-    /// @param withAlignment the alignment of each buffer, default is 64 so ony cache line aligned buffers, This value must be a pow of two and smaller than page size
     /// @param memoryResource resource for allocating and deallocating memory
     static std::shared_ptr<BufferManager> create(
         uint32_t bufferSize = DEFAULT_BUFFER_SIZE,
         uint32_t numOfBuffers = DEFAULT_NUMBER_OF_BUFFERS,
-        const std::shared_ptr<std::pmr::memory_resource>& memoryResource = std::make_shared<NesDefaultMemoryAllocator>(),
-        uint32_t withAlignment = DEFAULT_ALIGNMENT);
+        const std::shared_ptr<std::pmr::memory_resource>& memoryResource = std::make_shared<NesDefaultMemoryAllocator>());
 
     BufferManager(const BufferManager&) = delete;
     BufferManager& operator=(const BufferManager&) = delete;
@@ -99,11 +92,10 @@ public:
 
 private:
     /**
-     * @brief Configure the BufferManager to use numOfBuffers buffers of size bufferSize bytes.
-     * This is a one shot call. A second invocation of this call will fail
-     * @param withAlignment
+     * @brief Configure the BufferManager to use numOfBuffers buffers of size bufferSize bytes, aligned to
+     * DEFAULT_ALIGNMENT. This is a one shot call. A second invocation of this call will fail
      */
-    void initialize(uint32_t withAlignment);
+    void initialize();
 
 public:
     /// This blocks until a buffer is available.


### PR DESCRIPTION
## What

`BufferManager`'s constructor took a `withAlignment` argument but immediately discarded it (`((void)withAlignment)`) and always aligned to `DEFAULT_ALIGNMENT` (64 bytes = one cache line). So the parameter was dead — whatever a caller passed was ignored.

This removes the vestigial parameter from `create()` and the private constructor, and lets `initialize()` use `DEFAULT_ALIGNMENT` directly.

## What does *not* change
The alignment behaviour: buffers are still cache-line aligned via `DEFAULT_ALIGNMENT`. Only the ignored knob is gone. No call site passed `withAlignment` explicitly, so this is a pure no-op cleanup.

Verified: `nes-memory` builds, `child-buffer-tests` (3/3) and `tuple-buffer-memory-access-tests` (8/8) pass, clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)