### PR TITLE
feat(sql) Improved EXPLAIN statement output, and make EXPLAIN statements testable via systests 

### DIFF
--- a/nes-common/include/Util/QueryConsoleDumpHandler.hpp
+++ b/nes-common/include/Util/QueryConsoleDumpHandler.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <Util/PlanRenderer.hpp>
 
 template <typename T>
@@ -41,23 +42,27 @@ template <typename Plan, typename Operator>
 class QueryConsoleDumpHandler
 {
 public:
-    explicit QueryConsoleDumpHandler(std::ostream& out, bool multiline) : out(out), multiline(multiline) { }
+    explicit QueryConsoleDumpHandler(std::ostream& out, bool multiline, ExplainVerbosity verbosity)
+        : out(out), multiline(multiline), verbosity(std::move(verbosity))
+    {
+    }
 
-    void dump(const Operator& node) { dumpRecursive(node, 0, out, multiline); }
+    void dump(const Operator& node) { dumpRecursive(node, 0, out, multiline, verbosity); }
 
-    static void dumpRecursive(const Operator& op, const uint64_t level, std::ostream& out, const bool multiline)
+    static void
+    dumpRecursive(const Operator& op, const uint64_t level, std::ostream& out, const bool multiline, const ExplainVerbosity& verbosity)
     {
         const std::string indent(level * 2, ' ');
-        out << indent << (multiline ? "+ " : "") << op.explain(ExplainVerbosity::Debug) << '\n';
+        out << indent << (multiline ? "+ " : "") << op.explain(verbosity) << '\n';
         for (auto& child : op.getChildren())
         {
             if constexpr (is_shared_ptr_v<std::decay_t<decltype(child)>>)
             {
-                dumpRecursive(*child, level + 1, out, multiline);
+                dumpRecursive(*child, level + 1, out, multiline, verbosity);
             }
             else
             {
-                dumpRecursive(child, level + 1, out, multiline);
+                dumpRecursive(child, level + 1, out, multiline, verbosity);
             }
         }
     }
@@ -67,6 +72,7 @@ public:
 private:
     std::ostream& out;
     bool multiline;
+    ExplainVerbosity verbosity;
 };
 
 }

--- a/nes-frontend/apps/repl/tests/embedded.bats
+++ b/nes-frontend/apps/repl/tests/embedded.bats
@@ -78,3 +78,140 @@ setup()         { nes_offline_setup; }
   [ "$status" -ne 0 ]
   grep "invalid config parameter; Enum for INVALID was not found." nes-repl.log
 }
+
+
+
+@test "EXPLAIN over 2-node topology places sources upstream and join downstream" {
+  run $NES_REPL -f JSON <tests/sql-file-tests/good/explain_distributed.sql
+  [ "$status" -eq 0 ]
+
+  # The six EXPLAIN statements sit at the tail of the JSON output stream.
+  local n=${#lines[@]}
+  local i_logical_text=$((n - 6))
+  local i_optimized_text=$((n - 5))
+  local i_distributed_text=$((n - 4))
+  local i_logical_visual=$((n - 3))
+  local i_optimized_visual=$((n - 2))
+  local i_distributed_visual=$((n - 1))
+
+  # `sed` inside extract_explain right-trims each line so VISUAL padding does not need to
+  # live as trailing whitespace in the .bats source.
+  extract_explain() {
+    echo "$1" | jq -j '.[0].explain' | sed 's/[[:space:]]*$//'
+  }
+
+  assert_equal "$(extract_explain "${lines[$i_logical_text]}")" "$(cat <<'EOF'
+== Initial Logical Plan ==
+INLINE_SINK(InlineSink)
+  PROJECTION(fields: [START, END, ID, VALUE, TIMESTAMP, ID2, VALUE2, TIMESTAMP2])
+    PROJECTION(fields: [*])
+      Join(INNER_JOIN, ID = ID2)
+        WATERMARK_ASSIGNER(Event time)
+          PROJECTION(fields: [*])
+            SOURCE(STREAM)
+        WATERMARK_ASSIGNER(Event time)
+          PROJECTION(fields: [*])
+            SOURCE(STREAM2)
+EOF
+)"
+
+  assert_equal "$(extract_explain "${lines[$i_optimized_text]}")" "$(cat <<'EOF'
+== Optimized Global Plan ==
+SINK(VOID)
+  Join(INNER_JOIN, ID = ID2)
+    WATERMARK_ASSIGNER(Event time)
+      SOURCE(STREAM)
+    WATERMARK_ASSIGNER(Event time)
+      SOURCE(STREAM2)
+EOF
+)"
+
+  assert_equal "$(extract_explain "${lines[$i_distributed_text]}")" "$(cat <<'EOF'
+== Decomposed Plans ==
+-- 1 plan(s) on sink-node:8080 --
+0:
+SINK(VOID)
+  Join(INNER_JOIN, ID = ID2)
+    SOURCE(NETWORK)
+    SOURCE(NETWORK)
+
+
+-- 2 plan(s) on source-node:8080 --
+0:
+SINK(NETWORK)
+  WATERMARK_ASSIGNER(Event time)
+    SOURCE(STREAM)
+
+
+1:
+SINK(NETWORK)
+  WATERMARK_ASSIGNER(Event time)
+    SOURCE(STREAM2)
+EOF
+)"
+
+  assert_equal "$(extract_explain "${lines[$i_logical_visual]}")" "$(cat <<'EOF'
+== Initial Logical Plan ==
+
+                   INLINE_SINK(InlineSink)
+                              │
+PROJECTION(fields: [START, END, ID, VALUE, TIMESTAMP, ID2...
+                              │
+                   PROJECTION(fields: [*])
+                              │
+                 Join(INNER_JOIN, ID = ID2)
+               ┌──────────────┴───────────────┐
+WATERMARK_ASSIGNER(Event time) WATERMARK_ASSIGNER(Event time)
+               │                              │
+   PROJECTION(fields: [*])        PROJECTION(fields: [*])
+              ┌┘                             ┌┘
+       SOURCE(STREAM)                SOURCE(STREAM2)
+EOF
+)"
+
+  assert_equal "$(extract_explain "${lines[$i_optimized_visual]}")" "$(cat <<'EOF'
+== Optimized Global Plan ==
+
+                         SINK(VOID)
+                              │
+                 Join(INNER_JOIN, ID = ID2)
+               ┌──────────────┴───────────────┐
+WATERMARK_ASSIGNER(Event time) WATERMARK_ASSIGNER(Event time)
+              ┌┘                             ┌┘
+       SOURCE(STREAM)                SOURCE(STREAM2)
+EOF
+)"
+
+  assert_equal "$(extract_explain "${lines[$i_distributed_visual]}")" "$(cat <<'EOF'
+== Decomposed Plans ==
+-- 1 plan(s) on sink-node:8080 --
+0:
+
+          SINK(VOID)
+               │
+  Join(INNER_JOIN, ID = ID2)
+       ┌───────┴───────┐
+SOURCE(NETWORK) SOURCE(NETWORK)
+
+
+-- 2 plan(s) on source-node:8080 --
+0:
+
+        SINK(NETWORK)
+               │
+WATERMARK_ASSIGNER(Event time)
+               │
+        SOURCE(STREAM)
+
+
+1:
+
+        SINK(NETWORK)
+               │
+WATERMARK_ASSIGNER(Event time)
+               │
+       SOURCE(STREAM2)
+EOF
+)"
+}
+

--- a/nes-frontend/apps/repl/tests/sql-file-tests/good/explain_distributed.sql
+++ b/nes-frontend/apps/repl/tests/sql-file-tests/good/explain_distributed.sql
@@ -1,0 +1,26 @@
+CREATE LOGICAL SOURCE stream(id UINT64 NOT NULL, value UINT64 NOT NULL, timestamp UINT64 NOT NULL);
+CREATE PHYSICAL SOURCE FOR stream TYPE Generator SET(
+'ALL' as "SOURCE".STOP_GENERATOR_WHEN_SEQUENCE_FINISHES,
+'CSV' as INPUT_FORMATTER."TYPE",
+'source-node:8080' AS "SOURCE"."HOST",
+'SEQUENCE UINT32 0 10000000 1, SEQUENCE UINT64 0 10000000 1, SEQUENCE UINT64 0 10000000 1' AS "SOURCE".GENERATOR_SCHEMA);
+
+
+CREATE LOGICAL SOURCE stream2(id2 UINT64 NOT NULL, value2 UINT64 NOT NULL, timestamp2 UINT64 NOT NULL);
+CREATE PHYSICAL SOURCE FOR stream2 TYPE Generator SET(
+'ALL' as "SOURCE".STOP_GENERATOR_WHEN_SEQUENCE_FINISHES,
+'CSV' as INPUT_FORMATTER."TYPE",
+'source-node:8080' AS "SOURCE"."HOST",
+'SEQUENCE UINT32 0 10000000 1, SEQUENCE UINT64 0 10000000 1, SEQUENCE UINT64 0 10000000 1, SEQUENCE UINT64 0 10000000 1' AS "SOURCE".GENERATOR_SCHEMA);
+
+
+CREATE WORKER 'sink-node:8080' SET ('sink-node:9090' AS DATA);
+CREATE WORKER 'source-node:8080' SET ('source-node:9090' AS DATA, 'sink-node:8080' AS "DOWNSTREAM", 2 AS "CAPACITY");
+
+EXPLAIN (LOGICAL) FORMAT TEXT SELECT start, end, id, value, timestamp, id2, value2, timestamp2 FROM ( SELECT * FROM (SELECT * FROM stream) INNER JOIN (SELECT * FROM stream2) ON (id = id2) WINDOW TUMBLING (timestamp, timestamp2, size 1 sec)) INTO Void('sink-node:8080' AS "SINK"."HOST");
+EXPLAIN (OPTIMIZED) FORMAT TEXT SELECT start, end, id, value, timestamp, id2, value2, timestamp2 FROM ( SELECT * FROM (SELECT * FROM stream) INNER JOIN (SELECT * FROM stream2) ON (id = id2) WINDOW TUMBLING (timestamp, timestamp2, size 1 sec)) INTO Void('sink-node:8080' AS "SINK"."HOST");
+EXPLAIN (DISTRIBUTED) FORMAT TEXT SELECT start, end, id, value, timestamp, id2, value2, timestamp2 FROM ( SELECT * FROM (SELECT * FROM stream) INNER JOIN (SELECT * FROM stream2) ON (id = id2) WINDOW TUMBLING (timestamp, timestamp2, size 1 sec)) INTO Void('sink-node:8080' AS "SINK"."HOST");
+
+EXPLAIN (LOGICAL) FORMAT VISUAL SELECT start, end, id, value, timestamp, id2, value2, timestamp2 FROM ( SELECT * FROM (SELECT * FROM stream) INNER JOIN (SELECT * FROM stream2) ON (id = id2) WINDOW TUMBLING (timestamp, timestamp2, size 1 sec)) INTO Void('sink-node:8080' AS "SINK"."HOST");
+EXPLAIN (OPTIMIZED) FORMAT VISUAL SELECT start, end, id, value, timestamp, id2, value2, timestamp2 FROM ( SELECT * FROM (SELECT * FROM stream) INNER JOIN (SELECT * FROM stream2) ON (id = id2) WINDOW TUMBLING (timestamp, timestamp2, size 1 sec)) INTO Void('sink-node:8080' AS "SINK"."HOST");
+EXPLAIN (DISTRIBUTED) FORMAT VISUAL SELECT start, end, id, value, timestamp, id2, value2, timestamp2 FROM ( SELECT * FROM (SELECT * FROM stream) INNER JOIN (SELECT * FROM stream2) ON (id = id2) WINDOW TUMBLING (timestamp, timestamp2, size 1 sec)) INTO Void('sink-node:8080' AS "SINK"."HOST");

--- a/nes-frontend/include/Statements/StatementHandler.hpp
+++ b/nes-frontend/include/Statements/StatementHandler.hpp
@@ -228,6 +228,9 @@ public:
     std::expected<DropSinkStatementResult, Exception> operator()(const DropSinkStatement& statement);
 };
 
+/// Computes the EXPLAIN output for the given statement using the provided optimizer.
+std::string computeExplainOutput(const ExplainQueryStatement& statement, const QueryOptimizer& optimizer);
+
 class QueryStatementHandler final : public StatementHandler<QueryStatementHandler>
 {
     SharedPtr<QueryManager> queryManager;

--- a/nes-frontend/src/Statements/StatementHandler.cpp
+++ b/nes-frontend/src/Statements/StatementHandler.cpp
@@ -26,16 +26,20 @@
 #include <variant>
 #include <vector>
 #include <Identifiers/Identifiers.hpp>
+#include <Operators/LogicalOperatorFwd.hpp>
+#include <Plans/LogicalPlan.hpp>
 #include <QueryManager/QueryManager.hpp>
 #include <Runtime/Execution/QueryStatus.hpp>
 #include <SQLQueryParser/StatementBinder.hpp>
 #include <Sinks/SinkCatalog.hpp>
 #include <Sources/SourceCatalog.hpp>
 #include <Util/Overloaded.hpp>
+#include <Util/PlanRenderer.hpp>
 #include <Util/Pointers.hpp>
 #include <Util/Ranges.hpp>
 #include <Util/Strings.hpp>
 #include <cpptrace/from_current.hpp>
+#include <cpptrace/from_current_macros.hpp>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <fmt/ranges.h>
@@ -318,28 +322,66 @@ std::expected<DropQueryStatementResult, Exception> QueryStatementHandler::operat
         .transform([&statement] { return DropQueryStatementResult{statement.id}; });
 }
 
+std::string computeExplainOutput(const ExplainQueryStatement& statement, const QueryOptimizer& optimizer)
+{
+    auto formatPlan = [&](const LogicalPlan& plan) -> std::string
+    {
+        switch (statement.explainFormat)
+        {
+            case ExplainFormat::Visual: {
+                std::stringstream stringstream;
+                auto renderer = PlanRenderer<LogicalPlan, LogicalOperator>(stringstream, ExplainVerbosity::Short);
+                renderer.dump(plan);
+                return stringstream.str();
+            }
+            case ExplainFormat::Text:
+                return explain(plan, ExplainVerbosity::Short);
+            case ExplainFormat::Verbose:
+                return explain(plan, ExplainVerbosity::Debug);
+        }
+        std::unreachable();
+    };
+
+    std::stringstream explainMessage;
+    const auto distributedPlan = optimizer.optimize(statement.plan);
+
+
+    if (statement.explainStages.contains(ExplainStage::Logical))
+    {
+        fmt::println(explainMessage, "== Initial Logical Plan ==\n{}", formatPlan(statement.plan));
+    }
+
+    if (statement.explainStages.contains(ExplainStage::Optimized))
+    {
+        fmt::println(explainMessage, "== Optimized Global Plan ==\n{}", formatPlan(distributedPlan.getGlobalPlan()));
+    }
+
+    if (statement.explainStages.contains(ExplainStage::Distributed))
+    {
+        fmt::println(explainMessage, "== Decomposed Plans ==");
+        /// The distributed plan stores its local plans in an unordered map. Sort by host for deterministic output.
+        auto sortedWorkerPlans = std::ranges::to<std::vector>(
+            distributedPlan | std::views::transform([](const auto& entry) { return std::addressof(entry); }));
+        std::ranges::sort(sortedWorkerPlans, {}, [](const auto* entry) -> const auto& { return entry->first; });
+        for (const auto* entry : sortedWorkerPlans)
+        {
+            const auto& [worker, plans] = *entry;
+            fmt::println(explainMessage, "-- {} plan(s) on {} --", plans.size(), worker);
+            for (const auto& [index, plan] : plans | views::enumerate)
+            {
+                fmt::println(explainMessage, "{}:\n{}\n", index, formatPlan(plan));
+            }
+        }
+    }
+
+    return explainMessage.str();
+}
+
 std::expected<ExplainQueryStatementResult, Exception> QueryStatementHandler::operator()(const ExplainQueryStatement& statement)
 {
     CPPTRACE_TRY
     {
-        std::stringstream explainMessage;
-        fmt::println(explainMessage, "Query:\n{}", statement.plan.getOriginalSql());
-        fmt::println(explainMessage, "Initial Logical Plan:\n{}", statement.plan);
-
-        const auto distributedPlan = queryOptimizer->optimize(statement.plan);
-
-        fmt::println(explainMessage, "Optimized Global Plan:\n{}", distributedPlan.getGlobalPlan());
-
-        fmt::println(explainMessage, "Decomposed Plans:");
-        for (const auto& [worker, plans] : distributedPlan)
-        {
-            fmt::println(explainMessage, "{} plans on {}:", plans.size(), worker);
-            for (const auto& [index, plan] : plans | views::enumerate)
-            {
-                fmt::println(explainMessage, "{}:\n{}\n", index, plan);
-            }
-        }
-        return ExplainQueryStatementResult{explainMessage.str()};
+        return ExplainQueryStatementResult{computeExplainOutput(statement, *queryOptimizer)};
     }
     CPPTRACE_CATCH(...)
     {

--- a/nes-logical-operators/src/Functions/FieldAccessLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/FieldAccessLogicalFunction.cpp
@@ -68,7 +68,7 @@ std::string FieldAccessLogicalFunction::explain(ExplainVerbosity verbosity) cons
     {
         return fmt::format("FieldAccessLogicalFunction({})", field);
     }
-    return fmt::format("{}", field);
+    return fmt::format("{}", field.getLastName());
 }
 
 LogicalFunction FieldAccessLogicalFunction::withInferredDataType(const Schema<Field, Unordered>& schema) const

--- a/nes-logical-operators/src/Operators/Sinks/SinkLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Sinks/SinkLogicalOperator.cpp
@@ -115,6 +115,10 @@ std::string SinkLogicalOperator::explain(ExplainVerbosity verbosity, OperatorId 
         }
         return fmt::format("SINK(opId: {}, sinkName: {})", id, sinkName);
     }
+    if (sinkDescriptor.has_value() && sinkDescriptor->isInline())
+    {
+        return fmt::format("SINK({})", sinkDescriptor->getSinkType());
+    }
     return fmt::format("SINK({})", sinkName);
 }
 

--- a/nes-logical-operators/src/Plans/LogicalPlan.cpp
+++ b/nes-logical-operators/src/Plans/LogicalPlan.cpp
@@ -141,12 +141,15 @@ std::string explain(const LogicalPlan& plan, ExplainVerbosity verbosity)
     std::stringstream stringstream;
     if (verbosity == ExplainVerbosity::Short)
     {
-        auto dumpHandler = PlanRenderer<LogicalPlan, LogicalOperator>(stringstream, ExplainVerbosity::Short);
-        dumpHandler.dump(plan);
+        auto dumpHandler = QueryConsoleDumpHandler<LogicalPlan, LogicalOperator>(stringstream, false, ExplainVerbosity::Short);
+        for (const auto& rootOperator : plan.getRootOperators())
+        {
+            dumpHandler.dump({rootOperator});
+        }
     }
     else
     {
-        auto dumpHandler = QueryConsoleDumpHandler<LogicalPlan, LogicalOperator>(stringstream, false);
+        auto dumpHandler = QueryConsoleDumpHandler<LogicalPlan, LogicalOperator>(stringstream, false, ExplainVerbosity::Debug);
         for (const auto& rootOperator : plan.getRootOperators())
         {
             dumpHandler.dump({rootOperator});

--- a/nes-physical-operators/src/PhysicalPlan.cpp
+++ b/nes-physical-operators/src/PhysicalPlan.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 #include <Identifiers/Identifiers.hpp>
 #include <Util/ExecutionMode.hpp>
+#include <Util/PlanRenderer.hpp>
 #include <Util/QueryConsoleDumpHandler.hpp>
 #include <ErrorHandling.hpp>
 #include <PhysicalOperator.hpp>
@@ -47,7 +48,7 @@ PhysicalPlan::PhysicalPlan(
 std::string PhysicalPlan::toString() const
 {
     std::stringstream stringstream;
-    auto dumpHandler = QueryConsoleDumpHandler<PhysicalPlan, PhysicalOperatorWrapper>(stringstream, true);
+    auto dumpHandler = QueryConsoleDumpHandler<PhysicalPlan, PhysicalOperatorWrapper>(stringstream, true, ExplainVerbosity::Debug);
     for (const auto& rootOperator : rootOperators)
     {
         dumpHandler.dump(*rootOperator);

--- a/nes-query-optimizer/src/Rules/Static/ProjectionPushdownRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/ProjectionPushdownRule.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <array>
+#include <ranges>
 #include <set>
 #include <string_view>
 #include <typeindex>
@@ -69,6 +70,17 @@ std::unordered_set<Field> getAccessedFields(const LogicalFunction& logicalFuncti
     return result;
 }
 
+std::vector<Field> sortFields(const std::unordered_set<Field>& fields)
+{
+    auto sortedFields = std::ranges::to<std::vector>(fields);
+    std::ranges::sort(
+        sortedFields,
+        [](const Field& left, const Field& right)
+        { return left.getLastName().asCanonicalString() < right.getLastName().asCanonicalString(); });
+
+    return sortedFields;
+}
+
 LogicalOperator pushBeyondSink(const TypedLogicalOperator<SinkLogicalOperator>& op)
 {
     /// Use identifiers from output schema as starting point for required fields.
@@ -94,7 +106,9 @@ LogicalOperator pushBeyondSource(TypedLogicalOperator<SourceDescriptorLogicalOpe
     {
         std::vector<ProjectionLogicalOperator::UnboundProjection> projections;
         projections.reserve(required.size());
-        for (const auto& field : required)
+
+        /// Set a fix order in which the projections are applied to ensure deterministic behaviour of rule.
+        for (const auto& field : sortFields(required))
         {
             projections.emplace_back(field.getLastName(), UnboundFieldAccessLogicalFunction{field.getLastName()});
         }
@@ -134,8 +148,8 @@ LogicalOperator pushBeyondProjection(const TypedLogicalOperator<ProjectionLogica
     {
         projectionMap.emplace(field, function);
     }
-
-    for (const auto& field : required)
+    /// Set a fix order in which the projections are applied to ensure deterministic behaviour of rule.
+    for (const auto& field : sortFields(required))
     {
         if (auto iter = projectionMap.find(field); iter != projectionMap.end())
         {

--- a/nes-sources/include/Sources/SourceDescriptor.hpp
+++ b/nes-sources/include/Sources/SourceDescriptor.hpp
@@ -65,6 +65,8 @@ public:
     [[nodiscard]] Host getHost() const;
     [[nodiscard]] PhysicalSourceId getPhysicalSourceId() const;
 
+    [[nodiscard]] bool isInlineSource() const;
+
     [[nodiscard]] std::string explain(ExplainVerbosity verbosity) const;
 
 private:
@@ -78,6 +80,7 @@ private:
     std::string sourceType;
     Host host;
     InputFormatterDescriptor inputFormatterDescriptor;
+    bool isInline = false;
 
 
     /// Used by Sources to create a valid SourceDescriptor.
@@ -87,7 +90,8 @@ private:
         std::string_view sourceType,
         Host host,
         DescriptorConfig::Config config,
-        const InputFormatterDescriptor& inputFormatterDescriptor);
+        const InputFormatterDescriptor& inputFormatterDescriptor,
+        bool isInline);
 
 public:
     /// Per default, we set an 'invalid' number of max inflight buffers. We choose zero as an invalid number as giving zero buffers to a source would make it unusable.
@@ -137,6 +141,7 @@ struct ReflectedSourceDescriptor
     std::string type;
     Host host;
     InputFormatterDescriptor inputFormatterDescriptor;
+    bool isInline;
     Reflected config;
 };
 }

--- a/nes-sources/src/SourceCatalog.cpp
+++ b/nes-sources/src/SourceCatalog.cpp
@@ -104,7 +104,13 @@ std::expected<SourceDescriptor, Exception> SourceCatalog::addPhysicalSource(
     const InputFormatterDescriptor formatDescriptor{inputFormat, parserConfigObject.value()};
 
     SourceDescriptor descriptor{
-        id, logicalSource, sourceType.asCanonicalString(), std::move(host), std::move(descriptorConfigOpt.value()), formatDescriptor};
+        id,
+        logicalSource,
+        sourceType.asCanonicalString(),
+        std::move(host),
+        std::move(descriptorConfigOpt.value()),
+        formatDescriptor,
+        false};
     idsToPhysicalSources.emplace(id, descriptor);
     logicalPhysicalIter->second.insert(descriptor);
     NES_DEBUG("Successfully registered new physical source of type {} with id {}", descriptor.getSourceType(), id);
@@ -191,7 +197,7 @@ std::optional<SourceDescriptor> SourceCatalog::getInlineSource(
 
     const auto logicalSource = LogicalSource{name, schema};
     SourceDescriptor sourceDescriptor{
-        physicalId, logicalSource, sourceType.asCanonicalString(), std::move(host), descriptorConfig.value(), formatDescriptor};
+        physicalId, logicalSource, sourceType.asCanonicalString(), std::move(host), descriptorConfig.value(), formatDescriptor, true};
     return sourceDescriptor;
 }
 

--- a/nes-sources/src/SourceDescriptor.cpp
+++ b/nes-sources/src/SourceDescriptor.cpp
@@ -41,13 +41,15 @@ SourceDescriptor::SourceDescriptor(
     std::string_view sourceType,
     Host host,
     DescriptorConfig::Config config,
-    const InputFormatterDescriptor& inputFormatterDescriptor)
+    const InputFormatterDescriptor& inputFormatterDescriptor,
+    bool isInline)
     : Descriptor(std::move(config))
     , physicalSourceId(physicalSourceId)
     , logicalSource(std::move(logicalSource))
     , sourceType(std::move(sourceType))
     , host(std::move(host))
     , inputFormatterDescriptor(inputFormatterDescriptor)
+    , isInline(isInline)
 {
 }
 
@@ -81,6 +83,11 @@ PhysicalSourceId SourceDescriptor::getPhysicalSourceId() const
     return physicalSourceId;
 }
 
+bool SourceDescriptor::isInlineSource() const
+{
+    return isInline;
+}
+
 std::weak_ordering operator<=>(const SourceDescriptor& lhs, const SourceDescriptor& rhs)
 {
     return lhs.physicalSourceId <=> rhs.physicalSourceId;
@@ -95,7 +102,14 @@ std::string SourceDescriptor::explain(ExplainVerbosity verbosity) const
     }
     else if (verbosity == ExplainVerbosity::Short)
     {
-        stringstream << fmt::format("{}", logicalSource.getLogicalSourceName());
+        if (isInlineSource())
+        {
+            stringstream << sourceType;
+        }
+        else
+        {
+            stringstream << fmt::format("{}", logicalSource.getLogicalSourceName());
+        }
     }
     return stringstream.str();
 }
@@ -119,6 +133,7 @@ Reflected Reflector<SourceDescriptor>::operator()(const SourceDescriptor& source
         .type = sourceDescriptor.sourceType,
         .host = sourceDescriptor.host,
         .inputFormatterDescriptor = sourceDescriptor.inputFormatterDescriptor,
+        .isInline = sourceDescriptor.isInline,
         .config = sourceDescriptor.getReflectedConfig(context)};
 
     return context.reflect(descriptor);
@@ -134,6 +149,7 @@ SourceDescriptor Unreflector<SourceDescriptor>::operator()(const Reflected& rfl,
         reflectedSourceDescriptor.type,
         reflectedSourceDescriptor.host,
         Descriptor::unreflectConfig(reflectedSourceDescriptor.config, context),
-        reflectedSourceDescriptor.inputFormatterDescriptor};
+        reflectedSourceDescriptor.inputFormatterDescriptor,
+        reflectedSourceDescriptor.isInline};
 }
 }

--- a/nes-sql-parser/AntlrSQL.g4
+++ b/nes-sql-parser/AntlrSQL.g4
@@ -60,7 +60,11 @@ terminatedStatement: statement ';';
 multipleStatements: (statement (';' statement)* ';'?)? EOF;
 statement: queryWithOptions | createStatement | dropStatement | showStatement | explainStatement;
 
-explainStatement: EXPLAIN query;
+explainStatement: EXPLAIN ('(' explainStages ')')? (FORMAT explainFormat)? query;
+explainStages: explainStage (',' explainStage)*;
+explainStage: identifier | LOGICAL;
+explainFormat: identifier | TEXT;
+
 createStatement: CREATE createDefinition;
 createDefinition: createLogicalSourceDefinition | createPhysicalSourceDefinition | createSinkDefinition | createWorkerDefinition | createModelDefinition;
 createLogicalSourceDefinition: LOGICAL SOURCE sourceName=identifier schemaDefinition fromQuery?;
@@ -619,10 +623,10 @@ UNSIGNED_TYPE_QUALIFIER: 'UNSIGNED ';
 
 
 SHOW : 'SHOW';
-FORMAT : 'FORMAT';
+FORMAT : 'FORMAT' | 'format';
 CREATE : 'CREATE';
 SOURCE : 'SOURCE';
-LOGICAL: 'LOGICAL';
+LOGICAL: 'LOGICAL' | 'logical';
 PHYSICAL: 'PHYSICAL';
 WORKER: 'WORKER';
 SINK : 'SINK';

--- a/nes-sql-parser/include/SQLQueryParser/StatementBinder.hpp
+++ b/nes-sql-parser/include/SQLQueryParser/StatementBinder.hpp
@@ -14,6 +14,7 @@
 
 
 #pragma once
+
 #include <cstddef>
 #include <cstdint>
 #include <expected>
@@ -24,6 +25,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <variant>
 #include <vector>
 #include <AntlrSQLParser.h>
@@ -125,9 +127,25 @@ struct QueryStatement
     std::optional<DistributedQueryId> id;
 };
 
+enum class ExplainFormat : uint8_t
+{
+    Visual,
+    Text,
+    Verbose
+};
+
+enum class ExplainStage : uint8_t
+{
+    Logical,
+    Optimized,
+    Distributed
+};
+
 struct ExplainQueryStatement
 {
     LogicalPlan plan;
+    ExplainFormat explainFormat = ExplainFormat::Visual;
+    std::unordered_set<ExplainStage> explainStages = {ExplainStage::Logical, ExplainStage::Optimized, ExplainStage::Distributed};
 };
 
 struct ShowQueriesStatement

--- a/nes-sql-parser/src/StatementBinder.cpp
+++ b/nes-sql-parser/src/StatementBinder.cpp
@@ -30,6 +30,7 @@
 #include <Util/Strings.hpp>
 
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -531,6 +532,95 @@ public:
         throw InvalidStatement("Unrecognized DROP statement");
     }
 
+    std::unordered_set<ExplainStage> bindExplainStages(AntlrSQLParser::ExplainStagesContext* stagesContext) const
+    {
+        std::unordered_set<ExplainStage> explainStages;
+
+        for (auto* const stageContext : stagesContext->explainStage())
+        {
+            if (stageContext->LOGICAL() != nullptr)
+            {
+                if (!explainStages.insert(ExplainStage::Logical).second)
+                {
+                    throw InvalidStatement("Duplicate EXPLAIN stage: LOGICAL");
+                }
+            }
+            else
+            {
+                const auto identifier = bindIdentifier(stageContext->identifier());
+
+                if (identifier == Identifier::parse("logical"))
+                {
+                    if (!explainStages.insert(ExplainStage::Logical).second)
+                    {
+                        throw InvalidStatement("Duplicate EXPLAIN stage: LOGICAL");
+                    }
+                }
+                else if (identifier == Identifier::parse("optimized"))
+                {
+                    if (!explainStages.insert(ExplainStage::Optimized).second)
+                    {
+                        throw InvalidStatement("Duplicate EXPLAIN stage: OPTIMIZED");
+                    }
+                }
+                else if (identifier == Identifier::parse("distributed"))
+                {
+                    if (!explainStages.insert(ExplainStage::Distributed).second)
+                    {
+                        throw InvalidStatement("Duplicate EXPLAIN stage: DISTRIBUTED");
+                    }
+                }
+                else
+                {
+                    throw InvalidStatement("Unrecognized EXPLAIN stage: {}", identifier);
+                }
+            }
+        }
+
+        return explainStages;
+    }
+
+    ExplainFormat bindExplainFormat(AntlrSQLParser::ExplainFormatContext* formatAST) const
+    {
+        if (formatAST->TEXT() != nullptr)
+        {
+            return ExplainFormat::Text;
+        }
+
+        auto parsedFormatIdentifier = bindIdentifier(formatAST->identifier());
+
+        if (parsedFormatIdentifier == Identifier::parse("text"))
+        {
+            return ExplainFormat::Text;
+        }
+        if (parsedFormatIdentifier == Identifier::parse("verbose"))
+        {
+            return ExplainFormat::Verbose;
+        }
+        if (parsedFormatIdentifier == Identifier::parse("visual"))
+        {
+            return ExplainFormat::Visual;
+        }
+        throw InvalidStatement("Unrecognized EXPLAIN format: {}", parsedFormatIdentifier);
+    }
+
+    Statement bindExplainStatement(AntlrSQLParser::ExplainStatementContext* explainAst) const
+    {
+        INVARIANT(explainAst->query() != nullptr, "Should be enforced by antlr");
+        ExplainFormat format = ExplainFormat::Visual;
+        std::unordered_set<ExplainStage> stages = {ExplainStage::Logical, ExplainStage::Optimized, ExplainStage::Distributed};
+        if (auto* const stagesAST = explainAst->explainStages())
+        {
+            stages = bindExplainStages(stagesAST);
+        }
+        if (auto* const formatAST = explainAst->explainFormat())
+        {
+            format = bindExplainFormat(formatAST);
+        }
+
+        return ExplainQueryStatement{.plan = queryBinder(explainAst->query()), .explainFormat = format, .explainStages = stages};
+    }
+
     std::expected<Statement, Exception> bind(AntlrSQLParser::StatementContext* statementAST) const
     {
         try
@@ -549,8 +639,7 @@ public:
             }
             if (auto* const explainStatementAST = statementAST->explainStatement())
             {
-                INVARIANT(explainStatementAST->query() != nullptr, "Should be enforced by antlr");
-                return ExplainQueryStatement{queryBinder(explainStatementAST->query())};
+                return bindExplainStatement(explainStatementAST);
             }
             if (auto* const queryAst = statementAST->queryWithOptions(); queryAst != nullptr)
             {

--- a/nes-sql-parser/tests/StatementBinderTest.cpp
+++ b/nes-sql-parser/tests/StatementBinderTest.cpp
@@ -16,6 +16,7 @@
 #include <ranges>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -813,6 +814,69 @@ TEST_F(StatementBinderTest, ExplainStatement)
         const auto explainStatementResult = binder->parseAndBindSingle(explain);
         ASSERT_FALSE(explainStatementResult.has_value());
     }
+}
+
+TEST_F(StatementBinderTest, ExplainStatementStageOptions)
+{
+    const auto getExplainStatement = [&](std::string_view sql) -> ExplainQueryStatement
+    {
+        const auto result = binder->parseAndBindSingle(sql);
+        EXPECT_TRUE(result.has_value()) << "Failed to parse: " << sql;
+        return std::get<ExplainQueryStatement>(result.value());
+    };
+
+    EXPECT_EQ(
+        getExplainStatement("EXPLAIN SELECT * FROM testSource INTO testSink").explainStages,
+        (std::unordered_set<ExplainStage>{ExplainStage::Logical, ExplainStage::Optimized, ExplainStage::Distributed}));
+    EXPECT_EQ(
+        getExplainStatement("EXPLAIN (LOGICAL) SELECT * FROM testSource INTO testSink").explainStages,
+        std::unordered_set{ExplainStage::Logical});
+    EXPECT_EQ(
+        getExplainStatement("EXPLAIN (OPTIMIZED) SELECT * FROM testSource INTO testSink").explainStages,
+        std::unordered_set{ExplainStage::Optimized});
+    EXPECT_EQ(
+        getExplainStatement("EXPLAIN (DISTRIBUTED) SELECT * FROM testSource INTO testSink").explainStages,
+        std::unordered_set{ExplainStage::Distributed});
+    EXPECT_EQ(
+        getExplainStatement("EXPLAIN (LOGICAL, OPTIMIZED) SELECT * FROM testSource INTO testSink").explainStages,
+        (std::unordered_set{ExplainStage::Logical, ExplainStage::Optimized}));
+
+    EXPECT_FALSE(binder->parseAndBindSingle("EXPLAIN (LOGICAL, LOGICAL) SELECT * FROM testSource INTO testSink").has_value());
+}
+
+TEST_F(StatementBinderTest, ExplainStatementFormatOptions)
+{
+    const auto getExplainStatement = [&](std::string_view sql) -> ExplainQueryStatement
+    {
+        const auto result = binder->parseAndBindSingle(sql);
+        EXPECT_TRUE(result.has_value()) << "Failed to parse: " << sql;
+        return std::get<ExplainQueryStatement>(result.value());
+    };
+
+    EXPECT_EQ(getExplainStatement("EXPLAIN SELECT * FROM testSource INTO testSink").explainFormat, ExplainFormat::Visual);
+    EXPECT_EQ(getExplainStatement("EXPLAIN FORMAT VISUAL SELECT * FROM testSource INTO testSink").explainFormat, ExplainFormat::Visual);
+    EXPECT_EQ(getExplainStatement("EXPLAIN FORMAT TEXT SELECT * FROM testSource INTO testSink").explainFormat, ExplainFormat::Text);
+    EXPECT_EQ(getExplainStatement("EXPLAIN FORMAT VERBOSE SELECT * FROM testSource INTO testSink").explainFormat, ExplainFormat::Verbose);
+
+    const auto duplicateFormat = binder->parseAndBindSingle("EXPLAIN FORMAT TEXT FORMAT VERBOSE SELECT * FROM testSource INTO testSink");
+    EXPECT_FALSE(duplicateFormat.has_value());
+}
+
+TEST_F(StatementBinderTest, ExplainStatementCombinedOptions)
+{
+    const auto result = binder->parseAndBindSingle("EXPLAIN (LOGICAL) FORMAT VERBOSE SELECT * FROM testSource INTO testSink");
+    ASSERT_TRUE(result.has_value());
+    const auto& stmt = std::get<ExplainQueryStatement>(result.value());
+    EXPECT_EQ(stmt.explainStages, std::unordered_set{ExplainStage::Logical});
+    EXPECT_EQ(stmt.explainFormat, ExplainFormat::Verbose);
+}
+
+TEST_F(StatementBinderTest, ExplainStatementCaseInsensitive)
+{
+    const auto bind = [&](std::string_view sql) { return binder->parseAndBindSingle(sql); };
+    EXPECT_TRUE(bind("EXPLAIN (logical) SELECT * FROM testSource INTO testSink").has_value());
+    EXPECT_TRUE(bind("EXPLAIN format text SELECT * FROM testSource INTO testSink").has_value());
+    EXPECT_TRUE(bind("EXPLAIN (logical) format verbose SELECT * FROM testSource INTO testSink").has_value());
 }
 
 TEST_F(StatementBinderTest, CreateWorkerStatementTest)

--- a/nes-systests/explain/EXPLAIN.test
+++ b/nes-systests/explain/EXPLAIN.test
@@ -1,0 +1,122 @@
+# name: explain/EXPLAIN.test
+# description: Validates the output of EXPLAIN statements.
+# groups: [explain, inference]
+
+CREATE LOGICAL SOURCE stream(id UINT64 NOT NULL, value UINT64 NOT NULL, timestamp UINT64 NOT NULL);
+CREATE PHYSICAL SOURCE FOR stream TYPE File;
+ATTACH INLINE
+1,1,1000
+2,3,2000
+
+CREATE LOGICAL SOURCE stream2(id2 UINT64 NOT NULL, value2 UINT64 NOT NULL, timestamp2 UINT64 NOT NULL);
+CREATE PHYSICAL SOURCE FOR stream2 TYPE File;
+ATTACH INLINE
+1,2,1000
+2,4,2000
+
+CREATE SINK sinkFilter(id UINT64 NOT NULL, value UINT64 NOT NULL) TYPE File;
+CREATE SINK sinkJoin(start UINT64 NOT NULL, end UINT64 NOT NULL, id UINT64 NOT NULL, value UINT64 NOT NULL, timestamp UINT64 NOT NULL, id2 UINT64 NOT NULL, value2 UINT64 NOT NULL, timestamp2 UINT64 NOT NULL) TYPE File;
+
+CREATE MODEL iris ('model/iris.onnx')
+INPUT (p1 FLOAT32, p2 FLOAT32, p3 FLOAT32, p4 FLOAT32)
+OUTPUT (setosa FLOAT32, versicolor FLOAT32, virginica FLOAT32);
+
+CREATE LOGICAL SOURCE stream_inference(p1 FLOAT32 NOT NULL, p2 FLOAT32 NOT NULL, p3 FLOAT32 NOT NULL, p4 FLOAT32 NOT NULL);
+CREATE PHYSICAL SOURCE FOR stream_inference TYPE File;
+ATTACH INLINE
+6.1,3.5,1.4,0.2
+4.9,3.0,1.4,0.2
+4.7,3.2,1.3,0.2
+
+
+
+EXPLAIN (LOGICAL) FORMAT TEXT SELECT id, value FROM stream WHERE value > UINT64(2) INTO sinkFilter;
+----
+== Initial Logical Plan ==
+SINK(SINKFILTER)
+  PROJECTION(fields: [ID, VALUE])
+    SELECTION(VALUE > 2)
+      SOURCE(STREAM)
+==END==
+
+
+EXPLAIN (OPTIMIZED) FORMAT TEXT SELECT id, value FROM stream WHERE value > UINT64(2) INTO sinkFilter;
+----
+== Optimized Global Plan ==
+SINK(SINKFILTER)
+  PROJECTION(fields: [ID, VALUE])
+    SELECTION(VALUE > 2)
+      PROJECTION(fields: [ID, VALUE])
+        SOURCE(STREAM)
+==END==
+
+EXPLAIN (OPTIMIZED) FORMAT TEXT
+SELECT start, end, id, value, timestamp, id2, value2, timestamp2
+FROM (
+  SELECT * FROM (SELECT * FROM stream) INNER JOIN (SELECT * FROM stream2) ON (id = id2) WINDOW TUMBLING (timestamp, timestamp2, size 1 sec)
+)
+INTO sinkJoin;
+----
+== Optimized Global Plan ==
+SINK(SINKJOIN)
+  Join(INNER_JOIN, ID = ID2)
+    WATERMARK_ASSIGNER(Event time)
+      SOURCE(STREAM)
+    WATERMARK_ASSIGNER(Event time)
+      SOURCE(STREAM2)
+==END==
+# At least one EXPLAIN call for each logical operators
+
+# Covering: Projection Selection Union, Sink, Source
+
+EXPLAIN (LOGICAL) FORMAT TEXT
+SELECT *
+FROM (
+    SELECT id * UINT64(2) as id FROM stream WHERE id > UINT64(0)
+    UNION
+    SELECT id2 * UINT64(2) as id FROM stream2 WHERE id2 > UINT64(0))
+INTO File();
+----
+== Initial Logical Plan ==
+SINK(FILE)
+  PROJECTION(fields: [*])
+    UnionWith
+      PROJECTION(fields: [ID * 2 as ID])
+        SELECTION(ID > 0)
+          SOURCE(STREAM)
+      PROJECTION(fields: [ID2 * 2 as ID])
+        SELECTION(ID2 > 0)
+          SOURCE(STREAM2)
+==END==
+
+# Covering: Join, EventTime, Window
+EXPLAIN (LOGICAL) FORMAT TEXT
+SELECT *
+FROM (SELECT * FROM stream) INNER JOIN (SELECT * FROM stream2)
+ON (value = value2 AND id = id2)
+WINDOW TUMBLING (timestamp, timestamp2, size 1 sec)
+INTO File();
+----
+== Initial Logical Plan ==
+SINK(FILE)
+  PROJECTION(fields: [*])
+    Join(INNER_JOIN, VALUE = VALUE2 AND ID = ID2)
+      WATERMARK_ASSIGNER(Event time)
+        PROJECTION(fields: [*])
+          SOURCE(STREAM)
+      WATERMARK_ASSIGNER(Event time)
+        PROJECTION(fields: [*])
+          SOURCE(STREAM2)
+==END==
+
+# Covering: Model Inference
+EXPLAIN (LOGICAL) FORMAT TEXT
+SELECT * FROM MODEL_INFERENCE(iris, stream_inference)
+INTO File();
+----
+== Initial Logical Plan ==
+SINK(FILE)
+  PROJECTION(fields: [*])
+    INFER_MODEL_NAME(model: IRIS)
+      SOURCE(STREAM_INFERENCE)
+==END==

--- a/nes-systests/systest/include/SystestParser.hpp
+++ b/nes-systests/systest/include/SystestParser.hpp
@@ -39,6 +39,7 @@ using namespace std::literals;
 enum class TokenType : uint8_t
 {
     QUERY,
+    EXPLAIN,
     CREATE,
     RESULT_DELIMITER,
     ERROR_EXPECTATION,
@@ -52,6 +53,12 @@ enum class TestDataIngestionType : uint8_t
 {
     INLINE,
     FILE
+};
+
+enum class ResultType : uint8_t
+{
+    TUPLES,
+    VERBATIM
 };
 
 /// Assures that the number of parsed queries matches the number of parsed results
@@ -152,6 +159,7 @@ public:
     };
 
     using QueryCallback = std::function<void(std::string, SystestQueryId, bool)>;
+    using ExplainQueryCallback = std::function<void(std::string, SystestQueryId)>;
     using ResultTuplesCallback = std::function<void(std::vector<std::string>&&, SystestQueryId correspondingQueryId)>;
     using ErrorExpectationCallback = std::function<void(const ErrorExpectation&, SystestQueryId correspondingQueryId)>;
     using DifferentialQueryBlockCallback
@@ -162,6 +170,7 @@ public:
 
     /// Register callbacks to be called when the respective section is parsed
     void registerOnQueryCallback(QueryCallback callback);
+    void registerOnExplainQueryCallback(ExplainQueryCallback callback);
     void registerOnResultTuplesCallback(ResultTuplesCallback callback);
     void registerOnErrorExpectationCallback(ErrorExpectationCallback callback);
     void registerOnCreateCallback(CreateCallback callback);
@@ -186,6 +195,7 @@ private:
     void applySubstitutionRules(std::string& line);
 
     [[nodiscard]] std::vector<std::string> expectTuples(bool ignoreFirst);
+    [[nodiscard]] std::vector<std::string> expectVerbatimResultLines();
     [[nodiscard]] std::filesystem::path expectFilePath();
     [[nodiscard]] std::string expectQuery();
     [[nodiscard]] std::pair<std::string, std::optional<std::pair<TestDataIngestionType, std::vector<std::string>>>> expectCreateStatement();
@@ -197,6 +207,7 @@ private:
 
     std::vector<SubstitutionRule> substitutionRules;
     QueryCallback onQueryCallback;
+    ExplainQueryCallback onExplainQueryCallback;
     ResultTuplesCallback onResultTuplesCallback;
     ErrorExpectationCallback onErrorExpectationCallback;
     CreateCallback onCreateCallback;
@@ -206,6 +217,7 @@ private:
 
     std::optional<std::string> lastParsedQuery;
     std::optional<SystestQueryId> lastParsedQueryId;
+    ResultType expectedResultType = ResultType::TUPLES;
     bool firstToken = true;
     bool shouldRevisitCurrentLine = false;
     size_t currentLine = 0;

--- a/nes-systests/systest/include/SystestResultCheck.hpp
+++ b/nes-systests/systest/include/SystestResultCheck.hpp
@@ -36,6 +36,12 @@ namespace NES
 /// Returns an error message or an empty optional if the query result is correct
 std::optional<std::string> checkResult(const Systest::RunningQuery& runningQuery);
 
+/// Compares the explain output of an EXPLAIN statement (computed at bind time) against the expected result lines.
+/// Unlike checkResult, the comparison is ordered and line-based: lines are right-trimmed (indentation is significant)
+/// and empty lines are dropped on both sides, because expected blocks in test files cannot contain empty lines.
+/// Returns an error message or an empty optional if the explain output matches.
+std::optional<std::string> checkExplainResult(const Systest::RunningQuery& runningQuery);
+
 template <typename T>
 bool compareStringAsTypeWithError(const std::string& left, const std::string& right)
 {

--- a/nes-systests/systest/include/SystestState.hpp
+++ b/nes-systests/systest/include/SystestState.hpp
@@ -208,6 +208,7 @@ struct SystestQuery
     ConfigurationOverride configurationOverride;
     std::optional<DistributedLogicalPlan> differentialQueryPlan;
     std::optional<std::pair<TestName, SystestQueryId>> runAfter;
+    std::optional<std::string> actualExplainOutput;
 };
 
 struct RunningQuery

--- a/nes-systests/systest/src/SystestBinder.cpp
+++ b/nes-systests/systest/src/SystestBinder.cpp
@@ -95,6 +95,31 @@ public:
         const Schema<UnqualifiedUnboundField, Ordered>& schema,
         const std::unordered_map<Identifier, std::string>& /*config*/)
     {
+        std::unordered_map<Identifier, std::string> config{};
+        std::unordered_map<Identifier, std::string> formatConfig{};
+        if (sinkType == Identifier::parse("File"))
+        {
+            config[Identifier::parse("file_path")] = "/tmp/none.txt";
+            config[Identifier::parse("output_format")] = "CSV";
+        }
+        else if (sinkType == Identifier::parse("CHECKSUM"))
+        {
+            config[Identifier::parse("file_path")] = "/tmp/none.txt";
+            formatConfig[Identifier::parse("quote_strings")] = "true";
+        }
+        std::string host = possibleSinkPlacements.at(0).getRawValue();
+        if (auto hostIt = config.find(Identifier::parse("host")); hostIt != config.end())
+        {
+            host = hostIt->second;
+        }
+
+        const auto sink = sinkCatalog->addSinkDescriptor(sinkNameInFile, schema, sinkType, Host(host), std::move(config), formatConfig);
+        if (not sink.has_value())
+        {
+            throw SinkAlreadyExists("Failed to create file sink with assigned name {}", sinkNameInFile);
+        }
+
+
         auto [_, success] = sinkProviders.emplace(
             sinkNameInFile,
             [this, schema, sinkType](
@@ -279,8 +304,24 @@ public:
 
     void setDifferentialQueryPlan(LogicalPlan differentialQueryPlan) { this->differentialQueryPlan = std::move(differentialQueryPlan); }
 
+    void setExplainStatement(ExplainQueryStatement statement) { this->explainStatement = std::move(statement); }
+
     void optimizeQueries(const NES::QueryOptimizer& queryOptimizer)
     {
+        if (explainStatement.has_value())
+        {
+            /// EXPLAIN statements are never executed; compute the explain output now, as this is the only place with
+            /// access to the query optimizer (needed for the OPTIMIZED, DISTRIBUTED and ALL stages).
+            try
+            {
+                actualExplainOutput = computeExplainOutput(explainStatement.value(), queryOptimizer);
+            }
+            catch (Exception& e)
+            {
+                setException(e);
+            }
+            return;
+        }
         if (!boundPlan.has_value())
         {
             return;
@@ -326,6 +367,29 @@ public:
                 expectedResultsOrError.has_value() || differentialQueryPlan.has_value(),
                 "Differential query plan or error has not been set");
         }
+
+        if (explainStatement.has_value())
+        {
+            /// EXPLAIN statements have no executable plan and never touch the worker, so configuration overrides do not
+            /// apply and exactly one query is emitted. On success, the runner only reads actualExplainOutput.
+            return {
+                {.testName = testName.value(),
+                 .queryIdInFile = queryIdInFile,
+                 .testFilePath = testFilePath.value(),
+                 .workingDir = workingDir.value(),
+                 .queryDefinition = queryDefinition.value(),
+                 .planInfoOrException = std::
+                     unexpected{exception.has_value() ? exception.value() : Exception{TestException("EXPLAIN statements are not executed and have no plan info")}},
+                 .expectedResultsOrExpectedError = expectedResultsOrError.has_value()
+                     ? expectedResultsOrError.value()
+                     : std::variant<std::vector<std::string>, ExpectedError>{std::vector<std::string>{}},
+                 .additionalSourceThreads = additionalSourceThreads.value(),
+                 .configurationOverride = ConfigurationOverride{},
+                 .differentialQueryPlan = std::nullopt,
+                 .runAfter = runAfter,
+                 .actualExplainOutput = exception.has_value() ? std::nullopt : actualExplainOutput}};
+        }
+
         const auto createPlanInfoOrException = [this]() -> std::expected<SystestQuery::PlanInfo, Exception>
         {
             if (not exception.has_value())
@@ -359,7 +423,8 @@ public:
                  .additionalSourceThreads = additionalSourceThreads.value(),
                  .configurationOverride = std::move(configurationOverride),
                  .differentialQueryPlan = optimizedDifferentialQueryPlan,
-                 .runAfter = runAfter});
+                 .runAfter = runAfter,
+                 .actualExplainOutput = std::nullopt});
         }
         return queries;
     }
@@ -384,6 +449,8 @@ private:
     std::optional<LogicalPlan> differentialQueryPlan;
     std::optional<DistributedLogicalPlan> optimizedDifferentialQueryPlan;
     std::optional<std::pair<TestName, SystestQueryId>> runAfter;
+    std::optional<ExplainQueryStatement> explainStatement;
+    std::optional<std::string> actualExplainOutput;
     bool built = false;
 };
 
@@ -829,6 +896,29 @@ struct SystestBinder::Impl
         }
     }
 
+    void setInlineSinks(
+        LogicalPlan& plan,
+        const std::string_view& testFileName,
+        SLTSinkFactory& sltSinkProvider,
+        const SystestQueryId& currentQueryNumberInTest) const
+    {
+        std::vector<LogicalOperator> newRoots;
+
+
+        for (const auto& rootOperator : plan.getRootOperators())
+        {
+            if (auto inlineSink = rootOperator.tryGetAs<InlineSinkLogicalOperator>(); inlineSink.has_value())
+            {
+                newRoots.emplace_back(setInlineSink(testFileName, sltSinkProvider, currentQueryNumberInTest, inlineSink.value()));
+            }
+            else
+            {
+                newRoots.emplace_back(rootOperator);
+            }
+        }
+        plan = plan.withRootOperators(newRoots);
+    }
+
     void queryCallback(
         const std::string_view& testFileName,
         std::unordered_map<SystestQueryId, SystestQueryBuilder>& plans,
@@ -852,6 +942,51 @@ struct SystestBinder::Impl
             plan.setQueryId(QueryId::createDistributed(DistributedQueryId(fmt::format("{}:{}", testFileName, currentQueryNumberInTest))));
             setInlineSources(plan);
             currentBuilder.setBoundPlan(std::move(plan));
+        }
+        catch (Exception& e)
+        {
+            currentBuilder.setException(e);
+        }
+
+        plans.emplace(currentQueryNumberInTest, currentBuilder);
+    }
+
+    void explainCallback(
+        const StatementBinder& binder,
+        const std::string_view& testFileName,
+        std::unordered_map<SystestQueryId, SystestQueryBuilder>& plans,
+        SLTSinkFactory& sltSinkProvider,
+        const std::string& statementString,
+        const SystestQueryId& currentQueryNumberInTest) const
+    {
+        SystestQueryBuilder currentBuilder{currentQueryNumberInTest};
+        currentBuilder.setQueryDefinition(statementString);
+        try
+        {
+            const auto managedParser = NES::AntlrSQLQueryParser::ManagedAntlrParser::create(statementString);
+            const auto parseResult = managedParser->parseSingle();
+            if (not parseResult.has_value())
+            {
+                throw InvalidQuerySyntax("failed to parse the statement \"{}\"", replaceAll(statementString, "\n", " "));
+            }
+
+            auto binding = binder.bind(parseResult.value().get());
+            if (not binding.has_value())
+            {
+                throw InvalidQuerySyntax("failed to bind the statement \"{}\": {}", statementString, binding.error());
+            }
+
+            auto* explainStatement = std::get_if<ExplainQueryStatement>(&binding.value());
+            if (explainStatement == nullptr)
+            {
+                throw UnsupportedQuery("expected an EXPLAIN statement, but got: \"{}\"", replaceAll(statementString, "\n", " "));
+            }
+
+            /// The inner query plan needs the same rewrites as a regular systest query, so that its sinks and inline
+            /// sources resolve during optimization (the OPTIMIZED, DISTRIBUTED and ALL stages run the optimizer).
+            setInlineSinks(explainStatement->plan, testFileName, sltSinkProvider, currentQueryNumberInTest);
+            setInlineSources(explainStatement->plan);
+            currentBuilder.setExplainStatement(std::move(*explainStatement));
         }
         catch (Exception& e)
         {
@@ -968,6 +1103,15 @@ struct SystestBinder::Impl
                 lastMergedConfigOverrides = mergedConfigOverrides;
                 queryCallback(
                     testFileName, plans, sltSinkProvider, query, currentQueryNumberInTest, mergedConfigOverrides, sequentialExecution);
+                configOverrides = {ConfigurationOverride{}};
+            });
+
+        parser.registerOnExplainQueryCallback(
+            [&](const std::string& statement, SystestQueryId currentQueryNumberInTest)
+            {
+                explainCallback(binder, testFileName, plans, sltSinkProvider, statement, currentQueryNumberInTest);
+                /// EXPLAIN statements are not executed, so configuration overrides do not apply; reset them so they
+                /// do not leak into the next query.
                 configOverrides = {ConfigurationOverride{}};
             });
 

--- a/nes-systests/systest/src/SystestParser.cpp
+++ b/nes-systests/systest/src/SystestParser.cpp
@@ -130,6 +130,7 @@ using namespace std::string_view_literals;
 
 static constexpr std::string_view CreateToken = "CREATE"sv;
 static constexpr std::string_view QueryToken = "SELECT"sv;
+static constexpr std::string_view ExplainToken = "EXPLAIN"sv;
 static constexpr std::string_view ResultDelimiter = "----"sv;
 static constexpr std::string_view ErrorToken = "ERROR"sv;
 static constexpr std::string_view DifferentialToken = "===="sv;
@@ -140,6 +141,7 @@ static constexpr std::string_view SequentialExecutionToken = "SEQUENTIAL_EXECUTI
 static const std::array stringToToken = std::to_array<std::pair<std::string_view, TokenType>>(
     {{CreateToken, TokenType::CREATE},
      {QueryToken, TokenType::QUERY},
+     {ExplainToken, TokenType::EXPLAIN},
      {ResultDelimiter, TokenType::RESULT_DELIMITER},
      {ErrorToken, TokenType::ERROR_EXPECTATION},
      {ConfigurationToken, TokenType::CONFIGURATION},
@@ -202,6 +204,11 @@ void SystestParser::registerOnQueryCallback(QueryCallback callback)
     this->onQueryCallback = std::move(callback);
 }
 
+void SystestParser::registerOnExplainQueryCallback(ExplainQueryCallback callback)
+{
+    this->onExplainQueryCallback = std::move(callback);
+}
+
 void SystestParser::registerOnResultTuplesCallback(ResultTuplesCallback callback)
 {
     this->onResultTuplesCallback = std::move(callback);
@@ -235,6 +242,8 @@ void SystestParser::registerOnDifferentialQueryBlockCallback(DifferentialQueryBl
 /// Here we model the structure of the test file by what we `expect` to see.
 void SystestParser::parse()
 {
+    static const std::unordered_set<TokenType> DefaultQueryStopTokens{TokenType::RESULT_DELIMITER, TokenType::DIFFERENTIAL};
+
     SystestQueryIdAssigner queryIdAssigner{};
     bool sequentialExecution = false;
     while (auto token = getNextToken())
@@ -247,9 +256,8 @@ void SystestParser::parse()
                 break;
             }
             case TokenType::QUERY: {
-                static const std::unordered_set<TokenType> DefaultQueryStopTokens{TokenType::RESULT_DELIMITER, TokenType::DIFFERENTIAL};
-
                 auto query = expectQuery(DefaultQueryStopTokens);
+                expectedResultType = ResultType::TUPLES;
                 lastParsedQuery = query;
                 auto queryId = queryIdAssigner.getNextQueryNumber();
                 lastParsedQueryId = queryId;
@@ -259,15 +267,39 @@ void SystestParser::parse()
                 }
                 break;
             }
+            case TokenType::EXPLAIN: {
+                auto statement = expectQuery(DefaultQueryStopTokens);
+                expectedResultType = ResultType::VERBATIM;
+                /// EXPLAIN statements cannot be part of a differential block
+                lastParsedQuery.reset();
+                lastParsedQueryId.reset();
+                auto queryId = queryIdAssigner.getNextQueryNumber();
+                if (onExplainQueryCallback)
+                {
+                    onExplainQueryCallback(statement, queryId);
+                }
+                break;
+            }
             case TokenType::RESULT_DELIMITER: {
                 const auto optionalToken = peekToken();
                 if (optionalToken == TokenType::ERROR_EXPECTATION)
                 {
+                    expectedResultType = ResultType::TUPLES;
                     ++currentLine;
                     auto expectation = expectError();
                     if (onErrorExpectationCallback)
                     {
                         onErrorExpectationCallback(expectation, queryIdAssigner.getNextQueryResultNumber());
+                    }
+                }
+                else if (expectedResultType == ResultType::VERBATIM)
+                {
+                    expectedResultType = ResultType::TUPLES;
+                    /// EXPLAIN output is free-form plan text, so it is read verbatim instead of as result tuples
+                    auto verbatimResultLines = expectVerbatimResultLines();
+                    if (onResultTuplesCallback)
+                    {
+                        onResultTuplesCallback(std::move(verbatimResultLines), queryIdAssigner.getNextQueryResultNumber());
                     }
                 }
                 else
@@ -296,6 +328,9 @@ void SystestParser::parse()
                 break;
             }
             case TokenType::DIFFERENTIAL: {
+                INVARIANT(
+                    expectedResultType == ResultType::TUPLES,
+                    "DIFFERENTIAL block cannot follow an EXPLAIN statement (verbatim result expected)");
                 INVARIANT(lastParsedQuery.has_value() && lastParsedQueryId.has_value(), "Differential block without preceding query");
 
                 auto [leftQuery, rightQuery] = expectDifferentialBlock();
@@ -470,6 +505,23 @@ std::vector<std::string> SystestParser::expectTuples(const bool ignoreFirst)
         currentLine++;
     }
     return tuples;
+}
+
+std::vector<std::string> SystestParser::expectVerbatimResultLines()
+{
+    INVARIANT(currentLine < lines.size(), "current line to parse should exist: {}", currentLine);
+    std::vector<std::string> resultLines;
+    /// skip the result line `----`
+    if (toLowerCase(lines[currentLine]) == toLowerCase(ResultDelimiter))
+    {
+        currentLine++;
+    }
+    while (currentLine < lines.size() && !lines[currentLine].starts_with("==END=="))
+    {
+        resultLines.push_back(lines[currentLine]);
+        currentLine++;
+    }
+    return resultLines;
 }
 
 std::pair<std::string, std::optional<std::pair<TestDataIngestionType, std::vector<std::string>>>> SystestParser::expectCreateStatement()

--- a/nes-systests/systest/src/SystestResultCheck.cpp
+++ b/nes-systests/systest/src/SystestResultCheck.cpp
@@ -893,4 +893,57 @@ std::optional<std::string> checkResult(const Systest::RunningQuery& runningQuery
     }
     std::unreachable();
 }
+
+std::optional<std::string> checkExplainResult(const Systest::RunningQuery& runningQuery)
+{
+    INVARIANT(runningQuery.systestQuery.actualExplainOutput.has_value(), "checkExplainResult requires a computed explain output");
+
+    const auto rightTrim = [](const std::string_view line) -> std::string
+    {
+        const auto end = line.find_last_not_of(" \t\r");
+        return std::string{line.substr(0, end == std::string_view::npos ? 0 : end + 1)};
+    };
+
+    /// Right-trim every line and drop empty lines on both sides: indentation is significant, but expected blocks in
+    /// test files cannot contain empty lines (an empty line terminates the block).
+    const auto normalize = [&rightTrim](auto&& inputLines) -> std::vector<std::string>
+    {
+        std::vector<std::string> normalized;
+        for (auto&& line : inputLines)
+        {
+            if (auto trimmed = rightTrim(line); not trimmed.empty())
+            {
+                normalized.push_back(std::move(trimmed));
+            }
+        }
+        return normalized;
+    };
+
+    const auto* expectedResultLines = std::get_if<std::vector<std::string>>(&runningQuery.systestQuery.expectedResultsOrExpectedError);
+    INVARIANT(expectedResultLines != nullptr, "EXPLAIN statements must have expected result lines");
+
+    const auto expected = normalize(*expectedResultLines);
+    const auto actual = normalize(
+        runningQuery.systestQuery.actualExplainOutput.value() | std::views::split('\n')
+        | std::views::transform([](auto&& split) { return std::string_view(split.begin(), split.end()); }));
+
+    if (expected == actual)
+    {
+        return std::nullopt;
+    }
+
+    auto firstDifferingLine = std::ranges::mismatch(expected, actual).in1 - expected.begin();
+    static constexpr std::string_view EndOfOutput = "<end of output>";
+    return fmt::format(
+        "\n\n"
+        "Explain Output Mismatch (first difference at line {}, expected \"{}\" but got \"{}\")\n"
+        "----------------------\n"
+        "Expected:\n{}\n\n"
+        "Actual:\n{}",
+        firstDifferingLine + 1,
+        std::cmp_less(firstDifferingLine, expected.size()) ? std::string_view{expected[firstDifferingLine]} : EndOfOutput,
+        std::cmp_less(firstDifferingLine, actual.size()) ? std::string_view{actual[firstDifferingLine]} : EndOfOutput,
+        fmt::join(expected, "\n"),
+        fmt::join(actual, "\n"));
+}
 }

--- a/nes-systests/systest/src/SystestRunner.cpp
+++ b/nes-systests/systest/src/SystestRunner.cpp
@@ -244,6 +244,34 @@ std::vector<RunningQuery> runQueries(
                 nextQuery.testName,
                 nextQuery.queryIdInFile);
 
+            if (nextQuery.actualExplainOutput.has_value())
+            {
+                /// EXPLAIN statements are never submitted to the worker; their output was computed at bind time,
+                /// so compare it against the expected result lines and report immediately.
+                auto runningQuery = std::make_shared<RunningQuery>(nextQuery);
+                reportResult(
+                    runningQuery,
+                    progressTracker,
+                    failed,
+                    [&]
+                    {
+                        if (std::holds_alternative<ExpectedError>(nextQuery.expectedResultsOrExpectedError))
+                        {
+                            return fmt::format(
+                                "expected error {} but EXPLAIN succeeded",
+                                std::get<ExpectedError>(nextQuery.expectedResultsOrExpectedError).code);
+                        }
+                        if (auto err = checkExplainResult(*runningQuery))
+                        {
+                            return *err;
+                        }
+                        return std::string{};
+                    },
+                    queryPerformanceMessage);
+                moveDependentsToPending(nextQuery);
+                continue;
+            }
+
             if (nextQuery.differentialQueryPlan.has_value() and nextQuery.planInfoOrException.has_value())
             {
                 /// Start both differential queries

--- a/nes-systests/systest/tests/SystestParserTests.cpp
+++ b/nes-systests/systest/tests/SystestParserTests.cpp
@@ -251,6 +251,126 @@ SELECT id * UINT32(2) * UINT32(5) AS id, value, timestamp FROM stream INTO strea
     ASSERT_TRUE(differentialQueryCallbackCalled) << "The differential query callback was never called.";
 }
 
+/// NOLINTBEGIN(bugprone-unchecked-optional-access)
+TEST_F(SystestParserTest, testExplainCallbackWithVerbatimResultBlock)
+{
+    SystestParser parser{};
+
+    const std::string explainIn = "EXPLAIN (OPTIMIZED, FORMAT TEXT) SELECT id FROM stream WHERE value > UINT64(4) INTO sink;";
+    const std::string queryIn = "SELECT id FROM stream INTO sink;";
+
+    /// The expected explain output contains lines that look like parser tokens: a line starting with `----`,
+    /// a section header, and an indented line starting with `SELECT`. All must be delivered verbatim.
+    static constexpr std::string_view TestContent
+        = R"(EXPLAIN (OPTIMIZED, FORMAT TEXT) SELECT id FROM stream WHERE value > UINT64(4) INTO sink;
+----
+== Global Optimized Plan ==
+SINK(SINK1)
+  SELECTION(predicate: value > 4)
+    SOURCE(stream)
+==END==
+
+SELECT id FROM stream INTO sink;
+----
+1
+)";
+
+    std::optional<SystestQueryId> explainQueryId;
+    std::optional<SystestQueryId> selectQueryId;
+    std::string receivedExplainStatement;
+    std::vector<std::vector<std::string>> receivedResultBlocks;
+
+    parser.registerOnExplainQueryCallback(
+        [&](const std::string& statement, SystestQueryId queryId)
+        {
+            receivedExplainStatement = statement;
+            explainQueryId = queryId;
+        });
+    parser.registerOnQueryCallback(
+        [&](const std::string& queryOut, SystestQueryId queryId, bool)
+        {
+            ASSERT_EQ(queryIn, queryOut);
+            selectQueryId = queryId;
+        });
+    parser.registerOnResultTuplesCallback([&](std::vector<std::string>&& resultTuples, SystestQueryId)
+                                          { receivedResultBlocks.push_back(std::move(resultTuples)); });
+    parser.registerOnCreateCallback(
+        [&](const std::string&, const std::optional<std::pair<TestDataIngestionType, std::vector<std::string>>>&) { FAIL(); });
+
+    ASSERT_TRUE(parser.loadString(std::string(TestContent)));
+    EXPECT_NO_THROW(parser.parse());
+
+    ASSERT_EQ(receivedExplainStatement, explainIn);
+    ASSERT_TRUE(explainQueryId.has_value());
+    ASSERT_TRUE(selectQueryId.has_value());
+    EXPECT_EQ(explainQueryId->getRawValue() + 1, selectQueryId->getRawValue()) << "EXPLAIN must participate in query id accounting.";
+
+    ASSERT_EQ(receivedResultBlocks.size(), 2);
+    const std::vector<std::string> expectedExplainBlock{
+        "== Global Optimized Plan ==", "SINK(SINK1)", "  SELECTION(predicate: value > 4)", "    SOURCE(stream)"};
+    EXPECT_EQ(receivedResultBlocks.at(0), expectedExplainBlock);
+    EXPECT_EQ(receivedResultBlocks.at(1), std::vector<std::string>{"1"});
+}
+
+TEST_F(SystestParserTest, testExplainWithErrorExpectation)
+{
+    SystestParser parser{};
+
+    static constexpr std::string_view TestContent = R"(EXPLAIN (LOGICAL) SELECT id FROM unknownStream INTO sink;
+----
+ERROR 3000
+)";
+
+    bool explainCallbackCalled = false;
+    bool errorExpectationCallbackCalled = false;
+
+    parser.registerOnExplainQueryCallback([&](const std::string&, SystestQueryId) { explainCallbackCalled = true; });
+    parser.registerOnErrorExpectationCallback(
+        [&](const SystestParser::ErrorExpectation& expectation, SystestQueryId)
+        {
+            errorExpectationCallbackCalled = true;
+            EXPECT_EQ(expectation.code, 3000);
+        });
+    parser.registerOnResultTuplesCallback(
+        [](std::vector<std::string>&&, SystestQueryId) /// NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
+        { FAIL() << "Result tuple callback should not be called for an error expectation."; });
+
+    ASSERT_TRUE(parser.loadString(std::string(TestContent)));
+    EXPECT_NO_THROW(parser.parse());
+
+    ASSERT_TRUE(explainCallbackCalled);
+    ASSERT_TRUE(errorExpectationCallbackCalled);
+}
+
+TEST_F(SystestParserTest, testMultiLineExplainStatement)
+{
+    SystestParser parser{};
+
+    static constexpr std::string_view TestContent = R"(EXPLAIN (ALL, FORMAT TEXT)
+SELECT id FROM stream
+INTO sink;
+----
+== Initial Logical Plan ==
+SINK(SINK1)
+)";
+
+    std::string receivedExplainStatement;
+    std::vector<std::string> receivedResultLines;
+
+    parser.registerOnExplainQueryCallback([&](const std::string& statement, SystestQueryId) { receivedExplainStatement = statement; });
+    parser.registerOnResultTuplesCallback([&](std::vector<std::string>&& resultTuples, SystestQueryId)
+                                          { receivedResultLines = std::move(resultTuples); });
+
+    ASSERT_TRUE(parser.loadString(std::string(TestContent)));
+    EXPECT_NO_THROW(parser.parse());
+
+    EXPECT_EQ(receivedExplainStatement, "EXPLAIN (ALL, FORMAT TEXT)\nSELECT id FROM stream\nINTO sink;");
+    const std::vector<std::string> expectedResultLines{"== Initial Logical Plan ==", "SINK(SINK1)"};
+    EXPECT_EQ(receivedResultLines, expectedResultLines);
+}
+
+/// NOLINTEND(bugprone-unchecked-optional-access)
+
 /// Regression test for issue #945: substitution rules must not replace substrings inside longer identifiers.
 /// For example, a substitution rule for keyword "we" must not modify "producedPower" to "producedPowe<replaced>r".
 TEST_F(SystestParserTest, testSubstitutionRuleRespectsWordBoundaries)

--- a/nes-systests/systest/tests/SystestRunnerTest.cpp
+++ b/nes-systests/systest/tests/SystestRunnerTest.cpp
@@ -104,7 +104,8 @@ NES::Systest::SystestQuery makeQuery(
         .additionalSourceThreads = std::make_shared<std::vector<std::jthread>>(),
         .configurationOverride = NES::Systest::ConfigurationOverride{},
         .differentialQueryPlan = std::nullopt,
-        .runAfter = std::move(runAfter)};
+        .runAfter = std::move(runAfter),
+        .actualExplainOutput = std::nullopt};
 }
 }
 


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

This pull request improves the output of EXPLAIN statements and adds options to control what is shown. The
change list is as follows:
- Extended the SQL grammar (AntlrSQL.g4) so EXPLAIN accepts optional parenthesized options: a stage
(LOGICAL, OPTIMIZED, DISTRIBUTED, ALL) and a FORMAT (VISUAL, TEXT, VERBOSE), e.g. EXPLAIN (LOGICAL, FORMAT
TEXT) SELECT ....
- Added bindExplainStatement to the StatementBinder, which parses the new options, rejects duplicate
stage/format options, and produces an ExplainQueryStatement carrying the requested ExplainStage and
ExplainFormat.
- Updated the StatementHandler and QueryConsoleDumpHandler to render the selected stage in the requested
format with clearer, stage-labeled output (e.g. == Initial Logical Plan ==, == Optimized Global Plan ==).
- Improved the textual representation of plans and operators (LogicalPlan, PhysicalPlan,
SinkLogicalOperator, FieldAccessLogicalFunction, SourceDescriptor).
- Extended the systest framework to parse, run, and validate EXPLAIN statements against expected output.

## Verifying this change

This change is tested by:
- Added nes-systests/explain/EXPLAIN.test, a system test that validates the EXPLAIN output for logical and
optimized plans.
- Added unit tests in StatementBinderTest covering binding of the new EXPLAIN stage/format options.
- Added SystestParserTests covering parsing and validation of EXPLAIN statements in systests.

## What components does this pull request potentially affect?

- QueryCompiler / SQL parser (grammar and statement binding)
- Frontend statement handling and plan dumping
- Logical, physical, and source operator string representations
- Systest framework (parser, binder, result checking, runner)

## Issue Closed by this pull request:

This PR closes #1679 
