### PR TITLE
fix(reflection): evaluate aggregate field once to avoid O(2^depth) reflect

### DIFF
--- a/nes-common/include/Util/Reflection.hpp
+++ b/nes-common/include/Util/Reflection.hpp
@@ -75,10 +75,16 @@ Reflected reflect_aggregate_impl(const T& data)
 
     rfl::Generic::Object obj;
 
-    /// Reflect each field and add to the object
+    /// Reflect each field and add to the object.
     [&]<size_t... Is>(std::index_sequence<Is...>)
     {
-        ((obj[reflect_field_at_index<T, Is>(data).first] = *reflect_field_at_index<T, Is>(data).second), ...);
+        ((
+             [&]
+             {
+                 auto field = reflect_field_at_index<T, Is>(data);
+                 obj[std::move(field.first)] = *std::move(field.second);
+             }()),
+         ...);
     }(std::make_index_sequence<numFields>{});
 
     return Reflected{rfl::Generic::Object{std::move(obj)}};


### PR DESCRIPTION
## Summary
- `reflect_aggregate_impl` in `nes-common/include/Util/Reflection.hpp` evaluated `reflect_field_at_index<T, Is>(data)` twice per field (once for the pair's `.first`, once for `.second`). Each call re-runs `reflect(*fieldValue)`, so for recursively-aggregate types like nested `LogicalFunction` / boolean function trees the work becomes O(2^depth).
- Evaluate the pair once per field and move its results into the object. Aggregate reflection is now linear in tree depth.
- Systest's round-trip serialize/deserialize validation in `QuerySubmitter::registerQuery` (which stresses this path) drops from >5 minutes at predicate depth 30 to ~0.36 s.

Measured on RelWithDebInfo, single filter with a left-linear AND chain, via `systest -b`:

| depth N | before | after | speedup |
|---|---|---|---|
| 20 | 11.374 s | 0.379 s | ~30x |
| 30 | >300 s (timeout) | 0.364 s | >800x |

## Test plan
- [ ] Build passes (`cmake --build cmake-build-relwithdebinfo -j`).
- [ ] `check-format` passes.
- [ ] Existing reflection round-trip tests still pass.
- [ ] Run a systest with a deeply nested `WHERE` predicate (e.g. 20+ ANDed comparisons) — round-trip validation should complete in well under a second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)