### PR TITLE
Decouple VariableSizedAccess from nes-memory/TupleBuffer. Add ChildBufferIndex

### DIFF
--- a/nes-input-formatters/tests/Util/FileUtil.hpp
+++ b/nes-input-formatters/tests/Util/FileUtil.hpp
@@ -29,9 +29,9 @@
 #include <DataTypes/UnboundField.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/VariableSizedAccess.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Runtime/VariableSizedAccess.hpp>
 #include <Sequencing/SequenceData.hpp>
 #include <Util/Ranges.hpp>
 #include <ErrorHandling.hpp>
@@ -255,9 +255,9 @@ inline void updateChildBufferIdx(
     const size_t sizeOfSchemaInBytes)
 {
     /// Write index of child buffer that 'parentBuffer' returned to the corresponding place in the parent buffer
-    const auto tupleIdx = varSizedAccess.getIndex() / varSizedFieldOffsets.size();
+    const auto tupleIdx = varSizedAccess.getIndex().getRawValue() / varSizedFieldOffsets.size();
     const auto tupleByteOffset = tupleIdx * sizeOfSchemaInBytes;
-    const size_t varSizedOffsetIdx = varSizedAccess.getIndex() % varSizedFieldOffsets.size();
+    const size_t varSizedOffsetIdx = varSizedAccess.getIndex().getRawValue() % varSizedFieldOffsets.size();
     const auto varSizedOffset = varSizedFieldOffsets.at(varSizedOffsetIdx) + tupleByteOffset;
     const auto combinedIndexOffsetBytes = std::as_bytes(std::span{&varSizedAccess, 1});
     std::ranges::copy(combinedIndexOffsetBytes, parentBuffer.getAvailableMemoryArea().begin() + varSizedOffset);

--- a/nes-input-formatters/tests/Util/InputFormatterTestUtil.hpp
+++ b/nes-input-formatters/tests/Util/InputFormatterTestUtil.hpp
@@ -43,7 +43,6 @@
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/Allocator/NesDefaultMemoryAllocator.hpp>
 #include <Runtime/BufferManager.hpp>
-#include <Runtime/VariableSizedAccess.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Sources/SourceHandle.hpp>
 #include <Sources/SourceReturnType.hpp>

--- a/nes-memory/CMakeLists.txt
+++ b/nes-memory/CMakeLists.txt
@@ -17,7 +17,6 @@ add_library(nes-memory
         NesDefaultMemoryAllocator.cpp
         TaggedPointer.cpp
         UnpooledChunksManager.cpp
-        VariableSizedAccess.cpp
         MemoryUtils.cpp
 )
 

--- a/nes-memory/MemoryUtils.cpp
+++ b/nes-memory/MemoryUtils.cpp
@@ -20,7 +20,6 @@
 #include <span>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Runtime/VariableSizedAccess.hpp>
 #include <ErrorHandling.hpp>
 
 namespace NES
@@ -62,7 +61,7 @@ TupleBuffer deepCopyBuffer(const TupleBuffer& buffer, AbstractBufferProvider& pr
 
     for (size_t childIdx = 0; childIdx < buffer.getNumberOfChildBuffers(); ++childIdx)
     {
-        const VariableSizedAccess::Index varSizedIndex{childIdx};
+        const ChildBufferIndex varSizedIndex{static_cast<uint32_t>(childIdx)};
         auto childBuffer = buffer.loadChildBuffer(varSizedIndex);
         auto copiedChildBuffer = deepCopyBuffer(childBuffer, provider);
         auto ret = copiedBuffer.storeChildBuffer(copiedChildBuffer);

--- a/nes-memory/TupleBuffer.cpp
+++ b/nes-memory/TupleBuffer.cpp
@@ -23,7 +23,6 @@
 #include <Identifiers/NESStrongTypeFormat.hpp> ///NOLINT: required for fmt
 #include <Time/Timestamp.hpp>
 #include <fmt/format.h>
-#include <include/Runtime/VariableSizedAccess.hpp>
 #include <ErrorHandling.hpp>
 #include <TupleBufferImpl.hpp>
 
@@ -174,7 +173,7 @@ void TupleBuffer::setOriginId(const OriginId id) noexcept
     controlBlock->setOriginId(id);
 }
 
-VariableSizedAccess::Index TupleBuffer::storeChildBuffer(TupleBuffer& buffer) noexcept
+ChildBufferIndex TupleBuffer::storeChildBuffer(TupleBuffer& buffer) noexcept
 {
     TupleBuffer empty;
     auto* control = buffer.controlBlock;
@@ -184,7 +183,7 @@ VariableSizedAccess::Index TupleBuffer::storeChildBuffer(TupleBuffer& buffer) no
     return index;
 }
 
-TupleBuffer TupleBuffer::loadChildBuffer(VariableSizedAccess::Index bufferIndex) const noexcept
+TupleBuffer TupleBuffer::loadChildBuffer(ChildBufferIndex bufferIndex) const noexcept
 {
     TupleBuffer childBuffer;
     const auto ret = controlBlock->loadChildBuffer(bufferIndex, childBuffer.controlBlock, childBuffer.ptr, childBuffer.size);

--- a/nes-memory/TupleBufferImpl.cpp
+++ b/nes-memory/TupleBufferImpl.cpp
@@ -22,7 +22,6 @@
 #include <Runtime/TupleBuffer.hpp>
 #include <Time/Timestamp.hpp>
 #include <Util/Logger/Logger.hpp>
-#include <include/Runtime/VariableSizedAccess.hpp>
 #include <magic_enum/magic_enum.hpp>
 #include <ErrorHandling.hpp>
 
@@ -303,19 +302,18 @@ void BufferControlBlock::setOriginId(const OriginId originId)
 /// ------------------ VarLen fields support for TupleBuffer --------------------
 /// -----------------------------------------------------------------------------
 
-VariableSizedAccess::Index BufferControlBlock::storeChildBuffer(BufferControlBlock* control)
+ChildBufferIndex BufferControlBlock::storeChildBuffer(BufferControlBlock* control)
 {
     control->retain();
     children.emplace_back(control->owner);
-    return VariableSizedAccess::Index{children.size() - 1};
+    return ChildBufferIndex{static_cast<uint32_t>(children.size() - 1)};
 }
 
-bool BufferControlBlock::loadChildBuffer(
-    const VariableSizedAccess::Index index, BufferControlBlock*& control, uint8_t*& ptr, uint32_t& size) const
+bool BufferControlBlock::loadChildBuffer(const ChildBufferIndex index, BufferControlBlock*& control, uint8_t*& ptr, uint32_t& size) const
 {
-    PRECONDITION(index.index < children.size(), "Index={} is out of range={}", index, children.size());
+    PRECONDITION(index.getRawValue() < children.size(), "Index={} is out of range={}", index, children.size());
 
-    auto* child = children[index.index];
+    auto* child = children[index.getRawValue()];
     control = child->controlBlock->retain();
     ptr = child->ptr;
     size = child->size;

--- a/nes-memory/TupleBufferImpl.hpp
+++ b/nes-memory/TupleBufferImpl.hpp
@@ -22,8 +22,8 @@
 #include <memory>
 #include <vector>
 #include <Identifiers/Identifiers.hpp>
+#include <Runtime/TupleBuffer.hpp>
 #include <Time/Timestamp.hpp>
-#include <include/Runtime/VariableSizedAccess.hpp>
 #include <TaggedPointer.hpp>
 #ifdef NES_DEBUG_TUPLE_BUFFER_LEAKS
     #include <deque>
@@ -98,8 +98,8 @@ public:
     void setOriginId(OriginId originId);
     void setCreationTimestamp(Timestamp timestamp);
     [[nodiscard]] Timestamp getCreationTimestamp() const noexcept;
-    [[nodiscard]] VariableSizedAccess::Index storeChildBuffer(BufferControlBlock* control);
-    [[nodiscard]] bool loadChildBuffer(VariableSizedAccess::Index index, BufferControlBlock*& control, uint8_t*& ptr, uint32_t& size) const;
+    [[nodiscard]] ChildBufferIndex storeChildBuffer(BufferControlBlock* control);
+    [[nodiscard]] bool loadChildBuffer(ChildBufferIndex index, BufferControlBlock*& control, uint8_t*& ptr, uint32_t& size) const;
 
     [[nodiscard]] uint32_t getNumberOfChildBuffers() const noexcept { return children.size(); }
 #ifdef NES_DEBUG_TUPLE_BUFFER_LEAKS

--- a/nes-memory/include/Runtime/TupleBuffer.hpp
+++ b/nes-memory/include/Runtime/TupleBuffer.hpp
@@ -26,14 +26,17 @@
 #include <string>
 #include <utility>
 #include <Identifiers/Identifiers.hpp>
+#include <Identifiers/NESStrongType.hpp>
 #include <Runtime/BufferRecycler.hpp>
-#include <Runtime/VariableSizedAccess.hpp>
 #include <Time/Timestamp.hpp>
 #include <ErrorHandling.hpp>
 
 namespace NES
 {
 class UnpooledChunksManager;
+
+/// @brief Identifies a child TupleBuffer attached to a parent TupleBuffer by its position among the parent's children.
+using ChildBufferIndex = NESStrongType<uint32_t, struct ChildBufferIndex_Tag, std::numeric_limits<uint32_t>::max(), 0>;
 }
 
 namespace NES
@@ -83,8 +86,8 @@ class TupleBuffer
 
 public:
     /// @brief Flag value for uninitialized child buffers.
-    inline static const VariableSizedAccess::Index INVALID_CHILD_BUFFER_INDEX_VALUE{
-        std::numeric_limits<VariableSizedAccess::Index::Underlying>::max()}; /// NOLINT(cert-err58-cpp)
+    /// NOLINTNEXTLINE(cert-err58-cpp)
+    inline static const ChildBufferIndex INVALID_CHILD_BUFFER_INDEX_VALUE{std::numeric_limits<ChildBufferIndex::Underlying>::max()};
 
     /// @brief Default constructor creates an empty wrapper around nullptr without controlBlock (nullptr) and size 0.
     [[nodiscard]] TupleBuffer() noexcept = default;
@@ -176,10 +179,10 @@ public:
     void setOriginId(OriginId id) noexcept;
 
     ///@brief attach a child tuple buffer to the parent. the child tuple buffer is then identified via NestedTupleBufferKey
-    [[nodiscard]] VariableSizedAccess::Index storeChildBuffer(TupleBuffer& buffer) noexcept;
+    [[nodiscard]] ChildBufferIndex storeChildBuffer(TupleBuffer& buffer) noexcept;
 
     ///@brief retrieve a child tuple buffer via its NestedTupleBufferKey
-    [[nodiscard]] TupleBuffer loadChildBuffer(VariableSizedAccess::Index bufferIndex) const noexcept;
+    [[nodiscard]] TupleBuffer loadChildBuffer(ChildBufferIndex bufferIndex) const noexcept;
 
     [[nodiscard]] uint32_t getNumberOfChildBuffers() const noexcept;
 

--- a/nes-memory/tests/ChildBufferTests.cpp
+++ b/nes-memory/tests/ChildBufferTests.cpp
@@ -54,7 +54,7 @@ TEST(ChildBufferTests, StoreAndLoadChildBufferOddSizes)
 
         const auto bufferSizeBeforeStore = buffer.value().getBufferSize();
         const auto bufferIndex = baseBuffer.storeChildBuffer(buffer.value());
-        EXPECT_EQ(bufferIndex.getRawIndex(), i);
+        EXPECT_EQ(bufferIndex.getRawValue(), i);
         EXPECT_EQ(baseBuffer.getNumberOfChildBuffers(), i + 1);
 
         auto loadedBuffer = baseBuffer.loadChildBuffer(bufferIndex);
@@ -82,7 +82,7 @@ TEST(ChildBufferTests, StoreAndLoadChildBufferPowerOfTwoSizes)
 
         const auto bufferSizeBeforeStore = buffer.value().getBufferSize();
         const auto bufferIndex = baseBuffer.storeChildBuffer(buffer.value());
-        EXPECT_EQ(bufferIndex.getRawIndex(), i);
+        EXPECT_EQ(bufferIndex.getRawValue(), i);
         EXPECT_EQ(baseBuffer.getNumberOfChildBuffers(), i + 1);
 
         auto loadedBuffer = baseBuffer.loadChildBuffer(bufferIndex);
@@ -122,7 +122,7 @@ TEST(ChildBufferTests, StoreAndLoadChildBufferRandomSizes)
 
         const auto bufferSizeBeforeStore = buffer.value().getBufferSize();
         const auto bufferIndex = baseBuffer.storeChildBuffer(buffer.value());
-        EXPECT_EQ(bufferIndex.getRawIndex(), i);
+        EXPECT_EQ(bufferIndex.getRawValue(), i);
         EXPECT_EQ(baseBuffer.getNumberOfChildBuffers(), i + 1);
 
         auto loadedBuffer = baseBuffer.loadChildBuffer(bufferIndex);

--- a/nes-nautilus/include/Interface/BufferRef/TupleBufferRef.hpp
+++ b/nes-nautilus/include/Interface/BufferRef/TupleBufferRef.hpp
@@ -23,9 +23,9 @@
 #include <DataTypes/VarVal.hpp>
 #include <Interface/Record.hpp>
 #include <Interface/RecordBuffer.hpp>
+#include <Interface/VariableSizedAccess.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Runtime/VariableSizedAccess.hpp>
 #include <val_bool.hpp>
 #include <val_concepts.hpp>
 #include <val_ptr.hpp>

--- a/nes-nautilus/include/Interface/HashMap/ChainedHashMap/ChainedHashMap.hpp
+++ b/nes-nautilus/include/Interface/HashMap/ChainedHashMap/ChainedHashMap.hpp
@@ -26,7 +26,6 @@
 #include <Interface/HashMap/HashMap.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Runtime/VariableSizedAccess.hpp>
 
 namespace NES
 {
@@ -106,8 +105,8 @@ public:
 
     [[nodiscard]] uint64_t getMask() const { return header().mask; }
 
-    [[nodiscard]] VariableSizedAccess::Index getStorageBufferIdx() const;
-    [[nodiscard]] VariableSizedAccess::Index getVarSizedBufferIdx() const;
+    [[nodiscard]] ChildBufferIndex getStorageBufferIdx() const;
+    [[nodiscard]] ChildBufferIndex getVarSizedBufferIdx() const;
     [[nodiscard]] ChainedHashMapEntry* getChain(uint64_t pos);
 
     /// @warning Be super careful with this. Sometimes you need a pointer to the TupleBuffer but you should never alter it outside of this
@@ -141,8 +140,8 @@ private:
         uint64_t entriesPerPage;
         uint64_t numRecords = 0;
         uint64_t mask;
-        VariableSizedAccess::Index storageSpaceIndex;
-        VariableSizedAccess::Index varSizedSpaceIndex;
+        ChildBufferIndex storageSpaceIndex;
+        ChildBufferIndex varSizedSpaceIndex;
 
         /// Chains array starts immediately after this header
         /// it is dynamically sized based on numChains, so nothing to store in here.

--- a/nes-nautilus/include/Interface/NautilusBuffer.hpp
+++ b/nes-nautilus/include/Interface/NautilusBuffer.hpp
@@ -17,6 +17,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <variant>
+#include <Interface/NESStrongTypeRef.hpp> /// NOLINT(misc-include-cleaner): re-exported so callers get the nautilus val<> specialization for ChildBufferIndex.
 #include <Runtime/TupleBuffer.hpp>
 #include <val_details.hpp>
 #include <val_ptr.hpp>
@@ -58,9 +59,9 @@ public:
 
     [[nodiscard]] nautilus::val<size_t> getNumberOfRecords() const;
 
-    nautilus::val<size_t> storeChild(OwnedNautilusBuffer&& child);
-    nautilus::val<size_t> storeChild(BorrowedNautilusBuffer&& child);
-    [[nodiscard]] OwnedNautilusBuffer getChild(const nautilus::val<size_t>& index) const;
+    nautilus::val<ChildBufferIndex> storeChild(OwnedNautilusBuffer&& child);
+    nautilus::val<ChildBufferIndex> storeChild(BorrowedNautilusBuffer&& child);
+    [[nodiscard]] OwnedNautilusBuffer getChild(const nautilus::val<ChildBufferIndex>& index) const;
     [[nodiscard]] nautilus::val<bool> isValid() const;
 
     /// Returns a pointer to the wrapped TupleBuffer that is only valid for as long as this buffer is alive.
@@ -87,11 +88,11 @@ public:
 
     [[nodiscard]] nautilus::val<size_t> getNumberOfRecords() const;
 
-    [[nodiscard]] OwnedNautilusBuffer getChild(const nautilus::val<size_t>& index) const;
+    [[nodiscard]] OwnedNautilusBuffer getChild(const nautilus::val<ChildBufferIndex>& index) const;
 
-    nautilus::val<size_t> storeChild(OwnedNautilusBuffer&& child);
+    nautilus::val<ChildBufferIndex> storeChild(OwnedNautilusBuffer&& child);
 
-    nautilus::val<size_t> storeChild(BorrowedNautilusBuffer&& child);
+    nautilus::val<ChildBufferIndex> storeChild(BorrowedNautilusBuffer&& child);
 
     /// Returns a pointer to the wrapped TupleBuffer that is only valid for as long as this buffer is alive.
     /// It is solely intended to be passed as an argument to a `nautilus::invoke` and MUST NOT be stored or used to outlive this buffer.
@@ -108,10 +109,10 @@ public:
 
     nautilus::val<int8_t*> data();
 
-    nautilus::val<size_t> storeChild(NautilusBuffer&& buffer);
+    nautilus::val<ChildBufferIndex> storeChild(NautilusBuffer&& buffer);
 
     /// Loading a child buffer always yields an owned buffer, as its lifetime must be managed by the nautilus execution.
-    [[nodiscard]] OwnedNautilusBuffer getChild(const nautilus::val<size_t>& index) const;
+    [[nodiscard]] OwnedNautilusBuffer getChild(const nautilus::val<ChildBufferIndex>& index) const;
 
     [[nodiscard]] nautilus::val<size_t> getNumberOfRecords() const;
 

--- a/nes-nautilus/include/Interface/VariableSizedAccess.hpp
+++ b/nes-nautilus/include/Interface/VariableSizedAccess.hpp
@@ -17,15 +17,12 @@
 #include <compare>
 #include <cstdint>
 #include <ostream>
+#include <Runtime/TupleBuffer.hpp>
 #include <Util/Logger/Formatter.hpp>
 #include <ErrorHandling.hpp>
 
 namespace NES
 {
-namespace detail
-{
-class BufferControlBlock;
-}
 
 /// @brief This class is a helper class for accessing variable sized data in a tuple buffer.
 /// We store variable sized data as child buffer. To reference one variable sized data object, we require an index to the child buffer and
@@ -36,36 +33,9 @@ class BufferControlBlock;
 /// This allows us to have 4 billion child buffer (unless we have only one var sized object per child)
 struct VariableSizedAccess
 {
-    class Index
-    {
-    public:
-        /// Required for allowing VariableSizedAccess to access offset in VariableSizedAccess::getCombinedIdxOffset()
-        friend struct VariableSizedAccess;
-
-        /// Required for allowing BufferControlBlock to access offset in BufferControlBlock::loadChildBuffer()
-        friend class detail::BufferControlBlock;
-
-        using Underlying = uint32_t;
-        static constexpr auto UnderlyingBits = sizeof(Underlying) * 8;
-
-        explicit Index(uint64_t index) noexcept;
-
-        [[nodiscard]] Underlying getRawIndex() const;
-        friend std::ostream& operator<<(std::ostream& os, const Index& index);
-        friend std::strong_ordering operator<=>(const Index& lhs, const Index& rhs) = default;
-
-        friend Underlying operator/(const Index& index, Underlying other);
-        friend Underlying operator%(const Index& index, Underlying other);
-
-    private:
-        Underlying index;
-    };
-
     class Offset
     {
     public:
-        /// Required for allowing VariableSizedAccess to access offset in VariableSizedAccess::getCombinedIdxOffset()
-        friend struct VariableSizedAccess;
         using Underlying = uint32_t;
         static constexpr auto UnderlyingBits = sizeof(Underlying) * 8;
 
@@ -101,21 +71,23 @@ struct VariableSizedAccess
     /// By calling the C++-runtime (via nautilus::invoke()), we do not call any conversion but rather "bit_cast" the CombinedIndex.
     /// Thus, we initialize the values of the offset and index indirectly and not via the constructor call.
     Offset offset;
-    Index index;
+    ChildBufferIndex index;
     Size size;
 
-public:
     VariableSizedAccess() : offset(0), index(0), size(0) { }
 
-    explicit VariableSizedAccess(const Index index, const Size size) : offset(0), index(index), size(size) { }
+    explicit VariableSizedAccess(const ChildBufferIndex index, const Size size) : offset(0), index(index), size(size) { }
 
-    explicit VariableSizedAccess(const Index index, const Offset offset, const Size size) : offset(offset), index(index), size(size) { }
+    explicit VariableSizedAccess(const ChildBufferIndex index, const Offset offset, const Size size)
+        : offset(offset), index(index), size(size)
+    {
+    }
 
     explicit VariableSizedAccess(const Offset offset, const Size size) : offset(offset), index(0), size(size) { }
 
     ~VariableSizedAccess() = default;
 
-    [[nodiscard]] Index getIndex() const { return index; }
+    [[nodiscard]] ChildBufferIndex getIndex() const { return index; }
 
     [[nodiscard]] Offset getOffset() const { return offset; };
 
@@ -130,10 +102,8 @@ public:
 static_assert(sizeof(VariableSizedAccess) == 16, "VariableSizedAccess must be 16 bytes");
 static_assert(sizeof(VariableSizedAccess::Size) == 8, "VariableSizedAccess::Size must be 8 bytes");
 static_assert(sizeof(VariableSizedAccess::Offset) == 4, "VariableSizedAccess::Offset must be 4 bytes");
-static_assert(sizeof(VariableSizedAccess::Index) == 4, "VariableSizedAccess::Index must be 4 bytes");
 }
 
-FMT_OSTREAM(NES::VariableSizedAccess::Index);
 FMT_OSTREAM(NES::VariableSizedAccess::Offset);
 FMT_OSTREAM(NES::VariableSizedAccess::Size);
 FMT_OSTREAM(NES::VariableSizedAccess);

--- a/nes-nautilus/include/Interface/VariableSizedAccessRef.hpp
+++ b/nes-nautilus/include/Interface/VariableSizedAccessRef.hpp
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <type_traits>
-#include <Runtime/VariableSizedAccess.hpp>
+#include <Interface/VariableSizedAccess.hpp>
 #include <nautilus/tracing/TypedValueRef.hpp>
 #include <nautilus/tracing/Types.hpp>
 #include <nautilus/val.hpp>
@@ -23,41 +23,6 @@
 
 namespace nautilus
 {
-namespace tracing
-{
-template <typename T>
-requires(std::is_base_of_v<NES::VariableSizedAccess, T>)
-struct TypeResolver<T>
-{
-    [[nodiscard]] static constexpr Type to_type() { return TypeResolver<typename T::CombinedIndex>::to_type(); }
-};
-
-}
-
-namespace details
-{
-template <typename LHS>
-requires(std::is_base_of_v<NES::VariableSizedAccess, LHS>)
-struct RawValueResolver<LHS>
-{
-    static LHS getRawValue(const val<LHS>& val)
-    {
-        return LHS{details::RawValueResolver<typename LHS::CombinedIndex>::getRawValue(val.variableSizedAccess)};
-    }
-};
-
-template <typename T>
-requires(std::is_base_of_v<val<NES::VariableSizedAccess>, std::remove_cvref_t<T>>)
-struct StateResolver<T>
-{
-    template <typename U = T>
-    static tracing::TypedValueRef getState(U&& value)
-    {
-        return StateResolver<typename std::remove_cvref_t<T>::Underlying>::getState(value.variableSizedAccess);
-    }
-};
-
-}
 
 /// We are specializing the nautilus::val<> implementation so that we can use nautilus::val<VariableSizedAccess>
 template <>
@@ -75,7 +40,7 @@ public:
 
     /// ReSharper disable once CppNonExplicitConvertingConstructor
     explicit val(const Underlying variableSizedAccess)
-        : index(variableSizedAccess.getIndex().getRawIndex())
+        : index(variableSizedAccess.getIndex().getRawValue())
         , offset(variableSizedAccess.getOffset().getRawOffset())
         , size(variableSizedAccess.getSize().getRawSize())
     {

--- a/nes-nautilus/src/Interface/BufferRef/TupleBufferRef.cpp
+++ b/nes-nautilus/src/Interface/BufferRef/TupleBufferRef.cpp
@@ -32,10 +32,10 @@
 #include <DataTypes/VariableSizedData.hpp>
 #include <Interface/Record.hpp>
 #include <Interface/RecordBuffer.hpp>
+#include <Interface/VariableSizedAccess.hpp>
 #include <Interface/VariableSizedAccessRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Runtime/VariableSizedAccess.hpp>
 #include <magic_enum/magic_enum.hpp>
 #include <ErrorHandling.hpp>
 #include <function.hpp>
@@ -102,14 +102,14 @@ VariableSizedAccess TupleBufferRef::writeVarSized(
 
     /// If there is no space in the lastChildBuffer, we get a new buffer and copy the var sized into the newly acquired
     /// We store the number of used bytes in the no. tuples field.  We plan on getting rid of this "mis"-use in the near future.
-    const VariableSizedAccess::Index childIndex{numberOfChildBuffers - 1};
+    const ChildBufferIndex childIndex{numberOfChildBuffers - 1};
     auto lastChildBuffer = tupleBuffer.loadChildBuffer(childIndex);
     const auto usedMemorySize = lastChildBuffer.getNumberOfTuples();
     if (usedMemorySize + totalVarSizedLength >= lastChildBuffer.getBufferSize())
     {
         auto newChildBuffer = getNewBufferForVarSized(bufferProvider, totalVarSizedLength);
         copyVarSizedAndIncrementMetaData(newChildBuffer, VariableSizedAccess::Offset{0}, varSizedValue);
-        const VariableSizedAccess::Index childBufferIndex{tupleBuffer.storeChildBuffer(newChildBuffer)};
+        const ChildBufferIndex childBufferIndex{tupleBuffer.storeChildBuffer(newChildBuffer)};
         return VariableSizedAccess{childBufferIndex, VariableSizedAccess::Size{totalVarSizedLength}};
     }
 

--- a/nes-nautilus/src/Interface/CMakeLists.txt
+++ b/nes-nautilus/src/Interface/CMakeLists.txt
@@ -19,4 +19,5 @@ add_source_files(nes-nautilus
         Record.cpp
         RecordBuffer.cpp
         NautilusBuffer.cpp
+        VariableSizedAccess.cpp
 )

--- a/nes-nautilus/src/Interface/HashMap/ChainedHashMap/ChainedHashMap.cpp
+++ b/nes-nautilus/src/Interface/HashMap/ChainedHashMap/ChainedHashMap.cpp
@@ -24,7 +24,6 @@
 #include <string>
 #include <tuple>
 #include <utility>
-#include <Runtime/VariableSizedAccess.hpp>
 
 #include <Interface/Hash/HashFunction.hpp>
 #include <Interface/HashMap/HashMap.hpp>
@@ -328,12 +327,12 @@ AbstractHashMapEntry* ChainedHashMap::insertEntry(const HashFunction::HashValue:
     return newEntry;
 }
 
-[[nodiscard]] VariableSizedAccess::Index ChainedHashMap::getStorageBufferIdx() const
+[[nodiscard]] ChildBufferIndex ChainedHashMap::getStorageBufferIdx() const
 {
     return header().storageSpaceIndex;
 }
 
-[[nodiscard]] VariableSizedAccess::Index ChainedHashMap::getVarSizedBufferIdx() const
+[[nodiscard]] ChildBufferIndex ChainedHashMap::getVarSizedBufferIdx() const
 {
     return header().varSizedSpaceIndex;
 }
@@ -345,7 +344,7 @@ TupleBuffer ChainedHashMap::getPage(const uint64_t pageIndex) const
     auto storageBuffer = buffer.loadChildBuffer(storageBufferIdx);
     uint64_t numberOfPages = storageBuffer.getNumberOfChildBuffers();
     PRECONDITION(pageIndex < numberOfPages, "Page index {} is greater than the number of pages {}", pageIndex, numberOfPages);
-    const VariableSizedAccess::Index pageBufferIdx{pageIndex};
+    const ChildBufferIndex pageBufferIdx{static_cast<uint32_t>(pageIndex)};
     TupleBuffer page = storageBuffer.loadChildBuffer(pageBufferIdx);
     return page;
 }
@@ -358,7 +357,7 @@ TupleBuffer ChainedHashMap::getVarSizedPage(const uint64_t pageIndex) const
     auto varSizedBuffer = buffer.loadChildBuffer(varSizedSpaceIdx);
     uint64_t numberOfPages = varSizedBuffer.getNumberOfChildBuffers();
     PRECONDITION(pageIndex < numberOfPages, "Page index {} is greater than the number of pages {}", pageIndex, numberOfPages);
-    const VariableSizedAccess::Index pageBufferIdx{pageIndex};
+    const ChildBufferIndex pageBufferIdx{static_cast<uint32_t>(pageIndex)};
     TupleBuffer page = varSizedBuffer.loadChildBuffer(pageBufferIdx);
     return page;
 }

--- a/nes-nautilus/src/Interface/NautilusBuffer.cpp
+++ b/nes-nautilus/src/Interface/NautilusBuffer.cpp
@@ -19,8 +19,8 @@
 #include <cstdint>
 #include <utility>
 #include <variant>
+#include <Interface/NESStrongTypeRef.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Runtime/VariableSizedAccess.hpp>
 #include <Util/Overloaded.hpp>
 #include <ErrorHandling.hpp>
 #include <function.hpp>
@@ -53,31 +53,24 @@ nautilus::val<size_t> OwnedNautilusBuffer::getNumberOfRecords() const
 }
 
 /// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved): && signals ownership transfer; the nautilus tracer only needs the buffer's address.
-nautilus::val<size_t> OwnedNautilusBuffer::storeChild(OwnedNautilusBuffer&& child)
+nautilus::val<ChildBufferIndex> OwnedNautilusBuffer::storeChild(OwnedNautilusBuffer&& child)
 {
     return nautilus::invoke(
-        +[](NES::TupleBuffer* buffer, NES::TupleBuffer* child)
-        { return static_cast<size_t>(buffer->storeChildBuffer(*child).getRawIndex()); },
-        &buffer,
-        &child.buffer);
+        +[](NES::TupleBuffer* buffer, NES::TupleBuffer* child) { return buffer->storeChildBuffer(*child); }, &buffer, &child.buffer);
 }
 
 /// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved): && signals ownership transfer; the nautilus tracer only needs the buffer's address.
-nautilus::val<size_t> OwnedNautilusBuffer::storeChild(BorrowedNautilusBuffer&& child)
+nautilus::val<ChildBufferIndex> OwnedNautilusBuffer::storeChild(BorrowedNautilusBuffer&& child)
 {
     return nautilus::invoke(
-        +[](NES::TupleBuffer* buffer, NES::TupleBuffer* child)
-        { return static_cast<size_t>(buffer->storeChildBuffer(*child).getRawIndex()); },
-        &buffer,
-        child.asArg());
+        +[](NES::TupleBuffer* buffer, NES::TupleBuffer* child) { return buffer->storeChildBuffer(*child); }, &buffer, child.asArg());
 }
 
-OwnedNautilusBuffer OwnedNautilusBuffer::getChild(const nautilus::val<size_t>& index) const
+OwnedNautilusBuffer OwnedNautilusBuffer::getChild(const nautilus::val<ChildBufferIndex>& index) const
 {
     OwnedNautilusBuffer child;
     nautilus::invoke(
-        +[](const TupleBuffer* self, TupleBuffer* child, size_t index)
-        { *child = self->loadChildBuffer(VariableSizedAccess::Index{index}); },
+        +[](const TupleBuffer* self, TupleBuffer* child, ChildBufferIndex index) { *child = self->loadChildBuffer(index); },
         asArg(),
         child.asArg(),
         index);
@@ -124,11 +117,11 @@ nautilus::val<size_t> BorrowedNautilusBuffer::getNumberOfRecords() const
     return nautilus::invoke(+[](const NES::TupleBuffer* buffer) { return buffer->getNumberOfTuples(); }, buffer);
 }
 
-OwnedNautilusBuffer BorrowedNautilusBuffer::getChild(const nautilus::val<size_t>& index) const
+OwnedNautilusBuffer BorrowedNautilusBuffer::getChild(const nautilus::val<ChildBufferIndex>& index) const
 {
     OwnedNautilusBuffer child;
     nautilus::invoke(
-        +[](TupleBuffer* self, TupleBuffer* child, size_t index) { *child = self->loadChildBuffer(VariableSizedAccess::Index{index}); },
+        +[](TupleBuffer* self, TupleBuffer* child, ChildBufferIndex index) { *child = self->loadChildBuffer(index); },
         buffer,
         child.asArg(),
         index);
@@ -136,17 +129,15 @@ OwnedNautilusBuffer BorrowedNautilusBuffer::getChild(const nautilus::val<size_t>
 }
 
 /// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved): && signals ownership transfer; the nautilus tracer only needs the buffer's address.
-nautilus::val<size_t> BorrowedNautilusBuffer::storeChild(OwnedNautilusBuffer&& child)
+nautilus::val<ChildBufferIndex> BorrowedNautilusBuffer::storeChild(OwnedNautilusBuffer&& child)
 {
-    return nautilus::invoke(
-        +[](TupleBuffer* self, TupleBuffer* child) { return self->storeChildBuffer(*child).getRawIndex(); }, buffer, child.asArg());
+    return nautilus::invoke(+[](TupleBuffer* self, TupleBuffer* child) { return self->storeChildBuffer(*child); }, buffer, child.asArg());
 }
 
 /// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved): && signals ownership transfer; the nautilus tracer only needs the buffer's address.
-nautilus::val<size_t> BorrowedNautilusBuffer::storeChild(BorrowedNautilusBuffer&& child)
+nautilus::val<ChildBufferIndex> BorrowedNautilusBuffer::storeChild(BorrowedNautilusBuffer&& child)
 {
-    return nautilus::invoke(
-        +[](TupleBuffer* self, TupleBuffer* child) { return self->storeChildBuffer(*child).getRawIndex(); }, buffer, child.asArg());
+    return nautilus::invoke(+[](TupleBuffer* self, TupleBuffer* child) { return self->storeChildBuffer(*child); }, buffer, child.asArg());
 }
 
 nautilus::val<NES::TupleBuffer*> BorrowedNautilusBuffer::asArg()
@@ -165,17 +156,17 @@ nautilus::val<int8_t*> NautilusBuffer::data()
 }
 
 /// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved): the moved-from state is transferred via buffer.underlying below.
-nautilus::val<size_t> NautilusBuffer::storeChild(NautilusBuffer&& buffer)
+nautilus::val<ChildBufferIndex> NautilusBuffer::storeChild(NautilusBuffer&& buffer)
 {
     return std::visit(
         Overloaded{
-            [](auto& underlying, auto&& other) -> nautilus::val<size_t>
+            [](auto& underlying, auto&& other) -> nautilus::val<ChildBufferIndex>
             { return underlying.storeChild(std::forward<decltype(other)>(other)); }},
         underlying,
         std::move(buffer.underlying));
 }
 
-OwnedNautilusBuffer NautilusBuffer::getChild(const nautilus::val<size_t>& index) const
+OwnedNautilusBuffer NautilusBuffer::getChild(const nautilus::val<ChildBufferIndex>& index) const
 {
     return std::visit(Overloaded{[&](const auto& underlying) -> OwnedNautilusBuffer { return underlying.getChild(index); }}, underlying);
 }

--- a/nes-nautilus/src/Interface/PagedVector/PagedVector.cpp
+++ b/nes-nautilus/src/Interface/PagedVector/PagedVector.cpp
@@ -28,7 +28,6 @@
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/MemoryUtils.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Runtime/VariableSizedAccess.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <ErrorHandling.hpp>
 
@@ -86,12 +85,12 @@ void PagedVector::updateCumulativeSumLastItem() const
     uint64_t penultimateCumulativeSum = 0;
     if (lastPageIndex >= 1)
     {
-        const VariableSizedAccess::Index childBufferIndex{lastPageIndex - 1};
+        const ChildBufferIndex childBufferIndex{static_cast<uint32_t>(lastPageIndex - 1)};
         auto childBuffer = buffer.loadChildBuffer(childBufferIndex);
         const Page penultimatePage = Page::load(childBuffer);
         penultimateCumulativeSum = penultimatePage.getCumulativeSum();
     }
-    const VariableSizedAccess::Index lastBufferIndex{lastPageIndex};
+    const ChildBufferIndex lastBufferIndex{static_cast<uint32_t>(lastPageIndex)};
     auto lastBuffer = buffer.loadChildBuffer(lastBufferIndex);
     Page lastPage = Page::load(lastBuffer);
     lastPage.setCumulativeSum(lastPage.getNumberOfTuples() + penultimateCumulativeSum);
@@ -103,7 +102,7 @@ void PagedVector::updateCumulativeSumAllPages() const
     const uint64_t totalPages = getNumberOfPages();
     for (uint64_t i = 0; i < totalPages; i++)
     {
-        const VariableSizedAccess::Index pageChildIdx{i};
+        const ChildBufferIndex pageChildIdx{static_cast<uint32_t>(i)};
         auto pageBuffer = buffer.loadChildBuffer(pageChildIdx);
         Page page = Page::load(pageBuffer);
         page.setCumulativeSum(page.getNumberOfTuples() + curCumulativeSum);
@@ -121,7 +120,7 @@ void PagedVector::copyPagesFrom(AbstractBufferProvider& bufferProvider, const Pa
 
     for (uint64_t pageIdx = 0; pageIdx < numPagesToCopy; ++pageIdx)
     {
-        auto sourcePage = other.buffer.loadChildBuffer(VariableSizedAccess::Index{pageIdx});
+        auto sourcePage = other.buffer.loadChildBuffer(ChildBufferIndex{static_cast<uint32_t>(pageIdx)});
         auto destPage = deepCopyBuffer(sourcePage, bufferProvider);
         std::ignore = buffer.storeChildBuffer(destPage);
         header().numPages++;
@@ -138,7 +137,7 @@ void PagedVector::movePagesFrom(PagedVector& other)
     const uint64_t numPages = other.getNumberOfPages();
     for (uint64_t i = 0; i < numPages; ++i)
     {
-        auto otherPageBuffer = other.buffer.loadChildBuffer(VariableSizedAccess::Index{i});
+        auto otherPageBuffer = other.buffer.loadChildBuffer(ChildBufferIndex{static_cast<uint32_t>(i)});
         std::ignore = buffer.storeChildBuffer(otherPageBuffer);
         header().numPages++;
     }
@@ -174,7 +173,7 @@ void PagedVector::appendPageIfFull(AbstractBufferProvider* bufferProvider)
     auto numPages = getNumberOfPages();
     if (numPages > 0)
     {
-        const VariableSizedAccess::Index lastPageIndex{numPages - 1};
+        const ChildBufferIndex lastPageIndex{static_cast<uint32_t>(numPages - 1)};
         auto lastPage = buffer.loadChildBuffer(lastPageIndex);
         if (lastPage.getNumberOfTuples() < getPageCapacity())
         {
@@ -197,7 +196,7 @@ size_t PagedVector::getPageIndex(const uint64_t recordIndex) const
     /// so for it we recompute the effective cumSum from penultimate + current numTuples.
     const auto effectiveCumulativeSum = [this, numPages](uint64_t pageIdx) -> uint64_t
     {
-        const auto pageBuffer = buffer.loadChildBuffer(VariableSizedAccess::Index{pageIdx});
+        const auto pageBuffer = buffer.loadChildBuffer(ChildBufferIndex{static_cast<uint32_t>(pageIdx)});
         const Page page = Page::load(pageBuffer);
         if (pageIdx + 1 < numPages)
         {
@@ -206,7 +205,7 @@ size_t PagedVector::getPageIndex(const uint64_t recordIndex) const
         uint64_t penultimateCumulativeSum = 0;
         if (pageIdx > 0)
         {
-            const auto penultimateBuffer = buffer.loadChildBuffer(VariableSizedAccess::Index{pageIdx - 1});
+            const auto penultimateBuffer = buffer.loadChildBuffer(ChildBufferIndex{static_cast<uint32_t>(pageIdx - 1)});
             penultimateCumulativeSum = Page::load(penultimateBuffer).getCumulativeSum();
         }
         return penultimateCumulativeSum + page.getNumberOfTuples();
@@ -226,7 +225,7 @@ uint64_t PagedVector::getTotalNumberOfRecords() const
     uint64_t penultimateCumulativeSum = 0;
     if (numPages > 1)
     {
-        const VariableSizedAccess::Index penultimateIndex{numPages - 2};
+        const ChildBufferIndex penultimateIndex{static_cast<uint32_t>(numPages - 2)};
         auto penultimateBuffer = buffer.loadChildBuffer(penultimateIndex);
         const Page penultimatePage = Page::load(penultimateBuffer);
         penultimateCumulativeSum = penultimatePage.getCumulativeSum();
@@ -234,7 +233,7 @@ uint64_t PagedVector::getTotalNumberOfRecords() const
     uint64_t lastNumberOfTuples = 0;
     if (numPages > 0)
     {
-        const VariableSizedAccess::Index lastIndex{numPages - 1};
+        const ChildBufferIndex lastIndex{static_cast<uint32_t>(numPages - 1)};
         auto lastBuffer = buffer.loadChildBuffer(lastIndex);
         const Page lastPage = Page::load(lastBuffer);
         lastNumberOfTuples = lastPage.getNumberOfTuples();

--- a/nes-nautilus/src/Interface/PagedVector/PagedVectorRef.cpp
+++ b/nes-nautilus/src/Interface/PagedVector/PagedVectorRef.cpp
@@ -32,9 +32,9 @@
 #include <Interface/PagedVector/PagedVector.hpp>
 #include <Interface/Record.hpp>
 #include <Interface/RecordBuffer.hpp>
+#include <Interface/VariableSizedAccess.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Runtime/VariableSizedAccess.hpp>
 #include <nautilus/function.hpp>
 #include <nautilus/val.hpp>
 #include <ErrorHandling.hpp>
@@ -60,11 +60,11 @@ uint64_t loadPageForEntryProxy(const TupleBuffer* pagedVectorBuffer, const uint6
     const PagedVector pagedVector = PagedVector::load(*pagedVectorBuffer);
     PRECONDITION(pagedVector.getStatus() == PagedVector::VALID_PV, "Paged Vector must be valid for access.");
     const auto pageIdx = pagedVector.getPageIndex(entryPos);
-    *outPageBuffer = pagedVectorBuffer->loadChildBuffer(VariableSizedAccess::Index{pageIdx});
+    *outPageBuffer = pagedVectorBuffer->loadChildBuffer(ChildBufferIndex{static_cast<uint32_t>(pageIdx)});
     uint64_t prevCumulativeSum = 0;
     if (pageIdx > 0)
     {
-        const auto prevPageBuffer = pagedVectorBuffer->loadChildBuffer(VariableSizedAccess::Index{pageIdx - 1});
+        const auto prevPageBuffer = pagedVectorBuffer->loadChildBuffer(ChildBufferIndex{static_cast<uint32_t>(pageIdx - 1)});
         prevCumulativeSum = PagedVector::Page::load(prevPageBuffer).getCumulativeSum();
     }
     return entryPos - prevCumulativeSum;
@@ -124,7 +124,7 @@ auto makeVarSizedAllocFunction(const NautilusBuffer& lastPageBuffer, const nauti
                 auto numChildren = pageBuffer->getNumberOfChildBuffers();
                 if (numChildren > 0)
                 {
-                    auto lastVarSizedBufferIndex = VariableSizedAccess::Index{numChildren - 1};
+                    auto lastVarSizedBufferIndex = ChildBufferIndex{static_cast<uint32_t>(numChildren - 1)};
                     TupleBuffer lastVarSizedBuffer = pageBuffer->loadChildBuffer(lastVarSizedBufferIndex);
                     const uint64_t lastVarSizedBufferSize = lastVarSizedBuffer.getBufferSize();
                     const uint64_t lastVarSizedBufferNumTuples = lastVarSizedBuffer.getNumberOfTuples();
@@ -298,7 +298,7 @@ void PagedVectorRef::pushBack(const Record& record, const nautilus::val<Abstract
             PRECONDITION(pagedVector.getStatus() == PagedVector::VALID_PV, "Paged Vector must be valid for push_back.");
             pagedVector.appendPageIfFull(bufferProvider);
             auto numPages = pagedVector.getNumberOfPages();
-            const VariableSizedAccess::Index lastPageIndex{numPages - 1};
+            const ChildBufferIndex lastPageIndex{static_cast<uint32_t>(numPages - 1)};
             *currentPage = pagedVectorBuffer->loadChildBuffer(lastPageIndex);
         },
         pagedVectorBuffer.asArg(),

--- a/nes-nautilus/src/Interface/VariableSizedAccess.cpp
+++ b/nes-nautilus/src/Interface/VariableSizedAccess.cpp
@@ -11,7 +11,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-#include <Runtime/VariableSizedAccess.hpp>
+#include <Interface/VariableSizedAccess.hpp>
 
 #include <cstdint>
 #include <ostream>
@@ -19,32 +19,6 @@
 
 namespace NES
 {
-VariableSizedAccess::Index::Index(const uint64_t index) noexcept : index(index)
-{
-}
-
-VariableSizedAccess::Index::Underlying VariableSizedAccess::Index::getRawIndex() const
-{
-    return index;
-}
-
-std::ostream& operator<<(std::ostream& os, const VariableSizedAccess::Index& index)
-{
-    return os << index.index;
-}
-
-VariableSizedAccess::Index::Underlying
-operator/(const VariableSizedAccess::Index& index, const VariableSizedAccess::Index::Underlying other)
-{
-    return index.index / other;
-}
-
-VariableSizedAccess::Index::Underlying
-operator%(const VariableSizedAccess::Index& index, const VariableSizedAccess::Index::Underlying other)
-{
-    return index.index % other;
-}
-
 VariableSizedAccess::Offset::Offset(const uint64_t offset) : offset(offset)
 {
 }

--- a/nes-output-formatters/include/OutputFormatters/OutputFormatterUtil.hpp
+++ b/nes-output-formatters/include/OutputFormatters/OutputFormatterUtil.hpp
@@ -28,7 +28,6 @@
 #include <Interface/RecordBuffer.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Runtime/VariableSizedAccess.hpp>
 #include <Util/Strings.hpp>
 #include <ErrorHandling.hpp>
 #include <function.hpp>
@@ -73,7 +72,7 @@ inline uint64_t writeValueToBuffer(
     while (remainingBytes > 0)
     {
         /// Write as many bytes in the latest child buffer as possible and allocate a new one if space does not suffice
-        const VariableSizedAccess::Index childIndex{numOfChildBuffers - 1};
+        const ChildBufferIndex childIndex{numOfChildBuffers - 1};
         auto lastChildBuffer = tupleBuffer->loadChildBuffer(childIndex);
         const auto bufferOffset = lastChildBuffer.getNumberOfTuples();
         const uint32_t valueOffset = valueString.size() - remainingBytes;

--- a/nes-physical-operators/include/HashMapSlice.hpp
+++ b/nes-physical-operators/include/HashMapSlice.hpp
@@ -25,7 +25,6 @@
 #include <Interface/HashMap/HashMap.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Runtime/VariableSizedAccess.hpp>
 #include <SliceStore/Slice.hpp>
 #include <CompilationContext.hpp>
 
@@ -104,11 +103,10 @@ protected:
     /// otherwise. Never allocates, so it is safe to call without synchronization: it only ever reads state that
     /// is either not-yet-written (nullptr) or was already fully written by whichever thread first-touched this
     /// index via getOrCreateHashMapBufferRef.
-    [[nodiscard]] const TupleBuffer* getHashMapBufferRef(VariableSizedAccess::Index childBufferIndex) const;
+    [[nodiscard]] const TupleBuffer* getHashMapBufferRef(ChildBufferIndex childBufferIndex) const;
 
     /// @brief Loads a specific hash map from the slice based on the index, lazily allocating it on first access.
-    [[nodiscard]] const TupleBuffer*
-    getOrCreateHashMapBufferRef(AbstractBufferProvider& bufferProvider, VariableSizedAccess::Index childBufferIndex);
+    [[nodiscard]] const TupleBuffer* getOrCreateHashMapBufferRef(AbstractBufferProvider& bufferProvider, ChildBufferIndex childBufferIndex);
 
     /// metadata
     uint64_t numHashMaps;

--- a/nes-physical-operators/src/Aggregation/AggregationProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/Aggregation/AggregationProbePhysicalOperator.cpp
@@ -31,7 +31,6 @@
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Runtime/VariableSizedAccess.hpp>
 #include <SliceStore/WindowSlicesStoreInterface.hpp>
 #include <Time/Timestamp.hpp>
 #include <Util/Logger/Logger.hpp>
@@ -73,7 +72,7 @@ void AggregationProbePhysicalOperator::open(ExecutionContext& executionCtx, Reco
         {
             INVARIANT(parent != nullptr, "Parent Tuplebuffer MUST NOT be null at this point");
             /// load the first hash map
-            const VariableSizedAccess::Index bufferIndex{0};
+            const ChildBufferIndex bufferIndex{0};
             auto buffer = parent->loadChildBuffer(bufferIndex);
             const auto chm = ChainedHashMap::load(buffer);
             /// get a buffer and for the final hash map with the same config
@@ -109,7 +108,7 @@ void AggregationProbePhysicalOperator::open(ExecutionContext& executionCtx, Reco
             +[](TupleBuffer* parent, uint32_t curHashMapIdx, TupleBuffer* hashMapBuffer)
             {
                 INVARIANT(parent != nullptr, "Parent Tuplebuffer MUST NOT be null at this point");
-                const VariableSizedAccess::Index bufferIndex{curHashMapIdx};
+                const ChildBufferIndex bufferIndex{curHashMapIdx};
                 *hashMapBuffer = parent->loadChildBuffer(bufferIndex);
             },
             recordBuffer.getReference(),

--- a/nes-physical-operators/src/Aggregation/AggregationSlice.cpp
+++ b/nes-physical-operators/src/Aggregation/AggregationSlice.cpp
@@ -21,7 +21,6 @@
 #include <Interface/HashMap/HashMap.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Runtime/VariableSizedAccess.hpp>
 #include <SliceStore/Slice.hpp>
 #include <ErrorHandling.hpp>
 #include <HashMapSlice.hpp>
@@ -41,7 +40,7 @@ const TupleBuffer* AggregationSlice::getHashMapBufferRefForWorker(const WorkerTh
 {
     const auto hashMapIndex = workerThreadId % getNumberOfHashMaps();
     INVARIANT(hashMapIndex < getNumberOfHashMaps(), "The worker thread id should be smaller than the number of hashmaps");
-    return getHashMapBufferRef(VariableSizedAccess::Index{hashMapIndex});
+    return getHashMapBufferRef(ChildBufferIndex{static_cast<uint32_t>(hashMapIndex)});
 }
 
 const TupleBuffer*
@@ -49,7 +48,7 @@ AggregationSlice::getOrCreateHashMapBufferRefForWorker(AbstractBufferProvider& b
 {
     const auto hashMapIndex = workerThreadId % getNumberOfHashMaps();
     INVARIANT(hashMapIndex < getNumberOfHashMaps(), "The worker thread id should be smaller than the number of hashmaps");
-    return getOrCreateHashMapBufferRef(bufferProvider, VariableSizedAccess::Index{hashMapIndex});
+    return getOrCreateHashMapBufferRef(bufferProvider, ChildBufferIndex{static_cast<uint32_t>(hashMapIndex)});
 }
 
 }

--- a/nes-physical-operators/src/Aggregation/Function/MedianAggregationPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Aggregation/Function/MedianAggregationPhysicalFunction.cpp
@@ -30,7 +30,6 @@
 
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Runtime/VariableSizedAccess.hpp>
 #include <nautilus/std/cstring.h>
 #include <AggregationPhysicalFunctionRegistry.hpp>
 #include <ErrorHandling.hpp>
@@ -74,7 +73,7 @@ void MedianAggregationPhysicalFunction::lift(
             OwnedNautilusBuffer pagedVecBuffer;
             nautilus::invoke(
                 +[](TupleBuffer* parent, TupleBuffer* out, const uint32_t* indexPtr)
-                { *out = parent->loadChildBuffer(VariableSizedAccess::Index{*indexPtr}); },
+                { *out = parent->loadChildBuffer(ChildBufferIndex{*indexPtr}); },
                 parentBuffer,
                 pagedVecBuffer.asArg(),
                 static_cast<nautilus::val<uint32_t*>>(memArea));
@@ -90,7 +89,7 @@ void MedianAggregationPhysicalFunction::lift(
         OwnedNautilusBuffer pagedVecBuffer;
         nautilus::invoke(
             +[](TupleBuffer* parent, TupleBuffer* out, const uint32_t* indexPtr)
-            { *out = parent->loadChildBuffer(VariableSizedAccess::Index{*indexPtr}); },
+            { *out = parent->loadChildBuffer(ChildBufferIndex{*indexPtr}); },
             parentBuffer,
             pagedVecBuffer.asArg(),
             static_cast<nautilus::val<uint32_t*>>(memArea));
@@ -130,8 +129,8 @@ void MedianAggregationPhysicalFunction::combine(
             TupleBuffer* parent2,
             const uint32_t* indexPtr2) -> void
         {
-            const TupleBuffer vec1Buf = parent1->loadChildBuffer(VariableSizedAccess::Index{*indexPtr1});
-            const TupleBuffer vec2Buf = parent2->loadChildBuffer(VariableSizedAccess::Index{*indexPtr2});
+            const TupleBuffer vec1Buf = parent1->loadChildBuffer(ChildBufferIndex{*indexPtr1});
+            const TupleBuffer vec2Buf = parent2->loadChildBuffer(ChildBufferIndex{*indexPtr2});
             auto vector1 = PagedVector::load(vec1Buf);
             const auto vector2 = PagedVector::load(vec2Buf);
             vector1.copyPagesFrom(*bufferProvider, vector2);
@@ -166,7 +165,7 @@ Record MedianAggregationPhysicalFunction::lower(
         OwnedNautilusBuffer pagedVecBuffer;
         nautilus::invoke(
             +[](TupleBuffer* parent, TupleBuffer* out, const uint32_t* indexPtr)
-            { *out = parent->loadChildBuffer(VariableSizedAccess::Index{*indexPtr}); },
+            { *out = parent->loadChildBuffer(ChildBufferIndex{*indexPtr}); },
             parentBuffer,
             pagedVecBuffer.asArg(),
             static_cast<nautilus::val<uint32_t*>>(memArea));
@@ -273,7 +272,7 @@ void MedianAggregationPhysicalFunction::reset(
                 auto pagedVectorBuffer = pagedVectorBufferOpt.value();
                 PagedVector::init(pagedVectorBuffer, bufferProvider->getBufferSize(), tupleSize);
                 auto childBufferIndex = parentBuffer->storeChildBuffer(pagedVectorBuffer);
-                return childBufferIndex.getRawIndex();
+                return childBufferIndex.getRawValue();
             }
             throw BufferAllocationFailure("No unpooled TupleBuffer available for median aggregation paged vector!");
         },

--- a/nes-physical-operators/src/HashMapSlice.cpp
+++ b/nes-physical-operators/src/HashMapSlice.cpp
@@ -27,7 +27,6 @@
 #include <Interface/HashMap/HashMap.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Runtime/VariableSizedAccess.hpp>
 #include <SliceStore/Slice.hpp>
 #include <ErrorHandling.hpp>
 
@@ -65,18 +64,18 @@ uint64_t HashMapSlice::getNumHashMapsPerInputStream() const
     return numHashmapsPerInputStream;
 }
 
-const TupleBuffer* HashMapSlice::getHashMapBufferRef(const VariableSizedAccess::Index childBufferIndex) const
+const TupleBuffer* HashMapSlice::getHashMapBufferRef(const ChildBufferIndex childBufferIndex) const
 {
-    PRECONDITION(childBufferIndex.getRawIndex() < numHashMaps, "Hash Map index out of range in hash map slice getHashMapBufferRef!");
-    const auto pos = childBufferIndex.getRawIndex();
+    PRECONDITION(childBufferIndex.getRawValue() < numHashMaps, "Hash Map index out of range in hash map slice getHashMapBufferRef!");
+    const auto pos = childBufferIndex.getRawValue();
     return hashMapBuffersState[pos] == HashMapBufferState::INITIALIZED ? &hashMapBuffers[pos] : nullptr;
 }
 
 const TupleBuffer*
-HashMapSlice::getOrCreateHashMapBufferRef(AbstractBufferProvider& bufferProvider, const VariableSizedAccess::Index childBufferIndex)
+HashMapSlice::getOrCreateHashMapBufferRef(AbstractBufferProvider& bufferProvider, const ChildBufferIndex childBufferIndex)
 {
-    PRECONDITION(childBufferIndex.getRawIndex() < numHashMaps, "Hash Map index out of range in hash map slice loadHashMapBuffer!");
-    const auto pos = childBufferIndex.getRawIndex();
+    PRECONDITION(childBufferIndex.getRawValue() < numHashMaps, "Hash Map index out of range in hash map slice loadHashMapBuffer!");
+    const auto pos = childBufferIndex.getRawValue();
     /// Check whether the hash map is initialized
     if (hashMapBuffersState[pos] == HashMapBufferState::UNINITIALIZED)
     {

--- a/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
@@ -32,7 +32,6 @@
 #include <Join/StreamJoinUtil.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Runtime/VariableSizedAccess.hpp>
 #include <Time/Timestamp.hpp>
 #include <ErrorHandling.hpp>
 #include <ExecutionContext.hpp>
@@ -100,7 +99,7 @@ void HJBuildPhysicalOperator::execute(ExecutionContext& ctx, Record& record) con
                         {
                             PagedVector::init(pagedVectorBuffer.value(), bufferProvider->getBufferSize(), tupleSize);
                             auto childIndex = hashMapBuf->storeChildBuffer(pagedVectorBuffer.value());
-                            *valueMemArea = childIndex.getRawIndex();
+                            *valueMemArea = childIndex.getRawValue();
                             return;
                         }
                         throw BufferAllocationFailure("No unpooled TupleBuffer available for chained hash map entry's paged vector!");
@@ -119,7 +118,7 @@ void HJBuildPhysicalOperator::execute(ExecutionContext& ctx, Record& record) con
         OwnedNautilusBuffer pagedVecBuffer;
         nautilus::invoke(
             +[](TupleBuffer* hashMapBuf, TupleBuffer* out, const uint32_t* indexPtr)
-            { *out = hashMapBuf->loadChildBuffer(VariableSizedAccess::Index{*indexPtr}); },
+            { *out = hashMapBuf->loadChildBuffer(ChildBufferIndex{*indexPtr}); },
             hashMapBuffer.asArg(),
             pagedVecBuffer.asArg(),
             static_cast<nautilus::val<uint32_t*>>(entryMemArea));

--- a/nes-physical-operators/src/Join/HashJoin/HJOuterProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJOuterProbePhysicalOperator.cpp
@@ -33,7 +33,6 @@
 #include <Operators/Windows/WindowMetaData.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Runtime/VariableSizedAccess.hpp>
 #include <SliceStore/WindowSlicesStoreInterface.hpp>
 #include <Time/Timestamp.hpp>
 #include <magic_enum/magic_enum.hpp>
@@ -60,7 +59,7 @@ loadEntryPagedVector(const ChainedHashMapRef::ChainedEntryRef& entryRef, const s
     OwnedNautilusBuffer pagedVectorBuffer;
     nautilus::invoke(
         +[](TupleBuffer* hashMapBuf, TupleBuffer* out, const uint32_t* indexPtr)
-        { *out = hashMapBuf->loadChildBuffer(VariableSizedAccess::Index{*indexPtr}); },
+        { *out = hashMapBuf->loadChildBuffer(ChildBufferIndex{*indexPtr}); },
         entryRef.hashMapBuffer,
         pagedVectorBuffer.asArg(),
         static_cast<nautilus::val<uint32_t*>>(valueMemArea));

--- a/nes-physical-operators/src/Join/HashJoin/HJProbePhysicalOperatorBase.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJProbePhysicalOperatorBase.cpp
@@ -28,7 +28,6 @@
 #include <Operators/Windows/WindowMetaData.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Runtime/VariableSizedAccess.hpp>
 #include <Time/Timestamp.hpp>
 #include <ErrorHandling.hpp>
 #include <ExecutionContext.hpp>
@@ -65,7 +64,7 @@ HJProbePhysicalOperatorBase::pinHashMapBuffer(const nautilus::val<TupleBuffer*>&
         +[](TupleBuffer* parent, uint32_t idx, TupleBuffer* out)
         {
             INVARIANT(parent != nullptr, "Parent TupleBuffer must not be null when pinning a hash map child buffer");
-            *out = parent->loadChildBuffer(VariableSizedAccess::Index{idx});
+            *out = parent->loadChildBuffer(ChildBufferIndex{idx});
         },
         recordBufferRef,
         index,
@@ -89,7 +88,7 @@ loadEntryPagedVector(const ChainedHashMapRef::ChainedEntryRef& entryRef, const s
     OwnedNautilusBuffer pagedVectorBuffer;
     nautilus::invoke(
         +[](TupleBuffer* hashMapBuf, TupleBuffer* out, const uint32_t* indexPtr)
-        { *out = hashMapBuf->loadChildBuffer(VariableSizedAccess::Index{*indexPtr}); },
+        { *out = hashMapBuf->loadChildBuffer(ChildBufferIndex{*indexPtr}); },
         entryRef.hashMapBuffer,
         pagedVectorBuffer.asArg(),
         static_cast<nautilus::val<uint32_t*>>(valueMemArea));

--- a/nes-physical-operators/src/Join/HashJoin/HJSlice.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJSlice.cpp
@@ -23,7 +23,6 @@
 #include <Join/StreamJoinUtil.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Runtime/VariableSizedAccess.hpp>
 #include <SliceStore/Slice.hpp>
 #include <ErrorHandling.hpp>
 #include <HashMapSlice.hpp>
@@ -49,7 +48,7 @@ HJSlice::getHashMapBufferRefForSide(const WorkerThreadId workerThreadId, const J
         workerThreadId,
         pos,
         numHashMaps);
-    return getHashMapBufferRef(VariableSizedAccess::Index(pos));
+    return getHashMapBufferRef(ChildBufferIndex(pos));
 }
 
 [[nodiscard]] const TupleBuffer* HJSlice::getOrCreateHashMapBufferRefForSide(
@@ -65,7 +64,7 @@ HJSlice::getHashMapBufferRefForSide(const WorkerThreadId workerThreadId, const J
         workerThreadId,
         pos,
         numHashMaps);
-    const VariableSizedAccess::Index bufferIndex{pos};
+    const ChildBufferIndex bufferIndex(pos);
     return getOrCreateHashMapBufferRef(bufferProvider, bufferIndex);
 }
 

--- a/nes-plugins/Sinks/MQTTSink/MQTTSink.cpp
+++ b/nes-plugins/Sinks/MQTTSink/MQTTSink.cpp
@@ -25,7 +25,6 @@
 #include <MQTTAsync.h>
 #include <Configurations/Descriptor.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Runtime/VariableSizedAccess.hpp>
 #include <Sinks/Sink.hpp>
 #include <Sinks/SinkDescriptor.hpp>
 #include <Util/Logger/Logger.hpp>
@@ -114,7 +113,7 @@ MQTTSink::PublishResult MQTTSink::tryPublish(const TupleBuffer& buffer)
     size_t messageSize = buffer.getNumberOfTuples();
     for (size_t index = 0; index < buffer.getNumberOfChildBuffers(); index++)
     {
-        messageSize += buffer.loadChildBuffer(VariableSizedAccess::Index(index)).getNumberOfTuples();
+        messageSize += buffer.loadChildBuffer(ChildBufferIndex(index)).getNumberOfTuples();
     }
     mqtt::binary payload;
     payload.reserve(messageSize);
@@ -122,7 +121,7 @@ MQTTSink::PublishResult MQTTSink::tryPublish(const TupleBuffer& buffer)
     payload.append(data.begin(), data.end());
     for (size_t index = 0; index < buffer.getNumberOfChildBuffers(); index++)
     {
-        auto child = buffer.loadChildBuffer(VariableSizedAccess::Index(index));
+        auto child = buffer.loadChildBuffer(ChildBufferIndex(index));
         auto childData = child.getAvailableMemoryArea<char>().first(child.getNumberOfTuples());
         payload.append(childData.begin(), childData.end());
     }

--- a/nes-sinks/src/NetworkSink.cpp
+++ b/nes-sinks/src/NetworkSink.cpp
@@ -28,7 +28,6 @@
 #include <Configurations/Descriptor.hpp>
 #include <Identifiers/NESStrongType.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Runtime/VariableSizedAccess.hpp>
 #include <Sinks/Sink.hpp>
 #include <Sinks/SinkDescriptor.hpp>
 #include <Util/Logger/Logger.hpp>
@@ -124,7 +123,7 @@ void NetworkSink::execute(const TupleBuffer& inputBuffer, PipelineExecutionConte
         children.reserve(currentBuffer->getNumberOfChildBuffers());
         for (size_t childIdx = 0; childIdx < currentBuffer->getNumberOfChildBuffers(); ++childIdx)
         {
-            auto childBuffer = currentBuffer->loadChildBuffer(VariableSizedAccess::Index(childIdx));
+            auto childBuffer = currentBuffer->loadChildBuffer(ChildBufferIndex(childIdx));
             auto childMemory = childBuffer.getAvailableMemoryArea<const uint8_t>();
             children.emplace_back(childMemory);
         }

--- a/nes-sinks/src/SinksParsing/BufferIterator.cpp
+++ b/nes-sinks/src/SinksParsing/BufferIterator.cpp
@@ -16,7 +16,7 @@
 
 #include <cstdint>
 #include <optional>
-#include <Runtime/VariableSizedAccess.hpp>
+#include <Runtime/TupleBuffer.hpp>
 
 namespace NES
 {
@@ -39,7 +39,7 @@ std::optional<BufferIterator::BufferElement> BufferIterator::getNextElement()
 
     /// Iterate through the children
     /// Child buffers store the number of written bytes in them as the number of tuples
-    const TupleBuffer childBuffer = tupleBuffer.loadChildBuffer(VariableSizedAccess::Index(bufferIndex - 1));
+    const TupleBuffer childBuffer = tupleBuffer.loadChildBuffer(ChildBufferIndex(bufferIndex - 1));
     ++bufferIndex;
     return std::optional<BufferElement>({.buffer = childBuffer, .contentLength = childBuffer.getNumberOfTuples()});
 }

--- a/nes-systests/operator/aggregation/WindowAggregationVarSizedMinimal.test
+++ b/nes-systests/operator/aggregation/WindowAggregationVarSizedMinimal.test
@@ -1,0 +1,20 @@
+# name: window/WindowAggregationVarSizedMinimal.test
+# description: Test window aggregations over different data types for keyed windows with the key being a varsized
+# groups: [Aggregation, WindowOperators, CompilationIntensive] TODO #1272
+
+
+CREATE LOGICAL SOURCE stream(key VARSIZED NOT NULL, i8 INT8 NOT NULL, ts UINT64 NOT NULL);
+CREATE PHYSICAL SOURCE FOR stream TYPE File;
+ATTACH INLINE
+apple,10,0
+book,5,25
+cat,20,50
+
+# Checking if a count over a keyed window works for all data types
+SELECT start, end, key, COUNT(i8) as i8_out
+FROM stream GROUP BY (key) WINDOW TUMBLING(ts, size 100 ms) INTO FILE ();
+----
+0,100,apple,1
+0,100,book,1
+0,100,cat,1
+


### PR DESCRIPTION
# Purpose of the Change and Brief Change Log

This pull request splits the child buffer indexing role out of ```VariableSizedAccess``` into a new, dedicated ```ChildBufferIndex``` type, and ```VariableSizedAccess``` to ```nes-nautilus```.

# Requirements

This branch builds on top of the ```chained_hash_map_redesign``` branch because it introduces a lot more new usages for children buffers. When that branch is merged, then this one should follow.

# Documentation

```VariableSizedAccess``` was overloaded for two different purposes: locating variable-sized field data (index + offset + size) and simply identifying which child buffer of a ```TupleBuffer``` to load/store (index only, no offset/size semantics). Because ```TupleBuffer::storeChildBuffer/loadChildBuffer``` were typed with ```VariableSizedAccess::Index```, this locator type ended up as a dependency of around twenty unrelated call sites (ChainedHashMap, PagedVector, hash-join/aggregation slices and operators, sinks, output formatters) that never needed the offset/size semantics at all.

This redesign introduces ```ChildBufferIndex```, a new type that now backs ```TupleBuffer'```s child-buffer API and all of these pure-index call sites.```VariableSizedAccess``` keeps its original locator role (index + offset + size, still required since multiple variable-sized values are packed into a shared child buffer) unchanged, and moves from ```nes-memory``` to ```nes-nautilus```, since every remaining consumer of the full locator type already lives there. This removes ```nes-memory```'s dependency on a nautilus-tracing-oriented type it no longer needs.

As part of this cleanup, some dead code left over from an earlier, abandoned refactor attempt was also removed: an unused nautilus::val<VariableSizedAccess> template specialization referencing nonexistent members, and stale friend declarations/doc comments on VariableSizedAccess's nested types.

# Issues
This PR closes issue #1674 