### PR TITLE
Added rustfmt package in nix build tools

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -645,6 +645,7 @@
           mold
           rustc
           cargo
+          rustfmt
         ];
 
         # LLVM toolchain with versioned symlinks for vcpkg


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
When building with nix, the CLion format target is not linked to the correct nix format script/command and has to always be run through the command line.
To fix, we add the ```rustfmt``` package in the build tools in flake.nix.

## Verifying this change
This change is tested by running the format target in Clion and not getting red words in your terminal.
