### PR TITLE
fix(optimizer): support constant-only projections

### DIFF
--- a/nes-query-optimizer/src/Rules/Static/ProjectionPushdownRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/ProjectionPushdownRule.cpp
@@ -100,7 +100,7 @@ LogicalOperator pushBeyondSource(TypedLogicalOperator<SourceDescriptorLogicalOpe
     /// Recursion stop. Add projection if required is a strict subset of output schema.
 
     const auto outputSchema = op.getOutputSchema();
-    if (required.empty() && outputSchema.begin() != outputSchema.end())
+    if (required.empty() && not(outputSchema.empty()))
     {
         required.insert(*outputSchema.begin());
     }

--- a/nes-query-optimizer/src/Rules/Static/ProjectionPushdownRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/ProjectionPushdownRule.cpp
@@ -99,8 +99,14 @@ LogicalOperator pushBeyondSource(TypedLogicalOperator<SourceDescriptorLogicalOpe
 {
     /// Recursion stop. Add projection if required is a strict subset of output schema.
 
+    const auto outputSchema = op.getOutputSchema();
+    if (required.empty() && outputSchema.begin() != outputSchema.end())
+    {
+        required.insert(*outputSchema.begin());
+    }
+
     const auto allFieldsAreRequired
-        = std::ranges::all_of(op.getOutputSchema(), [&required](const Field& field) { return required.contains(field); });
+        = std::ranges::all_of(outputSchema, [&required](const Field& field) { return required.contains(field); });
 
     if (!allFieldsAreRequired)
     {

--- a/nes-query-optimizer/src/Rules/Static/ProjectionPushdownRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/ProjectionPushdownRule.cpp
@@ -99,14 +99,14 @@ LogicalOperator pushBeyondSource(TypedLogicalOperator<SourceDescriptorLogicalOpe
 {
     /// Recursion stop. Add projection if required is a strict subset of output schema.
 
-    const auto outputSchema = op.getOutputSchema();
-    if (required.empty() && not(outputSchema.empty()))
+    /// Preserve the input schema for constant-only projections.
+    if (required.empty())
     {
-        required.insert(*outputSchema.begin());
+        return op;
     }
 
     const auto allFieldsAreRequired
-        = std::ranges::all_of(outputSchema, [&required](const Field& field) { return required.contains(field); });
+        = std::ranges::all_of(op.getOutputSchema(), [&required](const Field& field) { return required.contains(field); });
 
     if (!allFieldsAreRequired)
     {

--- a/nes-systests/regression/ConstantOnlyProjection.test
+++ b/nes-systests/regression/ConstantOnlyProjection.test
@@ -1,0 +1,18 @@
+# name: regression/ConstantOnlyProjection.test
+# description: Constant-only projections over sources preserve input cardinality.
+# groups: [regression]
+
+CREATE LOGICAL SOURCE input(dummy UINT8 NOT NULL);
+CREATE PHYSICAL SOURCE FOR input TYPE File;
+ATTACH INLINE
+1
+2
+3
+
+CREATE SINK out(x UINT8 NOT NULL) TYPE File;
+
+SELECT UINT8(1) AS x FROM input INTO out;
+----
+1
+1
+1


### PR DESCRIPTION
Until now queries consisting entirely of constants fail.

E.g.:

```
SELECT UINT8(1) AS x FROM input INTO out;
----
1
```

fails with bc of an empty schema:
`
Precondition violated: (!std::ranges::empty(schema)): We can not lower an empty schema!
`

This PR adds a mitigation and a regression systest.

