### PR TITLE
chore(logger): drop periodic flusher thread

### DIFF
--- a/nes-common/include/Util/Logger/impl/NesLogger.hpp
+++ b/nes-common/include/Util/Logger/impl/NesLogger.hpp
@@ -101,7 +101,6 @@ private:
     LogLevel currentLogLevel = LogLevel::LOG_INFO;
     bool consoleLoggingEnabled = true;
     std::atomic<bool> isShutdown{false};
-    std::unique_ptr<spdlog::details::periodic_worker> flusher{nullptr};
 };
 }
 

--- a/nes-common/src/Util/Logger/NesLogger.cpp
+++ b/nes-common/src/Util/Logger/NesLogger.cpp
@@ -141,8 +141,6 @@ Logger::Logger(const std::string& logFileName, const LogLevel level, const bool 
 
     changeLogLevel(level);
 
-    flusher = std::make_unique<spdlog::details::periodic_worker>([this]() { impl->flush(); }, std::chrono::seconds(1));
-
     /// Enable rust logger
     initialize_logging(impl);
 }
@@ -175,7 +173,6 @@ void Logger::shutdown()
     bool expected = false;
     if (isShutdown.compare_exchange_strong(expected, true))
     {
-        flusher.reset();
         impl.reset();
     }
 }


### PR DESCRIPTION
## Summary

Removes the spdlog `periodic_worker` flusher owned by `Logger`. Motivation is reducing thread count to improve the debugging and performance-analysis experience; the existing shutdown path already flushes the sink.

## Test plan
- [x] `format` target clean
- [ ] CI build + tidy