### PR TITLE
fix(frontend): cap query status poll backoff at 500ms

### DIFF
--- a/nes-frontend/src/QueryManager/QueryManager.cpp
+++ b/nes-frontend/src/QueryManager/QueryManager.cpp
@@ -162,9 +162,14 @@ void QueryManager::QueryManagerBackends::rebuildBackendsIfNeeded() const
     auto waitForStatusChange = query.iterate()
         | std::views::transform([](const auto& pair) { return std::pair{std::get<0>(pair), std::get<1>(pair)}; })
         | std::ranges::to<std::vector>();
-    constexpr auto statusPollInterval = std::chrono::milliseconds(10);
-    constexpr size_t statusRetries = 17;
-    for (size_t i = 0; i < statusRetries; ++i)
+    /// The query is expected to be moved into the started state pretty quickly after lowering, so we start with a rapid polling
+    /// interval. If the system is overloaded the state change may take much longer, so we back off exponentially, but cap the
+    /// interval at 500ms: unbounded backoff would leave long periods where no one observes the query status.
+    constexpr auto initialStatusPollInterval = std::chrono::milliseconds(10);
+    constexpr auto maxStatusPollInterval = std::chrono::milliseconds(500);
+    constexpr auto statusPollTimeout = std::chrono::seconds(1000);
+    const auto statusPollDeadline = std::chrono::steady_clock::now() + statusPollTimeout;
+    for (auto pollInterval = initialStatusPollInterval;; pollInterval = std::min(pollInterval * 2, maxStatusPollInterval))
     {
         std::erase_if(
             waitForStatusChange,
@@ -180,18 +185,18 @@ void QueryManager::QueryManagerBackends::rebuildBackendsIfNeeded() const
                 return result->state != QueryStatus::Registered;
             });
 
-        if (waitForStatusChange.empty())
+        if (waitForStatusChange.empty() or std::chrono::steady_clock::now() >= statusPollDeadline)
         {
             break;
         }
-        std::this_thread::sleep_for(statusPollInterval * std::pow(2, i));
+        std::this_thread::sleep_for(pollInterval);
     }
 
     if (!waitForStatusChange.empty())
     {
         exceptions.emplace_back(QueryStartFailed(
-            "Query state did not change for local queries after {} retries: {}",
-            statusRetries,
+            "Query state did not change for local queries within {}: {}",
+            statusPollTimeout,
             fmt::join(
                 waitForStatusChange
                     | std::views::transform([](const auto& pair) { return fmt::format("{}@{}", std::get<1>(pair), std::get<0>(pair)); }),


### PR DESCRIPTION
## Summary

`QueryManager::start` polled query status with unbounded exponential backoff over 17 retries, occasionally sleeping for hours and masking hung workers. Switch to bounded backoff capped at 500ms with a 1000s wall-clock deadline; error message now reports the timeout instead of the retry count.

The 1000s deadline is realistic for very heavy queries: combined with the identifier equality/hash perf fix (separate PR), workloads like linearroad block the task queue with many triggered windows, which prevents new queries from being accepted (by design). Under those conditions the old unbounded backoff would sleep far past any reasonable observation window before rechecking status.

## Test plan
- [ ] CI build + tidy