### PR TITLE
cleanup(DataType): Removed unused formattedBytesToString function

### DIFF
--- a/nes-data-types/include/DataTypes/DataType.hpp
+++ b/nes-data-types/include/DataTypes/DataType.hpp
@@ -124,7 +124,6 @@ struct DataType final
     /// example usage a binary arithmetical function: 'const auto commonStamp = left->getStamp().join(right->getStamp());'
     [[nodiscard]] std::optional<DataType> join(const DataType& otherDataType) const;
     [[nodiscard]] DataType::NULLABLE joinNullable(const DataType& otherDataType) const;
-    [[nodiscard]] std::string formattedBytesToString(const void* data) const;
 
     [[nodiscard]] bool isType(Type type) const;
     [[nodiscard]] bool isInteger() const;

--- a/nes-data-types/src/DataTypes/DataType.cpp
+++ b/nes-data-types/src/DataTypes/DataType.cpp
@@ -169,50 +169,6 @@ uint32_t DataType::getSizeInBytesWithNull() const
 
 /// NOLINTEND(readability-magic-numbers)
 
-std::string DataType::formattedBytesToString(const void* data) const
-{
-    PRECONDITION(data != nullptr, "Pointer to data is invalid.");
-    switch (type)
-    {
-        case Type::INT8:
-            return std::to_string(*static_cast<const int8_t*>(data));
-        case Type::UINT8:
-            return std::to_string(*static_cast<const uint8_t*>(data));
-        case Type::INT16:
-            return std::to_string(*static_cast<const int16_t*>(data));
-        case Type::UINT16:
-            return std::to_string(*static_cast<const uint16_t*>(data));
-        case Type::INT32:
-            return std::to_string(*static_cast<const int32_t*>(data));
-        case Type::UINT32:
-            return std::to_string(*static_cast<const uint32_t*>(data));
-        case Type::INT64:
-            return std::to_string(*static_cast<const int64_t*>(data));
-        case Type::UINT64:
-            return std::to_string(*static_cast<const uint64_t*>(data));
-        case Type::FLOAT32:
-            return formatFloat(*static_cast<const float*>(data));
-        case Type::FLOAT64:
-            return formatFloat(*static_cast<const double*>(data));
-        case Type::BOOLEAN:
-            return std::to_string(static_cast<int>(*static_cast<const bool*>(data)));
-        case Type::CHAR: {
-            if (getSizeInBytesWithoutNull() != 1)
-            {
-                return "invalid char type";
-            }
-            return std::string{*static_cast<const char*>(data)};
-        }
-        case Type::VARSIZED: {
-            const auto* textPointer = static_cast<const char*>(data);
-            return textPointer;
-        }
-        case Type::UNDEFINED:
-            return "invalid physical type";
-    }
-    std::unreachable();
-}
-
 bool DataType::isType(const Type type) const
 {
     return this->type == type;


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This pull request removes the `DataType::formattedBytesToString` function, which is unused ever since the `OutputFormatter` component was introduced and handles the binary-textual parsing.

## Verifying this change
- Function is unused, nothing depends on it

## What components does this pull request potentially affect?
- nes-data-types

## Issue Closed by this pull request:
This PR closes #1751 
