### PR TITLE
Enable raw string & boolean literals

### DIFF
--- a/docs/guide/query_api.md
+++ b/docs/guide/query_api.md
@@ -370,6 +370,21 @@ Use an explicit type constructor when a query depends on an exact literal type:
 SELECT UINT64(1) AS id, FLOAT32(3.6) AS scale FROM s INTO sink
 ```
 
+### String and boolean literals
+
+String and boolean constants can also be written directly in query expressions:
+
+```sql
+SELECT 'hello' AS message, TRUE AS enabled FROM s INTO sink
+SELECT * FROM s WHERE status == 'completed' AND enabled == false INTO sink
+```
+
+Raw string literals infer `VARSIZED`, including numeric-looking strings such as `'123'`. Raw `TRUE` and `FALSE` literals infer `BOOLEAN`; lowercase `true` and `false` are also supported. Explicit constructors remain available when desired:
+
+```sql
+SELECT VARSIZED('hello') AS message, BOOLEAN(TRUE) AS enabled FROM s INTO sink
+```
+
 ---
 
 ## Operators

--- a/docs/guide/query_api.md
+++ b/docs/guide/query_api.md
@@ -325,6 +325,24 @@ CREATE SINK sink_name TYPE FILE SET(
        ...
 );
 ```
+
+---
+## Identifiers and Quotation Marks
+
+Identifiers are the names of SQL objects, including sources, sinks, fields, aliases, and configuration keys. Simple identifiers can be written without quotes. Double quotes allow identifiers to contain spaces or preserve their exact spelling:
+
+```sql
+SELECT "event type" AS "Event Type" FROM "input stream" INTO sink;
+```
+
+Double-quoted text refers to an identifier, while single-quoted text represents a string value:
+
+```sql
+SELECT "status" AS field_value, 'status' AS literal_value FROM stream INTO sink;
+```
+
+Here, `"status"` refers to a field named `status`, whereas `'status'` is the literal string `status`.
+
 ---
 ## Data Types
 In NebulaStream, each field is associated with exactly one data type.

--- a/nes-logical-operators/src/Functions/ConstantValueLogicalFunction.cpp
+++ b/nes-logical-operators/src/Functions/ConstantValueLogicalFunction.cpp
@@ -90,6 +90,14 @@ DataType inferIntegerLiteralDataType(const std::string_view literal)
 
 DataType inferConstantValueDataType(const std::string_view literal)
 {
+    if (literal.size() >= 2 and literal.front() == '\'' and literal.back() == '\'')
+    {
+        return DataTypeProvider::provideDataType(DataType::Type::VARSIZED);
+    }
+    if (literal == "TRUE" or literal == "FALSE" or literal == "true" or literal == "false")
+    {
+        return DataTypeProvider::provideDataType(DataType::Type::BOOLEAN);
+    }
     try
     {
         return inferIntegerLiteralDataType(literal);
@@ -159,7 +167,12 @@ LogicalFunction ConstantValueLogicalFunction::withInferredDataType(const Schema<
     {
         return *this;
     }
-    return ConstantValueLogicalFunction(inferConstantValueDataType(constantValue), constantValue);
+    auto inferredDataType = inferConstantValueDataType(constantValue);
+    if (inferredDataType.isType(DataType::Type::VARSIZED))
+    {
+        return ConstantValueLogicalFunction(std::move(inferredDataType), constantValue.substr(1, constantValue.size() - 2));
+    }
+    return ConstantValueLogicalFunction(std::move(inferredDataType), constantValue);
 }
 
 Reflected

--- a/nes-sql-parser/AntlrSQL.g4
+++ b/nes-sql-parser/AntlrSQL.g4
@@ -425,7 +425,7 @@ constant
     ;
 
 booleanValue
-    : TRUE | FALSE
+    : TRUE | FALSE | BOOLEAN_VALUE
     ;
 
 ///****************************

--- a/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
+++ b/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
@@ -186,9 +186,9 @@ bool isInsideDataTypeConstructorArgument(antlr4::ParserRuleContext* context)
     return false;
 }
 
-LogicalFunction createNumericLiteralFunction(AntlrSQLParser::NumericLiteralContext* numericLiteralContext)
+LogicalFunction createRawLiteralFunction(std::string literal)
 {
-    return ConstantValueLogicalFunction(DataTypeProvider::provideDataType(DataType::Type::UNDEFINED), numericLiteralContext->getText());
+    return ConstantValueLogicalFunction(DataTypeProvider::provideDataType(DataType::Type::UNDEFINED), std::move(literal));
 }
 
 LogicalFunction createNegatedNumericLiteralFunction(const ConstantValueLogicalFunction& constantFunction)
@@ -1088,11 +1088,10 @@ void AntlrSQLQueryPlanCreator::exitConstantDefault(AntlrSQLParser::ConstantDefau
     }
 
     const auto insideDataTypeConstructorArgument = isInsideDataTypeConstructorArgument(context);
-    if (auto* const numericLiteralContext = dynamic_cast<AntlrSQLParser::NumericLiteralContext*>(context->constant());
-        numericLiteralContext != nullptr and !insideDataTypeConstructorArgument)
+    if (dynamic_cast<AntlrSQLParser::NumericLiteralContext*>(context->constant()) != nullptr and !insideDataTypeConstructorArgument)
     {
         auto& functionBuilder = helpers.top().isJoinRelation ? helpers.top().joinKeyRelationHelper : helpers.top().functionBuilder;
-        functionBuilder.emplace_back(createNumericLiteralFunction(numericLiteralContext));
+        functionBuilder.emplace_back(createRawLiteralFunction(context->getText()));
         return;
     }
 
@@ -1103,7 +1102,18 @@ void AntlrSQLQueryPlanCreator::exitConstantDefault(AntlrSQLParser::ConstantDefau
             throw InvalidQuerySyntax(
                 "A constant string literal must contain at least two quotes and must not be empty at {}", context->getText());
         }
+        if (!insideDataTypeConstructorArgument)
+        {
+            auto& functionBuilder = helpers.top().isJoinRelation ? helpers.top().joinKeyRelationHelper : helpers.top().functionBuilder;
+            functionBuilder.emplace_back(createRawLiteralFunction(context->getText()));
+            return;
+        }
         helpers.top().constantBuilder.push_back(context->getText().substr(1, stringLiteralContext->getText().size() - 2));
+    }
+    else if (dynamic_cast<AntlrSQLParser::BooleanLiteralContext*>(context->constant()) != nullptr and !insideDataTypeConstructorArgument)
+    {
+        auto& functionBuilder = helpers.top().isJoinRelation ? helpers.top().joinKeyRelationHelper : helpers.top().functionBuilder;
+        functionBuilder.emplace_back(createRawLiteralFunction(context->getText()));
     }
     else
     {

--- a/nes-sql-parser/tests/StatementBinderTest.cpp
+++ b/nes-sql-parser/tests/StatementBinderTest.cpp
@@ -148,6 +148,23 @@ TEST_F(StatementBinderTest, BindQueryWithRawNumericLiterals)
     EXPECT_EQ(predicate, "B < 256 AND C > -1 AND D < 1.5");
 }
 
+TEST_F(StatementBinderTest, BindQueryWithRawStringAndBooleanLiterals)
+{
+    const std::string queryString
+        = "SELECT 'hello' AS s, TRUE AS b, VARSIZED('world') AS explicit_s, BOOLEAN(FALSE) AS explicit_b FROM inputStream "
+          "WHERE text == '123' AND flag == false AND FALSE == FALSE INTO outputStream";
+    const auto statement = binder->parseAndBindSingle(queryString);
+    ASSERT_TRUE(statement.has_value());
+    ASSERT_TRUE(std::holds_alternative<QueryStatement>(*statement));
+
+    const auto plan = std::get<QueryStatement>(*statement).plan;
+    const auto selectionOperators = getOperatorByType<SelectionLogicalOperator>(plan);
+    ASSERT_EQ(selectionOperators.size(), 1);
+
+    const auto predicate = selectionOperators.front()->getPredicate().explain(ExplainVerbosity::Short);
+    EXPECT_EQ(predicate, "TEXT = '123' AND FLAG = false AND FALSE = FALSE");
+}
+
 TEST_F(StatementBinderTest, BindQueryWithDoubleNegativeTypedFloatLiteralInWherePredicate)
 {
     const std::string queryString = "SELECT a FROM inputStream WHERE b < FLOAT64(- -0.5) INTO outputStream";

--- a/nes-systests/datatype/IdentifiersAndStringLiterals.test
+++ b/nes-systests/datatype/IdentifiersAndStringLiterals.test
@@ -1,0 +1,18 @@
+# name: datatype/IdentifiersAndStringLiterals.test
+# description: Double-quoted identifiers are distinct from single-quoted string literals
+# groups: [DataTypes, Identifiers]
+
+CREATE LOGICAL SOURCE "INPUT STREAM" ("EVENT TYPE" VARSIZED NOT NULL, "STATUS" VARSIZED NOT NULL);
+CREATE PHYSICAL SOURCE FOR "INPUT STREAM" TYPE File;
+ATTACH INLINE
+click,active
+
+CREATE SINK "OUTPUT SINK" ("EVENT TYPE" VARSIZED NOT NULL, field_value VARSIZED NOT NULL, literal_value VARSIZED NOT NULL) TYPE File;
+
+SELECT
+    "EVENT TYPE" AS "EVENT TYPE",
+    "STATUS" AS field_value,
+    'status' AS literal_value
+FROM "INPUT STREAM" INTO "OUTPUT SINK";
+----
+click,active,status

--- a/nes-systests/datatype/RawStringAndBooleanLiterals.test
+++ b/nes-systests/datatype/RawStringAndBooleanLiterals.test
@@ -1,0 +1,24 @@
+# name: datatype/RawStringAndBooleanLiterals.test
+# description: Raw string and boolean literals infer their data types
+# groups: [DataTypes, RawStringAndBooleanLiterals]
+
+CREATE LOGICAL SOURCE stream(text VARSIZED NOT NULL, flag BOOLEAN NOT NULL);
+CREATE PHYSICAL SOURCE FOR stream TYPE File;
+ATTACH INLINE
+hello,true
+other,false
+
+CREATE SINK sink(raw_string VARSIZED NOT NULL, numeric_string VARSIZED NOT NULL, raw_boolean BOOLEAN NOT NULL, lowercase_boolean BOOLEAN NOT NULL, string_comparison BOOLEAN NOT NULL, boolean_comparison BOOLEAN NOT NULL, explicit_string VARSIZED NOT NULL, explicit_boolean BOOLEAN NOT NULL) TYPE File;
+
+SELECT
+    'hello' AS raw_string,
+    '123' AS numeric_string,
+    TRUE AS raw_boolean,
+    false AS lowercase_boolean,
+    text == 'hello' AS string_comparison,
+    flag == TRUE AS boolean_comparison,
+    VARSIZED('explicit') AS explicit_string,
+    BOOLEAN(FALSE) AS explicit_boolean
+FROM stream WHERE text == 'hello' AND flag == TRUE AND FALSE == FALSE INTO sink;
+----
+hello,123,true,false,true,true,explicit,false


### PR DESCRIPTION
### Varsize & boolean literals

With this change we simplify our SQL syntax to not require type literals for varsize and booleans.

Before type constructors where always required:

SELECT **VARSIUZED('text')**, **BOOLEAN(true)** FROM s INTO sink;

Now also allowed:

SELECT **'text'**, **true** FROM s INTO sink;


### Identifiers syntax

Aligned with standard SQL we reserve double quotes for identiers, i.e.:

SELECT 'text', true FROM **"source name with whitespace"** INTO sink;

This PR add documetation for this differenciation.
