### PR TITLE
nes-memory: drop unused nes-data-types dependency

### DIFF
--- a/nes-memory/CMakeLists.txt
+++ b/nes-memory/CMakeLists.txt
@@ -19,7 +19,6 @@ add_library(nes-memory
         UnpooledChunksManager.cpp
         VariableSizedAccess.cpp
         MemoryUtils.cpp
-        ${MEMORY_LAYOUT_SOURCES}
 )
 
 target_include_directories(nes-memory
@@ -30,5 +29,5 @@ target_include_directories(nes-memory
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
 find_package(folly REQUIRED)
-target_link_libraries(nes-memory PUBLIC nes-common nes-data-types PRIVATE folly::folly)
+target_link_libraries(nes-memory PUBLIC nes-common PRIVATE folly::folly)
 add_tests_if_enabled(tests)


### PR DESCRIPTION
## Summary

- remove the unused public `nes-data-types` link dependency from `nes-memory`
- remove the undefined, empty `MEMORY_LAYOUT_SOURCES` entry from its source list

`nes-memory` does not use symbols from `nes-data-types`, so this reduces its public dependency surface without changing runtime behavior. The source-list entry expands to nothing and is dead configuration.

## Validation

- `cmake -G Ninja -B cmake-build-debug ...` (Debug configuration)
- `MOLD_JOBS=1 cmake --build cmake-build-debug --target nes-memory -j`

Tests were not run (not requested).
