### PR TITLE
Remove stale MemCom assertion

### DIFF
--- a/nes-network/network/src/memcom.rs
+++ b/nes-network/network/src/memcom.rs
@@ -155,15 +155,7 @@ impl MemCom {
             Retry::spawn(retry, || async { try_connect(self, connection).await }).await?;
         match handshake_channel.send(server_channel).await {
             Ok(_) => Ok(client_channel),
-            Err(SendError(_)) => {
-                // The handshake channel receiver was dropped, which means the registry
-                // entry should have been removed by the listening side already
-                debug_assert!(
-                    !self.listening.read().await.contains_key(connection),
-                    "Entry should have been removed when handshake receiver was dropped"
-                );
-                Err("could not connect".into())
-            }
+            Err(SendError(_)) => Err("could not connect".into()),
         }
     }
 }


### PR DESCRIPTION
## Summary

Remove the non-load-bearing debug assertion after a MemCom handshake send fails. The CI infrequently fails with 
```
panic: panicked at /home/runner/work/nebulastream/nebulastream/nes-network/network/src/memcom.rs:161:17:
Entry should have been removed when handshake receiver was dropped
Caught signal SIGSEGV
```
https://github.com/nebulastream/nebulastream/actions/runs/29334160904/job/87091142567

## Why

A receiver shutdown can drop the handshake receiver while its sender remains in the global MemCom registry. The assertion incorrectly assumes that registry cleanup has already occurred, turning the expected failed connection into a debug-build panic. The upcoming async I/O work will address the lifecycle cleanup.

## Impact

Failed handshakes continue to return `could not connect` without panicking in debug builds.

## Validation

- `cargo fmt --manifest-path nes-network/network/Cargo.toml --check`
- `cargo check --manifest-path nes-network/network/Cargo.toml`