### PR TITLE
feat(Clang-Tidy): Add origin/main tidy-diff targets

### DIFF
--- a/cmake/ClangTidyDiff.cmake
+++ b/cmake/ClangTidyDiff.cmake
@@ -63,7 +63,7 @@ function(project_enable_tidy_diff)
     message(STATUS "Enabling tidy-diff targets using ${CLANG_TIDY_DIFF_EXECUTABLE} (binary: ${CLANG_TIDY_EXECUTABLE})")
 
     # tidy-diff: check mode. The driver discovers the diff base from the
-    # NES_TIDY_DIFF_BASE env var (default 'git diff --cached'), prints a summary,
+    # NES_TIDY_DIFF_BASE env var (default 'git diff HEAD'), prints a summary,
     # then runs clang-tidy-diff, teeing colored output to stdout and a de-colored
     # copy to the report file. USES_TERMINAL preserves the colored stdout.
     add_custom_target(tidy-diff
@@ -88,6 +88,35 @@ function(project_enable_tidy_diff)
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
             USES_TERMINAL
             COMMENT "Running clang-tidy on the local diff (fix)")
+
+    # tidy-diff-to-main / -fix: same targets, but pin the base to origin/main so
+    # the check covers the whole branch instead of just uncommitted changes.
+    # We pin via `cmake -E env`, which sets NES_TIDY_DIFF_BASE in the child
+    # process regardless of whether the outer (Docker) toolchain forwards the
+    # variable -- so these work as one-click targets from CLion with no env setup.
+    add_custom_target(tidy-diff-to-main
+            COMMAND ${CMAKE_COMMAND} -E env NES_TIDY_DIFF_BASE=origin/main
+                ${TIDY_DIFF_DRIVER}
+                ${CLANG_TIDY_DIFF_EXECUTABLE}
+                ${CLANG_TIDY_EXECUTABLE}
+                ${CMAKE_BINARY_DIR}
+                ${TIDY_DIFF_REPORT}
+                check
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            USES_TERMINAL
+            COMMENT "Running clang-tidy on the diff vs origin/main (check)")
+
+    add_custom_target(tidy-diff-to-main-fix
+            COMMAND ${CMAKE_COMMAND} -E env NES_TIDY_DIFF_BASE=origin/main
+                ${TIDY_DIFF_DRIVER}
+                ${CLANG_TIDY_DIFF_EXECUTABLE}
+                ${CLANG_TIDY_EXECUTABLE}
+                ${CMAKE_BINARY_DIR}
+                ${TIDY_DIFF_REPORT}
+                fix
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            USES_TERMINAL
+            COMMENT "Running clang-tidy on the diff vs origin/main (fix)")
 
     # TODO #1609: migrate the handwritten bash in
     # .github/workflows/clang_tidy_diff.yml to invoke `cmake --build --target

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -93,6 +93,28 @@ docker run \
      ctest --test-dir build-docker -j
 ```
 
+### Code style & static analysis
+
+Code style and static analysis are available as CMake targets, so you do not need to invoke `clang-format` or
+`clang-tidy` by hand:
+
+- `format` / `check-format` — run clang-format (apply in place / check only).
+- `tidy-diff` / `tidy-diff-fix` — run clang-tidy over your diff (base `NES_TIDY_DIFF_BASE`, default `HEAD`).
+- `tidy-diff-to-main` / `tidy-diff-to-main-fix` — run clang-tidy over your whole branch relative to `origin/main`.
+
+For example, to fix clang-tidy findings on your branch inside the container:
+
+```shell
+docker run \
+    --workdir $(pwd) \
+    -v $(pwd):$(pwd) \
+    nebulastream/nes-development:local \
+    cmake --build build-docker --target tidy-diff-to-main-fix
+```
+
+In CLion these show up in the target dropdown and run like any other build target, so there is no need to edit the
+Docker toolchain environment. See [fixing clang-tidy warnings](fix_clang_tidy_warnings.md) for details.
+
 ### Modifying dependencies
 
 When using the docker images, it is not straightforward to edit the dependencies, as a new docker image would need to be

--- a/docs/development/fix_clang_tidy_warnings.md
+++ b/docs/development/fix_clang_tidy_warnings.md
@@ -6,6 +6,42 @@ For building it locally with vcpkg, the commands should be quite similar.
 This document provides a good starting point for fixing clang-tidy warnings.
 As every setup is different, it might be necessary to adjust the commands to your setup.
 
+# Running clang-tidy via CMake targets (recommended)
+Just like `clang-format` is available as the `format` / `check-format` CMake targets, clang-tidy on your diff is
+available as CMake targets. These wrap `clang-tidy-diff.py` so you no longer need the hand-written `git diff | clang-tidy-diff-19.py ...`
+command below. There are four targets:
+
+| Target | Diff base | Mode |
+| --- | --- | --- |
+| `tidy-diff` | `NES_TIDY_DIFF_BASE` (default `HEAD`, i.e. all uncommitted changes) | check |
+| `tidy-diff-fix` | same as above | applies `-fix` |
+| `tidy-diff-to-main` | `origin/main` (whole branch) | check |
+| `tidy-diff-to-main-fix` | `origin/main` (whole branch) | applies `-fix` |
+
+For reviewing a PR, the usual command is to fix everything on your branch relative to `origin/main`:
+```bash
+cmake --build build --target tidy-diff-to-main-fix
+```
+Or, wrapped in the development container (the `-to-main` targets pin the base internally, so no `-e NES_TIDY_DIFF_BASE=...`
+plumbing is needed):
+```bash
+docker run \
+    --workdir $(pwd) \
+    -v $(pwd):$(pwd) \
+    nebulastream/nes-development:local \
+    cmake --build build-docker --target tidy-diff-to-main-fix
+```
+In CLion these appear in the target dropdown, so you can run them like any other build target — no need to edit the
+Docker toolchain environment.
+
+Notes:
+- **Build first.** Some headers (gRPC/protobuf stubs, config headers) are generated during the build; without them
+  clang-tidy reports spurious `file not found` errors. The targets print a hint when this happens.
+- The targets are only registered when `CMAKE_EXPORT_COMPILE_COMMANDS=ON` (on by default) — clang-tidy-diff needs the
+  `compile_commands.json`.
+- To compare against an arbitrary base (a branch or commit other than `origin/main`), set `NES_TIDY_DIFF_BASE` and use
+  the plain `tidy-diff` / `tidy-diff-fix` targets, e.g. `NES_TIDY_DIFF_BASE=origin/some-branch cmake --build build --target tidy-diff-fix`.
+
 # Running the clang-tidy diff workflow with Nix
 If you want to reproduce the current clang-tidy diff workflow locally with the Nix toolchain, run the following command
 from the repository root.
@@ -17,7 +53,9 @@ To use another branch or commit, pass it after `--`, for example `nix run .#clan
 The command uses the official `clang-tidy-diff.py` workflow, applies fixes in place, and configures and builds
 `build/`.
 
-# Fixing clang-tidy warnings for a PR / compared to a branch
+# Manual invocation (fallback / custom setups)
+The CMake targets above are preferred. Use the manual commands below only for custom bases or non-CMake setups.
+
 As a pre-requisite, you need to have the docker image built and your git repository updated.
 Before running clang-tidy, we must create a running container from the image.
 If possible, you should run the Docker container in rootless mode. 


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

`tidy-diff` only covered uncommitted changes, so there was no one-click way to run clang-tidy over a whole branch — that meant hand-writing a `git diff origin/main | clang-tidy-diff-19.py ...` invocation. This pull request adds branch-wide tidy-diff targets. The change list is as follows:

- Added `tidy-diff-to-main` and `tidy-diff-to-main-fix` to `cmake/ClangTidyDiff.cmake`, pinning the diff base to `origin/main` via `cmake -E env` so the base is set in the child process even when the Docker toolchain does not forward `NES_TIDY_DIFF_BASE`. They show up in the CLion target dropdown with no environment setup.
- Changed the documented default base of `tidy-diff` / `tidy-diff-fix` from `git diff --cached` to `git diff HEAD`, so they cover all uncommitted changes rather than only staged ones.
- Documented all four targets in `fix_clang_tidy_warnings.md` and `development.md`, and demoted the hand-written `clang-tidy-diff.py` command to a fallback for custom bases and non-CMake setups.

## Verifying this change

Build tooling only — no library, engine, or test code is touched, so no automated tests were added. Verified manually in the `nebulastream/nes-development:local` container:

- All four targets (`tidy-diff`, `tidy-diff-fix`, `tidy-diff-to-main`, `tidy-diff-to-main-fix`) register in the generated build.
- `cmake --build <build> --target tidy-diff-to-main` runs end-to-end against a branch with local commits: it resolves `origin/main` as the base, restricts findings to the branch's own lines, and writes `clang-tidy-diff-report.txt`.
- The pinned base takes effect inside the container without any `-e NES_TIDY_DIFF_BASE=...` plumbing, which is the point of the `cmake -E env` wrapper.
