### PR TITLE
Systest .test file names do not need to be unique

### DIFF
--- a/nes-systests/systest/include/SystestState.hpp
+++ b/nes-systests/systest/include/SystestState.hpp
@@ -232,14 +232,26 @@ struct TestFile
         const std::filesystem::path& file, std::shared_ptr<SourceCatalog> sourceCatalog, std::shared_ptr<SinkCatalog> sinkCatalog);
     explicit TestFile(
         const std::filesystem::path& file,
+        TestName testName,
+        std::shared_ptr<SourceCatalog> sourceCatalog,
+        std::shared_ptr<SinkCatalog> sinkCatalog);
+    explicit TestFile(
+        const std::filesystem::path& file,
         std::unordered_set<SystestQueryId> onlyEnableQueriesWithTestQueryNumber,
+        std::shared_ptr<SourceCatalog> sourceCatalog,
+        std::shared_ptr<SinkCatalog> sinkCatalog);
+    explicit TestFile(
+        const std::filesystem::path& file,
+        std::unordered_set<SystestQueryId> onlyEnableQueriesWithTestQueryNumber,
+        TestName testName,
         std::shared_ptr<SourceCatalog> sourceCatalog,
         std::shared_ptr<SinkCatalog> sinkCatalog);
     [[nodiscard]] std::string getLogFilePath() const;
 
-    [[nodiscard]] TestName name() const { return file.stem().string(); }
+    [[nodiscard]] TestName name() const { return testName; }
 
     std::filesystem::path file;
+    TestName testName;
     std::unordered_set<SystestQueryId> onlyEnableQueriesWithTestQueryNumber;
     std::vector<TestGroup> groups;
     std::vector<SystestQuery> queries;

--- a/nes-systests/systest/src/SystestState.cpp
+++ b/nes-systests/systest/src/SystestState.cpp
@@ -173,8 +173,7 @@ namespace NES::Systest
 std::filesystem::path
 SystestQuery::resultFile(const std::filesystem::path& workingDir, std::string_view testName, const SystestQueryId queryIdInTestFile)
 {
-    auto resultPath = workingDir / "results"
-        / std::filesystem::path(fmt::format("{}_{}.csv", testName, queryIdInTestFile));
+    auto resultPath = workingDir / "results" / std::filesystem::path(fmt::format("{}_{}.csv", testName, queryIdInTestFile));
     const auto resultDir = resultPath.parent_path();
     if (not is_directory(resultDir))
     {
@@ -288,11 +287,7 @@ TestFile::TestFile(
     std::shared_ptr<SourceCatalog> sourceCatalog,
     std::shared_ptr<SinkCatalog> sinkCatalog)
     : TestFile(
-          file,
-          std::move(onlyEnableQueriesWithTestQueryNumber),
-          file.stem().string(),
-          std::move(sourceCatalog),
-          std::move(sinkCatalog))
+          file, std::move(onlyEnableQueriesWithTestQueryNumber), file.stem().string(), std::move(sourceCatalog), std::move(sinkCatalog))
 {
 }
 

--- a/nes-systests/systest/src/SystestState.cpp
+++ b/nes-systests/systest/src/SystestState.cpp
@@ -159,6 +159,12 @@ std::optional<std::string> getSkipReason(const NES::Systest::TestFile& testFile,
     }
     return std::nullopt;
 }
+
+NES::Systest::TestName testNameFromRelativePath(std::filesystem::path relativePath)
+{
+    relativePath.replace_extension();
+    return relativePath.generic_string();
+}
 }
 
 namespace NES::Systest
@@ -167,26 +173,29 @@ namespace NES::Systest
 std::filesystem::path
 SystestQuery::resultFile(const std::filesystem::path& workingDir, std::string_view testName, const SystestQueryId queryIdInTestFile)
 {
-    auto resultDir = workingDir / "results";
+    auto resultPath = workingDir / "results"
+        / std::filesystem::path(fmt::format("{}_{}.csv", testName, queryIdInTestFile));
+    const auto resultDir = resultPath.parent_path();
     if (not is_directory(resultDir))
     {
         create_directories(resultDir);
         std::cout << "Created working directory: file://" << resultDir.string() << "\n";
     }
 
-    return resultDir / std::filesystem::path(fmt::format("{}_{}.csv", testName, queryIdInTestFile));
+    return resultPath;
 }
 
 std::filesystem::path SystestQuery::sourceFile(const std::filesystem::path& workingDir, std::string_view testName, const uint64_t sourceId)
 {
-    auto sourceDir = workingDir / "sources";
+    auto sourcePath = workingDir / "sources" / std::filesystem::path(fmt::format("{}_{}.csv", testName, sourceId));
+    const auto sourceDir = sourcePath.parent_path();
     if (not is_directory(sourceDir))
     {
         create_directories(sourceDir);
         std::cout << "Created working directory: file://" << sourceDir.string() << "\n";
     }
 
-    return sourceDir / std::filesystem::path(fmt::format("{}_{}.csv", testName, sourceId));
+    return sourcePath;
 }
 
 std::filesystem::path SystestQuery::resultFile() const
@@ -218,7 +227,11 @@ TestFileMap discoverTestsRecursively(const std::filesystem::path& path, const st
         const std::string entryExt = toLowerCopy(entry.path().extension().string());
         if (!fileExtension || entryExt == desiredExtension)
         {
-            const TestFile testfile(entry.path(), std::make_shared<SourceCatalog>(), std::make_shared<SinkCatalog>());
+            const TestFile testfile(
+                entry.path(),
+                testNameFromRelativePath(entry.path().lexically_relative(path)),
+                std::make_shared<SourceCatalog>(),
+                std::make_shared<SinkCatalog>());
             testFiles.insert({testfile.file, testfile});
         }
     }
@@ -254,7 +267,17 @@ std::vector<TestGroup> readGroups(const TestFile& testfile)
 
 TestFile::TestFile(
     const std::filesystem::path& file, std::shared_ptr<SourceCatalog> sourceCatalog, std::shared_ptr<SinkCatalog> sinkCatalog)
+    : TestFile(file, file.stem().string(), std::move(sourceCatalog), std::move(sinkCatalog))
+{
+}
+
+TestFile::TestFile(
+    const std::filesystem::path& file,
+    TestName testName,
+    std::shared_ptr<SourceCatalog> sourceCatalog,
+    std::shared_ptr<SinkCatalog> sinkCatalog)
     : file(weakly_canonical(file))
+    , testName(std::move(testName))
     , groups(readGroups(*this))
     , sourceCatalog(std::move(sourceCatalog))
     , sinkCatalog(std::move(sinkCatalog)) { };
@@ -264,7 +287,23 @@ TestFile::TestFile(
     std::unordered_set<SystestQueryId> onlyEnableQueriesWithTestQueryNumber,
     std::shared_ptr<SourceCatalog> sourceCatalog,
     std::shared_ptr<SinkCatalog> sinkCatalog)
+    : TestFile(
+          file,
+          std::move(onlyEnableQueriesWithTestQueryNumber),
+          file.stem().string(),
+          std::move(sourceCatalog),
+          std::move(sinkCatalog))
+{
+}
+
+TestFile::TestFile(
+    const std::filesystem::path& file,
+    std::unordered_set<SystestQueryId> onlyEnableQueriesWithTestQueryNumber,
+    TestName testName,
+    std::shared_ptr<SourceCatalog> sourceCatalog,
+    std::shared_ptr<SinkCatalog> sinkCatalog)
     : file(weakly_canonical(file))
+    , testName(std::move(testName))
     , onlyEnableQueriesWithTestQueryNumber(std::move(onlyEnableQueriesWithTestQueryNumber))
     , groups(readGroups(*this))
     , sourceCatalog(std::move(sourceCatalog))

--- a/nes-systests/systest/src/SystestState.cpp
+++ b/nes-systests/systest/src/SystestState.cpp
@@ -165,6 +165,18 @@ NES::Systest::TestName testNameFromRelativePath(std::filesystem::path relativePa
     relativePath.replace_extension();
     return relativePath.generic_string();
 }
+
+NES::Systest::TestName testNameRelativeTo(const std::filesystem::path& file, const std::filesystem::path& discoveryRoot)
+{
+    const auto canonicalFile = std::filesystem::weakly_canonical(file);
+    const auto canonicalRoot = std::filesystem::weakly_canonical(discoveryRoot);
+    const auto relativePath = canonicalFile.lexically_relative(canonicalRoot);
+    if (relativePath.empty() || relativePath == std::filesystem::path{"."} || *relativePath.begin() == std::filesystem::path{".."})
+    {
+        return file.stem().string();
+    }
+    return testNameFromRelativePath(relativePath);
+}
 }
 
 namespace NES::Systest
@@ -338,10 +350,12 @@ TestFileMap loadTestFileMap(const SystestConfiguration& config)
     if (not config.directlySpecifiedTestFiles.getValue().empty())
     {
         const auto directlySpecifiedTestFiles = config.directlySpecifiedTestFiles.getValue();
+        const auto testName = testNameRelativeTo(directlySpecifiedTestFiles, config.testsDiscoverDir.getValue());
 
         if (config.testQueryNumbers.empty())
         {
-            const auto testfile = TestFile(directlySpecifiedTestFiles, std::make_shared<SourceCatalog>(), std::make_shared<SinkCatalog>());
+            const auto testfile
+                = TestFile(directlySpecifiedTestFiles, testName, std::make_shared<SourceCatalog>(), std::make_shared<SinkCatalog>());
             if (matchesDisabledTestFile(testfile, filters.disabledTestFiles))
             {
                 std::cout << fmt::format(
@@ -354,8 +368,8 @@ TestFileMap loadTestFileMap(const SystestConfiguration& config)
         const auto testNumbers = std::ranges::to<std::unordered_set<SystestQueryId>>(
             config.testQueryNumbers.getValues()
             | std::views::transform([](const auto& option) { return SystestQueryId(option.getValue()); }));
-        const auto testfile
-            = TestFile(directlySpecifiedTestFiles, testNumbers, std::make_shared<SourceCatalog>(), std::make_shared<SinkCatalog>());
+        const auto testfile = TestFile(
+            directlySpecifiedTestFiles, testNumbers, testName, std::make_shared<SourceCatalog>(), std::make_shared<SinkCatalog>());
         if (matchesDisabledTestFile(testfile, filters.disabledTestFiles))
         {
             std::cout << fmt::format(

--- a/nes-systests/systest/src/SystestState.cpp
+++ b/nes-systests/systest/src/SystestState.cpp
@@ -166,16 +166,28 @@ NES::Systest::TestName testNameFromRelativePath(std::filesystem::path relativePa
     return relativePath.generic_string();
 }
 
-NES::Systest::TestName testNameRelativeTo(const std::filesystem::path& file, const std::filesystem::path& discoveryRoot)
+NES::Systest::TestName testNameStem(const NES::Systest::TestFile& testFile)
 {
-    const auto canonicalFile = std::filesystem::weakly_canonical(file);
-    const auto canonicalRoot = std::filesystem::weakly_canonical(discoveryRoot);
-    const auto relativePath = canonicalFile.lexically_relative(canonicalRoot);
-    if (relativePath.empty() || relativePath == std::filesystem::path{"."} || *relativePath.begin() == std::filesystem::path{".."})
+    return std::filesystem::path(testFile.name()).filename().string();
+}
+
+/// Use the filename stem when it is unique, retaining the relative path to disambiguate duplicate stems.
+void shortenUniqueTestNames(NES::Systest::TestFileMap& testFiles)
+{
+    std::unordered_map<NES::Systest::TestName, size_t> testNameCounts;
+    for (const auto& testFile : testFiles | std::views::values)
     {
-        return file.stem().string();
+        ++testNameCounts[testNameStem(testFile)];
     }
-    return testNameFromRelativePath(relativePath);
+
+    for (auto& testFile : testFiles | std::views::values)
+    {
+        auto stem = testNameStem(testFile);
+        if (testNameCounts.at(stem) == 1)
+        {
+            testFile.testName = std::move(stem);
+        }
+    }
 }
 }
 
@@ -350,12 +362,10 @@ TestFileMap loadTestFileMap(const SystestConfiguration& config)
     if (not config.directlySpecifiedTestFiles.getValue().empty())
     {
         const auto directlySpecifiedTestFiles = config.directlySpecifiedTestFiles.getValue();
-        const auto testName = testNameRelativeTo(directlySpecifiedTestFiles, config.testsDiscoverDir.getValue());
 
         if (config.testQueryNumbers.empty())
         {
-            const auto testfile
-                = TestFile(directlySpecifiedTestFiles, testName, std::make_shared<SourceCatalog>(), std::make_shared<SinkCatalog>());
+            const auto testfile = TestFile(directlySpecifiedTestFiles, std::make_shared<SourceCatalog>(), std::make_shared<SinkCatalog>());
             if (matchesDisabledTestFile(testfile, filters.disabledTestFiles))
             {
                 std::cout << fmt::format(
@@ -368,8 +378,8 @@ TestFileMap loadTestFileMap(const SystestConfiguration& config)
         const auto testNumbers = std::ranges::to<std::unordered_set<SystestQueryId>>(
             config.testQueryNumbers.getValues()
             | std::views::transform([](const auto& option) { return SystestQueryId(option.getValue()); }));
-        const auto testfile = TestFile(
-            directlySpecifiedTestFiles, testNumbers, testName, std::make_shared<SourceCatalog>(), std::make_shared<SinkCatalog>());
+        const auto testfile
+            = TestFile(directlySpecifiedTestFiles, testNumbers, std::make_shared<SourceCatalog>(), std::make_shared<SinkCatalog>());
         if (matchesDisabledTestFile(testfile, filters.disabledTestFiles))
         {
             std::cout << fmt::format(
@@ -392,6 +402,7 @@ TestFileMap loadTestFileMap(const SystestConfiguration& config)
             }
             return false;
         });
+    shortenUniqueTestNames(testMap);
 
     return testMap;
 }

--- a/nes-systests/systest/tests/SystestStateTests.cpp
+++ b/nes-systests/systest/tests/SystestStateTests.cpp
@@ -136,4 +136,33 @@ TEST_F(SystestStateTest, DirectlySpecifiedTestFileOverridesDisabledTestFiles)
     ASSERT_EQ(testMap.size(), 1);
     EXPECT_TRUE(testMap.contains(std::filesystem::weakly_canonical(joinFile)));
 }
+
+TEST_F(SystestStateTest, DiscoveredTestNamesIncludeRelativeDirectory)
+{
+    const TemporaryDirectory tempDir;
+    const auto leftFile = tempDir.get() / "left" / "same.test";
+    const auto rightFile = tempDir.get() / "right" / "same.test";
+    writeTextFile(leftFile, "# groups:[Join]\n");
+    writeTextFile(rightFile, "# groups:[Join]\n");
+
+    SystestConfiguration config;
+    config.testsDiscoverDir = tempDir.get().string();
+    config.testFileExtension = ".test";
+
+    const auto testMap = loadTestFileMap(config);
+
+    ASSERT_EQ(testMap.size(), 2);
+    EXPECT_EQ(testMap.at(std::filesystem::weakly_canonical(leftFile)).name(), "left/same");
+    EXPECT_EQ(testMap.at(std::filesystem::weakly_canonical(rightFile)).name(), "right/same");
+}
+
+TEST_F(SystestStateTest, ResultFilesCreateDirectoriesForNestedTestNames)
+{
+    const TemporaryDirectory tempDir;
+
+    const auto resultFile = SystestQuery::resultFile(tempDir.get(), "left/same", SystestQueryId(1));
+
+    EXPECT_EQ(resultFile, tempDir.get() / "results" / "left" / "same_1.csv");
+    EXPECT_TRUE(std::filesystem::is_directory(resultFile.parent_path()));
+}
 }

--- a/nes-systests/systest/tests/SystestStateTests.cpp
+++ b/nes-systests/systest/tests/SystestStateTests.cpp
@@ -156,6 +156,50 @@ TEST_F(SystestStateTest, DiscoveredTestNamesIncludeRelativeDirectory)
     EXPECT_EQ(testMap.at(std::filesystem::weakly_canonical(rightFile)).name(), "right/same");
 }
 
+TEST_F(SystestStateTest, DirectlySpecifiedTestNamesMatchDiscoveredTestNames)
+{
+    const TemporaryDirectory tempDir;
+    const auto testFile = tempDir.get() / "left" / "same.test";
+    writeTextFile(testFile, "# groups:[Join]\n");
+
+    SystestConfiguration config;
+    config.testsDiscoverDir = tempDir.get().string();
+    config.testFileExtension = ".test";
+
+    const auto discoveredTestMap = loadTestFileMap(config);
+    config.directlySpecifiedTestFiles = testFile.string();
+    const auto directlySpecifiedTestMap = loadTestFileMap(config);
+    config.testQueryNumbers.add(1);
+    const auto queryFilteredTestMap = loadTestFileMap(config);
+
+    const auto canonicalTestFile = std::filesystem::weakly_canonical(testFile);
+    ASSERT_EQ(discoveredTestMap.size(), 1);
+    ASSERT_EQ(directlySpecifiedTestMap.size(), 1);
+    ASSERT_EQ(queryFilteredTestMap.size(), 1);
+    const auto discoveredTestName = discoveredTestMap.at(canonicalTestFile).name();
+    ASSERT_EQ(discoveredTestName, "left/same");
+    EXPECT_EQ(directlySpecifiedTestMap.at(canonicalTestFile).name(), discoveredTestName);
+    EXPECT_EQ(queryFilteredTestMap.at(canonicalTestFile).name(), discoveredTestName);
+}
+
+TEST_F(SystestStateTest, DirectlySpecifiedTestOutsideDiscoveryDirectoryUsesStem)
+{
+    const TemporaryDirectory tempDir;
+    const auto discoveryDirectory = tempDir.get() / "discovery";
+    const auto testFile = tempDir.get() / "outside" / "same.test";
+    std::filesystem::create_directories(discoveryDirectory);
+    writeTextFile(testFile, "# groups:[Join]\n");
+
+    SystestConfiguration config;
+    config.testsDiscoverDir = discoveryDirectory.string();
+    config.directlySpecifiedTestFiles = testFile.string();
+
+    const auto testMap = loadTestFileMap(config);
+
+    ASSERT_EQ(testMap.size(), 1);
+    EXPECT_EQ(testMap.at(std::filesystem::weakly_canonical(testFile)).name(), "same");
+}
+
 TEST_F(SystestStateTest, ResultFilesCreateDirectoriesForNestedTestNames)
 {
     const TemporaryDirectory tempDir;

--- a/nes-systests/systest/tests/SystestStateTests.cpp
+++ b/nes-systests/systest/tests/SystestStateTests.cpp
@@ -137,13 +137,15 @@ TEST_F(SystestStateTest, DirectlySpecifiedTestFileOverridesDisabledTestFiles)
     EXPECT_TRUE(testMap.contains(std::filesystem::weakly_canonical(joinFile)));
 }
 
-TEST_F(SystestStateTest, DiscoveredTestNamesIncludeRelativeDirectory)
+TEST_F(SystestStateTest, OnlyDuplicateDiscoveredTestNamesIncludeRelativeDirectory)
 {
     const TemporaryDirectory tempDir;
     const auto leftFile = tempDir.get() / "left" / "same.test";
     const auto rightFile = tempDir.get() / "right" / "same.test";
+    const auto uniqueFile = tempDir.get() / "right" / "unique.test";
     writeTextFile(leftFile, "# groups:[Join]\n");
     writeTextFile(rightFile, "# groups:[Join]\n");
+    writeTextFile(uniqueFile, "# groups:[Join]\n");
 
     SystestConfiguration config;
     config.testsDiscoverDir = tempDir.get().string();
@@ -151,12 +153,32 @@ TEST_F(SystestStateTest, DiscoveredTestNamesIncludeRelativeDirectory)
 
     const auto testMap = loadTestFileMap(config);
 
-    ASSERT_EQ(testMap.size(), 2);
+    ASSERT_EQ(testMap.size(), 3);
     EXPECT_EQ(testMap.at(std::filesystem::weakly_canonical(leftFile)).name(), "left/same");
     EXPECT_EQ(testMap.at(std::filesystem::weakly_canonical(rightFile)).name(), "right/same");
+    EXPECT_EQ(testMap.at(std::filesystem::weakly_canonical(uniqueFile)).name(), "unique");
 }
 
-TEST_F(SystestStateTest, DirectlySpecifiedTestNamesMatchDiscoveredTestNames)
+TEST_F(SystestStateTest, FilteredDuplicateTestNameUsesStem)
+{
+    const TemporaryDirectory tempDir;
+    const auto includedFile = tempDir.get() / "included" / "same.test";
+    const auto filteredFile = tempDir.get() / "filtered" / "same.test";
+    writeTextFile(includedFile, "# groups:[Included]\n");
+    writeTextFile(filteredFile, "# groups:[Filtered]\n");
+
+    SystestConfiguration config;
+    config.testsDiscoverDir = tempDir.get().string();
+    config.testFileExtension = ".test";
+    config.testGroups.add("Included");
+
+    const auto testMap = loadTestFileMap(config);
+
+    ASSERT_EQ(testMap.size(), 1);
+    EXPECT_EQ(testMap.at(std::filesystem::weakly_canonical(includedFile)).name(), "same");
+}
+
+TEST_F(SystestStateTest, DirectlySpecifiedTestNamesUseStem)
 {
     const TemporaryDirectory tempDir;
     const auto testFile = tempDir.get() / "left" / "same.test";
@@ -164,40 +186,17 @@ TEST_F(SystestStateTest, DirectlySpecifiedTestNamesMatchDiscoveredTestNames)
 
     SystestConfiguration config;
     config.testsDiscoverDir = tempDir.get().string();
-    config.testFileExtension = ".test";
-
-    const auto discoveredTestMap = loadTestFileMap(config);
     config.directlySpecifiedTestFiles = testFile.string();
+
     const auto directlySpecifiedTestMap = loadTestFileMap(config);
     config.testQueryNumbers.add(1);
     const auto queryFilteredTestMap = loadTestFileMap(config);
 
     const auto canonicalTestFile = std::filesystem::weakly_canonical(testFile);
-    ASSERT_EQ(discoveredTestMap.size(), 1);
     ASSERT_EQ(directlySpecifiedTestMap.size(), 1);
     ASSERT_EQ(queryFilteredTestMap.size(), 1);
-    const auto discoveredTestName = discoveredTestMap.at(canonicalTestFile).name();
-    ASSERT_EQ(discoveredTestName, "left/same");
-    EXPECT_EQ(directlySpecifiedTestMap.at(canonicalTestFile).name(), discoveredTestName);
-    EXPECT_EQ(queryFilteredTestMap.at(canonicalTestFile).name(), discoveredTestName);
-}
-
-TEST_F(SystestStateTest, DirectlySpecifiedTestOutsideDiscoveryDirectoryUsesStem)
-{
-    const TemporaryDirectory tempDir;
-    const auto discoveryDirectory = tempDir.get() / "discovery";
-    const auto testFile = tempDir.get() / "outside" / "same.test";
-    std::filesystem::create_directories(discoveryDirectory);
-    writeTextFile(testFile, "# groups:[Join]\n");
-
-    SystestConfiguration config;
-    config.testsDiscoverDir = discoveryDirectory.string();
-    config.directlySpecifiedTestFiles = testFile.string();
-
-    const auto testMap = loadTestFileMap(config);
-
-    ASSERT_EQ(testMap.size(), 1);
-    EXPECT_EQ(testMap.at(std::filesystem::weakly_canonical(testFile)).name(), "same");
+    EXPECT_EQ(directlySpecifiedTestMap.at(canonicalTestFile).name(), "same");
+    EXPECT_EQ(queryFilteredTestMap.at(canonicalTestFile).name(), "same");
 }
 
 TEST_F(SystestStateTest, ResultFilesCreateDirectoriesForNestedTestNames)


### PR DESCRIPTION
Fixes a limitation that discovered systest `.test` file names have to be unique.

I.e. the following crashes:
```
parser/regressionTests.test
operator/regressionTests.test
```

Stack PR to enable https://github.com/nebulastream/nebulastream/pull/1652.