### PR TITLE
ci: harden Docker image preparation

### DIFF
--- a/.github/steps/prepare-github/action.yml
+++ b/.github/steps/prepare-github/action.yml
@@ -1,11 +1,15 @@
 name: Prepare GitHub CI Server Instance
 description: |
-  Prepares a github ci server instance by removing unnecessary pre-installed software and pulling the docker image.
+  Prepares a github ci server instance by removing unnecessary pre-installed software and pulling Docker images.
 
 inputs:
-  image_name:
-    description: 'name of the docker image to prepare'
+  images:
+    description: 'newline-separated Docker images to preload'
     required: true
+  pull_timeout_minutes:
+    description: 'maximum minutes to retry each Docker image pull'
+    required: false
+    default: '10'
   docker_username:
     description: 'Docker Hub username for authenticated pulls'
     required: false
@@ -25,7 +29,47 @@ runs:
     - name: Maximize build space
       shell: bash
       run: |
-        docker pull ${{inputs.image_name}} &
+        pull_timeout_minutes="${{ inputs.pull_timeout_minutes }}"
+        if ! [[ "$pull_timeout_minutes" =~ ^[1-9][0-9]*$ ]]; then
+          echo "pull_timeout_minutes must be a positive integer, got: $pull_timeout_minutes" >&2
+          exit 1
+        fi
+        deadline=$((SECONDS + pull_timeout_minutes * 60))
+
+        pull_image() {
+          local image="$1" delay=1 remaining
+          until docker pull "$image"; do
+            remaining=$((deadline - SECONDS))
+            if ((remaining <= 0)); then
+              echo "Timed out pulling $image after ${pull_timeout_minutes} minutes" >&2
+              return 1
+            fi
+            if ((delay > remaining)); then
+              delay=$remaining
+            fi
+            echo "Retrying $image in ${delay}s" >&2
+            sleep "$delay"
+            if ((delay < 60)); then
+              delay=$((delay * 2))
+            fi
+            if ((delay > 60)); then
+              delay=60
+            fi
+          done
+        }
+
+        images=()
+        while IFS= read -r image; do
+          [ -n "$image" ] && images+=("$image")
+        done <<'EOF'
+        ${{ inputs.images }}
+        EOF
+
+        pids=()
+        for image in "${images[@]}"; do
+          pull_image "$image" &
+          pids+=("$!")
+        done
 
         df -h
         sudo rm -rf /usr/share/dotnet
@@ -33,4 +77,6 @@ runs:
         sudo rm -rf /opt/ghc
         sudo rm -rf /opt/hostedtoolcache/CodeQL
         df -h
-        wait
+        for pid in "${pids[@]}"; do
+          wait "$pid"
+        done

--- a/.github/steps/run-in-container/action.yml
+++ b/.github/steps/run-in-container/action.yml
@@ -32,6 +32,7 @@ runs:
         export DOCKER_HUB_USER="${{ inputs.docker_username }}"
         export DOCKER_HUB_PASS="${{ inputs.docker_password }}"
         docker run \
+             --pull=never \
              -v /var/run/docker.sock:/var/run/docker.sock \
              --group-add $(stat -c '%g' /var/run/docker.sock) \
              $DOCKER_LOGIN_ARGS \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -61,7 +61,6 @@ jobs:
         with:
           images: |
             nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{ matrix.sanitizer }}
-            nebulastream/nes-development:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{ matrix.sanitizer }}
             nebulastream/nes-runtime-base:${{ inputs.dev_image_tag }}
           docker_username: ${{ secrets.DOCKER_USER_NAME }}
           docker_password: ${{ secrets.DOCKER_SECRET }}
@@ -98,7 +97,7 @@ jobs:
         name: Run System Tests
         if: ${{ matrix.run_systest }}
         with:
-          image_name: nebulastream/nes-development:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{ matrix.sanitizer }}
+          image_name: nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{ matrix.sanitizer }}
           run: |
             source .github/.env/test-${{ matrix.sanitizer }}.env
             ctest --test-dir build -j -L Systest --output-on-failure --output-junit build/junit-systest.xml --timeout 4800 ${ADDITIONAL_CTEST_ARGS}
@@ -107,7 +106,7 @@ jobs:
         name: Run Docker Tests
         if: ${{ matrix.run_docker }}
         with:
-          image_name: nebulastream/nes-development:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{ matrix.sanitizer }}
+          image_name: nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{ matrix.sanitizer }}
           run: |
             source .github/.env/test-${{ matrix.sanitizer }}.env
             ctest --test-dir build -j 1 -L DockerCompose --output-on-failure --output-junit build/junit-docker.xml --timeout 2400 ${ADDITIONAL_CTEST_ARGS}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -59,7 +59,10 @@ jobs:
       - uses: ./.github/steps/prepare-github
         name: Preparing Github Runners
         with:
-          image_name: nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{ matrix.sanitizer }}
+          images: |
+            nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{ matrix.sanitizer }}
+            nebulastream/nes-development:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{ matrix.sanitizer }}
+            nebulastream/nes-runtime-base:${{ inputs.dev_image_tag }}
           docker_username: ${{ secrets.DOCKER_USER_NAME }}
           docker_password: ${{ secrets.DOCKER_SECRET }}
 
@@ -151,7 +154,8 @@ jobs:
           secret_key: ${{ secrets.SCCACHE_CACHE_SECRET_KEY }}
       - uses: ./.github/steps/prepare-github
         with:
-          image_name: nebulastream/nes-ci:${{ inputs.dev_image_tag }}-libcxx-none
+          images: |
+            nebulastream/nes-ci:${{ inputs.dev_image_tag }}-libcxx-none
           docker_username: ${{ secrets.DOCKER_USER_NAME }}
           docker_password: ${{ secrets.DOCKER_SECRET }}
       - uses: ./.github/steps/run-in-container
@@ -193,7 +197,9 @@ jobs:
       - uses: ./.github/steps/prepare-github
         name: Preparing Github Runners
         with:
-          image_name: nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{ matrix.sanitizer }}
+          images: |
+            nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{ matrix.sanitizer }}
+            nebulastream/nes-runtime-base:${{ inputs.dev_image_tag }}
           docker_username: ${{ secrets.DOCKER_USER_NAME }}
           docker_password: ${{ secrets.DOCKER_SECRET }}
       - uses: ./.github/steps/run-in-container
@@ -266,4 +272,3 @@ jobs:
             echo "clean-build-and-test-linux result: ${{ needs.clean-build-and-test-linux.result }}"
             exit 1
           fi
-

--- a/.github/workflows/clang_tidy_diff.yml
+++ b/.github/workflows/clang_tidy_diff.yml
@@ -61,7 +61,8 @@ jobs:
           secret_key: ${{ secrets.SCCACHE_CACHE_SECRET_KEY }}
       - uses: ./.github/steps/prepare-github
         with:
-          image_name: nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{matrix.sanitizer}}
+          images: |
+            nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{matrix.sanitizer}}
       - uses: ./.github/steps/run-in-container
         name: CMake Build
         with:

--- a/.github/workflows/endless-mode.yml
+++ b/.github/workflows/endless-mode.yml
@@ -46,7 +46,8 @@ jobs:
           secret_key: ${{ secrets.SCCACHE_CACHE_SECRET_KEY }}
       - uses: ./.github/steps/prepare-github
         with:
-          image_name: nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{matrix.sanitizer}}
+          images: |
+            nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{matrix.sanitizer}}
       - uses: ./.github/steps/run-in-container
         with:
           image_name: nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{matrix.sanitizer}}

--- a/.github/workflows/get_dev_images.yml
+++ b/.github/workflows/get_dev_images.yml
@@ -122,6 +122,35 @@ jobs:
     steps:
       - run: echo "Acquired lock for ${{ needs.detect-dependency-changes.outputs.tag }}"
 
+  build-runtime-image:
+    name: "Build Runtime Base Image"
+    needs: [ detect-dependency-changes, lock ]
+    if: needs.detect-dependency-changes.outputs.build-dependency == 'true'
+    runs-on: [ self-hosted, linux, Build, "${{ matrix.arch }}", dep-builder ]
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ x64, arm64 ]
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.head_sha }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER_NAME }}
+          password: ${{ secrets.DOCKER_SECRET }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: false
+      - uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: nebulastream/nes-runtime-base:${{ needs.detect-dependency-changes.outputs.tag }}-${{ matrix.arch }}
+          context: .
+          file: docker/runtime/RuntimeBase.dockerfile
+
   build-dev-images:
     # We run the docker image build on separate machines and combine them into a single
     # multi-arch docker image in the docker-development-images job.
@@ -214,8 +243,8 @@ jobs:
   merge-dev-images:
     # This Job merges platform specific images into a single multi-platform image
     name: "Merge Dev Images"
-    needs: [ build-dev-images, detect-dependency-changes ]
-    if: needs.detect-dependency-changes.outputs.build-dependency == 'true' && needs.build-dev-images.result == 'success'
+    needs: [ build-dev-images, build-runtime-image, detect-dependency-changes ]
+    if: needs.detect-dependency-changes.outputs.build-dependency == 'true' && needs.build-dev-images.result == 'success' && needs.build-runtime-image.result == 'success'
     runs-on: [ self-hosted, linux, Build, x64 ]
     steps:
       - uses: actions/checkout@v5
@@ -247,35 +276,68 @@ jobs:
       - name: Combine Manifests
         shell: bash
         run: |
-          docker buildx imagetools create -t nebulastream/nes-development-base:${{ needs.detect-dependency-changes.outputs.tag }} \
+          deadline=$((SECONDS + 600))
+          retry_merge() {
+            local delay=1 remaining
+            until docker buildx imagetools create "$@"; do
+              remaining=$((deadline - SECONDS))
+              if ((remaining <= 0)); then
+                echo "Timed out merging $1" >&2
+                return 1
+              fi
+              if ((delay > remaining)); then delay=$remaining; fi
+              echo "Retrying merge of $1 in ${delay}s" >&2
+              sleep "$delay"
+              if ((delay < 60)); then delay=$((delay * 2)); fi
+              if ((delay > 60)); then delay=60; fi
+            done
+          }
+
+          pids=()
+          merge() { retry_merge "$@" & pids+=("$!"); }
+
+          merge -t nebulastream/nes-development-base:${{ needs.detect-dependency-changes.outputs.tag }} \
             nebulastream/nes-development-base:${{ needs.detect-dependency-changes.outputs.tag }}-x64 \
             nebulastream/nes-development-base:${{ needs.detect-dependency-changes.outputs.tag }}-arm64
+
+          merge -t nebulastream/nes-runtime-base:${{ needs.detect-dependency-changes.outputs.tag }} \
+            nebulastream/nes-runtime-base:${{ needs.detect-dependency-changes.outputs.tag }}-x64 \
+            nebulastream/nes-runtime-base:${{ needs.detect-dependency-changes.outputs.tag }}-arm64
           
           for image_tag in development-dependency development ci; do
           
             for sanitizer in none address thread undefined; do
-              docker buildx imagetools create -t nebulastream/nes-$image_tag:${{ needs.detect-dependency-changes.outputs.tag }}-libcxx-$sanitizer \
+              merge -t nebulastream/nes-$image_tag:${{ needs.detect-dependency-changes.outputs.tag }}-libcxx-$sanitizer \
                 nebulastream/nes-$image_tag:${{ needs.detect-dependency-changes.outputs.tag }}-x64-libcxx-$sanitizer \
                 nebulastream/nes-$image_tag:${{ needs.detect-dependency-changes.outputs.tag }}-arm64-libcxx-$sanitizer
           
-              docker buildx imagetools create -t nebulastream/nes-$image_tag:${{ needs.detect-dependency-changes.outputs.tag }}-libstdcxx-$sanitizer \
+              merge -t nebulastream/nes-$image_tag:${{ needs.detect-dependency-changes.outputs.tag }}-libstdcxx-$sanitizer \
                 nebulastream/nes-$image_tag:${{ needs.detect-dependency-changes.outputs.tag }}-x64-libstdcxx-$sanitizer 
             done
           
           done
           
-          docker buildx imagetools create -t nebulastream/nes-benchmark:${{ needs.detect-dependency-changes.outputs.tag }}-libcxx \
+          merge -t nebulastream/nes-benchmark:${{ needs.detect-dependency-changes.outputs.tag }}-libcxx \
             nebulastream/nes-benchmark:${{ needs.detect-dependency-changes.outputs.tag }}-x64-libcxx \
             nebulastream/nes-benchmark:${{ needs.detect-dependency-changes.outputs.tag }}-arm64-libcxx
           
-          docker buildx imagetools create -t nebulastream/nes-benchmark:${{ needs.detect-dependency-changes.outputs.tag }}-libstdcxx \
+          merge -t nebulastream/nes-benchmark:${{ needs.detect-dependency-changes.outputs.tag }}-libstdcxx \
             nebulastream/nes-benchmark:${{ needs.detect-dependency-changes.outputs.tag }}-x64-libstdcxx
+
+          failed=0
+          for pid in "${pids[@]}"; do
+            if ! wait "$pid"; then failed=1; fi
+          done
+          exit "$failed"
 
       - name: Combine Manifests for branch specific docker image
         if: ${{ inputs.branch-name != '' }}
         run: |
           docker buildx imagetools create -t nebulastream/nes-development-base:${{ steps.sanitize.outputs.branch-name }} \
             nebulastream/nes-development-base:${{ needs.detect-dependency-changes.outputs.tag }}
+
+          docker buildx imagetools create -t nebulastream/nes-runtime-base:${{ steps.sanitize.outputs.branch-name }} \
+            nebulastream/nes-runtime-base:${{ needs.detect-dependency-changes.outputs.tag }}
 
           for image_tag in development-dependency development ci; do
             for sanitizer in none address thread undefined; do

--- a/.github/workflows/large_test.yml
+++ b/.github/workflows/large_test.yml
@@ -99,7 +99,7 @@ jobs:
   systest-remote-test:
     name: "Run systest remote test on ${{matrix.arch}} with ${{matrix.stdlib}}"
     container:
-      image: nebulastream/nes-development:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{ matrix.sanitizer }}
+      image: nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{ matrix.sanitizer }}
       volumes:
         - ccache:/ccache
         - test-file-cache:/test-file-cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,10 +236,20 @@ if (NES_ENABLES_TESTS)
     enable_testing()
     message(STATUS "Tests are enabled")
     if (ENABLE_DOCKER_TESTS)
-        set(NES_RUNTIME_BASE_IMAGE "nes-runtime-base:test" CACHE STRING "Docker image name for the runtime base used by DockerCompose tests")
+        if (NOT DEFINED VCPKG_HASH)
+            execute_process(
+                    COMMAND ${CMAKE_SOURCE_DIR}/docker/dependency/hash_dependencies.sh
+                    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                    OUTPUT_VARIABLE VCPKG_HASH
+                    OUTPUT_STRIP_TRAILING_WHITESPACE
+                    COMMAND_ERROR_IS_FATAL ANY
+            )
+        endif ()
+        set(NES_RUNTIME_BASE_IMAGE "nebulastream/nes-runtime-base:${VCPKG_HASH}" CACHE STRING "Docker image name for the runtime base used by DockerCompose tests")
         add_test(NAME build-runtime-base-image
-                COMMAND docker build --load -t ${NES_RUNTIME_BASE_IMAGE}
-                -f ${CMAKE_SOURCE_DIR}/docker/runtime/RuntimeBase.dockerfile
+                COMMAND bash -c "docker image inspect \"$0\" >/dev/null 2>&1 || docker build --load -t \"$0\" -f \"$1\" \"$2\""
+                ${NES_RUNTIME_BASE_IMAGE}
+                ${CMAKE_SOURCE_DIR}/docker/runtime/RuntimeBase.dockerfile
                 ${CMAKE_SOURCE_DIR}/docker/runtime
         )
         set_tests_properties(build-runtime-base-image PROPERTIES

--- a/docker/dependency/hash_dependencies.sh
+++ b/docker/dependency/hash_dependencies.sh
@@ -28,6 +28,7 @@ cd "$(git rev-parse --show-toplevel)"
 HASH_PATHS=(
   vcpkg
   docker/dependency
+  docker/runtime
 )
 # Auto-discover all Cargo manifests + lockfiles (any depth) under each Rust workspace.
 # Adding a new workspace later only requires extending the list of roots passed to find.

--- a/docker/runtime/RuntimeBase.dockerfile
+++ b/docker/runtime/RuntimeBase.dockerfile
@@ -3,6 +3,7 @@
 # Contains only the runtime dependencies: libc++, grpc_health_probe, and basic utilities.
 # This image is pre-built and pushed to the registry so that downstream images
 # (worker, CLI, REPL, test containers) can skip network-heavy apt/wget steps at build time.
+# Changes to this image are included in the development-image dependency hash.
 FROM ubuntu:25.04
 
 ARG LLVM_TOOLCHAIN_VERSION=19

--- a/scripts/testing/distributed_bats_lib.bash
+++ b/scripts/testing/distributed_bats_lib.bash
@@ -104,7 +104,7 @@ nes_build_runtime_image() {
   local image_tag="${prefix}-${suffix}"
   local ctx=$(mktemp -d)
   cp "$(realpath "$bin_path")" "$ctx/$container_bin"
-  docker build --load -t "$image_tag" -f - "$ctx" <<EOF
+  docker build --pull=false --network=none --load -t "$image_tag" -f - "$ctx" <<EOF
     FROM $NES_RUNTIME_BASE_IMAGE
     COPY $container_bin /usr/bin
     ENTRYPOINT ["$container_bin"]
@@ -125,7 +125,7 @@ nes_build_app_image() {
   local image_tag="${prefix}-${suffix}"
   local ctx=$(mktemp -d)
   cp "$(realpath "$bin_path")" "$ctx/$container_bin"
-  docker build --load -t "$image_tag" -f - "$ctx" <<EOF
+  docker build --pull=false --network=none --load -t "$image_tag" -f - "$ctx" <<EOF
     FROM $NES_RUNTIME_BASE_IMAGE
     COPY $container_bin /usr/bin
 EOF


### PR DESCRIPTION
## Summary
- preload all Docker images needed by CI jobs
- retry image pulls and manifest merges with bounded exponential backoff
- include and publish the runtime-base image with dependency images

## Test plan
- CI workflow validation
- Local YAML, shell, and retry checks