### PR TITLE
Fix(#1553) sql-parser: reject multi-argument type constructors

### DIFF
--- a/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
+++ b/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
@@ -1208,6 +1208,11 @@ void AntlrSQLQueryPlanCreator::exitFunctionCall(AntlrSQLParser::FunctionCallCont
             /// Check if the function is a constructor for a datatype
             if (const auto dataType = DataTypeProvider::tryProvideDataType(funcName); dataType.has_value())
             {
+                if (const auto numArgs = context->argument.size(); numArgs != 1)
+                {
+                    throw InvalidQuerySyntax(
+                        "Type constructor {} expects exactly 1 argument, got {} at {}", funcName, numArgs, context->getText());
+                }
                 if (helpers.top().constantBuilder.empty())
                 {
                     throw InvalidQuerySyntax("Expected constant, got nothing at {}", context->getText());

--- a/nes-systests/datatype/TypeConstructorMultipleArguments.test
+++ b/nes-systests/datatype/TypeConstructorMultipleArguments.test
@@ -1,0 +1,43 @@
+# name: datatype/TypeConstructorMultipleArguments.test
+# description: Type constructors with multiple arguments should be rejected
+# groups: [DataTypes, Parser]
+
+CREATE LOGICAL SOURCE single(id UINT64 NOT NULL);
+CREATE PHYSICAL SOURCE FOR single TYPE File;
+ATTACH INLINE
+42
+
+# Positive control: a type constructor with exactly one argument works
+SELECT UINT32(1) AS v FROM single INTO File();
+----
+1
+
+# Multiple string args to VARSIZED must be rejected
+SELECT VARSIZED('hello', 'world') AS v FROM single INTO File();
+----
+ERROR 2000
+
+# Multiple numeric args to UINT32 must be rejected
+SELECT UINT32(1, 2) AS v FROM single INTO File();
+----
+ERROR 2000
+
+# Multiple numeric args to UINT64 must be rejected
+SELECT UINT64(1, 2, 3) AS v FROM single INTO File();
+----
+ERROR 2000
+
+# Multiple numeric args to INT32 must be rejected
+SELECT INT32(1, 2) AS v FROM single INTO File();
+----
+ERROR 2000
+
+# Multiple numeric args to FLOAT64 must be rejected
+SELECT FLOAT64(1.0, 2.0) AS v FROM single INTO File();
+----
+ERROR 2000
+
+# A type constructor with zero arguments must be rejected as well
+SELECT UINT32() AS v FROM single INTO File();
+----
+ERROR 2000

--- a/nes-systests/datatype/TypeConstructorMultipleArguments.test
+++ b/nes-systests/datatype/TypeConstructorMultipleArguments.test
@@ -7,8 +7,9 @@ CREATE PHYSICAL SOURCE FOR single TYPE File;
 ATTACH INLINE
 42
 
-# Positive control: a type constructor with exactly one argument works
-SELECT UINT32(1) AS v FROM single INTO File();
+# Positive control: a type constructor with exactly one argument works.
+# The WHERE clause ensures the query accesses a source field: constant-only projections are not supported by the query compiler.
+SELECT UINT32(1) AS v FROM single WHERE id == 42 INTO File();
 ----
 1
 


### PR DESCRIPTION
## Root cause

In `AntlrSQLQueryPlanCreator::exitFunctionCall`, the datatype-constructor branch (`UINT32(...)`, `VARSIZED(...)`, ...) popped a single value from `constantBuilder.back()` without ever checking `context->argument.size()`. With `UINT32(1, 2)` the parser therefore built a `ConstantValueLogicalFunction` from the last argument only and silently discarded (and leaked into `constantBuilder`) the rest.

## Fix

Validate in the parser that a type constructor is called with exactly one argument and throw `InvalidQuerySyntax` (error 2000) otherwise, e.g. `Type constructor UINT32 expects exactly 1 argument, got 3 at UINT32(1,2,3)`. This also turns the zero-argument case `UINT32()` into a clear error instead of depending on whatever happened to be in the constant builder.

The deeper registry level is already safe: `RegisterCastToTypeLogicalFunction` rejects child counts != 1 with `CannotDeserialize`.

## Tests

New systest `nes-systests/datatype/TypeConstructorMultipleArguments.test` with the five negative cases from the issue (`VARSIZED('hello','world')`, `UINT32(1,2)`, `UINT64(1,2,3)`, `INT32(1,2)`, `FLOAT64(1.0,2.0)`), a zero-argument negative case, and a single-argument positive control.

Closes #1553

🤖 Generated with [Claude Code](https://claude.com/claude-code)