### PR TITLE
Task(#1579): construct TestTupleBuffer from the physical layout instead of Schema

### DIFF
--- a/nes-nautilus/tests/TestTupleBufferTest.cpp
+++ b/nes-nautilus/tests/TestTupleBufferTest.cpp
@@ -73,7 +73,7 @@ public:
 TEST_F(TestTupleBufferTest, AppendAndReadSingleField)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("value"), DataType::Type::INT64}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb = Testing::TestTupleBuffer::fromSchema(schema, bufferManager->getBufferSize());
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -89,7 +89,7 @@ TEST_F(TestTupleBufferTest, AppendAndReadMultipleFields)
     auto schema = Testing::TestSchema{
         UnqualifiedUnboundField{Identifier::parse("a"), DataType::Type::INT64},
         UnqualifiedUnboundField{Identifier::parse("b"), DataType::Type::UINT32}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb = Testing::TestTupleBuffer::fromSchema(schema, bufferManager->getBufferSize());
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -104,7 +104,7 @@ TEST_F(TestTupleBufferTest, AppendAndReadMultipleFields)
 TEST_F(TestTupleBufferTest, AppendMultipleRecords)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("x"), DataType::Type::INT32}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb = Testing::TestTupleBuffer::fromSchema(schema, bufferManager->getBufferSize());
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -122,7 +122,7 @@ TEST_F(TestTupleBufferTest, AppendMultipleRecords)
 TEST_F(TestTupleBufferTest, IndexedWriteAndRead)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("val"), DataType::Type::INT64}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb = Testing::TestTupleBuffer::fromSchema(schema, bufferManager->getBufferSize());
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -139,7 +139,7 @@ TEST_F(TestTupleBufferTest, IndexedWriteAndRead)
 TEST_F(TestTupleBufferTest, OutOfBoundsThrows)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("f"), DataType::Type::INT32}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb = Testing::TestTupleBuffer::fromSchema(schema, bufferManager->getBufferSize());
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -154,7 +154,7 @@ TEST_F(TestTupleBufferTest, OutOfBoundsThrows)
 TEST_F(TestTupleBufferTest, UnknownFieldThrows)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("exists"), DataType::Type::INT32}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb = Testing::TestTupleBuffer::fromSchema(schema, bufferManager->getBufferSize());
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -167,7 +167,7 @@ TEST_F(TestTupleBufferTest, UnknownFieldThrows)
 TEST_F(TestTupleBufferTest, TypeMismatchThrows)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("i64"), DataType::Type::INT64}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb = Testing::TestTupleBuffer::fromSchema(schema, bufferManager->getBufferSize());
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -181,7 +181,7 @@ TEST_F(TestTupleBufferTest, TypeMismatchThrows)
 TEST_F(TestTupleBufferTest, DanglingFieldViewThrows)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("f"), DataType::Type::INT32}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb = Testing::TestTupleBuffer::fromSchema(schema, bufferManager->getBufferSize());
 
     Testing::FieldView captured;
     {
@@ -198,7 +198,7 @@ TEST_F(TestTupleBufferTest, DanglingFieldViewThrows)
 TEST_F(TestTupleBufferTest, StringField)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("name"), DataType::Type::VARSIZED}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb = Testing::TestTupleBuffer::fromSchema(schema, bufferManager->getBufferSize());
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer, bufferManager.get());
@@ -214,7 +214,7 @@ TEST_F(TestTupleBufferTest, MixedFixedAndVarSizedFields)
     auto schema = Testing::TestSchema{
         UnqualifiedUnboundField{Identifier::parse("id"), DataType::Type::INT64},
         UnqualifiedUnboundField{Identifier::parse("label"), DataType::Type::VARSIZED}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb = Testing::TestTupleBuffer::fromSchema(schema, bufferManager->getBufferSize());
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer, bufferManager.get());
@@ -232,7 +232,7 @@ TEST_F(TestTupleBufferTest, MixedFixedAndVarSizedFields)
 TEST_F(TestTupleBufferTest, BooleanField)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("flag"), DataType::Type::BOOLEAN}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb = Testing::TestTupleBuffer::fromSchema(schema, bufferManager->getBufferSize());
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -250,7 +250,7 @@ TEST_F(TestTupleBufferTest, FloatingPointFields)
     auto schema = Testing::TestSchema{
         UnqualifiedUnboundField{Identifier::parse("f32"), DataType::Type::FLOAT32},
         UnqualifiedUnboundField{Identifier::parse("f64"), DataType::Type::FLOAT64}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb = Testing::TestTupleBuffer::fromSchema(schema, bufferManager->getBufferSize());
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -268,7 +268,7 @@ TEST_F(TestTupleBufferTest, AppendImplicitCastFromInt)
     auto schema = Testing::TestSchema{
         UnqualifiedUnboundField{Identifier::parse("a"), DataType::Type::INT64},
         UnqualifiedUnboundField{Identifier::parse("b"), DataType::Type::UINT32}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb = Testing::TestTupleBuffer::fromSchema(schema, bufferManager->getBufferSize());
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -288,7 +288,7 @@ TEST_F(TestTupleBufferTest, AppendImplicitCastMultipleRecords)
         UnqualifiedUnboundField{Identifier::parse("i8"), DataType::Type::INT8},
         UnqualifiedUnboundField{Identifier::parse("u64"), DataType::Type::UINT64},
         UnqualifiedUnboundField{Identifier::parse("f32"), DataType::Type::FLOAT32}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb = Testing::TestTupleBuffer::fromSchema(schema, bufferManager->getBufferSize());
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -312,7 +312,7 @@ TEST_F(TestTupleBufferTest, AppendImplicitCastStringLiteral)
     auto schema = Testing::TestSchema{
         UnqualifiedUnboundField{Identifier::parse("id"), DataType::Type::INT32},
         UnqualifiedUnboundField{Identifier::parse("name"), DataType::Type::VARSIZED}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb = Testing::TestTupleBuffer::fromSchema(schema, bufferManager->getBufferSize());
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer, bufferManager.get());
@@ -329,7 +329,7 @@ TEST_F(TestTupleBufferTest, AppendImplicitCastStringLiteral)
 TEST_F(TestTupleBufferTest, AppendImplicitCastStringToNumericThrows)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("value"), DataType::Type::INT64}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb = Testing::TestTupleBuffer::fromSchema(schema, bufferManager->getBufferSize());
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -343,7 +343,7 @@ TEST_F(TestTupleBufferTest, NullableFieldRoundTrip)
 {
     auto schema = Testing::TestSchema{
         UnqualifiedUnboundField{Identifier::parse("v"), DataType{DataType::Type::INT64, DataType::NULLABLE::IS_NULLABLE}}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb = Testing::TestTupleBuffer::fromSchema(schema, bufferManager->getBufferSize());
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer, bufferManager.get());
@@ -369,7 +369,7 @@ TEST_F(TestTupleBufferTest, NullableFieldReadWithoutOptionalThrows)
 {
     auto schema = Testing::TestSchema{
         UnqualifiedUnboundField{Identifier::parse("v"), DataType{DataType::Type::INT64, DataType::NULLABLE::IS_NULLABLE}}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb = Testing::TestTupleBuffer::fromSchema(schema, bufferManager->getBufferSize());
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer, bufferManager.get());
@@ -382,7 +382,7 @@ TEST_F(TestTupleBufferTest, NullableFieldReadWithoutOptionalThrows)
 TEST_F(TestTupleBufferTest, NonNullableFieldReadWithOptionalThrows)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("v"), DataType::Type::INT64}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb = Testing::TestTupleBuffer::fromSchema(schema, bufferManager->getBufferSize());
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer, bufferManager.get());
@@ -395,7 +395,7 @@ TEST_F(TestTupleBufferTest, NonNullableFieldReadWithOptionalThrows)
 TEST_F(TestTupleBufferTest, NullWriteToNonNullableFieldThrows)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("v"), DataType::Type::INT64}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb = Testing::TestTupleBuffer::fromSchema(schema, bufferManager->getBufferSize());
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer, bufferManager.get());
@@ -409,7 +409,7 @@ TEST_F(TestTupleBufferTest, NullWriteToNonNullableFieldThrows)
 TEST_F(TestTupleBufferTest, GetWithWrongTypeThrows)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("v"), DataType::Type::INT64}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb = Testing::TestTupleBuffer::fromSchema(schema, bufferManager->getBufferSize());
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer, bufferManager.get());
@@ -423,7 +423,7 @@ TEST_F(TestTupleBufferTest, NullableVarsizedRoundTrip)
 {
     auto schema = Testing::TestSchema{
         UnqualifiedUnboundField{Identifier::parse("s"), DataType{DataType::Type::VARSIZED, DataType::NULLABLE::IS_NULLABLE}}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb = Testing::TestTupleBuffer::fromSchema(schema, bufferManager->getBufferSize());
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer, bufferManager.get());

--- a/nes-nautilus/tests/TestUtils/include/TestTupleBuffer.hpp
+++ b/nes-nautilus/tests/TestUtils/include/TestTupleBuffer.hpp
@@ -25,12 +25,14 @@
 #include <type_traits>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include <DataTypes/DataType.hpp>
 #include <DataTypes/Schema.hpp>
 #include <DataTypes/SchemaFwd.hpp>
 #include <DataTypes/UnboundField.hpp>
 #include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/Record.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
 #include <Util/TypeTraits.hpp>
@@ -107,19 +109,23 @@ class FieldView;
 
 using TestSchema = Schema<UnqualifiedUnboundField, Ordered>;
 
-/// Entry point. Holds schema config.
+/// Entry point. Holds the physical buffer layout (a lowered TupleBufferRef) — no logical schema.
 class TestTupleBuffer
 {
 public:
-    explicit TestTupleBuffer(TestSchema schema);
+    /// Constructs from a physical buffer layout, e.g., produced by LowerSchemaProvider::lowerSchema.
+    explicit TestTupleBuffer(std::shared_ptr<TupleBufferRef> bufferRef);
 
-    /// Wraps an existing TupleBuffer for schema-aware access.
+    /// Convenience factory: lowers the schema to a row-layout TupleBufferRef for buffers of `bufferSize` bytes.
+    static TestTupleBuffer fromSchema(const TestSchema& schema, uint64_t bufferSize);
+
+    /// Wraps an existing TupleBuffer for layout-aware access.
     /// bufferProvider required for VARSIZED (string) field support.
     /// NOLINTNEXTLINE(fuchsia-default-arguments-declarations) convenience default for non-VARSIZED use
     TestTupleBufferView open(TupleBuffer& buffer, AbstractBufferProvider* bufferProvider = nullptr);
 
 private:
-    TestSchema schema;
+    std::shared_ptr<TupleBufferRef> bufferRef;
 };
 
 /// View over a TupleBuffer. Supports append and indexed record access.
@@ -129,9 +135,9 @@ public:
     /// Access record at index. Throws if index >= getNumberOfTuples().
     TestTupleBufferRecordView operator[](size_t index);
 
-    /// Append a record with values matching schema fields left-to-right.
+    /// Append a record with values matching layout fields left-to-right.
     /// Supports implicit numeric casting: append(10, 200) works when the
-    /// schema declares INT64 and UINT32 fields.
+    /// layout declares INT64 and UINT32 fields.
     template <typename... Args>
     void append(Args&&... values);
 
@@ -144,7 +150,8 @@ private:
 
     struct Impl
     {
-        TestSchema schema;
+        std::vector<Record::RecordFieldIdentifier> fieldNames;
+        std::vector<DataType> fieldTypes;
         TupleBuffer&
             buffer; /// NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members) intentional reference: Impl always outlived by the TupleBuffer it wraps
         AbstractBufferProvider* bufferProvider;
@@ -156,7 +163,7 @@ private:
     /// Append helper — writes each (possibly null) FieldValue as a full Record via bufRef->writeRecord.
     void appendImpl(std::span<const std::optional<FieldValue>> values);
 
-    /// Converts an argument to a (possibly null) FieldValue, casting to the schema's expected type.
+    /// Converts an argument to a (possibly null) FieldValue, casting to the layout's expected type.
     /// Accepts plain values (T), `std::nullopt` for null, and `std::optional<T>` for either.
     template <typename T>
     static std::optional<FieldValue> toFieldValue(T&& arg, DataType::Type targetType);
@@ -166,7 +173,7 @@ private:
 class TestTupleBufferRecordView
 {
 public:
-    /// Access field by name. Throws if field not in schema.
+    /// Access field by name. Throws if field not in the layout.
     FieldView operator[](const std::string& fieldName);
 
 private:
@@ -180,17 +187,17 @@ private:
 class FieldView
 {
 public:
-    /// Write a non-null value — type-checked against the schema DataType. Works for
+    /// Write a non-null value — type-checked against the layout DataType. Works for
     /// both nullable and non-nullable fields.
     FieldView& operator=(const FieldValue& value);
 
-    /// Write null — only valid for fields declared nullable in the schema.
+    /// Write null — only valid for fields declared nullable in the layout.
     FieldView& operator=(std::nullopt_t);
 
     /// Read a typed value. T must match the field's `DataType::Type`.
     /// - `as<T>()` reads a non-nullable field.
     /// - `as<std::optional<T>>()` reads a nullable field, returning `nullopt` when null.
-    /// Throws if T does not match the schema type or the schema's nullability.
+    /// Throws if T does not match the layout type or the layout's nullability.
     template <typename T>
     T as() const;
 
@@ -249,7 +256,7 @@ std::optional<FieldValue> TestTupleBufferView::toFieldValue(T&& arg, DataType::T
         }
         return FieldValue(arg);
     }
-    /// Arithmetic types — cast to the schema's expected type.
+    /// Arithmetic types — cast to the layout's expected type.
     else if constexpr (std::is_arithmetic_v<Raw>)
     {
         switch (targetType)
@@ -290,13 +297,12 @@ template <typename... Args>
 void TestTupleBufferView::append(Args&&... values)
 {
     static_assert(sizeof...(Args) > 0, "append requires at least one argument");
-    if (sizeof...(Args) != impl->schema.size())
+    if (sizeof...(Args) != impl->fieldTypes.size())
     {
-        throw TestException("append requires exactly {} arguments, got {}", impl->schema.size(), sizeof...(Args));
+        throw TestException("append requires exactly {} arguments, got {}", impl->fieldTypes.size(), sizeof...(Args));
     }
-    auto fieldIt = impl->schema.begin();
-    const std::array<std::optional<FieldValue>, sizeof...(Args)> fieldValues{
-        toFieldValue(std::forward<Args>(values), (fieldIt++)->getDataType().type)...};
+    auto typeIt = impl->fieldTypes.begin();
+    const std::array<std::optional<FieldValue>, sizeof...(Args)> fieldValues{toFieldValue(std::forward<Args>(values), (typeIt++)->type)...};
     appendImpl(fieldValues);
 }
 
@@ -312,7 +318,7 @@ T FieldView::as() const
         }
         if (dataType.type != detail::expectedType<Inner>())
         {
-            throw TestException("FieldView::as<std::optional<T>>(): T does not match the schema type of field '{}'", fieldName);
+            throw TestException("FieldView::as<std::optional<T>>(): T does not match the layout type of field '{}'", fieldName);
         }
         auto value = readFieldValue();
         if (!value.has_value())
@@ -329,7 +335,7 @@ T FieldView::as() const
         }
         if (dataType.type != detail::expectedType<T>())
         {
-            throw TestException("FieldView::as<T>(): T does not match the schema type of field '{}'", fieldName);
+            throw TestException("FieldView::as<T>(): T does not match the layout type of field '{}'", fieldName);
         }
         auto value = readFieldValue();
         return std::get<T>(*value);

--- a/nes-nautilus/tests/TestUtils/src/TestTupleBuffer.cpp
+++ b/nes-nautilus/tests/TestUtils/src/TestTupleBuffer.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <memory>
 #include <optional>
 #include <ranges>
@@ -34,6 +35,7 @@
 #include <DataTypes/VariableSizedData.hpp>
 #include <Identifiers/Identifier.hpp>
 #include <Interface/BufferRef/LowerSchemaProvider.hpp>
+#include <Interface/BufferRef/TupleBufferRef.hpp>
 #include <Interface/Record.hpp>
 #include <Interface/RecordBuffer.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
@@ -223,17 +225,36 @@ std::optional<FieldValue> varValToFieldValue(const VarVal& value, const DataType
 
 /// ---- TestTupleBuffer ----
 
-TestTupleBuffer::TestTupleBuffer(TestSchema schema) : schema(std::move(schema))
+TestTupleBuffer::TestTupleBuffer(std::shared_ptr<TupleBufferRef> bufferRef) : bufferRef(std::move(bufferRef))
 {
+    if (this->bufferRef == nullptr)
+    {
+        throw TestException("TestTupleBuffer requires a non-null TupleBufferRef");
+    }
+}
+
+TestTupleBuffer TestTupleBuffer::fromSchema(const TestSchema& schema, const uint64_t bufferSize)
+{
+    return TestTupleBuffer{LowerSchemaProvider::lowerSchema(bufferSize, schema, MemoryLayoutType::ROW_LAYOUT)};
 }
 
 TestTupleBufferView TestTupleBuffer::open(TupleBuffer& buffer, AbstractBufferProvider* bufferProvider)
 {
-    auto bufRef = LowerSchemaProvider::lowerSchema(buffer.getBufferSize(), schema, MemoryLayoutType::ROW_LAYOUT);
+    if (buffer.getBufferSize() != bufferRef->getBufferSize())
+    {
+        throw TestException(
+            "TestTupleBuffer: layout was lowered for buffers of {} bytes, but got a buffer of {} bytes",
+            bufferRef->getBufferSize(),
+            buffer.getBufferSize());
+    }
 
     TestTupleBufferView view;
-    view.impl = std::make_shared<TestTupleBufferView::Impl>(
-        TestTupleBufferView::Impl{.schema = schema, .buffer = buffer, .bufferProvider = bufferProvider, .bufRef = std::move(bufRef)});
+    view.impl = std::make_shared<TestTupleBufferView::Impl>(TestTupleBufferView::Impl{
+        .fieldNames = bufferRef->getAllFieldNames(),
+        .fieldTypes = bufferRef->getAllDataTypes(),
+        .buffer = buffer,
+        .bufferProvider = bufferProvider,
+        .bufRef = bufferRef});
     return view;
 }
 
@@ -258,9 +279,9 @@ uint64_t TestTupleBufferView::getNumberOfTuples() const
 
 void TestTupleBufferView::appendImpl(std::span<const std::optional<FieldValue>> values)
 {
-    if (values.size() != impl->schema.size())
+    if (values.size() != impl->fieldNames.size())
     {
-        throw TestException("TestTupleBufferView: expected {} fields, got {}", impl->schema.size(), values.size());
+        throw TestException("TestTupleBufferView: expected {} fields, got {}", impl->fieldNames.size(), values.size());
     }
 
     auto tupleIndex = nautilus::val<uint64_t>(impl->buffer.getNumberOfTuples());
@@ -269,9 +290,9 @@ void TestTupleBufferView::appendImpl(std::span<const std::optional<FieldValue>> 
     auto bufProviderVal = nautilus::val<AbstractBufferProvider*>(impl->bufferProvider);
 
     Record record;
-    for (const auto [value, field] : std::views::zip(values, impl->schema))
+    for (const auto& [value, name, type] : std::views::zip(values, impl->fieldNames, impl->fieldTypes))
     {
-        record.write(field.getFullyQualifiedName(), fieldValueToVarVal(value, field.getDataType()));
+        record.write(name, fieldValueToVarVal(value, type));
     }
 
     impl->bufRef->writeRecord(tupleIndex, recordBuffer, record, bufProviderVal);
@@ -282,17 +303,18 @@ void TestTupleBufferView::appendImpl(std::span<const std::optional<FieldValue>> 
 
 FieldView TestTupleBufferRecordView::operator[](const std::string& fieldName)
 {
-    const auto field = impl->schema[static_cast<QualifiedIdentifierBase<1>>(Identifier::parse(fieldName))];
-    if (!field.has_value())
+    const auto fieldId = QualifiedIdentifierBase<1>{Identifier::parse(fieldName)};
+    const auto fieldIt = std::ranges::find_if(impl->fieldNames, [&fieldId](const auto& name) { return name == fieldId; });
+    if (fieldIt == impl->fieldNames.end())
     {
-        throw FieldNotFound("TestTupleBufferRecordView: field '{}' not found in schema", fieldName);
+        throw FieldNotFound("TestTupleBufferRecordView: field '{}' not found in the buffer layout", fieldName);
     }
 
     FieldView fieldView;
     fieldView.implWeak = impl;
     fieldView.recordIndex = recordIndex;
     fieldView.fieldName = fieldName;
-    fieldView.dataType = field->getDataType();
+    fieldView.dataType = impl->fieldTypes[static_cast<size_t>(std::distance(impl->fieldNames.begin(), fieldIt))];
     return fieldView;
 }
 

--- a/nes-physical-operators/tests/InferModelPhysicalOperatorTest.cpp
+++ b/nes-physical-operators/tests/InferModelPhysicalOperatorTest.cpp
@@ -278,7 +278,7 @@ public:
         tupleBuffer.setLastChunk(true);
         tupleBuffer.setOriginId(INITIAL<OriginId>);
 
-        Testing::TestTupleBuffer ttb(inputSchema);
+        auto ttb = Testing::TestTupleBuffer::fromSchema(inputSchema, bufferSize);
         auto view = ttb.open(tupleBuffer, bufMgr.get());
         for (const auto& floats : recordFloats)
         {
@@ -331,7 +331,7 @@ TEST_F(InferModelPhysicalOperatorTest, IdentityModelCorrectness)
         auto lockedBuffers = *emittedBuffers.rlock();
         for (auto& outBuf : lockedBuffers)
         {
-            Testing::TestTupleBuffer ttb(outputSchema);
+            auto ttb = Testing::TestTupleBuffer::fromSchema(outputSchema, bufferSize);
             auto view = ttb.open(outBuf);
             for (size_t row = 0; row < view.getNumberOfTuples(); ++row)
             {
@@ -386,7 +386,7 @@ TEST_F(InferModelPhysicalOperatorTest, ReductionModelCorrectness)
         auto lockedBuffers = *emittedBuffers.rlock();
         for (auto& outBuf : lockedBuffers)
         {
-            Testing::TestTupleBuffer ttb(outputSchema);
+            auto ttb = Testing::TestTupleBuffer::fromSchema(outputSchema, bufferSize);
             auto view = ttb.open(outBuf);
             for (size_t row = 0; row < view.getNumberOfTuples(); ++row)
             {
@@ -441,7 +441,7 @@ TEST_F(InferModelPhysicalOperatorTest, ExpansionModelCorrectness)
         auto lockedBuffers = *emittedBuffers.rlock();
         for (auto& outBuf : lockedBuffers)
         {
-            Testing::TestTupleBuffer ttb(outputSchema);
+            auto ttb = Testing::TestTupleBuffer::fromSchema(outputSchema, bufferSize);
             auto view = ttb.open(outBuf);
             for (size_t row = 0; row < view.getNumberOfTuples(); ++row)
             {
@@ -504,7 +504,7 @@ TEST_F(InferModelPhysicalOperatorTest, MultiRecordIdentity)
         auto lockedBuffers = *emittedBuffers.rlock();
         for (auto& outBuf : lockedBuffers)
         {
-            Testing::TestTupleBuffer ttb(outputSchema);
+            auto ttb = Testing::TestTupleBuffer::fromSchema(outputSchema, bufferSize);
             auto view = ttb.open(outBuf);
             for (size_t row = 0; row < view.getNumberOfTuples(); ++row)
             {
@@ -560,7 +560,7 @@ TEST_F(InferModelPhysicalOperatorTest, ZeroRecordBuffer)
         auto lockedBuffers = *emittedBuffers.rlock();
         for (auto& outBuf : lockedBuffers)
         {
-            Testing::TestTupleBuffer ttb(outputSchema);
+            auto ttb = Testing::TestTupleBuffer::fromSchema(outputSchema, bufferSize);
             auto view = ttb.open(outBuf);
             totalRecords += view.getNumberOfTuples();
         }
@@ -653,7 +653,7 @@ TEST_F(InferModelPhysicalOperatorTest, ConcurrentStressTest)
     auto outputBuffers = *emittedBuffers.rlock();
     for (auto& outBuf : outputBuffers)
     {
-        Testing::TestTupleBuffer ttb(outputSchema);
+        auto ttb = Testing::TestTupleBuffer::fromSchema(outputSchema, bufferSize);
         auto view = ttb.open(outBuf);
         for (size_t row = 0; row < view.getNumberOfTuples(); ++row)
         {
@@ -723,7 +723,7 @@ TEST_F(InferModelPhysicalOperatorTest, VarsizedOutputCorrectness)
         auto lockedBuffers = *emittedBuffers.rlock();
         for (auto& outBuf : lockedBuffers)
         {
-            Testing::TestTupleBuffer ttb(outputSchema);
+            auto ttb = Testing::TestTupleBuffer::fromSchema(outputSchema, bufferSize);
             auto view = ttb.open(outBuf);
             for (size_t row = 0; row < view.getNumberOfTuples(); ++row)
             {


### PR DESCRIPTION
## Design

`TestTupleBuffer` (the test utility for populating/reading `TupleBuffer`s) previously stored a logical `TestSchema` and lowered it internally on every `open()`, coupling a logical component to a physical one (raised by @keyseven123 in the review of #1470).

It now stores only the **physical layout**:

- The constructor takes a `std::shared_ptr<TupleBufferRef>` (the lowered layout produced by `LowerSchemaProvider`). No logical `Schema` member remains.
- Field names and data types (incl. nullability) are derived from the layout via the existing `TupleBufferRef::getAllFieldNames()` / `getAllDataTypes()` accessors; `TestTupleBufferView::Impl` carries these vectors instead of a `TestSchema`.
- A convenience factory `TestTupleBuffer::fromSchema(schema, bufferSize)` performs the `Schema -> LowerSchemaProvider::lowerSchema -> RowTupleBufferRef` lowering at the call-site boundary, so tests stay one-liners.
- `open()` now validates that the wrapped buffer's size matches the size the layout was lowered for (previously the lowering silently adapted per buffer).

## Call sites

30 constructions updated mechanically, no test-semantics changes:
- `nes-nautilus/tests/TestTupleBufferTest.cpp` — 22 sites (`fromSchema(schema, bufferManager->getBufferSize())`)
- `nes-physical-operators/tests/InferModelPhysicalOperatorTest.cpp` — 8 sites (`fromSchema(..., bufferSize)`)

Closes #1579

🤖 Generated with [Claude Code](https://claude.com/claude-code)