### PR TITLE
Fix(#1493) nes-sinks: distinguish SinkCatalog registration failures

### DIFF
--- a/nes-frontend/apps/cli/tests/offline.bats
+++ b/nes-frontend/apps/cli/tests/offline.bats
@@ -365,7 +365,7 @@ bad_topology() {
   local f=$(bad_topology 's/type: Void/type: NonExistentSink/')
   run $NES_CLI -d -t "$f" dump
   [ "$status" -eq 1 ]
-  [[ "$output" == *"Invalid configuration for sink"* ]]
+  [[ "$output" == *"unknown sink type"* ]]
   [[ "$output" == *"NONEXISTENTSINK"* ]]
 }
 

--- a/nes-sinks/CMakeLists.txt
+++ b/nes-sinks/CMakeLists.txt
@@ -30,3 +30,5 @@ if (NES_ENABLE_PRECOMPILED_HEADERS)
 endif ()
 
 create_registries_for_component(Sink SinkValidation)
+
+add_tests_if_enabled(tests)

--- a/nes-sinks/src/SinkCatalog.cpp
+++ b/nes-sinks/src/SinkCatalog.cpp
@@ -25,6 +25,7 @@
 #include <utility>
 #include <variant>
 #include <vector>
+#include <Configurations/Descriptor.hpp>
 #include <DataTypes/Schema.hpp>
 #include <DataTypes/SchemaFwd.hpp>
 #include <DataTypes/UnboundField.hpp>
@@ -51,18 +52,35 @@ std::expected<SinkDescriptor, Exception> SinkCatalog::addSinkDescriptor(
         return std::unexpected{InvalidConfigParameter("Sink name '{}' is invalid: only-digit names are reserved", sinkName)};
     }
 
-    auto descriptorConfigOpt = SinkDescriptor::validateAndFormatConfig(sinkType.asCanonicalString(), std::move(config));
-    if (not descriptorConfigOpt.has_value())
+    auto descriptorConfig = [&]() -> std::expected<DescriptorConfig::Config, Exception>
     {
-        return std::unexpected{InvalidConfigParameter("Invalid configuration for sink '{}' of type '{}'", sinkName, sinkType)};
+        try
+        {
+            if (auto validated = SinkDescriptor::validateAndFormatConfig(sinkType.asCanonicalString(), std::move(config)))
+            {
+                return std::move(validated).value();
+            }
+            return std::unexpected{UnknownSinkType("{}", sinkType)};
+        }
+        catch (const Exception& configValidationError)
+        {
+            /// Validation of a known sink type throws on invalid configs; report what actually failed.
+            return std::unexpected{configValidationError};
+        }
+    }();
+    if (not descriptorConfig.has_value())
+    {
+        return std::unexpected{descriptorConfig.error()};
     }
 
     const auto lockedSinks = sinks.wlock();
     auto sinkDescriptor = SinkDescriptor{NamedSinkDescriptor{
-        sinkName, schema, sinkType.asCanonicalString(), std::move(host), formatConfig, std::move(descriptorConfigOpt.value())}};
+        sinkName, schema, sinkType.asCanonicalString(), std::move(host), formatConfig, std::move(descriptorConfig.value())}};
 
-    /// TODO #1504: duplicate sinks are not registered
-    lockedSinks->emplace(std::move(sinkName), sinkDescriptor);
+    if (const auto [existing, inserted] = lockedSinks->emplace(std::move(sinkName), sinkDescriptor); not inserted)
+    {
+        return std::unexpected{SinkAlreadyExists("{}", existing->first)};
+    }
     return sinkDescriptor;
 }
 

--- a/nes-sinks/tests/CMakeLists.txt
+++ b/nes-sinks/tests/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_nes_unit_test(sink-catalog-test SinkCatalogTest.cpp)
+target_link_libraries(sink-catalog-test nes-sinks)

--- a/nes-sinks/tests/SinkCatalogTest.cpp
+++ b/nes-sinks/tests/SinkCatalogTest.cpp
@@ -78,7 +78,8 @@ TEST_F(SinkCatalogTest, AddDuplicateSinkDescriptorReportsSinkAlreadyExists)
     /// The original registration must remain untouched.
     const auto retained = sinkCatalog.getSinkDescriptor(Identifier::parse("testSink"));
     ASSERT_TRUE(retained.has_value());
-    EXPECT_EQ(*retained, first.value());
+    ASSERT_TRUE(first.has_value());
+    EXPECT_EQ(*retained, *first);
     EXPECT_EQ(sinkCatalog.getAllSinkDescriptors().size(), size_t{1});
 }
 

--- a/nes-sinks/tests/SinkCatalogTest.cpp
+++ b/nes-sinks/tests/SinkCatalogTest.cpp
@@ -1,0 +1,114 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/Schema.hpp>
+#include <DataTypes/SchemaFwd.hpp>
+#include <DataTypes/UnboundField.hpp>
+#include <Identifiers/Identifier.hpp>
+#include <Identifiers/Identifiers.hpp>
+#include <Sinks/SinkCatalog.hpp>
+#include <Util/Logger/LogLevel.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <Util/Logger/impl/NesLogger.hpp>
+#include <gtest/gtest.h>
+#include <BaseUnitTest.hpp>
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+class SinkCatalogTest : public Testing::BaseUnitTest
+{
+public:
+    static void SetUpTestSuite()
+    {
+        Logger::setupLogging("SinkCatalogTest.log", LogLevel::LOG_DEBUG);
+        NES_DEBUG("Setup SinkCatalog test class.");
+    }
+
+    static Schema<UnqualifiedUnboundField, Ordered> createTestSchema()
+    {
+        return Schema<UnqualifiedUnboundField, Ordered>{
+            UnqualifiedUnboundField{Identifier::parse("stringField"), DataType::Type::VARSIZED},
+            UnqualifiedUnboundField{Identifier::parse("intField"), DataType::Type::INT32}};
+    }
+
+    static std::unordered_map<Identifier, std::string> createValidFileSinkConfig()
+    {
+        return {{Identifier::parse("file_path"), "/dev/null"}, {Identifier::parse("output_format"), "CSV"}};
+    }
+};
+
+TEST_F(SinkCatalogTest, AddInspectSinkDescriptor)
+{
+    auto sinkCatalog = SinkCatalog{};
+    const auto sink = sinkCatalog.addSinkDescriptor(
+        Identifier::parse("testSink"), createTestSchema(), Identifier::parse("File"), Host{"localhost"}, createValidFileSinkConfig(), {});
+    ASSERT_TRUE(sink.has_value());
+    ASSERT_TRUE(sinkCatalog.containsSinkDescriptor(sink.value()));
+    ASSERT_TRUE(sinkCatalog.getSinkDescriptor(Identifier::parse("testSink")).has_value());
+}
+
+TEST_F(SinkCatalogTest, AddDuplicateSinkDescriptorReportsSinkAlreadyExists)
+{
+    auto sinkCatalog = SinkCatalog{};
+    const auto first = sinkCatalog.addSinkDescriptor(
+        Identifier::parse("testSink"), createTestSchema(), Identifier::parse("File"), Host{"localhost"}, createValidFileSinkConfig(), {});
+    ASSERT_TRUE(first.has_value());
+
+    const auto duplicate = sinkCatalog.addSinkDescriptor(
+        Identifier::parse("testSink"), createTestSchema(), Identifier::parse("File"), Host{"localhost"}, createValidFileSinkConfig(), {});
+    ASSERT_FALSE(duplicate.has_value());
+    EXPECT_EQ(duplicate.error().code(), ErrorCode::SinkAlreadyExists);
+
+    /// The original registration must remain untouched.
+    ASSERT_TRUE(sinkCatalog.getSinkDescriptor(Identifier::parse("testSink")).has_value());
+    EXPECT_EQ(sinkCatalog.getSinkDescriptor(Identifier::parse("testSink")).value(), first.value());
+    EXPECT_EQ(sinkCatalog.getAllSinkDescriptors().size(), size_t{1});
+}
+
+TEST_F(SinkCatalogTest, AddSinkDescriptorWithInvalidConfigReportsValidationError)
+{
+    auto sinkCatalog = SinkCatalog{};
+    /// The file sink requires a file_path, so an empty config must fail validation.
+    const auto sink = sinkCatalog.addSinkDescriptor(
+        Identifier::parse("testSink"), createTestSchema(), Identifier::parse("File"), Host{"localhost"}, {}, {});
+    ASSERT_FALSE(sink.has_value());
+    EXPECT_EQ(sink.error().code(), ErrorCode::InvalidConfigParameter);
+    EXPECT_FALSE(sinkCatalog.containsSinkDescriptor(Identifier::parse("testSink")));
+}
+
+TEST_F(SinkCatalogTest, AddSinkDescriptorWithUnknownSinkTypeReportsUnknownSinkType)
+{
+    auto sinkCatalog = SinkCatalog{};
+    const auto sink = sinkCatalog.addSinkDescriptor(
+        Identifier::parse("testSink"), createTestSchema(), Identifier::parse("THIS_DOES_NOT_EXIST"), Host{"localhost"}, {}, {});
+    ASSERT_FALSE(sink.has_value());
+    EXPECT_EQ(sink.error().code(), ErrorCode::UnknownSinkType);
+    EXPECT_FALSE(sinkCatalog.containsSinkDescriptor(Identifier::parse("testSink")));
+}
+
+TEST_F(SinkCatalogTest, AddSinkDescriptorWithReservedNumericNameReportsInvalidConfigParameter)
+{
+    auto sinkCatalog = SinkCatalog{};
+    const auto sink = sinkCatalog.addSinkDescriptor(
+        Identifier::parse("12345"), createTestSchema(), Identifier::parse("File"), Host{"localhost"}, createValidFileSinkConfig(), {});
+    ASSERT_FALSE(sink.has_value());
+    EXPECT_EQ(sink.error().code(), ErrorCode::InvalidConfigParameter);
+    EXPECT_FALSE(sinkCatalog.containsSinkDescriptor(Identifier::parse("12345")));
+}
+}

--- a/nes-sinks/tests/SinkCatalogTest.cpp
+++ b/nes-sinks/tests/SinkCatalogTest.cpp
@@ -75,10 +75,13 @@ TEST_F(SinkCatalogTest, AddDuplicateSinkDescriptorReportsSinkAlreadyExists)
     ASSERT_FALSE(duplicate.has_value());
     EXPECT_EQ(duplicate.error().code(), ErrorCode::SinkAlreadyExists);
 
-    /// The original registration must remain untouched.
+    /// The original registration must remain untouched. Plain if-guard instead of ASSERT_TRUE:
+    /// bugprone-unchecked-optional-access does not track has_value() through gtest's assertion macros.
     const auto retained = sinkCatalog.getSinkDescriptor(Identifier::parse("testSink"));
-    ASSERT_TRUE(retained.has_value());
-    ASSERT_TRUE(first.has_value());
+    if (not(retained.has_value() and first.has_value()))
+    {
+        FAIL() << "original registration or its lookup is missing";
+    }
     EXPECT_EQ(*retained, *first);
     EXPECT_EQ(sinkCatalog.getAllSinkDescriptors().size(), size_t{1});
 }

--- a/nes-sinks/tests/SinkCatalogTest.cpp
+++ b/nes-sinks/tests/SinkCatalogTest.cpp
@@ -76,8 +76,9 @@ TEST_F(SinkCatalogTest, AddDuplicateSinkDescriptorReportsSinkAlreadyExists)
     EXPECT_EQ(duplicate.error().code(), ErrorCode::SinkAlreadyExists);
 
     /// The original registration must remain untouched.
-    ASSERT_TRUE(sinkCatalog.getSinkDescriptor(Identifier::parse("testSink")).has_value());
-    EXPECT_EQ(sinkCatalog.getSinkDescriptor(Identifier::parse("testSink")).value(), first.value());
+    const auto retained = sinkCatalog.getSinkDescriptor(Identifier::parse("testSink"));
+    ASSERT_TRUE(retained.has_value());
+    EXPECT_EQ(*retained, first.value());
     EXPECT_EQ(sinkCatalog.getAllSinkDescriptors().size(), size_t{1});
 }
 

--- a/nes-systests/operator/union/Union.test
+++ b/nes-systests/operator/union/Union.test
@@ -179,7 +179,6 @@ ATTACH INLINE
 3,1002
 2,2003
 
-CREATE SINK sink5(max_value UINT64 NOT NULL)  TYPE File;
 SELECT MAX(value) as max_value
 FROM (
     SELECT * FROM stream6 UNION SELECT * FROM stream7

--- a/nes-systests/systest/src/SystestBinder.cpp
+++ b/nes-systests/systest/src/SystestBinder.cpp
@@ -149,7 +149,19 @@ public:
                     host = hostIt->second;
                 }
 
-                return sinkCatalog->addSinkDescriptor(assignedSinkName, schema, sinkType, Host(host), std::move(config), formatConfig);
+                const auto sink
+                    = sinkCatalog->addSinkDescriptor(assignedSinkName, schema, sinkType, Host(host), std::move(config), formatConfig);
+                if (not sink.has_value() and sink.error().code() == ErrorCode::SinkAlreadyExists)
+                {
+                    /// A differential block binds its left query twice: once via the query callback and once as part
+                    /// of the block. The assigned sink name determines the descriptor, so the re-request is identical
+                    /// and can reuse the existing registration.
+                    if (auto existing = sinkCatalog->getSinkDescriptor(assignedSinkName))
+                    {
+                        return existing.value();
+                    }
+                }
+                return sink;
             });
         return success;
     }

--- a/nes-systests/systest/src/SystestBinder.cpp
+++ b/nes-systests/systest/src/SystestBinder.cpp
@@ -116,7 +116,7 @@ public:
         const auto sink = sinkCatalog->addSinkDescriptor(sinkNameInFile, schema, sinkType, Host(host), std::move(config), formatConfig);
         if (not sink.has_value())
         {
-            throw SinkAlreadyExists("Failed to create file sink with assigned name {}", sinkNameInFile);
+            throw sink.error();
         }
 
 
@@ -149,13 +149,7 @@ public:
                     host = hostIt->second;
                 }
 
-                const auto sink
-                    = sinkCatalog->addSinkDescriptor(assignedSinkName, schema, sinkType, Host(host), std::move(config), formatConfig);
-                if (not sink.has_value())
-                {
-                    return std::unexpected{SinkAlreadyExists("Failed to create file sink with assigned name {}", assignedSinkName)};
-                }
-                return sink.value();
+                return sinkCatalog->addSinkDescriptor(assignedSinkName, schema, sinkType, Host(host), std::move(config), formatConfig);
             });
         return success;
     }
@@ -686,7 +680,10 @@ struct SystestBinder::Impl
 
     static void createSink(SLTSinkFactory& sltSinkProvider, const CreateSinkStatement& statement)
     {
-        sltSinkProvider.registerSink(statement.sinkType, statement.name, statement.schema, statement.sinkConfig);
+        if (not sltSinkProvider.registerSink(statement.sinkType, statement.name, statement.schema, statement.sinkConfig))
+        {
+            throw SinkAlreadyExists("{}", statement.name);
+        }
     }
 
     void createModel(const std::shared_ptr<ModelCatalog>& modelCatalog, const CreateModelStatement& statement) const
@@ -841,17 +838,17 @@ struct SystestBinder::Impl
     }
 
     LogicalOperator setNamedSink(
-        SystestQueryBuilder& currentBuilder,
         const std::string_view& testFileName,
         SLTSinkFactory& sltSinkProvider,
         const SystestQueryId& currentQueryNumberInTest,
+        const std::string& assignedSinkNameSuffix,
         const TypedLogicalOperator<SinkLogicalOperator>& sinkOperator) const
     {
         const auto sinkNameInFile = sinkOperator->getSinkName();
 
         /// Replacing the sinkName with the created unique sink name
-        const auto sinkForQuery
-            = Identifier::parse(toUpperCase(sinkNameInFile.asCanonicalString() + std::to_string(currentQueryNumberInTest.getRawValue())));
+        const auto sinkForQuery = Identifier::parse(toUpperCase(
+            sinkNameInFile.asCanonicalString() + std::to_string(currentQueryNumberInTest.getRawValue()) + assignedSinkNameSuffix));
 
         /// Adding the sink to the sink config, such that we can create a fully specified query plan
         const auto resultFile = SystestQuery::resultFile(workingDir, testFileName, currentQueryNumberInTest);
@@ -859,7 +856,8 @@ struct SystestBinder::Impl
         auto sinkExpected = sltSinkProvider.createActualSink(sinkNameInFile, sinkForQuery, resultFile);
         if (not sinkExpected.has_value())
         {
-            currentBuilder.setException(sinkExpected.error());
+            /// The callers catch the exception and record it on the query builder.
+            throw std::move(sinkExpected).error();
         }
 
         const auto newOperator = SinkLogicalOperator::create(sinkExpected.value());
@@ -869,10 +867,10 @@ struct SystestBinder::Impl
 
     void setSinks(
         LogicalPlan& plan,
-        SystestQueryBuilder& currentBuilder,
         const std::string_view& testFileName,
         SLTSinkFactory& sltSinkProvider,
-        const SystestQueryId& currentQueryNumberInTest) const
+        const SystestQueryId& currentQueryNumberInTest,
+        const std::string& assignedSinkNameSuffix = "") const
     {
         std::vector<LogicalOperator> newRoots;
         for (const auto& rootOperator : plan.getRootOperators())
@@ -884,7 +882,7 @@ struct SystestBinder::Impl
             else if (auto namedSink = rootOperator.tryGetAs<SinkLogicalOperator>(); namedSink.has_value())
             {
                 newRoots.emplace_back(
-                    setNamedSink(currentBuilder, testFileName, sltSinkProvider, currentQueryNumberInTest, namedSink.value()));
+                    setNamedSink(testFileName, sltSinkProvider, currentQueryNumberInTest, assignedSinkNameSuffix, namedSink.value()));
             }
             else
             {
@@ -938,7 +936,7 @@ struct SystestBinder::Impl
         try
         {
             auto plan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString(query);
-            setSinks(plan, currentBuilder, testFileName, sltSinkProvider, currentQueryNumberInTest);
+            setSinks(plan, testFileName, sltSinkProvider, currentQueryNumberInTest);
             plan.setQueryId(QueryId::createDistributed(DistributedQueryId(fmt::format("{}:{}", testFileName, currentQueryNumberInTest))));
             setAnonymousSources(plan);
             currentBuilder.setBoundPlan(std::move(plan));
@@ -1037,8 +1035,9 @@ struct SystestBinder::Impl
             auto leftPlan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString(leftQuery);
             auto rightPlan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString(rightQuery);
 
-            setSinks(leftPlan, currentTest, testFileName, sltSinkProvider, currentQueryNumberInTest);
-            setSinks(rightPlan, currentTest, differentialTestResultFileName, sltSinkProvider, currentQueryNumberInTest);
+            setSinks(leftPlan, testFileName, sltSinkProvider, currentQueryNumberInTest);
+            /// The differential plan reuses the named sinks of the left plan, so its registrations need distinct names.
+            setSinks(rightPlan, differentialTestResultFileName, sltSinkProvider, currentQueryNumberInTest, "differential");
 
             setAnonymousSources(leftPlan);
             setAnonymousSources(rightPlan);

--- a/nes-systests/systest/src/SystestBinder.cpp
+++ b/nes-systests/systest/src/SystestBinder.cpp
@@ -858,9 +858,11 @@ struct SystestBinder::Impl
     {
         const auto sinkNameInFile = sinkOperator->getSinkName();
 
-        /// Replacing the sinkName with the created unique sink name
+        /// Replacing the sinkName with the created unique sink name. The '#' separator cannot appear in an unquoted
+        /// SQL identifier, so the assigned name cannot collide with a sink declared in the test file (e.g. a query
+        /// writing INTO sink with query number 4 must not clash with a user-declared sink4).
         const auto sinkForQuery = Identifier::parse(toUpperCase(
-            sinkNameInFile.asCanonicalString() + std::to_string(currentQueryNumberInTest.getRawValue()) + assignedSinkNameSuffix));
+            fmt::format("{}#{}{}", sinkNameInFile.asCanonicalString(), currentQueryNumberInTest.getRawValue(), assignedSinkNameSuffix)));
 
         /// Adding the sink to the sink config, such that we can create a fully specified query plan
         const auto resultFile = SystestQuery::resultFile(workingDir, testFileName, currentQueryNumberInTest);

--- a/nes-systests/systest/src/SystestBinder.cpp
+++ b/nes-systests/systest/src/SystestBinder.cpp
@@ -116,7 +116,7 @@ public:
         const auto sink = sinkCatalog->addSinkDescriptor(sinkNameInFile, schema, sinkType, Host(host), std::move(config), formatConfig);
         if (not sink.has_value())
         {
-            throw sink.error();
+            throw Exception(sink.error());
         }
 
 
@@ -884,7 +884,7 @@ struct SystestBinder::Impl
         const std::string_view& testFileName,
         SLTSinkFactory& sltSinkProvider,
         const SystestQueryId& currentQueryNumberInTest,
-        const std::string& assignedSinkNameSuffix = "") const
+        const std::string& assignedSinkNameSuffix) const
     {
         std::vector<LogicalOperator> newRoots;
         for (const auto& rootOperator : plan.getRootOperators())
@@ -950,7 +950,7 @@ struct SystestBinder::Impl
         try
         {
             auto plan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString(query);
-            setSinks(plan, testFileName, sltSinkProvider, currentQueryNumberInTest);
+            setSinks(plan, testFileName, sltSinkProvider, currentQueryNumberInTest, "");
             plan.setQueryId(QueryId::createDistributed(DistributedQueryId(fmt::format("{}:{}", testFileName, currentQueryNumberInTest))));
             setAnonymousSources(plan);
             currentBuilder.setBoundPlan(std::move(plan));
@@ -1049,7 +1049,7 @@ struct SystestBinder::Impl
             auto leftPlan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString(leftQuery);
             auto rightPlan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString(rightQuery);
 
-            setSinks(leftPlan, testFileName, sltSinkProvider, currentQueryNumberInTest);
+            setSinks(leftPlan, testFileName, sltSinkProvider, currentQueryNumberInTest, "");
             /// The differential plan reuses the named sinks of the left plan, so its registrations need distinct names.
             setSinks(rightPlan, differentialTestResultFileName, sltSinkProvider, currentQueryNumberInTest, "differential");
 


### PR DESCRIPTION
## Root cause

`SinkCatalog::addSinkDescriptor` could not tell its callers *why* a registration failed, and silently tolerated duplicates:

- It ignored the `bool` returned by `lockedSinks->emplace(...)`: registering a duplicate name was a silent no-op, yet the method returned the freshly built descriptor as if it had been registered (#1504). Callers ended up holding a descriptor the catalog never stored.
- Although the signature already promises `std::expected<SinkDescriptor, Exception>`, a validation failure of a **known** sink type threw straight out of the method (`DescriptorConfig::validateAndFormat` throws, and the validation registry does not catch), while an **unknown** sink type and an invalid config were both collapsed into one generic `InvalidConfigParameter` (#1493).

## Error-type design

`addSinkDescriptor` keeps the `std::expected<SinkDescriptor, Exception>` shape (existing factories from `ExceptionDefinitions.inc`, no new codes) and now returns one distinct error per failure:

| failure | error |
| --- | --- |
| reserved all-digit name | `InvalidConfigParameter` (1000) |
| unknown sink type | `UnknownSinkType` (2016) |
| invalid config of a known type | the **underlying** validation error, caught and channeled into the `expected` (e.g. `Non-default parameter file_path not specified in config of File`) |
| duplicate name | `SinkAlreadyExists` (2034), `emplace`'s bool is checked; the existing registration stays untouched |

`StatementHandler` already forwards `created.error()` verbatim, so `CREATE SINK` now reports the real failure instead of "sink already exists".

## Downstream systest fixes (#1504)

- `SLTSinkFactory::registerSink` and its per-query sink provider no longer fabricate an unconditional `SinkAlreadyExists`; they propagate the catalog's real error.
- `createSink` no longer discards `registerSink`'s `bool`.
- **UB fix:** `setNamedSink` called `currentBuilder.setException(...)` on failure and then fell through to `sinkExpected.value()` — dereferencing an `expected` without a value. It now throws; the callers' existing `catch (Exception&)` blocks record the exception on the query builder, matching the surrounding idiom.
- Differential blocks (`====`) run `setSinks` twice with the same query number, so left and right plans previously registered the *same* assigned sink name and relied on the silent duplicate no-op (the right plan received a descriptor the catalog never stored). The right-hand plan now registers its named sinks under a distinct `...DIFFERENTIAL` assigned name.
- `Union.test` declared `sink5` twice with different schemas — a latent bug the no-op masked. The second declaration is dead (its query writes `INTO sink4`) and is removed.

## Tests

- New `nes-sinks/tests/SinkCatalogTest.cpp` (new test target for nes-sinks) covering successful registration, duplicate name (`SinkAlreadyExists`, original entry preserved), invalid config (`InvalidConfigParameter`, nothing registered), unknown sink type (`UnknownSinkType`), and the reserved all-digit name.
- No systest repro for #1493 was added: `ERROR` expectations in `.test` files only attach to query blocks, not to `CREATE SINK` statements (a failing `CREATE` aborts loading the file), so the invalid-config-vs-already-exists distinction is covered by the unit tests instead.

Closes #1493
Closes #1504

🤖 Generated with [Claude Code](https://claude.com/claude-code)