### PR TITLE
Feature(#1731): human-readable byte-size config options

### DIFF
--- a/nes-configurations/include/Configurations/ByteAmount.hpp
+++ b/nes-configurations/include/Configurations/ByteAmount.hpp
@@ -1,0 +1,88 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+#pragma once
+
+#include <cstdint>
+#include <expected>
+#include <ostream>
+#include <string_view>
+#include <fmt/ostream.h>
+#include <yaml-cpp/yaml.h>
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+
+/// Parses a human-readable byte amount following the Kubernetes resource.Quantity suffix grammar
+/// (https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/):
+/// - binary suffixes Ki, Mi, Gi, Ti, Pi, Ei scale by powers of 1024
+/// - decimal suffixes k, M, G, T, P, E scale by powers of 1000
+/// - no suffix means bytes, so plain numbers ("4096") keep working
+/// - suffix matching is case-insensitive and an optional trailing 'B' is ignored: "4KiB" == "4Ki" == "4kib", "4kb" == "4k"
+/// - fractional values are allowed ("1.5Gi" == 1610612736 bytes) but must scale to a whole number of bytes ("1.5" alone is rejected)
+/// Rejects signed values, results that are not a whole number of bytes, results exceeding UINT64_MAX, and anything else
+/// not matching the grammar (empty input, bare suffixes, unknown suffixes, more than 20 significant fractional digits).
+std::expected<uint64_t, Exception> parseByteAmount(std::string_view amount);
+
+/// Strong typedef around uint64_t that marks a configuration value as a byte quantity, so that ScalarOption<Byte>
+/// accepts human-readable size strings ("4KiB", "1.5Gi") in addition to plain byte counts (see parseByteAmount).
+struct Byte
+{
+    constexpr Byte() = default;
+
+    constexpr explicit Byte(const uint64_t bytes) : bytes(bytes) { }
+
+    /// Implicit on purpose: options migrated from UIntOption to ByteOption keep treating the value as a plain number of bytes,
+    /// so existing call sites (`uint64_t size = option.getValue();`, arithmetic, function arguments) stay unchanged.
+    constexpr operator uint64_t() const { return bytes; } /// NOLINT(google-explicit-constructor,hicpp-explicit-conversions)
+
+    friend std::ostream& operator<<(std::ostream& os, const Byte& byte) { return os << byte.bytes; }
+
+    uint64_t bytes{0};
+};
+
+}
+
+namespace fmt
+{
+template <>
+struct formatter<NES::Byte> : ostream_formatter
+{
+};
+}
+
+namespace YAML
+{
+/// Allows YAML-based option parsing (`node.as<NES::Byte>()`) to accept human-readable byte amounts.
+template <>
+struct convert<NES::Byte>
+{
+    static Node encode(const NES::Byte& byte) { return Node(byte.bytes); }
+
+    static bool decode(const Node& node, NES::Byte& result)
+    {
+        if (!node.IsScalar())
+        {
+            return false;
+        }
+        const auto parsed = NES::parseByteAmount(node.Scalar());
+        if (!parsed.has_value())
+        {
+            return false;
+        }
+        result = NES::Byte(parsed.value());
+        return true;
+    }
+};
+}

--- a/nes-configurations/include/Configurations/ByteAmount.hpp
+++ b/nes-configurations/include/Configurations/ByteAmount.hpp
@@ -17,8 +17,10 @@
 #include <expected>
 #include <ostream>
 #include <string_view>
+#include <fmt/base.h>
 #include <fmt/ostream.h>
-#include <yaml-cpp/yaml.h>
+#include <yaml-cpp/node/convert.h>
+#include <yaml-cpp/node/node.h>
 #include <ErrorHandling.hpp>
 
 namespace NES

--- a/nes-configurations/include/Configurations/ByteAmount.hpp
+++ b/nes-configurations/include/Configurations/ByteAmount.hpp
@@ -26,27 +26,25 @@
 namespace NES
 {
 
-/// Parses a human-readable byte amount following the Kubernetes resource.Quantity suffix grammar
+/// Parses a byte amount following the Kubernetes resource.Quantity suffix grammar
 /// (https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/):
 /// - binary suffixes Ki, Mi, Gi, Ti, Pi, Ei scale by powers of 1024
 /// - decimal suffixes k, M, G, T, P, E scale by powers of 1000
-/// - no suffix means bytes, so plain numbers ("4096") keep working
-/// - suffix matching is case-insensitive and an optional trailing 'B' is ignored: "4KiB" == "4Ki" == "4kib", "4kb" == "4k"
-/// - fractional values are allowed ("1.5Gi" == 1610612736 bytes) but must scale to a whole number of bytes ("1.5" alone is rejected)
-/// Rejects signed values, results that are not a whole number of bytes, results exceeding UINT64_MAX, and anything else
-/// not matching the grammar (empty input, bare suffixes, unknown suffixes, more than 20 significant fractional digits).
+/// - no suffix means bytes
+/// - suffix matching is case-insensitive, an optional trailing 'B' is ignored: "4KiB" == "4Ki" == "4kib", "4kb" == "4k"
+/// - fractional values must scale to a whole number of bytes: "1.5Gi" == 1610612736, "1.5" is rejected
+/// Rejects signed values, non-integral results, results exceeding UINT64_MAX, empty input, bare or unknown suffixes,
+/// and more than 20 significant fractional digits.
 std::expected<uint64_t, Exception> parseByteAmount(std::string_view amount);
 
-/// Strong typedef around uint64_t that marks a configuration value as a byte quantity, so that ScalarOption<Byte>
-/// accepts human-readable size strings ("4KiB", "1.5Gi") in addition to plain byte counts (see parseByteAmount).
+/// A number of bytes. As the value type of ScalarOption<Byte>, it is parsed with parseByteAmount.
 struct Byte
 {
     constexpr Byte() = default;
 
     constexpr explicit Byte(const uint64_t bytes) : bytes(bytes) { }
 
-    /// Implicit on purpose: options migrated from UIntOption to ByteOption keep treating the value as a plain number of bytes,
-    /// so existing call sites (`uint64_t size = option.getValue();`, arithmetic, function arguments) stay unchanged.
+    /// Intentionally implicit: a Byte is used like a plain uint64_t byte count.
     constexpr operator uint64_t() const { return bytes; } /// NOLINT(google-explicit-constructor,hicpp-explicit-conversions)
 
     friend std::ostream& operator<<(std::ostream& os, const Byte& byte) { return os << byte.bytes; }
@@ -66,7 +64,7 @@ struct formatter<NES::Byte> : ostream_formatter
 
 namespace YAML
 {
-/// Allows YAML-based option parsing (`node.as<NES::Byte>()`) to accept human-readable byte amounts.
+/// Parses YAML scalars (`node.as<NES::Byte>()`) with parseByteAmount.
 template <>
 struct convert<NES::Byte>
 {

--- a/nes-configurations/include/Configurations/ByteAmount.hpp
+++ b/nes-configurations/include/Configurations/ByteAmount.hpp
@@ -26,8 +26,8 @@
 namespace NES
 {
 
-/// Parses a byte amount following the Kubernetes resource.Quantity suffix grammar
-/// (https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/):
+/// Parses a byte amount with a suffix grammar inspired by Kubernetes' resource.Quantity
+/// (not a strict implementation of it; e.g. exponent notation is not supported, and suffixes are case-insensitive here):
 /// - binary suffixes Ki, Mi, Gi, Ti, Pi, Ei scale by powers of 1024
 /// - decimal suffixes k, M, G, T, P, E scale by powers of 1000
 /// - no suffix means bytes

--- a/nes-configurations/include/Configurations/ScalarOption.hpp
+++ b/nes-configurations/include/Configurations/ScalarOption.hpp
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <ostream>
+#include <Configurations/ByteAmount.hpp>
 #include <Configurations/TypedBaseOption.hpp>
 #include <Configurations/Validation/ConfigurationValidation.hpp>
 #include <Util/Logger/Logger.hpp>
@@ -78,6 +79,16 @@ private:
         else if constexpr (std::same_as<Type, NES::URI>)
         {
             return URI(strValue);
+        }
+        else if constexpr (std::is_same_v<Type, Byte>)
+        {
+            /// Accepts human-readable byte amounts like "4KiB" or "1.5Gi" in addition to plain byte counts.
+            auto parsed = parseByteAmount(strValue);
+            if (!parsed.has_value())
+            {
+                throw parsed.error();
+            }
+            return Byte(parsed.value());
         }
         else if constexpr (std::is_same_v<Type, bool>)
         {
@@ -184,6 +195,8 @@ using StringOption = ScalarOption<std::string>;
 using FloatOption = ScalarOption<float>;
 using UIntOption = ScalarOption<uint64_t>;
 using BoolOption = ScalarOption<bool>;
+/// Byte-quantity option that accepts human-readable size strings, e.g. "4096", "4KiB", or "1.5Gi" (see ByteAmount.hpp).
+using ByteOption = ScalarOption<Byte>;
 
 }
 

--- a/nes-configurations/include/Configurations/ScalarOption.hpp
+++ b/nes-configurations/include/Configurations/ScalarOption.hpp
@@ -82,7 +82,6 @@ private:
         }
         else if constexpr (std::is_same_v<Type, Byte>)
         {
-            /// Accepts human-readable byte amounts like "4KiB" or "1.5Gi" in addition to plain byte counts.
             auto parsed = parseByteAmount(strValue);
             if (!parsed.has_value())
             {
@@ -195,7 +194,7 @@ using StringOption = ScalarOption<std::string>;
 using FloatOption = ScalarOption<float>;
 using UIntOption = ScalarOption<uint64_t>;
 using BoolOption = ScalarOption<bool>;
-/// Byte-quantity option that accepts human-readable size strings, e.g. "4096", "4KiB", or "1.5Gi" (see ByteAmount.hpp).
+/// Option holding a number of bytes, parsed with parseByteAmount ("4096", "4KiB", "1.5Gi", ...).
 using ByteOption = ScalarOption<Byte>;
 
 }

--- a/nes-configurations/include/Configurations/ScalarOption.hpp
+++ b/nes-configurations/include/Configurations/ScalarOption.hpp
@@ -86,7 +86,7 @@ private:
             auto parsed = parseByteAmount(strValue);
             if (!parsed.has_value())
             {
-                throw parsed.error();
+                throw Exception(parsed.error());
             }
             return Byte(parsed.value());
         }

--- a/nes-configurations/include/Configurations/Validation/ByteAmountValidation.hpp
+++ b/nes-configurations/include/Configurations/Validation/ByteAmountValidation.hpp
@@ -25,6 +25,6 @@ namespace NES
 class ByteAmountValidation : public ConfigurationValidation
 {
 public:
-    bool isValid(const std::string& byteAmount) const override;
+    [[nodiscard]] bool isValid(const std::string& byteAmount) const override;
 };
 }

--- a/nes-configurations/include/Configurations/Validation/ByteAmountValidation.hpp
+++ b/nes-configurations/include/Configurations/Validation/ByteAmountValidation.hpp
@@ -1,0 +1,30 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <string>
+#include <Configurations/Validation/ConfigurationValidation.hpp>
+
+namespace NES
+{
+
+/// Validates that a parameter is a byte amount, either a plain byte count ("4096") or human-readable ("4KiB", "1.5Gi").
+/// See parseByteAmount in <Configurations/ByteAmount.hpp> for the accepted grammar.
+class ByteAmountValidation : public ConfigurationValidation
+{
+public:
+    bool isValid(const std::string& byteAmount) const override;
+};
+}

--- a/nes-configurations/include/Configurations/Validation/ByteAmountValidation.hpp
+++ b/nes-configurations/include/Configurations/Validation/ByteAmountValidation.hpp
@@ -20,7 +20,7 @@
 namespace NES
 {
 
-/// Validates that a parameter is a byte amount, either a plain byte count ("4096") or human-readable ("4KiB", "1.5Gi").
+/// Validates that a parameter is a byte amount ("4096", "4KiB", "1.5Gi", ...).
 /// See parseByteAmount in <Configurations/ByteAmount.hpp> for the accepted grammar.
 class ByteAmountValidation : public ConfigurationValidation
 {

--- a/nes-configurations/src/Configurations/ByteAmount.cpp
+++ b/nes-configurations/src/Configurations/ByteAmount.cpp
@@ -1,0 +1,191 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Configurations/ByteAmount.hpp>
+
+#include <array>
+#include <cctype>
+#include <cstddef>
+#include <cstdint>
+#include <expected>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+namespace
+{
+/// 128-bit intermediates make the overflow checks trivial: no legal input can overflow them (see the static_asserts below).
+using UInt128 = unsigned __int128;
+
+constexpr uint64_t DECIMAL_BASE = 1000;
+constexpr uint64_t BINARY_BASE = 1024;
+/// Bounding the fraction keeps `fractionDigits * multiplier` within 128 bits (10^20 * 2^60 < 2^127) and loses nothing in practice:
+/// with the largest multiplier below 10^19, more than 20 significant fractional digits (almost) never scale to whole bytes.
+constexpr size_t MAX_FRACTIONAL_DIGITS = 20;
+
+constexpr uint64_t pow(const uint64_t base, const uint64_t exponent)
+{
+    uint64_t result = 1;
+    for (uint64_t i = 0; i < exponent; ++i)
+    {
+        result *= base;
+    }
+    return result;
+}
+
+/// Returns the multiplier for a byte-amount suffix (lowercased, optional trailing 'b' already stripped), or nullopt if unknown.
+std::optional<uint64_t> multiplierForSuffix(const std::string_view suffix)
+{
+    struct SuffixMultiplier
+    {
+        std::string_view suffix;
+        uint64_t multiplier;
+    };
+
+    static constexpr std::array<SuffixMultiplier, 13> SUFFIXES{
+        {{"", 1},
+         {"k", pow(DECIMAL_BASE, 1)},
+         {"m", pow(DECIMAL_BASE, 2)},
+         {"g", pow(DECIMAL_BASE, 3)},
+         {"t", pow(DECIMAL_BASE, 4)},
+         {"p", pow(DECIMAL_BASE, 5)},
+         {"e", pow(DECIMAL_BASE, 6)},
+         {"ki", pow(BINARY_BASE, 1)},
+         {"mi", pow(BINARY_BASE, 2)},
+         {"gi", pow(BINARY_BASE, 3)},
+         {"ti", pow(BINARY_BASE, 4)},
+         {"pi", pow(BINARY_BASE, 5)},
+         {"ei", pow(BINARY_BASE, 6)}}};
+    static_assert(pow(BINARY_BASE, 6) == UInt128{1} << 60);
+    static_assert(pow(DECIMAL_BASE, 6) < UInt128{1} << 60);
+
+    for (const auto& [candidate, multiplier] : SUFFIXES)
+    {
+        if (candidate == suffix)
+        {
+            return multiplier;
+        }
+    }
+    return std::nullopt;
+}
+
+std::string_view takeDigits(std::string_view& rest)
+{
+    size_t count = 0;
+    while (count < rest.size() && (std::isdigit(static_cast<unsigned char>(rest[count])) != 0))
+    {
+        ++count;
+    }
+    const auto digits = rest.substr(0, count);
+    rest.remove_prefix(count);
+    return digits;
+}
+}
+
+std::expected<uint64_t, Exception> parseByteAmount(const std::string_view amount)
+{
+    const auto invalid = [&](const std::string_view reason)
+    { return std::unexpected(InvalidConfigParameter("Invalid byte amount \"{}\": {}", amount, reason)); };
+
+    if (amount.empty())
+    {
+        return invalid("empty value");
+    }
+    if (amount.front() == '-' || amount.front() == '+')
+    {
+        return invalid("signed values are not supported");
+    }
+
+    auto rest = amount;
+    const auto integerDigits = takeDigits(rest);
+    auto fractionalDigits = std::string_view{};
+    if (!rest.empty() && rest.front() == '.')
+    {
+        rest.remove_prefix(1);
+        fractionalDigits = takeDigits(rest);
+        if (fractionalDigits.empty())
+        {
+            return invalid("expected digits after the decimal point");
+        }
+    }
+    if (integerDigits.empty() && fractionalDigits.empty())
+    {
+        return invalid("expected a number before the unit suffix");
+    }
+
+    /// Match the unit suffix case-insensitively, ignoring an optional trailing 'B' ("4KiB" == "4Ki", "4kb" == "4k").
+    std::string suffix{rest};
+    for (auto& character : suffix)
+    {
+        character = static_cast<char>(std::tolower(static_cast<unsigned char>(character)));
+    }
+    if (!suffix.empty() && suffix.back() == 'b')
+    {
+        suffix.pop_back();
+    }
+    const auto multiplier = multiplierForSuffix(suffix);
+    if (!multiplier.has_value())
+    {
+        return invalid("unknown unit suffix");
+    }
+
+    UInt128 integerPart = 0;
+    for (const char digit : integerDigits)
+    {
+        integerPart = integerPart * 10 + static_cast<UInt128>(digit - '0');
+        if (integerPart > UINT64_MAX)
+        {
+            return invalid("value exceeds the maximum of 2^64 - 1 bytes");
+        }
+    }
+    /// integerPart <= 2^64 - 1 and multiplier <= 2^60, so the product stays well within 128 bits.
+    UInt128 result = integerPart * static_cast<UInt128>(multiplier.value());
+
+    /// Trailing zeros carry no value, dropping them widens the accepted range of (pointless but valid) high-precision fractions.
+    while (!fractionalDigits.empty() && fractionalDigits.back() == '0')
+    {
+        fractionalDigits.remove_suffix(1);
+    }
+    if (!fractionalDigits.empty())
+    {
+        if (fractionalDigits.size() > MAX_FRACTIONAL_DIGITS)
+        {
+            return invalid("too many fractional digits");
+        }
+        UInt128 fraction = 0;
+        UInt128 fractionScale = 1;
+        for (const char digit : fractionalDigits)
+        {
+            fraction = fraction * 10 + static_cast<UInt128>(digit - '0');
+            fractionScale *= 10;
+        }
+        /// fraction < 10^20 < 2^67 and multiplier <= 2^60, so the product stays within 128 bits.
+        const UInt128 scaledFraction = fraction * static_cast<UInt128>(multiplier.value());
+        if (scaledFraction % fractionScale != 0)
+        {
+            return invalid("does not resolve to a whole number of bytes");
+        }
+        result += scaledFraction / fractionScale;
+    }
+
+    if (result > UINT64_MAX)
+    {
+        return invalid("value exceeds the maximum of 2^64 - 1 bytes");
+    }
+    return static_cast<uint64_t>(result);
+}
+}

--- a/nes-configurations/src/Configurations/ByteAmount.cpp
+++ b/nes-configurations/src/Configurations/ByteAmount.cpp
@@ -212,7 +212,7 @@ std::expected<uint64_t, Exception> parseByteAmount(const std::string_view amount
     }
 
     /// integerPart <= 2^64 - 1 and multiplier <= 2^60, so the sum stays well within 128 bits.
-    const UInt128 result = integerPart.value() * static_cast<UInt128>(multiplier.value()) + fractionBytes.value();
+    const UInt128 result = (integerPart.value() * static_cast<UInt128>(multiplier.value())) + fractionBytes.value();
     if (result > UINT64_MAX)
     {
         return invalid("value exceeds the maximum of 2^64 - 1 bytes");

--- a/nes-configurations/src/Configurations/ByteAmount.cpp
+++ b/nes-configurations/src/Configurations/ByteAmount.cpp
@@ -28,7 +28,7 @@ namespace NES
 {
 namespace
 {
-/// 128-bit intermediates make the overflow checks trivial: no legal input can overflow them (see the comments below).
+/// Intermediates use 128 bits so overflow checks reduce to comparisons (see the bounds in the comments below).
 using UInt128 = unsigned __int128;
 
 constexpr uint64_t DECIMAL_RADIX = 10;
@@ -37,8 +37,7 @@ constexpr uint64_t BINARY_BASE = 1024;
 /// The largest suffixes are E (1000^6) and Ei (1024^6 == 2^60).
 constexpr uint64_t LARGEST_SUFFIX_EXPONENT = 6;
 constexpr uint64_t LARGEST_MULTIPLIER_LOG2 = 60;
-/// Bounding the fraction keeps `fractionDigits * multiplier` within 128 bits (10^20 * 2^60 < 2^127) and loses nothing in practice:
-/// with the largest multiplier below 10^19, more than 20 significant fractional digits (almost) never scale to whole bytes.
+/// Bounding the fraction keeps `fraction * multiplier` within 128 bits (10^20 * 2^60 < 2^127).
 constexpr size_t MAX_FRACTIONAL_DIGITS = 20;
 
 constexpr uint64_t pow(const uint64_t base, const uint64_t exponent)
@@ -134,7 +133,7 @@ std::optional<UInt128> parseIntegerDigits(const std::string_view integerDigits)
 /// Scales the fractional digits by the multiplier; fails (with a reason) when the fraction does not resolve to whole bytes.
 std::expected<UInt128, std::string_view> scaledFractionBytes(std::string_view fractionalDigits, const uint64_t multiplier)
 {
-    /// Trailing zeros carry no value, dropping them widens the accepted range of (pointless but valid) high-precision fractions.
+    /// Trailing zeros do not change the value and would otherwise count against MAX_FRACTIONAL_DIGITS.
     while (!fractionalDigits.empty() && fractionalDigits.back() == '0')
     {
         fractionalDigits.remove_suffix(1);

--- a/nes-configurations/src/Configurations/ByteAmount.cpp
+++ b/nes-configurations/src/Configurations/ByteAmount.cpp
@@ -57,19 +57,19 @@ std::optional<uint64_t> multiplierForSuffix(const std::string_view suffix)
     };
 
     static constexpr std::array<SuffixMultiplier, 13> SUFFIXES{
-        {{"", 1},
-         {"k", pow(DECIMAL_BASE, 1)},
-         {"m", pow(DECIMAL_BASE, 2)},
-         {"g", pow(DECIMAL_BASE, 3)},
-         {"t", pow(DECIMAL_BASE, 4)},
-         {"p", pow(DECIMAL_BASE, 5)},
-         {"e", pow(DECIMAL_BASE, 6)},
-         {"ki", pow(BINARY_BASE, 1)},
-         {"mi", pow(BINARY_BASE, 2)},
-         {"gi", pow(BINARY_BASE, 3)},
-         {"ti", pow(BINARY_BASE, 4)},
-         {"pi", pow(BINARY_BASE, 5)},
-         {"ei", pow(BINARY_BASE, 6)}}};
+        {{.suffix = "", .multiplier = 1},
+         {.suffix = "k", .multiplier = pow(DECIMAL_BASE, 1)},
+         {.suffix = "m", .multiplier = pow(DECIMAL_BASE, 2)},
+         {.suffix = "g", .multiplier = pow(DECIMAL_BASE, 3)},
+         {.suffix = "t", .multiplier = pow(DECIMAL_BASE, 4)},
+         {.suffix = "p", .multiplier = pow(DECIMAL_BASE, 5)},
+         {.suffix = "e", .multiplier = pow(DECIMAL_BASE, 6)},
+         {.suffix = "ki", .multiplier = pow(BINARY_BASE, 1)},
+         {.suffix = "mi", .multiplier = pow(BINARY_BASE, 2)},
+         {.suffix = "gi", .multiplier = pow(BINARY_BASE, 3)},
+         {.suffix = "ti", .multiplier = pow(BINARY_BASE, 4)},
+         {.suffix = "pi", .multiplier = pow(BINARY_BASE, 5)},
+         {.suffix = "ei", .multiplier = pow(BINARY_BASE, 6)}}};
     static_assert(pow(BINARY_BASE, 6) == UInt128{1} << 60);
     static_assert(pow(DECIMAL_BASE, 6) < UInt128{1} << 60);
 

--- a/nes-configurations/src/Configurations/ByteAmount.cpp
+++ b/nes-configurations/src/Configurations/ByteAmount.cpp
@@ -28,11 +28,15 @@ namespace NES
 {
 namespace
 {
-/// 128-bit intermediates make the overflow checks trivial: no legal input can overflow them (see the static_asserts below).
+/// 128-bit intermediates make the overflow checks trivial: no legal input can overflow them (see the comments below).
 using UInt128 = unsigned __int128;
 
+constexpr uint64_t DECIMAL_RADIX = 10;
 constexpr uint64_t DECIMAL_BASE = 1000;
 constexpr uint64_t BINARY_BASE = 1024;
+/// The largest suffixes are E (1000^6) and Ei (1024^6 == 2^60).
+constexpr uint64_t LARGEST_SUFFIX_EXPONENT = 6;
+constexpr uint64_t LARGEST_MULTIPLIER_LOG2 = 60;
 /// Bounding the fraction keeps `fractionDigits * multiplier` within 128 bits (10^20 * 2^60 < 2^127) and loses nothing in practice:
 /// with the largest multiplier below 10^19, more than 20 significant fractional digits (almost) never scale to whole bytes.
 constexpr size_t MAX_FRACTIONAL_DIGITS = 20;
@@ -46,6 +50,10 @@ constexpr uint64_t pow(const uint64_t base, const uint64_t exponent)
     }
     return result;
 }
+
+/// All multipliers fit into uint64_t, the largest being Ei = 2^60.
+static_assert(pow(BINARY_BASE, LARGEST_SUFFIX_EXPONENT) == UInt128{1} << LARGEST_MULTIPLIER_LOG2);
+static_assert(pow(DECIMAL_BASE, LARGEST_SUFFIX_EXPONENT) < UInt128{1} << LARGEST_MULTIPLIER_LOG2);
 
 /// Returns the multiplier for a byte-amount suffix (lowercased, optional trailing 'b' already stripped), or nullopt if unknown.
 std::optional<uint64_t> multiplierForSuffix(const std::string_view suffix)
@@ -63,15 +71,13 @@ std::optional<uint64_t> multiplierForSuffix(const std::string_view suffix)
          {.suffix = "g", .multiplier = pow(DECIMAL_BASE, 3)},
          {.suffix = "t", .multiplier = pow(DECIMAL_BASE, 4)},
          {.suffix = "p", .multiplier = pow(DECIMAL_BASE, 5)},
-         {.suffix = "e", .multiplier = pow(DECIMAL_BASE, 6)},
+         {.suffix = "e", .multiplier = pow(DECIMAL_BASE, LARGEST_SUFFIX_EXPONENT)},
          {.suffix = "ki", .multiplier = pow(BINARY_BASE, 1)},
          {.suffix = "mi", .multiplier = pow(BINARY_BASE, 2)},
          {.suffix = "gi", .multiplier = pow(BINARY_BASE, 3)},
          {.suffix = "ti", .multiplier = pow(BINARY_BASE, 4)},
          {.suffix = "pi", .multiplier = pow(BINARY_BASE, 5)},
-         {.suffix = "ei", .multiplier = pow(BINARY_BASE, 6)}}};
-    static_assert(pow(BINARY_BASE, 6) == UInt128{1} << 60);
-    static_assert(pow(DECIMAL_BASE, 6) < UInt128{1} << 60);
+         {.suffix = "ei", .multiplier = pow(BINARY_BASE, LARGEST_SUFFIX_EXPONENT)}}};
 
     for (const auto& [candidate, multiplier] : SUFFIXES)
     {
@@ -81,6 +87,21 @@ std::optional<uint64_t> multiplierForSuffix(const std::string_view suffix)
         }
     }
     return std::nullopt;
+}
+
+/// Lowercases the unit suffix and strips the optional trailing 'B' ("4KiB" == "4Ki", "4kb" == "4k").
+std::string normalizeSuffix(const std::string_view suffix)
+{
+    std::string normalized{suffix};
+    for (auto& character : normalized)
+    {
+        character = static_cast<char>(std::tolower(static_cast<unsigned char>(character)));
+    }
+    if (!normalized.empty() && normalized.back() == 'b')
+    {
+        normalized.pop_back();
+    }
+    return normalized;
 }
 
 std::string_view takeDigits(std::string_view& rest)
@@ -93,6 +114,53 @@ std::string_view takeDigits(std::string_view& rest)
     const auto digits = rest.substr(0, count);
     rest.remove_prefix(count);
     return digits;
+}
+
+/// Parses the integer digits of a byte amount; fails if the value alone already exceeds uint64_t (the smallest multiplier is 1).
+std::optional<UInt128> parseIntegerDigits(const std::string_view integerDigits)
+{
+    UInt128 integerPart = 0;
+    for (const char digit : integerDigits)
+    {
+        integerPart = integerPart * DECIMAL_RADIX + static_cast<UInt128>(digit - '0');
+        if (integerPart > UINT64_MAX)
+        {
+            return std::nullopt;
+        }
+    }
+    return integerPart;
+}
+
+/// Scales the fractional digits by the multiplier; fails (with a reason) when the fraction does not resolve to whole bytes.
+std::expected<UInt128, std::string_view> scaledFractionBytes(std::string_view fractionalDigits, const uint64_t multiplier)
+{
+    /// Trailing zeros carry no value, dropping them widens the accepted range of (pointless but valid) high-precision fractions.
+    while (!fractionalDigits.empty() && fractionalDigits.back() == '0')
+    {
+        fractionalDigits.remove_suffix(1);
+    }
+    if (fractionalDigits.empty())
+    {
+        return UInt128{0};
+    }
+    if (fractionalDigits.size() > MAX_FRACTIONAL_DIGITS)
+    {
+        return std::unexpected("too many fractional digits");
+    }
+    UInt128 fraction = 0;
+    UInt128 fractionScale = 1;
+    for (const char digit : fractionalDigits)
+    {
+        fraction = fraction * DECIMAL_RADIX + static_cast<UInt128>(digit - '0');
+        fractionScale *= DECIMAL_RADIX;
+    }
+    /// fraction < 10^20 < 2^67 and multiplier <= 2^60, so the product stays within 128 bits.
+    const UInt128 scaledFraction = fraction * static_cast<UInt128>(multiplier);
+    if (scaledFraction % fractionScale != 0)
+    {
+        return std::unexpected("does not resolve to a whole number of bytes");
+    }
+    return scaledFraction / fractionScale;
 }
 }
 
@@ -127,61 +195,25 @@ std::expected<uint64_t, Exception> parseByteAmount(const std::string_view amount
         return invalid("expected a number before the unit suffix");
     }
 
-    /// Match the unit suffix case-insensitively, ignoring an optional trailing 'B' ("4KiB" == "4Ki", "4kb" == "4k").
-    std::string suffix{rest};
-    for (auto& character : suffix)
-    {
-        character = static_cast<char>(std::tolower(static_cast<unsigned char>(character)));
-    }
-    if (!suffix.empty() && suffix.back() == 'b')
-    {
-        suffix.pop_back();
-    }
-    const auto multiplier = multiplierForSuffix(suffix);
+    const auto multiplier = multiplierForSuffix(normalizeSuffix(rest));
     if (!multiplier.has_value())
     {
         return invalid("unknown unit suffix");
     }
 
-    UInt128 integerPart = 0;
-    for (const char digit : integerDigits)
+    const auto integerPart = parseIntegerDigits(integerDigits);
+    if (!integerPart.has_value())
     {
-        integerPart = integerPart * 10 + static_cast<UInt128>(digit - '0');
-        if (integerPart > UINT64_MAX)
-        {
-            return invalid("value exceeds the maximum of 2^64 - 1 bytes");
-        }
+        return invalid("value exceeds the maximum of 2^64 - 1 bytes");
     }
-    /// integerPart <= 2^64 - 1 and multiplier <= 2^60, so the product stays well within 128 bits.
-    UInt128 result = integerPart * static_cast<UInt128>(multiplier.value());
-
-    /// Trailing zeros carry no value, dropping them widens the accepted range of (pointless but valid) high-precision fractions.
-    while (!fractionalDigits.empty() && fractionalDigits.back() == '0')
+    const auto fractionBytes = scaledFractionBytes(fractionalDigits, multiplier.value());
+    if (!fractionBytes.has_value())
     {
-        fractionalDigits.remove_suffix(1);
-    }
-    if (!fractionalDigits.empty())
-    {
-        if (fractionalDigits.size() > MAX_FRACTIONAL_DIGITS)
-        {
-            return invalid("too many fractional digits");
-        }
-        UInt128 fraction = 0;
-        UInt128 fractionScale = 1;
-        for (const char digit : fractionalDigits)
-        {
-            fraction = fraction * 10 + static_cast<UInt128>(digit - '0');
-            fractionScale *= 10;
-        }
-        /// fraction < 10^20 < 2^67 and multiplier <= 2^60, so the product stays within 128 bits.
-        const UInt128 scaledFraction = fraction * static_cast<UInt128>(multiplier.value());
-        if (scaledFraction % fractionScale != 0)
-        {
-            return invalid("does not resolve to a whole number of bytes");
-        }
-        result += scaledFraction / fractionScale;
+        return invalid(fractionBytes.error());
     }
 
+    /// integerPart <= 2^64 - 1 and multiplier <= 2^60, so the sum stays well within 128 bits.
+    const UInt128 result = integerPart.value() * static_cast<UInt128>(multiplier.value()) + fractionBytes.value();
     if (result > UINT64_MAX)
     {
         return invalid("value exceeds the maximum of 2^64 - 1 bytes");

--- a/nes-configurations/src/Configurations/CMakeLists.txt
+++ b/nes-configurations/src/Configurations/CMakeLists.txt
@@ -13,6 +13,7 @@
 add_source_files(nes-configurations
         BaseConfiguration.cpp
         BaseOption.cpp
+        ByteAmount.cpp
         Descriptor.cpp
 )
 

--- a/nes-configurations/src/Configurations/Validation/ByteAmountValidation.cpp
+++ b/nes-configurations/src/Configurations/Validation/ByteAmountValidation.cpp
@@ -1,0 +1,27 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Configurations/Validation/ByteAmountValidation.hpp>
+
+#include <string>
+#include <Configurations/ByteAmount.hpp>
+
+namespace NES
+{
+
+bool ByteAmountValidation::isValid(const std::string& byteAmount) const
+{
+    return parseByteAmount(byteAmount).has_value();
+}
+}

--- a/nes-configurations/src/Configurations/Validation/CMakeLists.txt
+++ b/nes-configurations/src/Configurations/Validation/CMakeLists.txt
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 add_source_files(nes-configurations
+        ByteAmountValidation.cpp
         IpValidation.cpp
         NumberValidation.cpp
         NonZeroValidation.cpp

--- a/nes-configurations/tests/CMakeLists.txt
+++ b/nes-configurations/tests/CMakeLists.txt
@@ -14,4 +14,5 @@
 include(ExternalProject)
 ### Config Tests ###
 add_nes_unit_test(configuration-help-message-tests "UnitTests/Configurations/ConfigurationHelpMessageTests.cpp" "UnitTests/Validation/EndpointValidationTest.cpp" "UnitTests/Configurations/ExplicitlySetTrackingTests.cpp")
+add_nes_unit_test(byte-amount-tests "UnitTests/Configurations/ByteAmountTest.cpp")
 set_tests_properties(${Tests} PROPERTIES TIMEOUT 35)

--- a/nes-configurations/tests/UnitTests/Configurations/ByteAmountTest.cpp
+++ b/nes-configurations/tests/UnitTests/Configurations/ByteAmountTest.cpp
@@ -23,7 +23,7 @@
 #include <Configurations/ScalarOption.hpp>
 #include <Configurations/Validation/ByteAmountValidation.hpp>
 #include <gtest/gtest.h>
-#include <yaml-cpp/yaml.h>
+#include <yaml-cpp/node/node.h>
 #include <ErrorHandling.hpp>
 
 /// NOLINTBEGIN(readability-magic-numbers) -- byte-amount tests compare against literal byte counts throughout
@@ -59,12 +59,12 @@ TEST(ByteAmountTest, ParsesPlainByteCounts)
 TEST(ByteAmountTest, ParsesBinarySuffixes)
 {
     expectParses("4Ki", 4096);
-    expectParses("1Mi", 1ULL << 20);
-    expectParses("1Gi", 1ULL << 30);
-    expectParses("1Ti", 1ULL << 40);
-    expectParses("1Pi", 1ULL << 50);
-    expectParses("1Ei", 1ULL << 60);
-    expectParses("15Ei", 15ULL << 60);
+    expectParses("1Mi", 1ULL << 20U);
+    expectParses("1Gi", 1ULL << 30U);
+    expectParses("1Ti", 1ULL << 40U);
+    expectParses("1Pi", 1ULL << 50U);
+    expectParses("1Ei", 1ULL << 60U);
+    expectParses("15Ei", 15ULL << 60U);
 }
 
 TEST(ByteAmountTest, ParsesDecimalSuffixes)
@@ -88,7 +88,7 @@ TEST(ByteAmountTest, SuffixMatchingIsCaseInsensitiveWithOptionalTrailingB)
     expectParses("4kb", 4000);
     expectParses("4KB", 4000);
     expectParses("4GB", 4'000'000'000);
-    expectParses("4gib", 4ULL << 30);
+    expectParses("4gib", 4ULL << 30U);
 }
 
 TEST(ByteAmountTest, ParsesFractionalValues)
@@ -175,7 +175,7 @@ TEST(ByteOptionTest, DefaultValueSupportsHumanReadableAmounts)
 TEST(ByteOptionTest, ParsesHumanReadableAmountFromCommandLineInput)
 {
     ByteOptionTestConfig config;
-    std::unordered_map<std::string, std::string> inputParams{{"buffer_size", "8KiB"}};
+    const std::unordered_map<std::string, std::string> inputParams{{"buffer_size", "8KiB"}};
     config.overwriteConfigWithCommandLineInput(inputParams);
     EXPECT_EQ(config.bufferSize.getValue(), 8192);
 }
@@ -201,7 +201,7 @@ TEST(ByteOptionTest, PlainByteCountsKeepWorking)
 TEST(ByteOptionTest, RejectsInvalidAmount)
 {
     ByteOptionTestConfig config;
-    std::unordered_map<std::string, std::string> inputParams{{"buffer_size", "4Foo"}};
+    const std::unordered_map<std::string, std::string> inputParams{{"buffer_size", "4Foo"}};
     EXPECT_THROW(config.overwriteConfigWithCommandLineInput(inputParams), Exception);
 }
 

--- a/nes-configurations/tests/UnitTests/Configurations/ByteAmountTest.cpp
+++ b/nes-configurations/tests/UnitTests/Configurations/ByteAmountTest.cpp
@@ -189,7 +189,7 @@ TEST(ByteOptionTest, ParsesHumanReadableAmountFromYAML)
     EXPECT_EQ(config.bufferSize.getValue(), 1'610'612'736);
 }
 
-TEST(ByteOptionTest, PlainByteCountsKeepWorking)
+TEST(ByteOptionTest, ParsesPlainByteCountFromYAML)
 {
     ByteOptionTestConfig config;
     YAML::Node node;

--- a/nes-configurations/tests/UnitTests/Configurations/ByteAmountTest.cpp
+++ b/nes-configurations/tests/UnitTests/Configurations/ByteAmountTest.cpp
@@ -1,0 +1,211 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include <Configurations/BaseConfiguration.hpp>
+#include <Configurations/BaseOption.hpp>
+#include <Configurations/ByteAmount.hpp>
+#include <Configurations/ScalarOption.hpp>
+#include <Configurations/Validation/ByteAmountValidation.hpp>
+#include <gtest/gtest.h>
+#include <yaml-cpp/yaml.h>
+#include <ErrorHandling.hpp>
+
+/// NOLINTBEGIN(readability-magic-numbers) -- byte-amount tests compare against literal byte counts throughout
+
+namespace NES
+{
+namespace
+{
+
+void expectParses(const std::string& amount, const uint64_t expectedBytes)
+{
+    const auto parsed = parseByteAmount(amount);
+    ASSERT_TRUE(parsed.has_value()) << "Expected \"" << amount << "\" to parse, but it was rejected";
+    EXPECT_EQ(parsed.value(), expectedBytes) << "for input \"" << amount << "\"";
+}
+
+void expectRejects(const std::string& amount)
+{
+    EXPECT_FALSE(parseByteAmount(amount).has_value()) << "Expected \"" << amount << "\" to be rejected, but it parsed";
+}
+
+TEST(ByteAmountTest, ParsesPlainByteCounts)
+{
+    expectParses("0", 0);
+    expectParses("1", 1);
+    expectParses("4096", 4096);
+    expectParses("18446744073709551615", UINT64_MAX);
+    /// An optional, case-insensitive 'B' suffix is allowed
+    expectParses("4096B", 4096);
+    expectParses("4096b", 4096);
+}
+
+TEST(ByteAmountTest, ParsesBinarySuffixes)
+{
+    expectParses("4Ki", 4096);
+    expectParses("1Mi", 1ULL << 20);
+    expectParses("1Gi", 1ULL << 30);
+    expectParses("1Ti", 1ULL << 40);
+    expectParses("1Pi", 1ULL << 50);
+    expectParses("1Ei", 1ULL << 60);
+    expectParses("15Ei", 15ULL << 60);
+}
+
+TEST(ByteAmountTest, ParsesDecimalSuffixes)
+{
+    expectParses("4k", 4000);
+    expectParses("4K", 4000);
+    expectParses("1M", 1'000'000);
+    expectParses("1G", 1'000'000'000);
+    expectParses("1T", 1'000'000'000'000);
+    expectParses("1P", 1'000'000'000'000'000);
+    expectParses("1E", 1'000'000'000'000'000'000);
+    expectParses("18E", 18'000'000'000'000'000'000ULL);
+}
+
+TEST(ByteAmountTest, SuffixMatchingIsCaseInsensitiveWithOptionalTrailingB)
+{
+    expectParses("4KiB", 4096);
+    expectParses("4kib", 4096);
+    expectParses("4KIB", 4096);
+    expectParses("4kI", 4096);
+    expectParses("4kb", 4000);
+    expectParses("4KB", 4000);
+    expectParses("4GB", 4'000'000'000);
+    expectParses("4gib", 4ULL << 30);
+}
+
+TEST(ByteAmountTest, ParsesFractionalValues)
+{
+    expectParses("1.5Gi", 1'610'612'736);
+    expectParses("0.5Ki", 512);
+    expectParses("2.5k", 2500);
+    expectParses("1.1k", 1100);
+    expectParses(".5Ki", 512);
+    /// Trailing zeros in the fraction carry no value
+    expectParses("1.500Gi", 1'610'612'736);
+    expectParses("2.0Ki", 2048);
+}
+
+TEST(ByteAmountTest, RejectsNegativeAndSignedValues)
+{
+    expectRejects("-1");
+    expectRejects("-4Ki");
+    expectRejects("+4Ki");
+}
+
+TEST(ByteAmountTest, RejectsOverflow)
+{
+    expectRejects("18446744073709551616"); /// UINT64_MAX + 1
+    expectRejects("16Ei"); /// 2^64 bytes
+    expectRejects("18.5E");
+    expectRejects("99999999999999999999999999");
+}
+
+TEST(ByteAmountTest, RejectsNonIntegralResults)
+{
+    expectRejects("1.5"); /// 1.5 bytes
+    expectRejects("1.5B");
+    expectRejects("1.0000000001Gi");
+    expectRejects("0.0001Ki");
+}
+
+TEST(ByteAmountTest, RejectsGarbage)
+{
+    expectRejects("");
+    expectRejects(" ");
+    expectRejects("Ki"); /// bare suffix
+    expectRejects("B");
+    expectRejects("abc");
+    expectRejects("4X");
+    expectRejects("4KiBB");
+    expectRejects("4 Ki");
+    expectRejects(" 4Ki");
+    expectRejects("1..5Gi");
+    expectRejects("1.Gi");
+    expectRejects("1.");
+    expectRejects("0x10");
+    expectRejects("4Ki5");
+}
+
+TEST(ByteAmountValidationTest, AcceptsByteAmountsAndRejectsEverythingElse)
+{
+    const ByteAmountValidation validation;
+    EXPECT_TRUE(validation.isValid("4096"));
+    EXPECT_TRUE(validation.isValid("4KiB"));
+    EXPECT_TRUE(validation.isValid("1.5Gi"));
+    EXPECT_FALSE(validation.isValid("-1"));
+    EXPECT_FALSE(validation.isValid("fourKiB"));
+    EXPECT_FALSE(validation.isValid(""));
+}
+
+struct ByteOptionTestConfig : BaseConfiguration
+{
+    ByteOption bufferSize{"buffer_size", "4KiB", "Buffer size for the byte-option test", {std::make_shared<ByteAmountValidation>()}};
+
+protected:
+    std::vector<BaseOption*> getOptions() override { return {&bufferSize}; }
+};
+
+TEST(ByteOptionTest, DefaultValueSupportsHumanReadableAmounts)
+{
+    const ByteOptionTestConfig config;
+    EXPECT_EQ(config.bufferSize.getValue(), 4096);
+    /// The option value implicitly converts to a plain number of bytes
+    const uint64_t rawBytes = config.bufferSize.getValue();
+    EXPECT_EQ(rawBytes, 4096);
+}
+
+TEST(ByteOptionTest, ParsesHumanReadableAmountFromCommandLineInput)
+{
+    ByteOptionTestConfig config;
+    std::unordered_map<std::string, std::string> inputParams{{"buffer_size", "8KiB"}};
+    config.overwriteConfigWithCommandLineInput(inputParams);
+    EXPECT_EQ(config.bufferSize.getValue(), 8192);
+}
+
+TEST(ByteOptionTest, ParsesHumanReadableAmountFromYAML)
+{
+    ByteOptionTestConfig config;
+    YAML::Node node;
+    node["buffer_size"] = "1.5Gi";
+    config.overwriteConfigWithYAMLNode(node);
+    EXPECT_EQ(config.bufferSize.getValue(), 1'610'612'736);
+}
+
+TEST(ByteOptionTest, PlainByteCountsKeepWorking)
+{
+    ByteOptionTestConfig config;
+    YAML::Node node;
+    node["buffer_size"] = "4096";
+    config.overwriteConfigWithYAMLNode(node);
+    EXPECT_EQ(config.bufferSize.getValue(), 4096);
+}
+
+TEST(ByteOptionTest, RejectsInvalidAmount)
+{
+    ByteOptionTestConfig config;
+    std::unordered_map<std::string, std::string> inputParams{{"buffer_size", "4Foo"}};
+    EXPECT_THROW(config.overwriteConfigWithCommandLineInput(inputParams), Exception);
+}
+
+}
+}
+
+/// NOLINTEND(readability-magic-numbers)

--- a/nes-query-compiler/interface/QueryExecutionConfiguration.hpp
+++ b/nes-query-compiler/interface/QueryExecutionConfiguration.hpp
@@ -22,6 +22,7 @@
 #include <Configurations/BaseOption.hpp>
 #include <Configurations/Enums/EnumOption.hpp>
 #include <Configurations/ScalarOption.hpp>
+#include <Configurations/Validation/ByteAmountValidation.hpp>
 #include <Configurations/Validation/FloatValidation.hpp>
 #include <Configurations/Validation/NumberValidation.hpp>
 #include <Util/ExecutionMode.hpp>
@@ -52,11 +53,11 @@ public:
            std::to_string(DEFAULT_NUMBER_OF_PARTITIONS_DATASTRUCTURES),
            "Partitions in a hash table",
            {std::make_shared<NumberValidation>()}};
-    UIntOption pageSize
+    ByteOption pageSize
         = {"page_size",
            std::to_string(DEFAULT_PAGED_VECTOR_SIZE),
-           "Page size of any other paged data structure",
-           {std::make_shared<NumberValidation>()}};
+           "Page size of any other paged data structure. Accepts human-readable byte amounts, e.g., \"4KiB\" or \"1Mi\"",
+           {std::make_shared<ByteAmountValidation>()}};
     UIntOption numberOfRecordsPerKey
         = {"number_of_records_per_key",
            std::to_string(DEFAULT_NUMBER_OF_RECORDS_PER_KEY),
@@ -67,11 +68,11 @@ public:
         std::to_string(DEFAULT_MAX_NUMBER_OF_BUCKETS),
         "Maximal number of buckets for a hash table. If set too low or high degrades either the performance or increases the memory usage.",
         {std::make_shared<FloatValidation>()}};
-    UIntOption operatorBufferSize
+    ByteOption operatorBufferSize
         = {"operator_buffer_size",
            std::to_string(DEFAULT_OPERATOR_BUFFER_SIZE),
-           "Buffer size of a operator e.g. during scan",
-           {std::make_shared<NumberValidation>()}};
+           "Buffer size of a operator e.g. during scan. Accepts human-readable byte amounts, e.g., \"4KiB\" or \"1Mi\"",
+           {std::make_shared<ByteAmountValidation>()}};
 
     SliceCacheConfiguration sliceCacheConfiguration = {"slice_cache", "Configuration for the slice cache"};
 

--- a/nes-query-compiler/interface/QueryExecutionConfiguration.hpp
+++ b/nes-query-compiler/interface/QueryExecutionConfiguration.hpp
@@ -56,7 +56,7 @@ public:
     ByteOption pageSize
         = {"page_size",
            std::to_string(DEFAULT_PAGED_VECTOR_SIZE),
-           "Page size of any other paged data structure. Accepts human-readable byte amounts, e.g., \"4KiB\" or \"1Mi\"",
+           R"(Page size of any other paged data structure. Accepts human-readable byte amounts, e.g., "4KiB" or "1Mi")",
            {std::make_shared<ByteAmountValidation>()}};
     UIntOption numberOfRecordsPerKey
         = {"number_of_records_per_key",
@@ -71,7 +71,7 @@ public:
     ByteOption operatorBufferSize
         = {"operator_buffer_size",
            std::to_string(DEFAULT_OPERATOR_BUFFER_SIZE),
-           "Buffer size of a operator e.g. during scan. Accepts human-readable byte amounts, e.g., \"4KiB\" or \"1Mi\"",
+           R"(Buffer size of a operator e.g. during scan. Accepts human-readable byte amounts, e.g., "4KiB" or "1Mi")",
            {std::make_shared<ByteAmountValidation>()}};
 
     SliceCacheConfiguration sliceCacheConfiguration = {"slice_cache", "Configuration for the slice cache"};

--- a/nes-query-compiler/tests/CMakeLists.txt
+++ b/nes-query-compiler/tests/CMakeLists.txt
@@ -18,3 +18,4 @@ function(add_nes_compiler_test)
 endfunction()
 
 add_nes_compiler_test(PhysicalPlanBuilderFlipTest UnitTests/PhysicalPlanBuilderFlipTest.cpp)
+add_nes_compiler_test(QueryExecutionConfigurationTest UnitTests/QueryExecutionConfigurationTest.cpp)

--- a/nes-query-compiler/tests/UnitTests/QueryExecutionConfigurationTest.cpp
+++ b/nes-query-compiler/tests/UnitTests/QueryExecutionConfigurationTest.cpp
@@ -1,0 +1,56 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <yaml-cpp/yaml.h>
+#include <QueryExecutionConfiguration.hpp>
+
+/// NOLINTBEGIN(readability-magic-numbers) -- configuration tests compare against literal byte counts throughout
+
+namespace NES
+{
+
+TEST(QueryExecutionConfigurationTest, DefaultByteSizesAreUnchanged)
+{
+    const QueryExecutionConfiguration config;
+    EXPECT_EQ(config.pageSize.getValue(), 1024);
+    EXPECT_EQ(config.operatorBufferSize.getValue(), 4096);
+}
+
+TEST(QueryExecutionConfigurationTest, ByteSizesAcceptHumanReadableAmounts)
+{
+    QueryExecutionConfiguration config;
+    YAML::Node node;
+    node["page_size"] = "4KiB";
+    node["operator_buffer_size"] = "1Mi";
+    config.overwriteConfigWithYAMLNode(node);
+    EXPECT_EQ(config.pageSize.getValue(), 4096);
+    EXPECT_EQ(config.operatorBufferSize.getValue(), 1ULL << 20);
+}
+
+TEST(QueryExecutionConfigurationTest, ByteSizesAcceptPlainByteCounts)
+{
+    QueryExecutionConfiguration config;
+    YAML::Node node;
+    node["page_size"] = "2048";
+    node["operator_buffer_size"] = "8192";
+    config.overwriteConfigWithYAMLNode(node);
+    EXPECT_EQ(config.pageSize.getValue(), 2048);
+    EXPECT_EQ(config.operatorBufferSize.getValue(), 8192);
+}
+
+}
+
+/// NOLINTEND(readability-magic-numbers)

--- a/nes-query-compiler/tests/UnitTests/QueryExecutionConfigurationTest.cpp
+++ b/nes-query-compiler/tests/UnitTests/QueryExecutionConfigurationTest.cpp
@@ -12,9 +12,8 @@
     limitations under the License.
 */
 
-#include <cstdint>
 #include <gtest/gtest.h>
-#include <yaml-cpp/yaml.h>
+#include <yaml-cpp/node/node.h>
 #include <QueryExecutionConfiguration.hpp>
 
 /// NOLINTBEGIN(readability-magic-numbers) -- configuration tests compare against literal byte counts throughout
@@ -37,7 +36,7 @@ TEST(QueryExecutionConfigurationTest, ByteSizesAcceptHumanReadableAmounts)
     node["operator_buffer_size"] = "1Mi";
     config.overwriteConfigWithYAMLNode(node);
     EXPECT_EQ(config.pageSize.getValue(), 4096);
-    EXPECT_EQ(config.operatorBufferSize.getValue(), 1ULL << 20);
+    EXPECT_EQ(config.operatorBufferSize.getValue(), 1ULL << 20U);
 }
 
 TEST(QueryExecutionConfigurationTest, ByteSizesAcceptPlainByteCounts)


### PR DESCRIPTION
## Summary

Byte-sized configuration options now accept human-readable size strings such as `4KiB`, `1.5Gi`, or `4gb` instead of only raw byte counts, via a new `Byte` strong typedef and `ScalarOption<Byte>` (`ByteOption`), as recommended in #1731 (shape 2).

## Grammar

`parseByteAmount(std::string_view) -> std::expected<uint64_t, Exception>` (shared by `convertFromString<Byte>`, `YAML::convert<Byte>`, and the new `ByteAmountValidation`) follows the Kubernetes [`resource.Quantity`](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/) suffix grammar:

- **Binary** suffixes `Ki`, `Mi`, `Gi`, `Ti`, `Pi`, `Ei` scale by powers of 1024
- **Decimal** suffixes `k`, `M`, `G`, `T`, `P`, `E` scale by powers of 1000
- No suffix means bytes; an optional trailing `B` is ignored (`4KiB` == `4Ki`, `4kb` == `4k`); suffix matching is case-insensitive overall (`4kib`, `4GB`)
- Fractional values are allowed (`1.5Gi` == 1610612736) but are **rejected if they do not scale to a whole number of bytes** (e.g. `1.0000000001Gi`)
- Rejected: signed values, overflow beyond `UINT64_MAX` (checked with 128-bit intermediates), bare suffixes, empty input, garbage

## Migrated options

- `worker.default_query_execution.page_size` (default unchanged: `1024`)
- `worker.default_query_execution.operator_buffer_size` (default unchanged: `4096`)

These are the only worker options that are true byte quantities today; queue sizes and `number_of_buffers_in_global_buffer_manager` are element counts and stay `UIntOption`.

## Backward compatibility

Plain numbers keep parsing as bytes, so all existing YAML configs, CLI overrides (`--worker.default_query_execution.page_size=4096`), and systest `GlobalConfiguration` lines behave exactly as before. `Byte` converts implicitly to `uint64_t`, so `getValue()` call sites are unchanged.

## Tests

- `byte-amount-tests` (nes-configurations): all binary/decimal suffixes, case variants, fractional values, plain byte counts, and rejection of negatives, overflow, non-integral fractions, bare suffixes, and garbage; plus `ByteOption` round-trips through defaults, command-line input, and YAML.
- `QueryExecutionConfigurationTest` (nes-query-compiler): migrated options parse `4KiB`/`1Mi` and keep their numeric defaults.

Closes #1731

🤖 Generated with [Claude Code](https://claude.com/claude-code)