### PR TITLE
Task(#1730): non-throwing GeneratorSource validation

### DIFF
--- a/nes-configurations/include/Configurations/Descriptor.hpp
+++ b/nes-configurations/include/Configurations/Descriptor.hpp
@@ -16,6 +16,7 @@
 
 #include <concepts>
 #include <cstdint>
+#include <expected>
 #include <memory>
 #include <optional>
 #include <ostream>
@@ -149,10 +150,12 @@ public:
     /// Iterates over all parameters in a user provided config and checks if they are supported by a specific config.
     /// Then iterates over all supported config parameters, validates and formats the strings provided by the user.
     /// Uses default parameters if the user did not specify a parameter.
-    /// @throws If a mandatory parameter was not provided, an optional parameter was invalid, or a not-supported parameter was encountered.
+    /// Returns an error if a mandatory parameter was not provided, an optional parameter was invalid, or a not-supported parameter
+    /// was encountered.
     template <typename SpecificConfiguration>
     requires DescriptorConfigurationConstraints::HasParameterMap<SpecificConfiguration>
-    static Config validateAndFormat(std::unordered_map<std::string, std::string> config, const std::string_view implementationName)
+    static std::expected<Config, Exception>
+    tryValidateAndFormat(std::unordered_map<std::string, std::string> config, const std::string_view implementationName)
     {
         auto validatedConfig = Config{};
 
@@ -161,7 +164,7 @@ public:
         {
             if (not SpecificConfiguration::parameterMap.contains(key))
             {
-                throw InvalidConfigParameter(fmt::format("Unknown configuration parameter: {}.", key));
+                return std::unexpected(InvalidConfigParameter("Unknown configuration parameter: {}.", key));
             }
         }
         /// Next, try to validate all config parameters.
@@ -175,17 +178,31 @@ public:
                     validatedConfig.emplace(key, defaultValue.value());
                     continue;
                 }
-                throw InvalidConfigParameter(
-                    fmt::format("Non-default parameter {} not specified in config of {}", key, implementationName));
+                return std::unexpected(
+                    InvalidConfigParameter("Non-default parameter {} not specified in config of {}", key, implementationName));
             }
             if (const auto validatedParameter = configParameter.validate(config); validatedParameter.has_value())
             {
                 validatedConfig.emplace(key, validatedParameter.value());
                 continue;
             }
-            throw InvalidConfigParameter(fmt::format("Failed validation of config parameter: {}, in: {}", key, implementationName));
+            return std::unexpected(InvalidConfigParameter("Failed validation of config parameter: {}, in: {}", key, implementationName));
         }
         return validatedConfig;
+    }
+
+    /// Throwing variant of tryValidateAndFormat.
+    /// @throws If a mandatory parameter was not provided, an optional parameter was invalid, or a not-supported parameter was encountered.
+    template <typename SpecificConfiguration>
+    requires DescriptorConfigurationConstraints::HasParameterMap<SpecificConfiguration>
+    static Config validateAndFormat(std::unordered_map<std::string, std::string> config, const std::string_view implementationName)
+    {
+        auto validatedConfig = tryValidateAndFormat<SpecificConfiguration>(std::move(config), implementationName);
+        if (not validatedConfig.has_value())
+        {
+            throw std::move(validatedConfig).error();
+        }
+        return std::move(validatedConfig).value();
     }
 
 private:

--- a/nes-configurations/include/Configurations/Descriptor.hpp
+++ b/nes-configurations/include/Configurations/Descriptor.hpp
@@ -151,7 +151,8 @@ public:
     /// Then iterates over all supported config parameters, validates and formats the strings provided by the user.
     /// Uses default parameters if the user did not specify a parameter.
     /// Returns an error if a mandatory parameter was not provided, an optional parameter was invalid, or a not-supported parameter
-    /// was encountered.
+    /// was encountered. Guaranteed not to throw for these cases: per-parameter validators of plugins that still throw
+    /// (instead of returning nullopt) are caught here and reported as the error of the returned expected.
     template <typename SpecificConfiguration>
     requires DescriptorConfigurationConstraints::HasParameterMap<SpecificConfiguration>
     static std::expected<Config, Exception>
@@ -181,12 +182,21 @@ public:
                 return std::unexpected(
                     InvalidConfigParameter("Non-default parameter {} not specified in config of {}", key, implementationName));
             }
-            if (const auto validatedParameter = configParameter.validate(config); validatedParameter.has_value())
+            try
             {
-                validatedConfig.emplace(key, validatedParameter.value());
-                continue;
+                if (const auto validatedParameter = configParameter.validate(config); validatedParameter.has_value())
+                {
+                    validatedConfig.emplace(key, validatedParameter.value());
+                    continue;
+                }
+                return std::unexpected(
+                    InvalidConfigParameter("Failed validation of config parameter: {}, in: {}", key, implementationName));
             }
-            return std::unexpected(InvalidConfigParameter("Failed validation of config parameter: {}, in: {}", key, implementationName));
+            catch (const Exception& e)
+            {
+                /// Uphold the non-throwing contract even for validators that throw instead of returning nullopt.
+                return std::unexpected(e);
+            }
         }
         return validatedConfig;
     }

--- a/nes-configurations/include/Configurations/Descriptor.hpp
+++ b/nes-configurations/include/Configurations/Descriptor.hpp
@@ -21,6 +21,7 @@
 #include <optional>
 #include <ostream>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 #include <variant>

--- a/nes-plugins/Sources/GeneratorSource/CMakeLists.txt
+++ b/nes-plugins/Sources/GeneratorSource/CMakeLists.txt
@@ -16,3 +16,5 @@ add_plugin_as_library(Generator SourceValidation generator_validation_plugin_lib
 target_include_directories(generator_source_plugin_library PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/)
 target_compile_definitions(generator_source_plugin_library PRIVATE SYSTEST_DATA_DIR="${CMAKE_SOURCE_DIR}/nes-systests/testdata/")
 target_compile_definitions(generator_validation_plugin_library PRIVATE SYSTEST_DATA_DIR="${CMAKE_SOURCE_DIR}/nes-systests/testdata/")
+
+add_tests_if_enabled(tests)

--- a/nes-plugins/Sources/GeneratorSource/GeneratorFields.cpp
+++ b/nes-plugins/Sources/GeneratorSource/GeneratorFields.cpp
@@ -16,6 +16,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <expected>
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
@@ -25,6 +26,7 @@
 #include <ranges>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <variant>
 #include <vector>
 #include <DataTypes/DataType.hpp>
@@ -43,20 +45,12 @@ SequenceField::SequenceField(const FieldType start, const FieldType end, const F
 {
 }
 
-void SequenceField::validate(std::string_view rawSchemaLine)
+std::expected<void, Exception> SequenceField::validate(std::string_view rawSchemaLine)
 {
-    auto validateParameter = []<typename T>(std::string_view parameter, std::string_view name)
-    {
-        const auto opt = from_chars<T>(parameter);
-        if (!opt)
-        {
-            throw InvalidConfigParameter("Could not parse {} as SequenceField {}!", parameter, name);
-        }
-    };
     const auto parameters = splitWithStringDelimiter<std::string_view>(rawSchemaLine, " ");
     if (parameters.size() != NUM_PARAMETERS_SEQUENCE_FIELD)
     {
-        throw InvalidConfigParameter("Number of SequenceField parameters does not match! {}", rawSchemaLine);
+        return std::unexpected(InvalidConfigParameter("Number of SequenceField parameters does not match! {}", rawSchemaLine));
     }
     const auto type = parameters[1];
     const auto start = parameters[2];
@@ -66,87 +60,55 @@ void SequenceField::validate(std::string_view rawSchemaLine)
     const auto dataType = DataTypeProvider::tryProvideDataType(std::string{type});
     if (not dataType.has_value())
     {
-        throw InvalidConfigParameter("Invalid SequenceField type of {}!", type);
+        return std::unexpected(InvalidConfigParameter("Invalid SequenceField type of {}!", type));
     }
+
+    const auto validateParameters = [&]<typename T>() -> std::expected<void, Exception>
+    {
+        const auto validateParameter = [](const std::string_view parameter, const std::string_view name) -> std::expected<void, Exception>
+        {
+            if (not from_chars<T>(parameter).has_value())
+            {
+                return std::unexpected(InvalidConfigParameter("Could not parse {} as SequenceField {}!", parameter, name));
+            }
+            return {};
+        };
+        return validateParameter(start, "start")
+            .and_then([&] { return validateParameter(end, "end"); })
+            .and_then([&] { return validateParameter(step, "step"); });
+    };
+
     switch (dataType.value().type)
     {
-        case DataType::Type::UINT8: {
-            validateParameter.operator()<uint8_t>(start, "start");
-            validateParameter.operator()<uint8_t>(end, "end");
-            validateParameter.operator()<uint8_t>(step, "step");
-            break;
-        }
-        case DataType::Type::UINT16: {
-            validateParameter.operator()<uint16_t>(start, "start");
-            validateParameter.operator()<uint16_t>(end, "end");
-            validateParameter.operator()<uint16_t>(step, "step");
-            break;
-        }
-        case DataType::Type::UINT32: {
-            validateParameter.operator()<uint32_t>(start, "start");
-            validateParameter.operator()<uint32_t>(end, "end");
-            validateParameter.operator()<uint32_t>(step, "step");
-            break;
-        }
-        case DataType::Type::UINT64: {
-            validateParameter.operator()<uint64_t>(start, "start");
-            validateParameter.operator()<uint64_t>(end, "end");
-            validateParameter.operator()<uint64_t>(step, "step");
-            break;
-        }
-        case DataType::Type::INT8: {
-            validateParameter.operator()<int8_t>(start, "start");
-            validateParameter.operator()<int8_t>(end, "end");
-            validateParameter.operator()<int8_t>(step, "step");
-            break;
-        }
-        case DataType::Type::INT16: {
-            validateParameter.operator()<int16_t>(start, "start");
-            validateParameter.operator()<int16_t>(end, "end");
-            validateParameter.operator()<int16_t>(step, "step");
-            break;
-        }
-        case DataType::Type::INT32: {
-            validateParameter.operator()<int32_t>(start, "start");
-            validateParameter.operator()<int32_t>(end, "end");
-            validateParameter.operator()<int32_t>(step, "step");
-            break;
-        }
-        case DataType::Type::INT64: {
-            validateParameter.operator()<int64_t>(start, "start");
-            validateParameter.operator()<int64_t>(end, "end");
-            validateParameter.operator()<int64_t>(step, "step");
-            break;
-        }
-        case DataType::Type::FLOAT32: {
-            validateParameter.operator()<float>(start, "start");
-            validateParameter.operator()<float>(end, "end");
-            validateParameter.operator()<float>(step, "step");
-            break;
-        }
-        case DataType::Type::FLOAT64: {
-            validateParameter.operator()<double>(start, "start");
-            validateParameter.operator()<double>(end, "end");
-            validateParameter.operator()<double>(step, "step");
-            break;
-        }
-        case DataType::Type::BOOLEAN: {
-            validateParameter.operator()<bool>(start, "start");
-            validateParameter.operator()<bool>(end, "end");
-            validateParameter.operator()<bool>(step, "step");
-            break;
-        }
-        case DataType::Type::CHAR: {
-            validateParameter.operator()<char>(start, "start");
-            validateParameter.operator()<char>(end, "end");
-            validateParameter.operator()<char>(step, "step");
-            break;
-        }
+        case DataType::Type::UINT8:
+            return validateParameters.operator()<uint8_t>();
+        case DataType::Type::UINT16:
+            return validateParameters.operator()<uint16_t>();
+        case DataType::Type::UINT32:
+            return validateParameters.operator()<uint32_t>();
+        case DataType::Type::UINT64:
+            return validateParameters.operator()<uint64_t>();
+        case DataType::Type::INT8:
+            return validateParameters.operator()<int8_t>();
+        case DataType::Type::INT16:
+            return validateParameters.operator()<int16_t>();
+        case DataType::Type::INT32:
+            return validateParameters.operator()<int32_t>();
+        case DataType::Type::INT64:
+            return validateParameters.operator()<int64_t>();
+        case DataType::Type::FLOAT32:
+            return validateParameters.operator()<float>();
+        case DataType::Type::FLOAT64:
+            return validateParameters.operator()<double>();
+        case DataType::Type::BOOLEAN:
+            return validateParameters.operator()<bool>();
+        case DataType::Type::CHAR:
+            return validateParameters.operator()<char>();
         case DataType::Type::UNDEFINED:
-        case DataType::Type::VARSIZED: {
-            throw InvalidConfigParameter("Could not parse {} as SequenceField!", type);
-        }
+        case DataType::Type::VARSIZED:
+            return std::unexpected(InvalidConfigParameter("Could not parse {} as SequenceField!", type));
     }
+    std::unreachable();
 }
 
 template <typename T>
@@ -357,12 +319,12 @@ std::ostream& NormalDistributionField::generate(std::ostream& os, std::mt19937& 
     return os;
 }
 
-void NormalDistributionField::validate(std::string_view rawSchemaLine)
+std::expected<void, Exception> NormalDistributionField::validate(std::string_view rawSchemaLine)
 {
     const auto parameters = splitWithStringDelimiter<std::string_view>(rawSchemaLine, " ");
     if (parameters.size() < NUM_PARAMETERS_NORMAL_DISTRIBUTION_FIELD)
     {
-        throw InvalidConfigParameter("Invalid NORMAL_DISTRIBUTION schema line: {}", rawSchemaLine);
+        return std::unexpected(InvalidConfigParameter("Invalid NORMAL_DISTRIBUTION schema line: {}", rawSchemaLine));
     }
 
     const auto typeParam = parameters[1];
@@ -372,20 +334,20 @@ void NormalDistributionField::validate(std::string_view rawSchemaLine)
     if (const auto type = magic_enum::enum_cast<NES::DataType::Type>(typeParam); not type.has_value())
     {
         constexpr auto allDataTypes = magic_enum::enum_names<DataType::Type>();
-        NES_ERROR("Invalid Type in NORMAL_DISTRIBUTION, supported are only {} {}", fmt::join(allDataTypes, ","), rawSchemaLine);
-        throw InvalidConfigParameter(
-            "Invalid Type in NORMAL_DISTRIBUTION, supported are only {}: {}", fmt::join(allDataTypes, ","), rawSchemaLine);
+        return std::unexpected(InvalidConfigParameter(
+            "Invalid Type in NORMAL_DISTRIBUTION, supported are only {}: {}", fmt::join(allDataTypes, ","), rawSchemaLine));
     }
     const auto parsedMean = from_chars<double>(mean);
     const auto parsedStdDev = from_chars<double>(stddev);
     if (!parsedMean || !parsedStdDev)
     {
-        throw InvalidConfigParameter("Can not parse mean or stddev in {}", rawSchemaLine);
+        return std::unexpected(InvalidConfigParameter("Can not parse mean or stddev in {}", rawSchemaLine));
     }
     if (parsedStdDev < 0.0)
     {
-        throw InvalidConfigParameter("Stddev must be non-negative");
+        return std::unexpected(InvalidConfigParameter("Stddev must be non-negative, but got {} in {}", *parsedStdDev, rawSchemaLine));
     }
+    return {};
 }
 
 WordListField::WordListField(std::string_view rawSchemaLine)
@@ -421,24 +383,25 @@ std::ostream& WordListField::generate(std::ostream& os, std::mt19937& randEng)
     return os;
 }
 
-void WordListField::validate(std::string_view rawSchemaLine)
+std::expected<void, Exception> WordListField::validate(std::string_view rawSchemaLine)
 {
     const auto parameters = splitWithStringDelimiter<std::string_view>(rawSchemaLine, " ");
     if (parameters.size() != NUM_PARAMETERS_WORDLIST_FIELD)
     {
-        throw InvalidConfigParameter("Invalid WORDLIST schema line: {}", rawSchemaLine);
+        return std::unexpected(InvalidConfigParameter("Invalid WORDLIST schema line: {}", rawSchemaLine));
     }
 
     const auto path = std::filesystem::path(SYSTEST_DATA_DIR) / std::string(parameters[1]);
     if (not std::filesystem::exists(path))
     {
-        throw InvalidConfigParameter("Invalid WORDLIST schema! Path {} does not exist! Schema line: {}", path, rawSchemaLine);
+        return std::unexpected(
+            InvalidConfigParameter("Invalid WORDLIST schema! Path {} does not exist! Schema line: {}", path, rawSchemaLine));
     }
 
     std::ifstream wordListFile(std::string(path), std::ios::in);
     if (not wordListFile.is_open() or wordListFile.fail())
     {
-        throw InvalidConfigParameter("Failed to open file containing the word list at {}", path);
+        return std::unexpected(InvalidConfigParameter("Failed to open file containing the word list at {}", path));
     }
 
     size_t wordCount = 0;
@@ -453,9 +416,9 @@ void WordListField::validate(std::string_view rawSchemaLine)
 
     if (wordCount == 0)
     {
-        throw InvalidConfigParameter("Invalid WORDLIST schema! File at {} contains no words!", path);
+        return std::unexpected(InvalidConfigParameter("Invalid WORDLIST schema! File at {} contains no words!", path));
     }
-    wordListFile.close();
+    return {};
 }
 
 RandomStrField::RandomStrField(std::string_view rawSchemaLine)
@@ -501,12 +464,12 @@ RandomStrField::RandomStrField(std::string_view rawSchemaLine)
     this->maxLength = parsedMaxLength.value();
 }
 
-void RandomStrField::validate(std::string_view rawSchemaLine)
+std::expected<void, Exception> RandomStrField::validate(std::string_view rawSchemaLine)
 {
     const auto parameters = splitWithStringDelimiter<std::string_view>(rawSchemaLine, " ");
     if (parameters.size() != NUM_PARAMETERS_RANDOMSTR_FIELD)
     {
-        throw InvalidConfigParameter("Invalid RANDOMSTR schema line: {}", rawSchemaLine);
+        return std::unexpected(InvalidConfigParameter("Invalid RANDOMSTR schema line: {}", rawSchemaLine));
     }
     const auto minLength = parameters[1];
     const auto maxLength = parameters[2];
@@ -516,38 +479,41 @@ void RandomStrField::validate(std::string_view rawSchemaLine)
 
     if (not parsedMinLength)
     {
-        throw InvalidConfigParameter("Invalid RANDOMSTR parameter MINLENGTH! Cannot parse MINLENGTH! Schema line: {}", rawSchemaLine);
+        return std::unexpected(
+            InvalidConfigParameter("Invalid RANDOMSTR parameter MINLENGTH! Cannot parse MINLENGTH! Schema line: {}", rawSchemaLine));
     }
     if (not parsedMaxLength)
     {
-        throw InvalidConfigParameter("Invalid RANDOMSTR parameter MAXLENGTH! Cannot parse MAXLENGTH! Schema line: {}", rawSchemaLine);
+        return std::unexpected(
+            InvalidConfigParameter("Invalid RANDOMSTR parameter MAXLENGTH! Cannot parse MAXLENGTH! Schema line: {}", rawSchemaLine));
     }
 
     if (parsedMinLength <= 0)
     {
-        throw InvalidConfigParameter(
+        return std::unexpected(InvalidConfigParameter(
             "Invaild RANDOMSTR parameter MINLENGTH: {} <= 0! The MINLENGTH must be larger than 0! Schema line: {}",
             parsedMinLength,
-            rawSchemaLine);
+            rawSchemaLine));
     }
     if (parsedMaxLength <= 0)
     {
-        throw InvalidConfigParameter(
+        return std::unexpected(InvalidConfigParameter(
             "Invaild RANDOMSTR parameter MAXLENGTH: {} <= 0! The MAXLENGTH must be larger than 0! Schema line: {}",
             parsedMaxLength,
-            rawSchemaLine);
+            rawSchemaLine));
     }
 
     if (parsedMinLength > parsedMaxLength)
     {
-        throw InvalidConfigParameter(
+        return std::unexpected(InvalidConfigParameter(
             "Invalid RANDOMSTR parameters MINLENGTH: {} > MAXLENGTH: {}! The MINLENGTH can not be longer than the MAXLENGTH! Schema "
             "line: "
             "{}",
             parsedMinLength,
             parsedMaxLength,
-            rawSchemaLine);
+            rawSchemaLine));
     }
+    return {};
 }
 
 std::ostream& RandomStrField::generate(std::ostream& os, std::mt19937& randEng)
@@ -571,5 +537,34 @@ std::ostream& RandomStrField::generate(std::ostream& os, std::mt19937& randEng)
     return os;
 }
 
+std::expected<void, Exception> validateSchemaLine(const std::string_view line)
+{
+    const auto foundIdentifier = magic_enum::enum_cast<FieldIdentifier>(NES::toUpperCase(line.substr(0, line.find_first_of(' '))));
+    for (const auto& [identifier, validator] : Validators)
+    {
+        if (identifier == foundIdentifier)
+        {
+            return validator(line);
+        }
+    }
+    return std::unexpected(
+        InvalidConfigParameter("Cannot identify the type of field in \"{}\", does the field have a registered validator?", line));
+}
+
+std::expected<void, Exception> validateSchema(const std::string_view rawSchema)
+{
+    if (rawSchema.empty())
+    {
+        return std::unexpected(InvalidConfigParameter("Generator schema cannot be empty!"));
+    }
+    for (const auto lines = splitOnMultipleDelimiters(rawSchema, {',', '\n'}); const auto& line : lines)
+    {
+        if (auto validLine = validateSchemaLine(trimWhiteSpaces(line)); not validLine.has_value())
+        {
+            return validLine;
+        }
+    }
+    return {};
+}
 
 }

--- a/nes-plugins/Sources/GeneratorSource/GeneratorFields.hpp
+++ b/nes-plugins/Sources/GeneratorSource/GeneratorFields.hpp
@@ -17,6 +17,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <expected>
 #include <functional>
 #include <ostream>
 #include <random>
@@ -27,6 +28,7 @@
 #include <vector>
 
 #include <DataTypes/DataType.hpp>
+#include <ErrorHandling.hpp>
 
 namespace NES::GeneratorFields
 {
@@ -68,7 +70,7 @@ public:
 
     std::ostream& generate(std::ostream& os, std::mt19937& randEng) override;
 
-    static void validate(std::string_view rawSchemaLine);
+    [[nodiscard]] static std::expected<void, Exception> validate(std::string_view rawSchemaLine);
 
     FieldType sequencePosition;
     FieldType sequenceStart;
@@ -107,7 +109,7 @@ public:
 
     explicit NormalDistributionField(std::string_view rawSchemaLine);
     std::ostream& generate(std::ostream& os, std::mt19937& randEng) override;
-    static void validate(std::string_view rawSchemaLine);
+    [[nodiscard]] static std::expected<void, Exception> validate(std::string_view rawSchemaLine);
 
 private:
     DistributionVariant distribution;
@@ -122,7 +124,7 @@ class WordListField final : public BaseGeneratorField
 public:
     explicit WordListField(std::string_view rawSchemaLine);
     std::ostream& generate(std::ostream& os, std::mt19937& randEng) override;
-    static void validate(std::string_view rawSchemaLine);
+    [[nodiscard]] static std::expected<void, Exception> validate(std::string_view rawSchemaLine);
 
 private:
     std::vector<std::string> wordList;
@@ -136,7 +138,7 @@ class RandomStrField final : public BaseGeneratorField
 public:
     explicit RandomStrField(std::string_view rawSchemaLine);
     std::ostream& generate(std::ostream& os, std::mt19937& randEng) override;
-    static void validate(std::string_view rawSchemaLine);
+    [[nodiscard]] static std::expected<void, Exception> validate(std::string_view rawSchemaLine);
 
 private:
     std::size_t minLength;
@@ -153,7 +155,8 @@ using GeneratorFieldType = std::variant<SequenceField, NormalDistributionField, 
 struct FieldValidator
 {
     FieldIdentifier identifier;
-    std::function<void(std::string_view)> validator; /// Validator function throws an Exception if field is invalid
+    /// Returns an Exception describing the problem if the field is invalid
+    std::function<std::expected<void, Exception>(std::string_view)> validator;
 };
 
 /// @brief Array containing functions paired with the fields identifier used to validate the fields syntax
@@ -165,6 +168,12 @@ static const std::array<FieldValidator, 4> Validators = {
      {.identifier = FieldIdentifier::RANDOMSTR, .validator = RandomStrField::validate}},
 };
 /// NOLINTEND(cert-err58-cpp)
+
+/// Validates a single, trimmed schema line by dispatching to the field validator registered for its identifier.
+[[nodiscard]] std::expected<void, Exception> validateSchemaLine(std::string_view line);
+
+/// Validates a complete generator schema. Returns the first validation error encountered.
+[[nodiscard]] std::expected<void, Exception> validateSchema(std::string_view rawSchema);
 
 /// @brief Multimap containing key-value pairs of the existing generator fields and which types they accept
 /// NOLINTBEGIN(cert-err58-cpp): do not warn about static storage duration

--- a/nes-plugins/Sources/GeneratorSource/GeneratorSource.cpp
+++ b/nes-plugins/Sources/GeneratorSource/GeneratorSource.cpp
@@ -18,21 +18,28 @@
 #include <cstddef>
 #include <cstdint>
 #include <exception>
+#include <expected>
 #include <iostream>
 #include <memory>
 #include <stop_token>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <utility>
 #include <Configurations/Descriptor.hpp>
+#include <Configurations/Enums/EnumWrapper.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
 #include <Sources/Source.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Util/Logger/Logger.hpp>
+#include <fmt/ranges.h>
+#include <magic_enum/magic_enum.hpp>
+#include <ErrorHandling.hpp>
 #include <FixedGeneratorRate.hpp>
 #include <Generator.hpp>
+#include <GeneratorFields.hpp>
 #include <GeneratorRate.hpp>
 #include <SinusGeneratorRate.hpp>
 #include <SourceRegistry.hpp>
@@ -185,16 +192,80 @@ std::ostream& GeneratorSource::toString(std::ostream& str) const
     return str;
 }
 
-DescriptorConfig::Config GeneratorSource::validateAndFormat(std::unordered_map<std::string, std::string> config)
+std::expected<void, Exception> GeneratorSource::validateGeneratorRateConfig(const std::string_view configString)
 {
-    return DescriptorConfig::validateAndFormat<ConfigParametersGenerator>(std::move(config), NAME);
+    if (SinusGeneratorRate::parseAndValidateConfigString(configString).has_value()
+        or FixedGeneratorRate::parseAndValidateConfigString(configString).has_value())
+    {
+        return {};
+    }
+    return std::unexpected(InvalidConfigParameter(
+        "Cannot validate {}: \"{}\"! Expected \"emit_rate <rate>\" or \"amplitude <amplitude>, frequency <frequency>\"",
+        ConfigParametersGenerator::GENERATOR_RATE_CONFIG.name,
+        configString));
+}
+
+namespace
+{
+/// Produces informative errors for the generator-specific parameters upfront; the generic
+/// DescriptorConfig::tryValidateAndFormat afterwards only reports which parameter failed.
+std::expected<void, Exception> validateGeneratorSpecificConfig(const std::unordered_map<std::string, std::string>& config)
+{
+    const auto schema = config.find(ConfigParametersGenerator::GENERATOR_SCHEMA);
+    if (auto validSchema = GeneratorFields::validateSchema(schema != config.end() ? std::string_view{schema->second} : std::string_view{});
+        not validSchema.has_value())
+    {
+        return validSchema;
+    }
+    if (const auto stop = config.find(ConfigParametersGenerator::SEQUENCE_STOPS_GENERATOR);
+        stop != config.end() and not EnumWrapper{stop->second}.asEnum<GeneratorStop>().has_value())
+    {
+        constexpr auto stopBehaviors = magic_enum::enum_names<GeneratorStop>();
+        return std::unexpected(InvalidConfigParameter(
+            "Cannot validate {}: \"{}\"! Expected one of: {}",
+            ConfigParametersGenerator::SEQUENCE_STOPS_GENERATOR.name,
+            stop->second,
+            fmt::join(stopBehaviors, ", ")));
+    }
+    if (const auto rateType = config.find(ConfigParametersGenerator::GENERATOR_RATE_TYPE);
+        rateType != config.end() and not EnumWrapper{rateType->second}.asEnum<GeneratorRate::Type>().has_value())
+    {
+        constexpr auto rateTypes = magic_enum::enum_names<GeneratorRate::Type>();
+        return std::unexpected(InvalidConfigParameter(
+            "Cannot validate {}: \"{}\"! Expected one of: {}",
+            ConfigParametersGenerator::GENERATOR_RATE_TYPE.name,
+            rateType->second,
+            fmt::join(rateTypes, ", ")));
+    }
+    if (const auto rateConfig = config.find(ConfigParametersGenerator::GENERATOR_RATE_CONFIG); rateConfig != config.end())
+    {
+        if (auto validRate = GeneratorSource::validateGeneratorRateConfig(rateConfig->second); not validRate.has_value())
+        {
+            return validRate;
+        }
+    }
+    return {};
+}
+}
+
+std::expected<DescriptorConfig::Config, Exception> GeneratorSource::validateAndFormat(std::unordered_map<std::string, std::string> config)
+{
+    return validateGeneratorSpecificConfig(config).and_then(
+        [&config] { return DescriptorConfig::tryValidateAndFormat<ConfigParametersGenerator>(std::move(config), NAME); });
 }
 
 SourceValidationRegistryReturnType
 ///NOLINTNEXTLINE (performance-unnecessary-value-param)
 RegisterGeneratorSourceValidation(SourceValidationRegistryArguments sourceConfig)
 {
-    return GeneratorSource::validateAndFormat(sourceConfig.config);
+    /// The validation itself is non-throwing; the registry interface reports validation errors via
+    /// exceptions, so the returned error is thrown at this single, visible boundary.
+    auto validatedConfig = GeneratorSource::validateAndFormat(std::move(sourceConfig.config));
+    if (not validatedConfig.has_value())
+    {
+        throw std::move(validatedConfig).error();
+    }
+    return std::move(validatedConfig).value();
 }
 
 ///NOLINTNEXTLINE (performance-unnecessary-value-param)

--- a/nes-plugins/Sources/GeneratorSource/GeneratorSource.cpp
+++ b/nes-plugins/Sources/GeneratorSource/GeneratorSource.cpp
@@ -200,7 +200,7 @@ std::expected<void, Exception> GeneratorSource::validateGeneratorRateConfig(cons
         return {};
     }
     return std::unexpected(InvalidConfigParameter(
-        "Cannot validate {}: \"{}\"! Expected \"emit_rate <rate>\" or \"amplitude <amplitude>, frequency <frequency>\"",
+        R"(Cannot validate {}: "{}"! Expected "emit_rate <rate>" or "amplitude <amplitude>, frequency <frequency>")",
         ConfigParametersGenerator::GENERATOR_RATE_CONFIG.name,
         configString));
 }

--- a/nes-plugins/Sources/GeneratorSource/GeneratorSource.hpp
+++ b/nes-plugins/Sources/GeneratorSource/GeneratorSource.hpp
@@ -17,6 +17,7 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <expected>
 #include <memory>
 #include <optional>
 #include <ostream>
@@ -33,14 +34,10 @@
 #include <Runtime/TupleBuffer.hpp>
 #include <Sources/Source.hpp>
 #include <Sources/SourceDescriptor.hpp>
-#include <Util/Logger/Logger.hpp>
-#include <Util/Strings.hpp>
 #include <ErrorHandling.hpp>
-#include <FixedGeneratorRate.hpp>
 #include <Generator.hpp>
 #include <GeneratorFields.hpp>
 #include <GeneratorRate.hpp>
-#include <SinusGeneratorRate.hpp>
 
 namespace NES
 {
@@ -65,7 +62,12 @@ public:
     void open(std::shared_ptr<AbstractBufferProvider> bufferProvider) override;
     void close() override;
 
-    static DescriptorConfig::Config validateAndFormat(std::unordered_map<std::string, std::string> config);
+    /// Validates the generator config without throwing: a malformed user config is reported via the returned error.
+    [[nodiscard]] static std::expected<DescriptorConfig::Config, Exception>
+    validateAndFormat(std::unordered_map<std::string, std::string> config);
+
+    /// A rate config is valid if it parses as either a fixed or a sinus rate.
+    [[nodiscard]] static std::expected<void, Exception> validateGeneratorRateConfig(std::string_view configString);
 
 private:
     uint32_t seed;
@@ -83,37 +85,13 @@ private:
 
 struct ConfigParametersGenerator
 {
+    /// The validation lambdas must not throw on malformed user input: they return nullopt on invalid values,
+    /// GeneratorSource::validateAndFormat produces the informative error for the user.
     static inline const DescriptorConfig::ConfigParameter<EnumWrapper, GeneratorStop> SEQUENCE_STOPS_GENERATOR{
         "STOP_GENERATOR_WHEN_SEQUENCE_FINISHES",
         std::nullopt,
         [](const std::unordered_map<std::string, std::string>& config)
-        {
-            const auto optToken = DescriptorConfig::tryGet(SEQUENCE_STOPS_GENERATOR, config);
-            if (not optToken.has_value() || not optToken.value().asEnum<GeneratorStop>().has_value())
-            {
-                NES_ERROR("Cannot validate stop_generator_when_sequence_finishes: {}!", config.at("STOP_GENERATOR_WHEN_SEQUENCE_FINISHES"))
-                throw InvalidConfigParameter(
-                    "Cannot validate stop_generator_when_sequence_finishes: {}!", config.at("STOP_GENERATOR_WHEN_SEQUENCE_FINISHES"));
-            }
-            switch (optToken.value().asEnum<GeneratorStop>().value())
-            {
-                case GeneratorStop::ALL: {
-                    return std::optional(EnumWrapper(GeneratorStop::ALL));
-                }
-                case GeneratorStop::ONE: {
-                    return std::optional(EnumWrapper(GeneratorStop::ONE));
-                }
-                case GeneratorStop::NONE: {
-                    return std::optional(EnumWrapper(GeneratorStop::NONE));
-                }
-                default: {
-                    NES_ERROR(
-                        "Cannot validate stop_generator_when_sequence_finishes: {}!", config.at("STOP_GENERATOR_WHEN_SEQUENCE_FINISHES"))
-                    throw InvalidConfigParameter(
-                        "Cannot validate stop_generator_when_sequence_finishes: {}!", config.at("STOP_GENERATOR_WHEN_SEQUENCE_FINISHES"));
-                }
-            }
-        }};
+        { return DescriptorConfig::tryGet(SEQUENCE_STOPS_GENERATOR, config); }};
 
     static inline const DescriptorConfig::ConfigParameter<uint32_t> SEED{
         "SEED",
@@ -123,77 +101,32 @@ struct ConfigParametersGenerator
     static inline const DescriptorConfig::ConfigParameter<EnumWrapper, GeneratorRate::Type> GENERATOR_RATE_TYPE{
         "GENERATOR_RATE_TYPE",
         EnumWrapper{GeneratorRate::Type::FIXED},
-        [](const std::unordered_map<std::string, std::string>& config)
-        {
-            const auto optToken = DescriptorConfig::tryGet(GENERATOR_RATE_TYPE, config);
-            if (not optToken.has_value() || not optToken.value().asEnum<GeneratorRate::Type>().has_value())
-            {
-                return std::optional<EnumWrapper>();
-            }
-            switch (optToken.value().asEnum<GeneratorRate::Type>().value())
-            {
-                case GeneratorRate::Type::FIXED:
-                    return std::optional(EnumWrapper(GeneratorRate::Type::FIXED));
-                case GeneratorRate::Type::SINUS:
-                    return std::optional(EnumWrapper(GeneratorRate::Type::SINUS));
-            }
-            return std::optional<EnumWrapper>();
-        }};
+        [](const std::unordered_map<std::string, std::string>& config) { return DescriptorConfig::tryGet(GENERATOR_RATE_TYPE, config); }};
 
     static inline const DescriptorConfig::ConfigParameter<std::string> GENERATOR_RATE_CONFIG{
         "GENERATOR_RATE_CONFIG",
         "emit_rate 1000",
-        [](const std::unordered_map<std::string, std::string>& config)
+        [](const std::unordered_map<std::string, std::string>& config) -> std::optional<std::string>
         {
-            const auto optToken = DescriptorConfig::tryGet(GENERATOR_RATE_CONFIG, config);
-            if (not optToken.has_value())
+            auto configString = DescriptorConfig::tryGet(GENERATOR_RATE_CONFIG, config);
+            if (configString.has_value() and GeneratorSource::validateGeneratorRateConfig(configString.value()).has_value())
             {
-                return std::optional<std::string>();
+                return configString;
             }
-            if (SinusGeneratorRate::parseAndValidateConfigString(optToken.value()).has_value()
-                or FixedGeneratorRate::parseAndValidateConfigString(optToken.value()).has_value())
-            {
-                return DescriptorConfig::tryGet(GENERATOR_RATE_CONFIG, config);
-            }
-            return std::optional<std::string>();
+            return std::nullopt;
         }};
 
     static inline const DescriptorConfig::ConfigParameter<std::string> GENERATOR_SCHEMA{
         "GENERATOR_SCHEMA",
         {},
-        [](const std::unordered_map<std::string, std::string>& config)
+        [](const std::unordered_map<std::string, std::string>& config) -> std::optional<std::string>
         {
-            const std::string schema = DescriptorConfig::tryGet(GENERATOR_SCHEMA, config).value_or("");
-            if (schema.empty())
+            auto schema = DescriptorConfig::tryGet(GENERATOR_SCHEMA, config);
+            if (schema.has_value() and GeneratorFields::validateSchema(schema.value()).has_value())
             {
-                NES_ERROR("Generator schema cannot be empty!")
-                throw InvalidConfigParameter("Generator schema cannot be empty!");
+                return schema;
             }
-
-
-            for (const auto lines = splitOnMultipleDelimiters(schema, {',', '\n'}); auto line : lines)
-            {
-                line = trimWhiteSpaces(line);
-                const auto foundIdentifier
-                    = magic_enum::enum_cast<GeneratorFields::FieldIdentifier>(NES::toUpperCase(line.substr(0, line.find_first_of(' '))));
-                bool validatorExists = false;
-                for (const auto& [identifier, validator] : GeneratorFields::Validators)
-                {
-                    if (identifier == foundIdentifier)
-                    {
-                        validator(line);
-                        validatorExists = true;
-                        break;
-                    }
-                }
-                if (not validatorExists)
-                {
-                    NES_ERROR("Cannot identify the type of field in \"{}\", does the field have a registered validator?", line);
-                    throw InvalidConfigParameter(
-                        "Cannot identify the type of field in \"{}\", does the field have a registered validator?", line);
-                }
-            }
-            return DescriptorConfig::tryGet(GENERATOR_SCHEMA, config);
+            return std::nullopt;
         }};
 
     static inline const NES::DescriptorConfig::ConfigParameter<uint64_t> FLUSH_INTERVAL_MS{

--- a/nes-plugins/Sources/GeneratorSource/tests/CMakeLists.txt
+++ b/nes-plugins/Sources/GeneratorSource/tests/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_nes_unit_test(generator_source_validation_test GeneratorSourceValidationTest.cpp)
+target_link_libraries(generator_source_validation_test generator_source_plugin_library nes-sources)

--- a/nes-plugins/Sources/GeneratorSource/tests/GeneratorSourceValidationTest.cpp
+++ b/nes-plugins/Sources/GeneratorSource/tests/GeneratorSourceValidationTest.cpp
@@ -1,0 +1,235 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <variant>
+
+#include <Configurations/Descriptor.hpp>
+#include <Configurations/Enums/EnumWrapper.hpp>
+#include <Util/Logger/LogLevel.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <Util/Logger/impl/NesLogger.hpp>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <BaseUnitTest.hpp>
+#include <ErrorHandling.hpp>
+#include <GeneratorRate.hpp>
+#include <GeneratorSource.hpp>
+
+namespace NES
+{
+
+class GeneratorSourceValidationTest : public Testing::BaseUnitTest
+{
+public:
+    static void SetUpTestSuite() { Logger::setupLogging("GeneratorSourceValidationTest.log", LogLevel::LOG_DEBUG); }
+};
+
+namespace
+{
+std::unordered_map<std::string, std::string> validConfig()
+{
+    return {{"GENERATOR_SCHEMA", "SEQUENCE UINT64 0 10 1"}, {"STOP_GENERATOR_WHEN_SEQUENCE_FINISHES", "ALL"}};
+}
+
+void expectInvalidConfig(const std::unordered_map<std::string, std::string>& config, const std::string_view expectedMessagePart)
+{
+    const auto result = GeneratorSource::validateAndFormat(config);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code(), ErrorCode::InvalidConfigParameter);
+    EXPECT_THAT(result.error().what(), ::testing::HasSubstr(std::string{expectedMessagePart}));
+}
+}
+
+TEST_F(GeneratorSourceValidationTest, ValidConfigIsAccepted)
+{
+    const auto result = GeneratorSource::validateAndFormat(validConfig());
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(std::get<std::string>(result->at("GENERATOR_SCHEMA")), "SEQUENCE UINT64 0 10 1");
+    /// Unspecified parameters with defaults are filled in.
+    EXPECT_EQ(std::get<EnumWrapper>(result->at("GENERATOR_RATE_TYPE")).asEnum<GeneratorRate::Type>(), GeneratorRate::Type::FIXED);
+}
+
+TEST_F(GeneratorSourceValidationTest, ValidMultiFieldSchemaIsAccepted)
+{
+    auto config = validConfig();
+    config["GENERATOR_SCHEMA"] = "SEQUENCE UINT64 0 20 1, RANDOMSTR 1 6, NORMAL_DISTRIBUTION FLOAT64 5 1";
+    EXPECT_TRUE(GeneratorSource::validateAndFormat(config).has_value());
+}
+
+TEST_F(GeneratorSourceValidationTest, ValidSinusRateConfigIsAccepted)
+{
+    auto config = validConfig();
+    config["GENERATOR_RATE_TYPE"] = "SINUS";
+    config["GENERATOR_RATE_CONFIG"] = "amplitude 10, frequency 5";
+    EXPECT_TRUE(GeneratorSource::validateAndFormat(config).has_value());
+}
+
+TEST_F(GeneratorSourceValidationTest, MissingSchemaIsRejected)
+{
+    auto config = validConfig();
+    config.erase("GENERATOR_SCHEMA");
+    expectInvalidConfig(config, "Generator schema cannot be empty");
+}
+
+TEST_F(GeneratorSourceValidationTest, EmptySchemaIsRejected)
+{
+    auto config = validConfig();
+    config["GENERATOR_SCHEMA"] = "";
+    expectInvalidConfig(config, "Generator schema cannot be empty");
+}
+
+TEST_F(GeneratorSourceValidationTest, UnknownFieldTypeIsRejected)
+{
+    auto config = validConfig();
+    config["GENERATOR_SCHEMA"] = "FOO UINT64 0 10 1";
+    expectInvalidConfig(config, "Cannot identify the type of field");
+}
+
+TEST_F(GeneratorSourceValidationTest, SequenceFieldWithWrongParameterCountIsRejected)
+{
+    auto config = validConfig();
+    config["GENERATOR_SCHEMA"] = "SEQUENCE UINT64 0 10";
+    expectInvalidConfig(config, "Number of SequenceField parameters does not match");
+}
+
+TEST_F(GeneratorSourceValidationTest, SequenceFieldWithInvalidTypeIsRejected)
+{
+    auto config = validConfig();
+    config["GENERATOR_SCHEMA"] = "SEQUENCE FOO 0 10 1";
+    expectInvalidConfig(config, "Invalid SequenceField type of FOO");
+}
+
+TEST_F(GeneratorSourceValidationTest, SequenceFieldWithVarsizedTypeIsRejected)
+{
+    auto config = validConfig();
+    config["GENERATOR_SCHEMA"] = "SEQUENCE VARSIZED 0 10 1";
+    expectInvalidConfig(config, "Could not parse VARSIZED as SequenceField");
+}
+
+TEST_F(GeneratorSourceValidationTest, SequenceFieldWithUnparsableBoundIsRejected)
+{
+    auto config = validConfig();
+    config["GENERATOR_SCHEMA"] = "SEQUENCE UINT64 abc 10 1";
+    expectInvalidConfig(config, "Could not parse abc as SequenceField start");
+}
+
+TEST_F(GeneratorSourceValidationTest, NormalDistributionWithWrongParameterCountIsRejected)
+{
+    auto config = validConfig();
+    config["GENERATOR_SCHEMA"] = "NORMAL_DISTRIBUTION FLOAT64 5";
+    expectInvalidConfig(config, "Invalid NORMAL_DISTRIBUTION schema line");
+}
+
+TEST_F(GeneratorSourceValidationTest, NormalDistributionWithInvalidTypeIsRejected)
+{
+    auto config = validConfig();
+    config["GENERATOR_SCHEMA"] = "NORMAL_DISTRIBUTION FOO 5 1";
+    expectInvalidConfig(config, "Invalid Type in NORMAL_DISTRIBUTION");
+}
+
+TEST_F(GeneratorSourceValidationTest, NormalDistributionWithUnparsableMeanIsRejected)
+{
+    auto config = validConfig();
+    config["GENERATOR_SCHEMA"] = "NORMAL_DISTRIBUTION FLOAT64 abc 1";
+    expectInvalidConfig(config, "Can not parse mean or stddev");
+}
+
+TEST_F(GeneratorSourceValidationTest, NormalDistributionWithNegativeStddevIsRejected)
+{
+    auto config = validConfig();
+    config["GENERATOR_SCHEMA"] = "NORMAL_DISTRIBUTION FLOAT64 5 -1";
+    expectInvalidConfig(config, "Stddev must be non-negative");
+}
+
+TEST_F(GeneratorSourceValidationTest, WordListWithWrongParameterCountIsRejected)
+{
+    auto config = validConfig();
+    config["GENERATOR_SCHEMA"] = "WORDLIST";
+    expectInvalidConfig(config, "Invalid WORDLIST schema line");
+}
+
+TEST_F(GeneratorSourceValidationTest, WordListWithMissingFileIsRejected)
+{
+    auto config = validConfig();
+    config["GENERATOR_SCHEMA"] = "WORDLIST this-file-does-not-exist.csv";
+    expectInvalidConfig(config, "does not exist");
+}
+
+TEST_F(GeneratorSourceValidationTest, RandomStrWithWrongParameterCountIsRejected)
+{
+    auto config = validConfig();
+    config["GENERATOR_SCHEMA"] = "RANDOMSTR 1";
+    expectInvalidConfig(config, "Invalid RANDOMSTR schema line");
+}
+
+TEST_F(GeneratorSourceValidationTest, RandomStrWithUnparsableMinLengthIsRejected)
+{
+    auto config = validConfig();
+    config["GENERATOR_SCHEMA"] = "RANDOMSTR abc 5";
+    expectInvalidConfig(config, "Cannot parse MINLENGTH");
+}
+
+TEST_F(GeneratorSourceValidationTest, RandomStrWithZeroMinLengthIsRejected)
+{
+    auto config = validConfig();
+    config["GENERATOR_SCHEMA"] = "RANDOMSTR 0 5";
+    expectInvalidConfig(config, "MINLENGTH");
+}
+
+TEST_F(GeneratorSourceValidationTest, RandomStrWithMinLengthGreaterMaxLengthIsRejected)
+{
+    auto config = validConfig();
+    config["GENERATOR_SCHEMA"] = "RANDOMSTR 6 5";
+    expectInvalidConfig(config, "The MINLENGTH can not be longer than the MAXLENGTH");
+}
+
+TEST_F(GeneratorSourceValidationTest, InvalidStopBehaviorIsRejected)
+{
+    auto config = validConfig();
+    config["STOP_GENERATOR_WHEN_SEQUENCE_FINISHES"] = "SOMETIMES";
+    expectInvalidConfig(config, "STOP_GENERATOR_WHEN_SEQUENCE_FINISHES: \"SOMETIMES\"");
+}
+
+TEST_F(GeneratorSourceValidationTest, MissingStopBehaviorIsRejected)
+{
+    auto config = validConfig();
+    config.erase("STOP_GENERATOR_WHEN_SEQUENCE_FINISHES");
+    expectInvalidConfig(config, "Non-default parameter STOP_GENERATOR_WHEN_SEQUENCE_FINISHES not specified");
+}
+
+TEST_F(GeneratorSourceValidationTest, InvalidRateTypeIsRejected)
+{
+    auto config = validConfig();
+    config["GENERATOR_RATE_TYPE"] = "QUADRATIC";
+    expectInvalidConfig(config, "GENERATOR_RATE_TYPE: \"QUADRATIC\"");
+}
+
+TEST_F(GeneratorSourceValidationTest, InvalidRateConfigIsRejected)
+{
+    auto config = validConfig();
+    config["GENERATOR_RATE_CONFIG"] = "emit_rate abc";
+    expectInvalidConfig(config, "GENERATOR_RATE_CONFIG: \"emit_rate abc\"");
+}
+
+TEST_F(GeneratorSourceValidationTest, UnknownParameterIsRejected)
+{
+    auto config = validConfig();
+    config["FOO"] = "BAR";
+    expectInvalidConfig(config, "Unknown configuration parameter: FOO");
+}
+
+}

--- a/nes-plugins/Sources/GeneratorSource/tests/GeneratorSourceValidationTest.cpp
+++ b/nes-plugins/Sources/GeneratorSource/tests/GeneratorSourceValidationTest.cpp
@@ -12,10 +12,13 @@
     limitations under the License.
 */
 
+#include <cstdint>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
 
+#include <Configurations/Descriptor.hpp>
 #include <Configurations/Enums/EnumWrapper.hpp>
 #include <Util/Logger/LogLevel.hpp>
 #include <Util/Logger/impl/NesLogger.hpp>
@@ -227,6 +230,32 @@ TEST_F(GeneratorSourceValidationTest, UnknownParameterIsRejected)
     auto config = validConfig();
     config["FOO"] = "BAR";
     expectInvalidConfig(config, "Unknown configuration parameter: FOO");
+}
+
+namespace
+{
+/// A config whose validator throws (the legacy style) instead of returning nullopt.
+struct ThrowingValidatorConfig
+{
+    static inline const DescriptorConfig::ConfigParameter<uint32_t> ALWAYS_THROWS{
+        "ALWAYS_THROWS",
+        std::nullopt,
+        [](const std::unordered_map<std::string, std::string>&) -> std::optional<uint32_t>
+        { throw InvalidConfigParameter("thrown from a legacy validator"); }};
+
+    static inline std::unordered_map<std::string, DescriptorConfig::ConfigParameterContainer> parameterMap
+        = DescriptorConfig::createConfigParameterContainerMap(ALWAYS_THROWS);
+};
+}
+
+/// The non-throwing entry point must uphold its contract even when a plugin validator throws.
+TEST_F(GeneratorSourceValidationTest, ThrowingValidatorIsReportedAsError)
+{
+    const auto result
+        = DescriptorConfig::tryValidateAndFormat<ThrowingValidatorConfig>({{"ALWAYS_THROWS", "42"}}, "ThrowingValidatorConfig");
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code(), ErrorCode::InvalidConfigParameter);
+    EXPECT_THAT(result.error().what(), ::testing::HasSubstr("thrown from a legacy validator"));
 }
 
 }

--- a/nes-plugins/Sources/GeneratorSource/tests/GeneratorSourceValidationTest.cpp
+++ b/nes-plugins/Sources/GeneratorSource/tests/GeneratorSourceValidationTest.cpp
@@ -15,12 +15,9 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
-#include <variant>
 
-#include <Configurations/Descriptor.hpp>
 #include <Configurations/Enums/EnumWrapper.hpp>
 #include <Util/Logger/LogLevel.hpp>
-#include <Util/Logger/Logger.hpp>
 #include <Util/Logger/impl/NesLogger.hpp>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/nes-plugins/Sources/GeneratorSource/tests/GeneratorSourceValidationTest.cpp
+++ b/nes-plugins/Sources/GeneratorSource/tests/GeneratorSourceValidationTest.cpp
@@ -235,14 +235,18 @@ TEST_F(GeneratorSourceValidationTest, UnknownParameterIsRejected)
 namespace
 {
 /// A config whose validator throws (the legacy style) instead of returning nullopt.
+/// tryValidateAndFormat requires parameterMap as a static member, so this mirrors the static-inline
+/// declaration style of every production parameterMap (which predates the cert-err58 check).
 struct ThrowingValidatorConfig
 {
+    /// NOLINTNEXTLINE(cert-err58-cpp)
     static inline const DescriptorConfig::ConfigParameter<uint32_t> ALWAYS_THROWS{
         "ALWAYS_THROWS",
         std::nullopt,
         [](const std::unordered_map<std::string, std::string>&) -> std::optional<uint32_t>
         { throw InvalidConfigParameter("thrown from a legacy validator"); }};
 
+    /// NOLINTNEXTLINE(cert-err58-cpp)
     static inline std::unordered_map<std::string, DescriptorConfig::ConfigParameterContainer> parameterMap
         = DescriptorConfig::createConfigParameterContainerMap(ALWAYS_THROWS);
 };


### PR DESCRIPTION
## Summary

GeneratorSource config validation no longer throws on malformed user config. All validation functions return `std::expected<T, Exception>` (using the existing exception factories from `ExceptionDefinitions.inc` as error payload, so errors keep their code + message); the single remaining throw sits visibly at the registry adapter, whose interface reports errors via exceptions.

## Throw-site inventory (before → after)

Validation path (all converted to `std::expected` error returns):

| Location | Throws before | After |
|---|---|---|
| `ConfigParametersGenerator::SEQUENCE_STOPS_GENERATOR` lambda | 2 | plain `tryGet`, informative error in `validateGeneratorSpecificConfig` |
| `ConfigParametersGenerator::GENERATOR_SCHEMA` lambda | 2 (empty schema, unknown field type) | delegates to `GeneratorFields::validateSchema` |
| `GeneratorFields::SequenceField::validate` | 4 (param count, bad type, VARSIZED/UNDEFINED, unparsable start/end/step) | `std::expected<void, Exception>`, monadic `and_then` chain |
| `GeneratorFields::NormalDistributionField::validate` | 4 | `std::expected<void, Exception>` |
| `GeneratorFields::WordListField::validate` | 4 | `std::expected<void, Exception>` |
| `GeneratorFields::RandomStrField::validate` | 6 | `std::expected<void, Exception>` |
| `DescriptorConfig::validateAndFormat` (framework) | 3 (unknown key, missing mandatory, failed validator) | new non-throwing `tryValidateAndFormat`; the throwing overload delegates to it (other sources unchanged) |

Total: **25 throw statements** removed from the validation path.

Kept as-is (post-validation construction path, i.e. internal invariants per the issue): `Generator` ctor, `Generator::parseRawSchemaLine`, `SequenceField`/`RandomStrField` ctors, and the existing `INVARIANT`s in `NormalDistributionField`/`WordListField` ctors.

## Error shape

- `std::expected<void, Exception>` for per-field validators and `std::expected<DescriptorConfig::Config, Exception>` for the plugin entry point. `Exception` already carries an error code and a formatted message, and `std::expected<SourceDescriptor, Exception>` is established precedent (`SourceCatalog`), so no new error type is introduced and no exception type is defined outside `ExceptionDefinitions.inc`.
- `GeneratorSource::validateAndFormat` first runs `validateGeneratorSpecificConfig` (informative errors: parameter name + offending value + expected values) and then composes with `DescriptorConfig::tryValidateAndFormat` via `and_then`. Returns the first error.
- The `ConfigParameter` validation lambdas keep the framework-mandated `std::optional<T>` signature but are now thin, non-throwing `tryGet` wrappers; the deep checks stay reachable through them as defense in depth.
- `RegisterGeneratorSourceValidation` unwraps the expected and throws the contained error at this single, documented boundary, since `SourceValidationRegistryReturnType` is `DescriptorConfig::Config` for all sources.

## Behavioral notes

- Valid configs validate exactly as before.
- Error messages are at least as informative as the old throw messages; enum parameters now additionally list the accepted values, and a missing `GENERATOR_SCHEMA` now reports "Generator schema cannot be empty!" instead of the generic missing-parameter message.

## Tests

New `generator_source_validation_test` (first unit test for this plugin, wired via `add_tests_if_enabled`) with 24 cases: 3 accepting valid configs (defaults filled in, multi-field schema, sinus rate) and one per distinct validation failure, asserting `ErrorCode::InvalidConfigParameter` plus a message substring including the offending value.

Closes #1730

🤖 Generated with [Claude Code](https://claude.com/claude-code)