### PR TITLE
Fix sql parser issues to support slt corpus

### DIFF
--- a/nes-sql-parser/AntlrSQL.g4
+++ b/nes-sql-parser/AntlrSQL.g4
@@ -263,11 +263,25 @@ booleanExpression
     ;
 
 predicate
-    : NOT predicate                                          #logicalNotPredicate
-    | '(' predicate ')'                                      #parenthesizedPredicate
+    : orPredicate
+    ;
+
+orPredicate
+    : andPredicate (OR andPredicate)*
+    ;
+
+andPredicate
+    : notPredicate (AND notPredicate)*
+    ;
+
+notPredicate
+    : NOT notPredicate                                       #logicalNotPredicate
+    | predicatePrimary                                      #predicatePrimaryExpression
+    ;
+
+predicatePrimary
+    : '(' predicate ')'                                      #parenthesizedPredicate
     | valueExpression booleanComparison?                     #boolComparison
-    | left=predicate op=AND right=predicate                  #logicalBinary
-    | left=predicate op=OR right=predicate                   #logicalBinary
     ;
 
 /// Problem fixed that the querySpecification rule could match an empty string

--- a/nes-sql-parser/AntlrSQL.g4
+++ b/nes-sql-parser/AntlrSQL.g4
@@ -264,6 +264,7 @@ booleanExpression
 
 predicate
     : NOT predicate                                          #logicalNotPredicate
+    | '(' predicate ')'                                      #parenthesizedPredicate
     | valueExpression booleanComparison?                     #boolComparison
     | left=predicate op=AND right=predicate                  #logicalBinary
     | left=predicate op=OR right=predicate                   #logicalBinary

--- a/nes-sql-parser/AntlrSQL.g4
+++ b/nes-sql-parser/AntlrSQL.g4
@@ -399,7 +399,7 @@ primaryExpression
     | base=primaryExpression '.' fieldName=identifier                                          #dereference
     | '(' query ')'                                                                            #subqueryExpression
     | '(' namedExpression (',' namedExpression)+ ')'                                           #rowConstructor
-    | '(' expression ')'                                                                       #parenthesizedExpression
+    | '(' valueExpression ')'                                                                  #parenthesizedExpression
     | constant                                                                                 #constantDefault
     | identifier                                                                               #columnReference
     ;

--- a/nes-sql-parser/AntlrSQL.g4
+++ b/nes-sql-parser/AntlrSQL.g4
@@ -161,7 +161,7 @@ joinCriteria
     ;
 
 relationPrimary
-    : multipartIdentifier                     #tableName
+    : multipartIdentifier (AS alias=identifier)? #namedSource
     | '(' query ')'                           #aliasedQuery
     | '(' relation ')'                        #aliasedRelation
     | inlineTable                             #inlineTableDefault2
@@ -414,6 +414,7 @@ primaryExpression
     | '(' query ')'                                                                            #subqueryExpression
     | '(' namedExpression (',' namedExpression)+ ')'                                           #rowConstructor
     | '(' valueExpression ')'                                                                  #parenthesizedExpression
+    | '(' predicate ')'                                                                        #parenthesizedPredicateExpression
     | constant                                                                                 #constantDefault
     | identifier                                                                               #columnReference
     ;

--- a/nes-sql-parser/private/AntlrSQLParser/AntlrSQLHelper.hpp
+++ b/nes-sql-parser/private/AntlrSQLParser/AntlrSQLHelper.hpp
@@ -43,6 +43,8 @@ class AntlrSQLHelper
     std::vector<LogicalFunction> whereClauses; ///where and having clauses need to be accessed in reverse
     std::vector<LogicalFunction> havingClauses;
     std::optional<Identifier> source;
+    std::optional<Identifier> sourceAlias;
+    std::vector<Identifier> sourceQualifiers;
     std::optional<std::pair<Identifier, ConfigMap>> anonymousSourceConfig;
     std::vector<Projection> projectionBuilder;
 
@@ -85,7 +87,6 @@ public:
     /// Utility variables to keep state between enter/exit parser function calls.
     size_t opBoolean{}; ///anonymous token enum in AntlrSQLLexer.h
     std::string opValue;
-    std::optional<Identifier> newSourceName;
     std::optional<std::variant<Windowing::UnboundTimeCharacteristic, std::array<Windowing::UnboundTimeCharacteristic, 2>>> windowTimestamp;
 
     /// Utility variables used to keep track of the parsing state.
@@ -112,6 +113,10 @@ public:
     void addHavingClause(LogicalFunction expressionNode);
     void setSource(Identifier sourceName);
     [[nodiscard]] std::optional<Identifier> getSource() const;
+    void setSourceAlias(Identifier alias);
+    [[nodiscard]] std::optional<Identifier> getSourceAlias() const;
+    void addSourceQualifier(Identifier qualifier);
+    [[nodiscard]] const std::vector<Identifier>& getSourceQualifiers() const;
     void setAnonymousSource(const Identifier& type, const ConfigMap& parameters);
     [[nodiscard]] std::optional<std::pair<Identifier, ConfigMap>> getAnonymousSourceConfig();
     void addProjection(std::optional<Identifier>, LogicalFunction);

--- a/nes-sql-parser/private/AntlrSQLParser/AntlrSQLQueryPlanCreator.hpp
+++ b/nes-sql-parser/private/AntlrSQLParser/AntlrSQLQueryPlanCreator.hpp
@@ -44,6 +44,7 @@ public:
     void exitSelectClause(AntlrSQLParser::SelectClauseContext* context) override;
     void enterFromClause(AntlrSQLParser::FromClauseContext* context) override;
     void exitFromClause(AntlrSQLParser::FromClauseContext* context) override;
+    void exitNamedSource(AntlrSQLParser::NamedSourceContext* context) override;
     void enterWhereClause(AntlrSQLParser::WhereClauseContext* context) override;
     void exitWhereClause(AntlrSQLParser::WhereClauseContext* context) override;
     void enterComparisonOperator(AntlrSQLParser::ComparisonOperatorContext* context) override;
@@ -74,7 +75,8 @@ public:
     void exitAndPredicate(AntlrSQLParser::AndPredicateContext* context) override;
     void exitLogicalNotPredicate(AntlrSQLParser::LogicalNotPredicateContext* context) override;
     void exitBoolComparison(AntlrSQLParser::BoolComparisonContext* context) override;
-    void enterUnquotedIdentifier(AntlrSQLParser::UnquotedIdentifierContext* context) override;
+    void exitDereference(AntlrSQLParser::DereferenceContext* context) override;
+    void exitStar(AntlrSQLParser::StarContext* context) override;
     void enterIdentifier(AntlrSQLParser::IdentifierContext* context) override;
     void enterTimeUnit(AntlrSQLParser::TimeUnitContext* context) override;
     void exitSizeParameter(AntlrSQLParser::SizeParameterContext* context) override;

--- a/nes-sql-parser/private/AntlrSQLParser/AntlrSQLQueryPlanCreator.hpp
+++ b/nes-sql-parser/private/AntlrSQLParser/AntlrSQLQueryPlanCreator.hpp
@@ -70,7 +70,8 @@ public:
 
     /// enter or exit functions (no pairs)
     void enterSinkClause(AntlrSQLParser::SinkClauseContext* context) override;
-    void exitLogicalBinary(AntlrSQLParser::LogicalBinaryContext* context) override;
+    void exitOrPredicate(AntlrSQLParser::OrPredicateContext* context) override;
+    void exitAndPredicate(AntlrSQLParser::AndPredicateContext* context) override;
     void exitLogicalNotPredicate(AntlrSQLParser::LogicalNotPredicateContext* context) override;
     void exitBoolComparison(AntlrSQLParser::BoolComparisonContext* context) override;
     void enterUnquotedIdentifier(AntlrSQLParser::UnquotedIdentifierContext* context) override;

--- a/nes-sql-parser/private/AntlrSQLParser/AntlrSQLQueryPlanCreator.hpp
+++ b/nes-sql-parser/private/AntlrSQLParser/AntlrSQLQueryPlanCreator.hpp
@@ -75,7 +75,6 @@ public:
     void exitAndPredicate(AntlrSQLParser::AndPredicateContext* context) override;
     void exitLogicalNotPredicate(AntlrSQLParser::LogicalNotPredicateContext* context) override;
     void exitBoolComparison(AntlrSQLParser::BoolComparisonContext* context) override;
-    void exitDereference(AntlrSQLParser::DereferenceContext* context) override;
     void exitStar(AntlrSQLParser::StarContext* context) override;
     void enterIdentifier(AntlrSQLParser::IdentifierContext* context) override;
     void enterTimeUnit(AntlrSQLParser::TimeUnitContext* context) override;

--- a/nes-sql-parser/src/AntlrSQLHelper.cpp
+++ b/nes-sql-parser/src/AntlrSQLHelper.cpp
@@ -30,6 +30,16 @@ std::optional<Identifier> AntlrSQLHelper::getSource() const
     return this->source;
 }
 
+std::optional<Identifier> AntlrSQLHelper::getSourceAlias() const
+{
+    return sourceAlias;
+}
+
+const std::vector<Identifier>& AntlrSQLHelper::getSourceQualifiers() const
+{
+    return sourceQualifiers;
+}
+
 std::vector<LogicalFunction>& AntlrSQLHelper::getWhereClauses()
 {
     return whereClauses;
@@ -44,6 +54,16 @@ std::vector<LogicalFunction>& AntlrSQLHelper::getHavingClauses()
 void AntlrSQLHelper::setSource(Identifier sourceName)
 {
     this->source = std::move(sourceName);
+}
+
+void AntlrSQLHelper::setSourceAlias(Identifier alias)
+{
+    sourceAlias = std::move(alias);
+}
+
+void AntlrSQLHelper::addSourceQualifier(Identifier qualifier)
+{
+    sourceQualifiers.emplace_back(std::move(qualifier));
 }
 
 void AntlrSQLHelper::setAnonymousSource(const Identifier& type, const ConfigMap& parameters)

--- a/nes-sql-parser/src/AntlrSQLQueryParser.cpp
+++ b/nes-sql-parser/src/AntlrSQLQueryParser.cpp
@@ -97,9 +97,14 @@ LogicalPlan createLogicalQueryPlanFromSQLString(std::string_view queryString)
         antlr4::CommonTokenStream tokens(&lexer);
         AntlrSQLParser parser(&tokens);
         [[maybe_unused]] auto listener = installErrorListenerAndHandler(queryString, lexer, parser);
-        AntlrSQLParser::SingleStatementContext* tree = parser.singleStatement();
+        auto* const tree = parser.singleStatement();
+        auto* const statement = tree->statement();
+        if (statement == nullptr || statement->queryWithOptions() == nullptr)
+        {
+            throw InvalidQuerySyntax("Expected a query statement in {}", queryString);
+        }
         Parsers::AntlrSQLQueryPlanCreator queryPlanCreator;
-        antlr4::tree::ParseTreeWalker::DEFAULT.walk(&queryPlanCreator, tree);
+        antlr4::tree::ParseTreeWalker::DEFAULT.walk(&queryPlanCreator, statement->queryWithOptions()->query());
         auto queryPlan = queryPlanCreator.getQueryPlan();
         queryPlan.setOriginalSql(std::string(queryString));
         NES_DEBUG("Created the following query from antlr AST: \n{}", queryPlan);

--- a/nes-sql-parser/src/AntlrSQLQueryParser.cpp
+++ b/nes-sql-parser/src/AntlrSQLQueryParser.cpp
@@ -97,7 +97,7 @@ LogicalPlan createLogicalQueryPlanFromSQLString(std::string_view queryString)
         antlr4::CommonTokenStream tokens(&lexer);
         AntlrSQLParser parser(&tokens);
         [[maybe_unused]] auto listener = installErrorListenerAndHandler(queryString, lexer, parser);
-        AntlrSQLParser::QueryContext* tree = parser.query();
+        AntlrSQLParser::SingleStatementContext* tree = parser.singleStatement();
         Parsers::AntlrSQLQueryPlanCreator queryPlanCreator;
         antlr4::tree::ParseTreeWalker::DEFAULT.walk(&queryPlanCreator, tree);
         auto queryPlan = queryPlanCreator.getQueryPlan();

--- a/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
+++ b/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
@@ -228,23 +228,11 @@ LogicalFunction createInFunction(const LogicalFunction& valueFunction, std::vect
     return function;
 }
 
-Identifier collapseQualifiedField(std::vector<LogicalFunction>& functions, const std::string& expressionText)
+bool isSourceQualifier(AntlrSQLParser::IdentifierContext* context)
 {
-    if (functions.size() < 2)
-    {
-        throw InvalidQuerySyntax("Qualified field reference is missing an identifier at {}", expressionText);
-    }
-
-    const auto qualifierFunction = functions.at(functions.size() - 2).tryGetAs<UnboundFieldAccessLogicalFunction>();
-    const auto fieldFunction = functions.back().tryGetAs<UnboundFieldAccessLogicalFunction>();
-    if (!qualifierFunction.has_value() || !fieldFunction.has_value())
-    {
-        throw InvalidQuerySyntax("Only source-qualified field references are supported at {}", expressionText);
-    }
-
-    auto qualifier = qualifierFunction->get().getFieldName();
-    functions.erase(functions.end() - 2);
-    return qualifier;
+    const auto* column = dynamic_cast<AntlrSQLParser::ColumnReferenceContext*>(context->parent);
+    const auto* dereference = column == nullptr ? nullptr : dynamic_cast<AntlrSQLParser::DereferenceContext*>(column->parent);
+    return dereference != nullptr && dereference->base == column;
 }
 
 void validateSourceQualifiers(const AntlrSQLHelper& helper)
@@ -274,25 +262,31 @@ void validateSourceQualifiers(const AntlrSQLHelper& helper)
     }
 }
 
+/// Child predicates are visited first and append one function each. This folds
+/// the last numberOfFunctionsToCombine entries into one logical function.
 void combineLogicalFunctions(
-    std::vector<LogicalFunction>& functions, const size_t operandCount, const uint64_t tokenType, const std::string& expressionText)
+    std::vector<LogicalFunction>& functions,
+    const size_t numberOfFunctionsToCombine,
+    const uint64_t logicalOperatorTokenType,
+    const std::string& expressionText)
 {
-    if (operandCount < 2)
+    if (numberOfFunctionsToCombine < 2)
     {
         return;
     }
-    if (functions.size() < operandCount)
+    if (functions.size() < numberOfFunctionsToCombine)
     {
-        throw InvalidQuerySyntax("Expected {} operands for logical expression, got {}: {}", operandCount, functions.size(), expressionText);
+        throw InvalidQuerySyntax(
+            "Expected {} operands for logical expression, got {}: {}", numberOfFunctionsToCombine, functions.size(), expressionText);
     }
 
-    const auto firstOperandIndex = functions.size() - operandCount;
-    auto function = std::move(functions[firstOperandIndex]);
-    for (auto operandIndex = firstOperandIndex + 1; operandIndex < functions.size(); ++operandIndex)
+    const auto firstFunctionToCombine = functions.size() - numberOfFunctionsToCombine;
+    auto function = std::move(functions[firstFunctionToCombine]);
+    for (auto functionIndex = firstFunctionToCombine + 1; functionIndex < functions.size(); ++functionIndex)
     {
-        function = createLogicalBinaryFunction(std::move(function), std::move(functions[operandIndex]), tokenType);
+        function = createLogicalBinaryFunction(std::move(function), std::move(functions[functionIndex]), logicalOperatorTokenType);
     }
-    functions.resize(firstOperandIndex);
+    functions.resize(firstFunctionToCombine);
     functions.emplace_back(std::move(function));
 }
 
@@ -615,38 +609,6 @@ void AntlrSQLQueryPlanCreator::exitArithmeticUnary(AntlrSQLParser::ArithmeticUna
     functions.push_back(function);
 }
 
-void AntlrSQLQueryPlanCreator::exitDereference(AntlrSQLParser::DereferenceContext* context)
-{
-    if (helpers.empty())
-    {
-        throw InvalidQuerySyntax("Parser is confused at {}", context->getText());
-    }
-
-    auto& helper = helpers.top();
-    if (helper.isJoinRelation || (!helper.isSelect && !helper.isWhereOrHaving && !helper.isWindow && !helper.isGroupBy))
-    {
-        AntlrSQLBaseListener::exitDereference(context);
-        return;
-    }
-
-    auto qualifier = [&]() -> Identifier
-    {
-        if (!helper.isGroupBy)
-        {
-            return collapseQualifiedField(helper.functionBuilder, context->getText());
-        }
-        if (helper.groupByFields.size() < 2)
-        {
-            throw InvalidQuerySyntax("Qualified field reference is missing an identifier at {}", context->getText());
-        }
-        auto groupByQualifier = helper.groupByFields.at(helper.groupByFields.size() - 2).getFieldName();
-        helper.groupByFields.erase(helper.groupByFields.end() - 2);
-        return groupByQualifier;
-    }();
-    helper.addSourceQualifier(std::move(qualifier));
-    AntlrSQLBaseListener::exitDereference(context);
-}
-
 void AntlrSQLQueryPlanCreator::exitStar(AntlrSQLParser::StarContext* context)
 {
     if (!helpers.top().isSelect)
@@ -676,6 +638,15 @@ void AntlrSQLQueryPlanCreator::enterIdentifier(AntlrSQLParser::IdentifierContext
     {
         parentRuleIndex = parentContext->getRuleIndex();
     }
+    auto& helper = helpers.top();
+    if (!helper.isJoinRelation && (helper.isSelect || helper.isWhereOrHaving || helper.isWindow || helper.isGroupBy)
+        && isSourceQualifier(context))
+    {
+        helper.addSourceQualifier(bindIdentifier(context));
+        AntlrSQLBaseListener::enterIdentifier(context);
+        return;
+    }
+
     if (helpers.top().isGroupBy)
     {
         helpers.top().groupByFields.emplace_back(bindIdentifier(context));

--- a/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
+++ b/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
@@ -228,6 +228,28 @@ LogicalFunction createInFunction(const LogicalFunction& valueFunction, std::vect
     return function;
 }
 
+void combineLogicalFunctions(
+    std::vector<LogicalFunction>& functions, const size_t operandCount, const uint64_t tokenType, const std::string& expressionText)
+{
+    if (operandCount < 2)
+    {
+        return;
+    }
+    if (functions.size() < operandCount)
+    {
+        throw InvalidQuerySyntax("Expected {} operands for logical expression, got {}: {}", operandCount, functions.size(), expressionText);
+    }
+
+    const auto firstOperandIndex = functions.size() - operandCount;
+    auto function = std::move(functions[firstOperandIndex]);
+    for (auto operandIndex = firstOperandIndex + 1; operandIndex < functions.size(); ++operandIndex)
+    {
+        function = createLogicalBinaryFunction(std::move(function), std::move(functions[operandIndex]), tokenType);
+    }
+    functions.resize(firstOperandIndex);
+    functions.emplace_back(std::move(function));
+}
+
 void negateTopFunction(std::stack<AntlrSQLHelper>& helpers, const std::string& expressionText)
 {
     if (helpers.empty())
@@ -296,42 +318,18 @@ void AntlrSQLQueryPlanCreator::enterSinkClause(AntlrSQLParser::SinkClauseContext
     }
 }
 
-void AntlrSQLQueryPlanCreator::exitLogicalBinary(AntlrSQLParser::LogicalBinaryContext* context)
+void AntlrSQLQueryPlanCreator::exitOrPredicate(AntlrSQLParser::OrPredicateContext* context)
 {
-    /// If we are exiting a logical binary operator in a join relation, we need to build the binary function for the joinKey and
-    /// not for the general function
-    if (helpers.top().isJoinRelation)
-    {
-        if (helpers.top().joinKeyRelationHelper.size() < 2)
-        {
-            throw InvalidQuerySyntax(
-                "Expected two operands for binary op, got {}: {}", helpers.top().joinKeyRelationHelper.size(), context->getText());
-        }
-        const auto rightFunction = helpers.top().joinKeyRelationHelper.back();
-        helpers.top().joinKeyRelationHelper.pop_back();
-        const auto leftFunction = helpers.top().joinKeyRelationHelper.back();
-        helpers.top().joinKeyRelationHelper.pop_back();
+    auto& functions = helpers.top().isJoinRelation ? helpers.top().joinKeyRelationHelper : helpers.top().functionBuilder;
+    combineLogicalFunctions(functions, context->andPredicate().size(), AntlrSQLLexer::OR, context->getText());
+    AntlrSQLBaseListener::exitOrPredicate(context);
+}
 
-        const auto opTokenType = context->op->getType();
-        const auto function = createLogicalBinaryFunction(leftFunction, rightFunction, opTokenType);
-        helpers.top().joinKeyRelationHelper.push_back(function);
-    }
-    else
-    {
-        if (helpers.top().functionBuilder.size() < 2)
-        {
-            throw InvalidQuerySyntax(
-                "Expected two operands for binary op, got {}: {}", helpers.top().joinKeyRelationHelper.size(), context->getText());
-        }
-        const auto rightFunction = helpers.top().functionBuilder.back();
-        helpers.top().functionBuilder.pop_back();
-        const auto leftFunction = helpers.top().functionBuilder.back();
-        helpers.top().functionBuilder.pop_back();
-
-        const auto opTokenType = context->op->getType();
-        const auto function = createLogicalBinaryFunction(leftFunction, rightFunction, opTokenType);
-        helpers.top().functionBuilder.push_back(function);
-    }
+void AntlrSQLQueryPlanCreator::exitAndPredicate(AntlrSQLParser::AndPredicateContext* context)
+{
+    auto& functions = helpers.top().isJoinRelation ? helpers.top().joinKeyRelationHelper : helpers.top().functionBuilder;
+    combineLogicalFunctions(functions, context->notPredicate().size(), AntlrSQLLexer::AND, context->getText());
+    AntlrSQLBaseListener::exitAndPredicate(context);
 }
 
 void AntlrSQLQueryPlanCreator::exitBoolComparison(AntlrSQLParser::BoolComparisonContext* context)

--- a/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
+++ b/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
@@ -228,6 +228,52 @@ LogicalFunction createInFunction(const LogicalFunction& valueFunction, std::vect
     return function;
 }
 
+Identifier collapseQualifiedField(std::vector<LogicalFunction>& functions, const std::string& expressionText)
+{
+    if (functions.size() < 2)
+    {
+        throw InvalidQuerySyntax("Qualified field reference is missing an identifier at {}", expressionText);
+    }
+
+    const auto qualifierFunction = functions.at(functions.size() - 2).tryGetAs<UnboundFieldAccessLogicalFunction>();
+    const auto fieldFunction = functions.back().tryGetAs<UnboundFieldAccessLogicalFunction>();
+    if (!qualifierFunction.has_value() || !fieldFunction.has_value())
+    {
+        throw InvalidQuerySyntax("Only source-qualified field references are supported at {}", expressionText);
+    }
+
+    auto qualifier = qualifierFunction->get().getFieldName();
+    functions.erase(functions.end() - 2);
+    return qualifier;
+}
+
+void validateSourceQualifiers(const AntlrSQLHelper& helper)
+{
+    const auto& qualifiers = helper.getSourceQualifiers();
+    if (qualifiers.empty())
+    {
+        return;
+    }
+
+    auto expectedQualifier = helper.getSourceAlias();
+    if (!expectedQualifier.has_value())
+    {
+        expectedQualifier = helper.getSource();
+    }
+    if (!expectedQualifier.has_value())
+    {
+        throw InvalidQuerySyntax("Qualified field references require a named source");
+    }
+
+    for (const auto& qualifier : qualifiers)
+    {
+        if (qualifier != expectedQualifier.value())
+        {
+            throw InvalidQuerySyntax("Unknown source qualifier {}, expected {}", qualifier, expectedQualifier.value());
+        }
+    }
+}
+
 void combineLogicalFunctions(
     std::vector<LogicalFunction>& functions, const size_t operandCount, const uint64_t tokenType, const std::string& expressionText)
 {
@@ -424,6 +470,15 @@ void AntlrSQLQueryPlanCreator::exitFromClause(AntlrSQLParser::FromClauseContext*
     AntlrSQLBaseListener::exitFromClause(context);
 }
 
+void AntlrSQLQueryPlanCreator::exitNamedSource(AntlrSQLParser::NamedSourceContext* context)
+{
+    if (context->alias != nullptr && !helpers.top().isJoinRelation)
+    {
+        helpers.top().setSourceAlias(bindIdentifier(context->alias));
+    }
+    AntlrSQLBaseListener::exitNamedSource(context);
+}
+
 void AntlrSQLQueryPlanCreator::enterWhereClause(AntlrSQLParser::WhereClauseContext* context)
 {
     helpers.top().isWhereOrHaving = true;
@@ -560,14 +615,57 @@ void AntlrSQLQueryPlanCreator::exitArithmeticUnary(AntlrSQLParser::ArithmeticUna
     functions.push_back(function);
 }
 
-void AntlrSQLQueryPlanCreator::enterUnquotedIdentifier(AntlrSQLParser::UnquotedIdentifierContext* context)
+void AntlrSQLQueryPlanCreator::exitDereference(AntlrSQLParser::DereferenceContext* context)
 {
-    /// Get Index of Parent Rule to check type of parent rule in conditions
-    if (helpers.top().isFrom && !helpers.top().isJoinRelation)
+    if (helpers.empty())
     {
-        helpers.top().newSourceName = bindIdentifier(context);
+        throw InvalidQuerySyntax("Parser is confused at {}", context->getText());
     }
-    AntlrSQLBaseListener::enterUnquotedIdentifier(context);
+
+    auto& helper = helpers.top();
+    if (helper.isJoinRelation || (!helper.isSelect && !helper.isWhereOrHaving && !helper.isWindow && !helper.isGroupBy))
+    {
+        AntlrSQLBaseListener::exitDereference(context);
+        return;
+    }
+
+    auto qualifier = [&]() -> Identifier
+    {
+        if (!helper.isGroupBy)
+        {
+            return collapseQualifiedField(helper.functionBuilder, context->getText());
+        }
+        if (helper.groupByFields.size() < 2)
+        {
+            throw InvalidQuerySyntax("Qualified field reference is missing an identifier at {}", context->getText());
+        }
+        auto groupByQualifier = helper.groupByFields.at(helper.groupByFields.size() - 2).getFieldName();
+        helper.groupByFields.erase(helper.groupByFields.end() - 2);
+        return groupByQualifier;
+    }();
+    helper.addSourceQualifier(std::move(qualifier));
+    AntlrSQLBaseListener::exitDereference(context);
+}
+
+void AntlrSQLQueryPlanCreator::exitStar(AntlrSQLParser::StarContext* context)
+{
+    if (!helpers.top().isSelect)
+    {
+        AntlrSQLBaseListener::exitStar(context);
+        return;
+    }
+
+    if (auto* const qualifiedName = context->qualifiedName(); qualifiedName != nullptr)
+    {
+        const auto identifiers = qualifiedName->identifier();
+        if (identifiers.size() != 1)
+        {
+            throw InvalidQuerySyntax("Source-qualified asterisk requires exactly one qualifier at {}", context->getText());
+        }
+        helpers.top().addSourceQualifier(bindIdentifier(identifiers.front()));
+    }
+    helpers.top().asterisk = true;
+    AntlrSQLBaseListener::exitStar(context);
 }
 
 void AntlrSQLQueryPlanCreator::enterIdentifier(AntlrSQLParser::IdentifierContext* context)
@@ -655,6 +753,7 @@ void AntlrSQLQueryPlanCreator::enterPrimaryQuery(AntlrSQLParser::PrimaryQueryCon
 
 void AntlrSQLQueryPlanCreator::exitPrimaryQuery(AntlrSQLParser::PrimaryQueryContext* context)
 {
+    validateSourceQualifiers(helpers.top());
     LogicalPlan queryPlan = [&]
     {
         if (not helpers.top().queryPlans.empty())
@@ -883,10 +982,6 @@ void AntlrSQLQueryPlanCreator::exitNamedExpression(AntlrSQLParser::NamedExpressi
         /// Project onto the specified field and remove the field access from the active functions.
         helpers.top().addProjection(std::make_optional(fieldName), std::move(helpers.top().functionBuilder.back()));
         helpers.top().functionBuilder.pop_back();
-    }
-    else if (helper.isSelect && context->getText() == "*" && helper.functionBuilder.empty())
-    {
-        helper.asterisk = true;
     }
     /// The user did not specify a new name (... AS THE_NAME) for the aggregation function.
     /// The aggregation's asField is already set in exitFunctionCall. Project the expression directly,

--- a/nes-sql-parser/tests/StatementBinderTest.cpp
+++ b/nes-sql-parser/tests/StatementBinderTest.cpp
@@ -931,6 +931,21 @@ TEST_F(StatementBinderTest, CreateLogicalQueryPlanConsumesInlineSinkAfterWhere)
     EXPECT_TRUE(plan.getRootOperators().front().tryGetAs<InlineSinkLogicalOperator>().has_value());
 }
 
+TEST_F(StatementBinderTest, ParenthesizedPredicatesParse)
+{
+    const std::vector<std::string> queries{
+        "SELECT pk FROM input WHERE (col1 BETWEEN FLOAT64(90.54) AND FLOAT64(27.89)) INTO File();",
+        "SELECT pk FROM input WHERE (col0 IN (INT64(1), INT64(2))) INTO File();",
+        "SELECT pk FROM input WHERE (col1 IS NULL) INTO File();"};
+
+    for (const auto& query : queries)
+    {
+        const auto plan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString(query);
+        ASSERT_FALSE(plan.getRootOperators().empty());
+        EXPECT_TRUE(plan.getRootOperators().front().tryGetAs<InlineSinkLogicalOperator>().has_value());
+    }
+}
+
 TEST_F(StatementBinderTest, LeftOuterJoinParsesToOuterLeftJoinType)
 {
     const std::string query = "SELECT * FROM (SELECT * FROM s1) LEFT OUTER JOIN (SELECT * FROM s2) "

--- a/nes-sql-parser/tests/StatementBinderTest.cpp
+++ b/nes-sql-parser/tests/StatementBinderTest.cpp
@@ -27,8 +27,11 @@
 #include <DataTypes/Schema.hpp>
 #include <DataTypes/SchemaFwd.hpp>
 #include <DataTypes/UnboundField.hpp>
+#include <Functions/BooleanFunctions/EqualsLogicalFunction.hpp>
+#include <Functions/BooleanFunctions/OrLogicalFunction.hpp>
 #include <Identifiers/Identifier.hpp>
 #include <Identifiers/Identifiers.hpp>
+#include <Operators/ProjectionLogicalOperator.hpp>
 #include <Operators/SelectionLogicalOperator.hpp>
 #include <Operators/Sinks/AnonymousSinkLogicalOperator.hpp>
 #include <Operators/Sources/AnonymousSourceLogicalOperator.hpp>
@@ -931,6 +934,20 @@ TEST_F(StatementBinderTest, CreateLogicalQueryPlanConsumesInlineSinkAfterWhere)
     EXPECT_TRUE(plan.getRootOperators().front().tryGetAs<InlineSinkLogicalOperator>().has_value());
 }
 
+TEST_F(StatementBinderTest, CreateLogicalQueryPlanConsumesQueryOptions)
+{
+    const std::string query = R"(SELECT pk FROM input INTO File() SET ('query-id' AS "QUERY"."ID");)";
+    const auto plan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString(query);
+
+    ASSERT_FALSE(plan.getRootOperators().empty());
+    EXPECT_TRUE(plan.getRootOperators().front().tryGetAs<InlineSinkLogicalOperator>().has_value());
+}
+
+TEST_F(StatementBinderTest, CreateLogicalQueryPlanRejectsNonQueryStatements)
+{
+    EXPECT_THROW(AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString("CREATE WORKER 'localhost:8080';"), Exception);
+}
+
 TEST_F(StatementBinderTest, ParenthesizedPredicatesParse)
 {
     const std::vector<std::string> queries{
@@ -966,6 +983,63 @@ TEST_F(StatementBinderTest, NestedPredicateExpressionsParse)
         ASSERT_FALSE(plan.getRootOperators().empty());
         EXPECT_TRUE(plan.getRootOperators().front().tryGetAs<InlineSinkLogicalOperator>().has_value());
     }
+}
+
+TEST_F(StatementBinderTest, ParenthesizedPredicateCanBeComparisonOperand)
+{
+    const auto plan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString(
+        "SELECT pk FROM input WHERE flag = (col0 = INT64(1) OR col1 = INT64(2)) INTO File();");
+    const auto selections = getOperatorByType<SelectionLogicalOperator>(plan);
+    ASSERT_EQ(selections.size(), 1);
+
+    const auto predicate = selections.front()->getPredicate();
+    EXPECT_TRUE(predicate.tryGetAs<EqualsLogicalFunction>().has_value());
+    const auto children = predicate.getChildren();
+    ASSERT_EQ(children.size(), 2);
+    EXPECT_TRUE(children.back().tryGetAs<OrLogicalFunction>().has_value());
+}
+
+TEST_F(StatementBinderTest, NamedSourceAliasesParse)
+{
+    const std::vector<std::string> queries{
+        "SELECT pk FROM slt_q1655_tab2 AS tab2 WHERE col3 BETWEEN INT64(315) AND INT64(895) OR col3 BETWEEN INT64(49) AND INT64(917) "
+        "OR col3 >= INT64(853) INTO File();",
+        "SELECT pk FROM slt_q1656_tab2 AS tab2 WHERE (col3 >= INT64(315) AND col3 <= INT64(895)) OR (col3 >= INT64(49) AND col3 <= "
+        "INT64(917)) OR col3 >= INT64(853) INTO File();"};
+
+    for (const auto& query : queries)
+    {
+        const auto plan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString(query);
+        ASSERT_FALSE(plan.getRootOperators().empty());
+        EXPECT_TRUE(plan.getRootOperators().front().tryGetAs<InlineSinkLogicalOperator>().has_value());
+    }
+}
+
+TEST_F(StatementBinderTest, NamedSourceAliasesQualifyFields)
+{
+    const auto plan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString(
+        "SELECT tab2.pk FROM input AS tab2 WHERE tab2.col0 = INT64(1) INTO File();");
+
+    const auto selections = getOperatorByType<SelectionLogicalOperator>(plan);
+    ASSERT_EQ(selections.size(), 1);
+    EXPECT_EQ(selections.front()->getPredicate().explain(ExplainVerbosity::Short), "COL0 = 1");
+
+    const auto projections = getOperatorByType<ProjectionLogicalOperator>(plan);
+    ASSERT_EQ(projections.size(), 1);
+    EXPECT_EQ(projections.front()->explain(ExplainVerbosity::Short, OperatorId{1}), "PROJECTION(fields: [PK])");
+}
+
+TEST_F(StatementBinderTest, NamedSourceAliasesQualifyAsterisk)
+{
+    const auto plan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString("SELECT tab2.* FROM input AS tab2 INTO File();");
+    const auto projections = getOperatorByType<ProjectionLogicalOperator>(plan);
+    ASSERT_EQ(projections.size(), 1);
+    EXPECT_TRUE(projections.front()->hasAsterisk());
+}
+
+TEST_F(StatementBinderTest, NamedSourceAliasesRejectUnknownQualifier)
+{
+    EXPECT_THROW(AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString("SELECT wrong.pk FROM input AS tab2 INTO File();"), Exception);
 }
 
 TEST_F(StatementBinderTest, LeftOuterJoinParsesToOuterLeftJoinType)

--- a/nes-sql-parser/tests/StatementBinderTest.cpp
+++ b/nes-sql-parser/tests/StatementBinderTest.cpp
@@ -936,7 +936,11 @@ TEST_F(StatementBinderTest, ParenthesizedPredicatesParse)
     const std::vector<std::string> queries{
         "SELECT pk FROM input WHERE (col1 BETWEEN FLOAT64(90.54) AND FLOAT64(27.89)) INTO File();",
         "SELECT pk FROM input WHERE (col0 IN (INT64(1), INT64(2))) INTO File();",
-        "SELECT pk FROM input WHERE (col1 IS NULL) INTO File();"};
+        "SELECT pk FROM input WHERE (col1 IS NULL) INTO File();",
+        "SELECT pk FROM input WHERE col3 > INT64(360) AND col0 >= INT64(837) OR (col1 BETWEEN FLOAT64(998.16) AND FLOAT64(106.9)) INTO "
+        "File();",
+        "SELECT pk FROM input WHERE col3 > INT64(360) AND col0 >= INT64(837) OR ((col1 >= FLOAT64(998.16) AND col1 <= FLOAT64(106.9))) "
+        "INTO File();"};
 
     for (const auto& query : queries)
     {

--- a/nes-sql-parser/tests/StatementBinderTest.cpp
+++ b/nes-sql-parser/tests/StatementBinderTest.cpp
@@ -27,11 +27,8 @@
 #include <DataTypes/Schema.hpp>
 #include <DataTypes/SchemaFwd.hpp>
 #include <DataTypes/UnboundField.hpp>
-#include <Functions/BooleanFunctions/EqualsLogicalFunction.hpp>
-#include <Functions/BooleanFunctions/OrLogicalFunction.hpp>
 #include <Identifiers/Identifier.hpp>
 #include <Identifiers/Identifiers.hpp>
-#include <Operators/ProjectionLogicalOperator.hpp>
 #include <Operators/SelectionLogicalOperator.hpp>
 #include <Operators/Sinks/AnonymousSinkLogicalOperator.hpp>
 #include <Operators/Sources/AnonymousSourceLogicalOperator.hpp>
@@ -925,121 +922,9 @@ TEST_F(StatementBinderTest, CreateWorkerStatementTest)
     ASSERT_EQ(std::get<CreateWorkerStatement>(*statement).dataAddress, "localhost:9090");
 }
 
-TEST_F(StatementBinderTest, CreateLogicalQueryPlanConsumesInlineSinkAfterWhere)
-{
-    const std::string query = "SELECT pk FROM input WHERE col0 = INT64(1) INTO File();";
-    const auto plan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString(query);
-
-    ASSERT_FALSE(plan.getRootOperators().empty());
-    EXPECT_TRUE(plan.getRootOperators().front().tryGetAs<InlineSinkLogicalOperator>().has_value());
-}
-
-TEST_F(StatementBinderTest, CreateLogicalQueryPlanConsumesQueryOptions)
-{
-    const std::string query = R"(SELECT pk FROM input INTO File() SET ('query-id' AS "QUERY"."ID");)";
-    const auto plan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString(query);
-
-    ASSERT_FALSE(plan.getRootOperators().empty());
-    EXPECT_TRUE(plan.getRootOperators().front().tryGetAs<InlineSinkLogicalOperator>().has_value());
-}
-
 TEST_F(StatementBinderTest, CreateLogicalQueryPlanRejectsNonQueryStatements)
 {
     EXPECT_THROW(AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString("CREATE WORKER 'localhost:8080';"), Exception);
-}
-
-TEST_F(StatementBinderTest, ParenthesizedPredicatesParse)
-{
-    const std::vector<std::string> queries{
-        "SELECT pk FROM input WHERE (col1 BETWEEN FLOAT64(90.54) AND FLOAT64(27.89)) INTO File();",
-        "SELECT pk FROM input WHERE (col0 IN (INT64(1), INT64(2))) INTO File();",
-        "SELECT pk FROM input WHERE (col1 IS NULL) INTO File();",
-        "SELECT pk FROM input WHERE col3 > INT64(360) AND col0 >= INT64(837) OR (col1 BETWEEN FLOAT64(998.16) AND FLOAT64(106.9)) INTO "
-        "File();",
-        "SELECT pk FROM input WHERE col3 > INT64(360) AND col0 >= INT64(837) OR ((col1 >= FLOAT64(998.16) AND col1 <= FLOAT64(106.9))) "
-        "INTO File();"};
-
-    for (const auto& query : queries)
-    {
-        const auto plan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString(query);
-        ASSERT_FALSE(plan.getRootOperators().empty());
-        EXPECT_TRUE(plan.getRootOperators().front().tryGetAs<InlineSinkLogicalOperator>().has_value());
-    }
-}
-
-TEST_F(StatementBinderTest, NestedPredicateExpressionsParse)
-{
-    const std::vector<std::string> queries{
-        "SELECT pk FROM input WHERE col3 BETWEEN INT64(34) AND INT64(61) INTO File();",
-        "SELECT pk FROM input WHERE ((col3 > INT64(761))) AND (((col3 BETWEEN INT64(97) AND INT64(22)))) INTO File();",
-        "SELECT pk FROM input WHERE col4 <= FLOAT64(563.88) AND (col3 >= INT64(922) OR (col0 BETWEEN INT64(559) AND INT64(162))) "
-        "INTO File();",
-        "SELECT pk FROM input WHERE (col3 >= INT64(34) AND col3 <= INT64(61)) INTO File();",
-        "SELECT pk FROM input WHERE col0 IN (INT64(1), INT64(2)) AND (col1 IS NULL OR col2 IS NOT NULL) INTO File();"};
-
-    for (const auto& query : queries)
-    {
-        const auto plan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString(query);
-        ASSERT_FALSE(plan.getRootOperators().empty());
-        EXPECT_TRUE(plan.getRootOperators().front().tryGetAs<InlineSinkLogicalOperator>().has_value());
-    }
-}
-
-TEST_F(StatementBinderTest, ParenthesizedPredicateCanBeComparisonOperand)
-{
-    const auto plan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString(
-        "SELECT pk FROM input WHERE flag = (col0 = INT64(1) OR col1 = INT64(2)) INTO File();");
-    const auto selections = getOperatorByType<SelectionLogicalOperator>(plan);
-    ASSERT_EQ(selections.size(), 1);
-
-    const auto predicate = selections.front()->getPredicate();
-    EXPECT_TRUE(predicate.tryGetAs<EqualsLogicalFunction>().has_value());
-    const auto children = predicate.getChildren();
-    ASSERT_EQ(children.size(), 2);
-    EXPECT_TRUE(children.back().tryGetAs<OrLogicalFunction>().has_value());
-}
-
-TEST_F(StatementBinderTest, NamedSourceAliasesParse)
-{
-    const std::vector<std::string> queries{
-        "SELECT pk FROM slt_q1655_tab2 AS tab2 WHERE col3 BETWEEN INT64(315) AND INT64(895) OR col3 BETWEEN INT64(49) AND INT64(917) "
-        "OR col3 >= INT64(853) INTO File();",
-        "SELECT pk FROM slt_q1656_tab2 AS tab2 WHERE (col3 >= INT64(315) AND col3 <= INT64(895)) OR (col3 >= INT64(49) AND col3 <= "
-        "INT64(917)) OR col3 >= INT64(853) INTO File();"};
-
-    for (const auto& query : queries)
-    {
-        const auto plan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString(query);
-        ASSERT_FALSE(plan.getRootOperators().empty());
-        EXPECT_TRUE(plan.getRootOperators().front().tryGetAs<InlineSinkLogicalOperator>().has_value());
-    }
-}
-
-TEST_F(StatementBinderTest, NamedSourceAliasesQualifyFields)
-{
-    const auto plan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString(
-        "SELECT tab2.pk FROM input AS tab2 WHERE tab2.col0 = INT64(1) INTO File();");
-
-    const auto selections = getOperatorByType<SelectionLogicalOperator>(plan);
-    ASSERT_EQ(selections.size(), 1);
-    EXPECT_EQ(selections.front()->getPredicate().explain(ExplainVerbosity::Short), "COL0 = 1");
-
-    const auto projections = getOperatorByType<ProjectionLogicalOperator>(plan);
-    ASSERT_EQ(projections.size(), 1);
-    EXPECT_EQ(projections.front()->explain(ExplainVerbosity::Short, OperatorId{1}), "PROJECTION(fields: [PK])");
-}
-
-TEST_F(StatementBinderTest, NamedSourceAliasesQualifyAsterisk)
-{
-    const auto plan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString("SELECT tab2.* FROM input AS tab2 INTO File();");
-    const auto projections = getOperatorByType<ProjectionLogicalOperator>(plan);
-    ASSERT_EQ(projections.size(), 1);
-    EXPECT_TRUE(projections.front()->hasAsterisk());
-}
-
-TEST_F(StatementBinderTest, NamedSourceAliasesRejectUnknownQualifier)
-{
-    EXPECT_THROW(AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString("SELECT wrong.pk FROM input AS tab2 INTO File();"), Exception);
 }
 
 TEST_F(StatementBinderTest, LeftOuterJoinParsesToOuterLeftJoinType)

--- a/nes-sql-parser/tests/StatementBinderTest.cpp
+++ b/nes-sql-parser/tests/StatementBinderTest.cpp
@@ -922,6 +922,15 @@ TEST_F(StatementBinderTest, CreateWorkerStatementTest)
     ASSERT_EQ(std::get<CreateWorkerStatement>(*statement).dataAddress, "localhost:9090");
 }
 
+TEST_F(StatementBinderTest, CreateLogicalQueryPlanConsumesInlineSinkAfterWhere)
+{
+    const std::string query = "SELECT pk FROM input WHERE col0 = INT64(1) INTO File();";
+    const auto plan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString(query);
+
+    ASSERT_FALSE(plan.getRootOperators().empty());
+    EXPECT_TRUE(plan.getRootOperators().front().tryGetAs<InlineSinkLogicalOperator>().has_value());
+}
+
 TEST_F(StatementBinderTest, LeftOuterJoinParsesToOuterLeftJoinType)
 {
     const std::string query = "SELECT * FROM (SELECT * FROM s1) LEFT OUTER JOIN (SELECT * FROM s2) "

--- a/nes-sql-parser/tests/StatementBinderTest.cpp
+++ b/nes-sql-parser/tests/StatementBinderTest.cpp
@@ -950,6 +950,24 @@ TEST_F(StatementBinderTest, ParenthesizedPredicatesParse)
     }
 }
 
+TEST_F(StatementBinderTest, NestedPredicateExpressionsParse)
+{
+    const std::vector<std::string> queries{
+        "SELECT pk FROM input WHERE col3 BETWEEN INT64(34) AND INT64(61) INTO File();",
+        "SELECT pk FROM input WHERE ((col3 > INT64(761))) AND (((col3 BETWEEN INT64(97) AND INT64(22)))) INTO File();",
+        "SELECT pk FROM input WHERE col4 <= FLOAT64(563.88) AND (col3 >= INT64(922) OR (col0 BETWEEN INT64(559) AND INT64(162))) "
+        "INTO File();",
+        "SELECT pk FROM input WHERE (col3 >= INT64(34) AND col3 <= INT64(61)) INTO File();",
+        "SELECT pk FROM input WHERE col0 IN (INT64(1), INT64(2)) AND (col1 IS NULL OR col2 IS NOT NULL) INTO File();"};
+
+    for (const auto& query : queries)
+    {
+        const auto plan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString(query);
+        ASSERT_FALSE(plan.getRootOperators().empty());
+        EXPECT_TRUE(plan.getRootOperators().front().tryGetAs<InlineSinkLogicalOperator>().has_value());
+    }
+}
+
 TEST_F(StatementBinderTest, LeftOuterJoinParsesToOuterLeftJoinType)
 {
     const std::string query = "SELECT * FROM (SELECT * FROM s1) LEFT OUTER JOIN (SELECT * FROM s2) "

--- a/nes-systests/parser/SQLParserRegressions.test
+++ b/nes-systests/parser/SQLParserRegressions.test
@@ -1,0 +1,110 @@
+# name: parser/SQLParserRegressions.test
+# description: SQL parser regressions for predicates, source qualifiers, and complete statements
+# groups: [Parser, Selection]
+
+CREATE LOGICAL SOURCE predicate_input(
+    pk UINT64 NOT NULL,
+    col0 INT64 NOT NULL,
+    col1 FLOAT64,
+    col2 INT64,
+    col3 INT64 NOT NULL,
+    col4 FLOAT64 NOT NULL,
+    flag BOOLEAN NOT NULL
+);
+CREATE PHYSICAL SOURCE FOR predicate_input TYPE File;
+ATTACH INLINE
+1,1,10.5,,761,500.0,true
+2,2,20.0,7,100,563.88,true
+3,3,,8,922,600.0,false
+4,1,40.0,,600,100.0,false
+5,5,27.89,9,34,700.0,true
+
+CREATE LOGICAL SOURCE alias_input(pk UINT64 NOT NULL, value INT64 NOT NULL);
+CREATE PHYSICAL SOURCE FOR alias_input TYPE File;
+ATTACH INLINE
+1,10
+2,20
+
+SELECT pk FROM predicate_input WHERE col0 = INT64(1) INTO File();
+----
+1
+4
+
+SELECT pk FROM predicate_input WHERE (col1 BETWEEN FLOAT64(10.0) AND FLOAT64(30.0)) INTO File();
+----
+1
+2
+5
+
+SELECT pk FROM predicate_input WHERE (col0 IN (INT64(1), INT64(2))) INTO File();
+----
+1
+2
+4
+
+SELECT pk FROM predicate_input WHERE (col1 IS NULL) INTO File();
+----
+3
+
+SELECT pk
+FROM predicate_input
+WHERE col4 <= FLOAT64(563.88) AND (col3 >= INT64(922) OR (col0 BETWEEN INT64(1) AND INT64(2)))
+INTO File();
+----
+1
+2
+4
+
+SELECT pk
+FROM predicate_input
+WHERE ((col3 > INT64(700))) AND (((col3 BETWEEN INT64(700) AND INT64(950))))
+INTO File();
+----
+1
+3
+
+SELECT pk
+FROM predicate_input
+WHERE col0 IN (INT64(1), INT64(2)) AND (col1 IS NULL OR col2 IS NOT NULL)
+INTO File();
+----
+2
+
+SELECT pk
+FROM predicate_input
+WHERE flag = (col0 = INT64(1) OR col1 = FLOAT64(20.0))
+INTO File();
+----
+1
+2
+
+SELECT pk FROM alias_input AS source_alias WHERE value = INT64(10) INTO File();
+----
+1
+
+SELECT source_alias.pk FROM alias_input AS source_alias WHERE source_alias.value = INT64(10) INTO File();
+----
+1
+
+SELECT source_alias.* FROM alias_input AS source_alias INTO File();
+----
+1,10
+2,20
+
+SELECT alias_input.pk FROM alias_input INTO File();
+----
+1
+2
+
+SELECT pk FROM alias_input INTO File() SET ('query-id' AS "QUERY"."ID");
+----
+1
+2
+
+SELECT wrong_alias.pk FROM alias_input AS source_alias INTO File();
+----
+ERROR 2000
+
+SELECT pk FROM alias_input INTO File(); trailing_tokens;
+----
+ERROR 2000

--- a/nes-systests/parser/SQLParserRegressions.test
+++ b/nes-systests/parser/SQLParserRegressions.test
@@ -25,27 +25,26 @@ ATTACH INLINE
 1,10
 2,20
 
-SELECT pk FROM predicate_input WHERE col0 = INT64(1) INTO File();
-----
-1
-4
-
+# Parses a parenthesized BETWEEN predicate.
 SELECT pk FROM predicate_input WHERE (col1 BETWEEN FLOAT64(10.0) AND FLOAT64(30.0)) INTO File();
 ----
 1
 2
 5
 
+# Parses a parenthesized IN predicate.
 SELECT pk FROM predicate_input WHERE (col0 IN (INT64(1), INT64(2))) INTO File();
 ----
 1
 2
 4
 
+# Parses a parenthesized IS NULL predicate.
 SELECT pk FROM predicate_input WHERE (col1 IS NULL) INTO File();
 ----
 3
 
+# Preserves precedence in nested AND and OR predicates.
 SELECT pk
 FROM predicate_input
 WHERE col4 <= FLOAT64(563.88) AND (col3 >= INT64(922) OR (col0 BETWEEN INT64(1) AND INT64(2)))
@@ -55,6 +54,7 @@ INTO File();
 2
 4
 
+# Parses deeply nested predicate parentheses.
 SELECT pk
 FROM predicate_input
 WHERE ((col3 > INT64(700))) AND (((col3 BETWEEN INT64(700) AND INT64(950))))
@@ -63,6 +63,7 @@ INTO File();
 1
 3
 
+# Combines IN and null predicates.
 SELECT pk
 FROM predicate_input
 WHERE col0 IN (INT64(1), INT64(2)) AND (col1 IS NULL OR col2 IS NOT NULL)
@@ -70,6 +71,7 @@ INTO File();
 ----
 2
 
+# Uses a parenthesized predicate as a comparison operand.
 SELECT pk
 FROM predicate_input
 WHERE flag = (col0 = INT64(1) OR col1 = FLOAT64(20.0))
@@ -78,33 +80,34 @@ INTO File();
 1
 2
 
+# Accepts a named source alias with unqualified fields.
 SELECT pk FROM alias_input AS source_alias WHERE value = INT64(10) INTO File();
 ----
 1
 
+# Resolves alias-qualified fields.
 SELECT source_alias.pk FROM alias_input AS source_alias WHERE source_alias.value = INT64(10) INTO File();
 ----
 1
 
+# Resolves an alias-qualified asterisk.
 SELECT source_alias.* FROM alias_input AS source_alias INTO File();
 ----
 1,10
 2,20
 
+# Resolves fields qualified by the source name.
 SELECT alias_input.pk FROM alias_input INTO File();
 ----
 1
 2
 
-SELECT pk FROM alias_input INTO File() SET ('query-id' AS "QUERY"."ID");
-----
-1
-2
-
+# Rejects an unknown source qualifier.
 SELECT wrong_alias.pk FROM alias_input AS source_alias INTO File();
 ----
 ERROR 2000
 
+# Rejects trailing tokens after a complete query.
 SELECT pk FROM alias_input INTO File(); trailing_tokens;
 ----
 ERROR 2000


### PR DESCRIPTION
Fixes a set of issues in SQL parsing blocking #1652.

Now validated via `nes-systests/parser/SQLParserRegressions.test`:
```
CREATE LOGICAL SOURCE predicate_input(
    pk UINT64 NOT NULL,
    col0 INT64 NOT NULL,
    col1 FLOAT64,
    col2 INT64,
    col3 INT64 NOT NULL,
    col4 FLOAT64 NOT NULL,
    flag BOOLEAN NOT NULL
);

CREATE PHYSICAL SOURCE FOR predicate_input TYPE File;
ATTACH INLINE
1,1,10.5,,761,500.0,true
2,2,20.0,7,100,563.88,true
3,3,,8,922,600.0,false
4,1,40.0,,600,100.0,false
5,5,27.89,9,34,700.0,true

CREATE LOGICAL SOURCE alias_input(pk UINT64 NOT NULL, value INT64 NOT NULL);
CREATE PHYSICAL SOURCE FOR alias_input TYPE File;
ATTACH INLINE
1,10
2,20

# Parses a parenthesized BETWEEN predicate.
SELECT pk FROM predicate_input WHERE (col1 BETWEEN FLOAT64(10.0) AND FLOAT64(30.0)) INTO File();
----
1
2
5

# Parses a parenthesized IN predicate.
SELECT pk FROM predicate_input WHERE (col0 IN (INT64(1), INT64(2))) INTO File();
----
1
2
4

# Parses a parenthesized IS NULL predicate.
SELECT pk FROM predicate_input WHERE (col1 IS NULL) INTO File();
----
3

# Preserves precedence in nested AND and OR predicates.
SELECT pk
FROM predicate_input
WHERE col4 <= FLOAT64(563.88) AND (col3 >= INT64(922) OR (col0 BETWEEN INT64(1) AND INT64(2)))
INTO File();
----
1
2
4

# Parses deeply nested predicate parentheses.
SELECT pk
FROM predicate_input
WHERE ((col3 > INT64(700))) AND (((col3 BETWEEN INT64(700) AND INT64(950))))
INTO File();
----
1
3

# Combines IN and null predicates.
SELECT pk
FROM predicate_input
WHERE col0 IN (INT64(1), INT64(2)) AND (col1 IS NULL OR col2 IS NOT NULL)
INTO File();
----
2

# Uses a parenthesized predicate as a comparison operand.
SELECT pk
FROM predicate_input
WHERE flag = (col0 = INT64(1) OR col1 = FLOAT64(20.0))
INTO File();
----
1
2

# Accepts a named source alias with unqualified fields.
SELECT pk FROM alias_input AS source_alias WHERE value = INT64(10) INTO File();
----
1

# Resolves alias-qualified fields.
SELECT source_alias.pk FROM alias_input AS source_alias WHERE source_alias.value = INT64(10) INTO File();
----
1

# Resolves an alias-qualified asterisk.
SELECT source_alias.* FROM alias_input AS source_alias INTO File();
----
1,10
2,20

# Resolves fields qualified by the source name.
SELECT alias_input.pk FROM alias_input INTO File();
----
1
2

# Rejects an unknown source qualifier.
SELECT wrong_alias.pk FROM alias_input AS source_alias INTO File();
----
ERROR 2000

# Rejects trailing tokens after a complete query.
SELECT pk FROM alias_input INTO File(); trailing_tokens;
----
ERROR 2000
```