### PR TITLE
Add configurable combined unit-test binary

### DIFF
--- a/.github/ci/nightly_matrix.yaml
+++ b/.github/ci/nightly_matrix.yaml
@@ -8,6 +8,7 @@ default_cmake_flags:
   ALL_HASHMAP_TESTS: "1"
   NES_LOG_LEVEL: DEBUG
   ALL_SLICE_CACHE_TESTS: "ON"
+  NES_SPLIT_TEST_BINARIES: "OFF"
 
 runners:
   github-x64: ubuntu-24.04

--- a/.github/ci/pr_matrix.yaml
+++ b/.github/ci/pr_matrix.yaml
@@ -16,6 +16,7 @@
 default_cmake_flags:
   ALL_HASHMAP_TESTS: "1"
   NES_LOG_LEVEL: DEBUG
+  NES_SPLIT_TEST_BINARIES: "OFF"
 
 runners:
   github-x64: ubuntu-24.04

--- a/.github/workflows/clang_tidy_diff.yml
+++ b/.github/workflows/clang_tidy_diff.yml
@@ -68,7 +68,8 @@ jobs:
           image_name: nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{matrix.sanitizer}}
           run: |
             source .github/.env/test-${{matrix.sanitizer}}.env
-            cmake -GNinja -B build -DUSE_SANITIZER=${{ matrix.sanitizer }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DNES_LOG_LEVEL=DEBUG
+            # TODO #1788: Replace the full build with a code-generation-only target for static analysis.
+            cmake -GNinja -B build -DUSE_SANITIZER=${{ matrix.sanitizer }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DNES_LOG_LEVEL=DEBUG -DNES_SPLIT_TEST_BINARIES=OFF
             # We need to build the project, as some headers are only created during the build.
             cmake --build build -j  -- -k 0
       - name: Create results directory

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Configure via devShell
         run: |
-          ./.nix/nix-cmake.sh -DCMAKE_BUILD_TYPE=Debug -DUSE_BUILD_CACHE=OFF -DCMAKE_C_COMPILER_LAUNCHER="$SCCACHE_BIN" -DCMAKE_CXX_COMPILER_LAUNCHER="$SCCACHE_BIN" -G Ninja -S . -B cmake-build-nix
+          ./.nix/nix-cmake.sh -DCMAKE_BUILD_TYPE=Debug -DUSE_BUILD_CACHE=OFF -DNES_SPLIT_TEST_BINARIES=OFF -DCMAKE_C_COMPILER_LAUNCHER="$SCCACHE_BIN" -DCMAKE_CXX_COMPILER_LAUNCHER="$SCCACHE_BIN" -G Ninja -S . -B cmake-build-nix
 
       - name: Build via devShell
         run: |

--- a/cmake/NebulaStreamTest.cmake
+++ b/cmake/NebulaStreamTest.cmake
@@ -22,15 +22,14 @@ else ()
     set(RAPIDCHECK_MAX_SUCCESS 20)
 endif ()
 
+option(NES_SPLIT_TEST_BINARIES "Build each unit-test suite as a separate executable" ON)
+
 # Target to build all integration tests
 add_custom_target(integration_tests)
 # Target to build all e2e tests
 add_custom_target(e2e_tests)
 
-# This function registers a test with gtest_discover_tests
-function(add_nes_test)
-    add_executable(${ARGN})
-    set(TARGET_NAME ${ARGV0})
+function(configure_nes_test_target TARGET_NAME)
     target_link_libraries(${TARGET_NAME} nes-test-util rapidcheck rapidcheck_gtest)
     if (NES_ENABLE_PRECOMPILED_HEADERS)
         target_precompile_headers(${TARGET_NAME} REUSE_FROM nes-common)
@@ -41,12 +40,47 @@ function(add_nes_test)
         target_code_coverage(${TARGET_NAME} PUBLIC AUTO ALL EXTERNAL OBJECTS nes nes-common)
         message(STATUS "Added cc test ${TARGET_NAME}")
     endif ()
+endfunction()
+
+function(discover_nes_test TARGET_NAME TEST_WORKING_DIRECTORY)
     gtest_discover_tests(${TARGET_NAME}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        WORKING_DIRECTORY ${TEST_WORKING_DIRECTORY}
         DISCOVERY_MODE PRE_TEST
         DISCOVERY_TIMEOUT 30
         PROPERTIES ENVIRONMENT "RC_PARAMS=max_success=${RAPIDCHECK_MAX_SUCCESS}")
     message(STATUS "Added ut ${TARGET_NAME}")
+endfunction()
+
+function(finalize_nes_combined_test TARGET_NAME)
+    get_target_property(TEST_OBJECT_TARGETS ${TARGET_NAME} NES_TEST_OBJECT_TARGETS)
+    foreach (TEST_OBJECT_TARGET ${TEST_OBJECT_TARGETS})
+        target_link_libraries(${TARGET_NAME} PRIVATE ${TEST_OBJECT_TARGET})
+    endforeach ()
+    if (CODE_COVERAGE)
+        target_code_coverage(${TARGET_NAME} PUBLIC AUTO ALL EXTERNAL OBJECTS nes nes-common)
+    endif ()
+    discover_nes_test(${TARGET_NAME} ${CMAKE_BINARY_DIR})
+endfunction()
+
+# This function registers a test with gtest_discover_tests. The combined layout compiles each suite as an object library
+# so that suite-specific compile settings remain isolated while the static NES libraries are linked only once.
+function(add_nes_test TARGET_NAME)
+    if (NES_SPLIT_TEST_BINARIES)
+        add_executable(${TARGET_NAME} ${ARGN})
+        configure_nes_test_target(${TARGET_NAME})
+        discover_nes_test(${TARGET_NAME} ${CMAKE_CURRENT_BINARY_DIR})
+        return()
+    endif ()
+
+    add_library(${TARGET_NAME} OBJECT ${ARGN})
+    configure_nes_test_target(${TARGET_NAME})
+
+    if (NOT TARGET nes-unit-tests)
+        add_executable(nes-unit-tests)
+        cmake_language(DEFER DIRECTORY "${CMAKE_SOURCE_DIR}" CALL finalize_nes_combined_test nes-unit-tests)
+    endif ()
+    set_property(TARGET nes-unit-tests APPEND PROPERTY NES_TEST_OBJECT_TARGETS ${TARGET_NAME})
+    message(STATUS "Added ut ${TARGET_NAME} to nes-unit-tests")
 endfunction()
 
 function(add_nes_common_test)

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -163,6 +163,15 @@ docker run \
     cmake -B build-docker
 ```
 
+### Unit-test binaries
+
+`NES_SPLIT_TEST_BINARIES` defaults to `ON` and builds one executable per unit-test suite. Set it to `OFF` to link all
+unit tests into `nes-unit-tests`, as CI does:
+
+```shell
+cmake -B build-docker -DNES_SPLIT_TEST_BINARIES=OFF
+```
+
 ### CLion Integration
 
 To integrate the container-based development environment you need to create a new docker-based toolchain. With the

--- a/nes-executable/tests/TestUtils/TestTaskQueue.cpp
+++ b/nes-executable/tests/TestUtils/TestTaskQueue.cpp
@@ -123,10 +123,10 @@ void SingleThreadedTestTaskQueue::enqueueTasks(std::vector<TestPipelineTask> pip
         {
             const auto pecFromWeakCapturedPtr = weakPipelineExecutionContext.lock();
             PRECONDITION(pecFromWeakCapturedPtr != nullptr, "The pipelineExecutionContext must be valid in the repeat callback function");
-            tasks.emplace(WorkTask{.task = testTask, .pipelineExecutionContext = pecFromWeakCapturedPtr});
+            tasks.emplace(TestTaskQueueEntry{.task = testTask, .pipelineExecutionContext = pecFromWeakCapturedPtr});
         };
         pipelineExecutionContext->setRepeatTaskCallback(std::move(repeatTaskCallback));
-        tasks.emplace(WorkTask{.task = testTask, .pipelineExecutionContext = pipelineExecutionContext});
+        tasks.emplace(TestTaskQueueEntry{.task = testTask, .pipelineExecutionContext = pipelineExecutionContext});
     }
 }
 

--- a/nes-executable/tests/TestUtils/TestTaskQueue.hpp
+++ b/nes-executable/tests/TestUtils/TestTaskQueue.hpp
@@ -176,7 +176,7 @@ struct TestPipelineTask
     std::shared_ptr<ExecutablePipelineStage> eps;
 };
 
-struct WorkTask
+struct TestTaskQueueEntry
 {
     TestPipelineTask task;
     std::shared_ptr<TestPipelineExecutionContext> pipelineExecutionContext;
@@ -197,7 +197,7 @@ public:
     void processTasks(std::vector<TestPipelineTask> pipelineTasks);
 
 private:
-    std::queue<WorkTask> tasks;
+    std::queue<TestTaskQueueEntry> tasks;
     std::shared_ptr<AbstractBufferProvider> bufferProvider;
     std::shared_ptr<std::vector<std::vector<TupleBuffer>>> resultBuffers;
 

--- a/nes-query-engine/tests/DelayedTaskSubmitterTest.cpp
+++ b/nes-query-engine/tests/DelayedTaskSubmitterTest.cpp
@@ -40,7 +40,7 @@
 namespace NES::Testing
 {
 
-QueryId randomQueryId()
+static QueryId randomQueryId()
 {
     return QueryId::createLocal(LocalQueryId(generateUUID()));
 }

--- a/nes-query-engine/tests/QueryPlanTest.cpp
+++ b/nes-query-engine/tests/QueryPlanTest.cpp
@@ -53,7 +53,7 @@ namespace NES::Testing
 {
 using namespace NES;
 
-QueryId randomQueryId()
+static QueryId randomQueryId()
 {
     return QueryId::createLocal(LocalQueryId(generateUUID()));
 }


### PR DESCRIPTION
## Summary
- add `NES_SPLIT_TEST_BINARIES` to select per-suite or combined unit-test binaries
- use the combined `nes-unit-tests` binary in PR and nightly CI
- fix test-only ODR and duplicate-symbol conflicts exposed by combined linking

Closes #1785

## Test plan
- [x] Debug build with `NES_SPLIT_TEST_BINARIES=ON`
- [x] Aggregate unit tests with `NES_SPLIT_TEST_BINARIES=OFF` (855 passed, 1 disabled)
- [x] Formatting check