### PR TITLE
[DD] Dynamic, variable-sized memory management

### DIFF
--- a/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
+++ b/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
@@ -1,0 +1,284 @@
+# The Problem
+
+NebulaStream (NES) is a compiled stream-processing engine that routes every record through a single unit of memory: a pooled, reference-counted `TupleBuffer` handed out by one `BufferManager` (`nes-memory/include/Runtime/BufferManager.hpp`).
+In a compiled streaming engine this buffer is unusually central.
+It is the unit of data movement, the substrate for operator state (join hash tables, windowed aggregations, paged vectors), the payload of network transfer between pipelines, and — because the engine generates code — a compile-time constant that the code generator folds into the pipeline as `capacity = bufferSize / tupleSize`.
+The buffer is therefore woven into the data path, the state, the network, and the generated program at once.
+
+This consolidation is efficient, but today the buffer substrate is *rigid*, and the rigidity shows up at every point where the buffer is woven in.
+
+The `BufferManager` hands out a **single fixed size** (default 8 KiB); any other size falls through to a slow, per-thread *unpooled* path (`nes-memory/include/Runtime/UnpooledChunksManager.hpp`) with a heap-allocated control block and RW-locked chunk maps (**P1**).
+A microbenchmark measures this unpooled path at 1.4–3.4× the latency of the pooled path, and it fragments because it suballocates variable sizes from rolling chunks (**P1**).
+
+The unpooled path is **unbounded**: a large group-by or join whose state overflows the pool allocates from unpooled memory until it exhausts physical RAM and the OS OOM-kills the entire worker, taking every co-located query down with it (**P2**).
+
+Because the per-buffer capacity is **baked into generated code** and the size is **fixed in the network wire format** (`SerializedTupleBufferHeader`, `nes-network/nes-rust-bindings/network/src/lib.rs:34`), variable-sized data cannot ride the pooled path end to end even if the allocator could serve it: a right-sized buffer would be mis-deserialized at the receiver (**P3**).
+
+Output buffers are acquired **eagerly at full size**: `EmitPhysicalOperator::open` (`nes-physical-operators/src/EmitPhysicalOperator.cpp:54`) grabs a full operator-buffer-size buffer and emits it regardless of occupancy, so a pipeline that produces three tuples still pins a full 8 KiB buffer (**P4**).
+
+Each source is throttled by a **static** inflight cap — a fixed `std::counting_semaphore` sized once at `maxInflightBuffers` (`nes-query-engine/RunningSource.cpp`) — so an idle source is permitted buffers it never uses while a fast source is capped even when memory is free (**P5**).
+
+Finally, there is a consequence specific to *streaming*.
+Because a streaming query never terminates, its state grows monotonically and pins buffers that are not released until a window fires, which itself requires processing more input, which requires more buffers from the same pool.
+When the pool is exhausted a producer waits for a buffer while the only action that would free one also needs a buffer.
+The result is not a slowdown but a **circular wait**: the engine deadlocks (**P6**).
+Batch engines never face this, because query completion is a guaranteed reclamation event; a streaming engine has no such event.
+
+These six problems are not independent.
+They are the same rigidity — a fixed buffer size — viewed from the allocator (**P1**), the budget (**P2**), the compiler and network (**P3**), the emit path (**P4**), the source scheduler (**P5**), and the liveness of a non-terminating query (**P6**).
+
+# Goals
+
+(**G1**): Serve a variable-sized buffer request from the fast pooled path in O(1), at pooled-path latency, without fragmentation.
+This addresses **P1** by removing the single-size constraint so that most variable-sized requests no longer fall to the slow unpooled path.
+
+(**G2**): Bound total execution memory by a configurable budget, and make an over-budget request fail cleanly with a recoverable error rather than OOM-killing the worker.
+This addresses **P2** by turning an unbounded allocation into a bounded one with a defined failure mode. Essentially, we need to get rid of all unpooled buffers and turn them into a sequence of pooled buffers.
+
+(**G3**): Make code generation and the network wire protocol size-aware, so one generated pipeline handles buffers of any size and the receiver reconstructs the right size.
+This addresses **P3**, which is the part of the design unique to a *compiled* engine.
+
+(**G4**): Defer output-buffer acquisition and size the buffer to the tuples actually produced, making execution memory proportional to live tuples rather than to buffer count.
+This addresses **P4** and is essentially important if the buffer leaves the node to reduce network traffic.
+
+(**G5**): Replace the static per-source inflight cap with an elastic, fair quota drawn from the global budget that grows under load and decays on idle.
+This addresses **P5** and would also allow for a priority based buffer hand-out.
+
+(**G6**): Guarantee progress when the budget is reached: resolve pool exhaustion as a liveness condition rather than a deadlock, and provide disk spilling for state that exceeds the resident budget.
+This addresses **P6** and allows us to decide which buffer should be spilled (the one who guarantee progression) and which not (maybe source buffers that would add new work to an already overloaded systems).
+
+(**G7**): Preserve NES's performance envelope.
+The dynamic substrate must not regress throughput on fixed-size pipelines and must keep the zero-GC, lock-free, reference-counted recycling on the hot path.
+This is a cross-cutting requirement that constrains every other goal.
+
+(**G8**): Deliver the redesign incrementally.
+Each axis must be independently reviewable, mergeable, and backward compatible, so that a partial rollout leaves the engine correct and the default configuration behaves byte-for-byte as today.
+
+# Non-Goals
+
+(**NG1**): We do not build a general-purpose disk-backed buffer manager with page-level eviction and pointer swizzling in the style of Umbra or LeanStore.
+NES's execution memory is in-memory, reference-counted, and latency-critical; page-fault-driven paging and swizzling add machinery and latency that a streaming hot path does not need.
+Disk spilling in this design is scoped to *operator state slices* (G6), not to every buffer as the main purpose is to make the system able to continue processing.
+
+(**NG2**): We do not change the reference-counting and recycling model.
+The `BufferControlBlock` atomic refcount and the recycle callback (`nes-memory/TupleBufferImpl.hpp`) stay exactly as they are; size classes reuse them per class.
+Changing the ownership model is out of scope and would jeopardize **G7**.
+
+(**NG3**): Full runtime capacity for the *columnar* layout is out of scope for the first iteration.
+Columnar capacity fixes per-column offsets at lowering time (`LowerSchemaProvider.cpp:114`) and requires computing offsets at runtime; the row layout lands first and columnar follows in a dedicated change. Anyhow, the columnar layout is not used at all in NES atm.
+
+(**NG4**): We do not coordinate memory across nodes.
+The budget (**G2**) is a single-node budget; a distributed or cluster-wide memory budget is a separate problem.
+
+(**NG5**): We do not redesign the query scheduler or the task queue.
+Liveness (**G6**) interposes on buffer allocation and query termination but leaves the work-distribution model untouched.
+
+# Alternatives
+
+We evaluate the alternatives per axis, because the redesign spans several loosely coupled decisions.
+
+**A1 — Keep the fixed pool and only make the unpooled path faster and bounded.**
+This is the smallest change: cap the unpooled byte counter (which #1701/#1702 already do) and optimize its chunk manager.
+It partially addresses **P2** but leaves **P1** (the pooled path is still single-size), **P3**, and **P4** untouched, and it keeps the fragmenting, RW-locked chunk machinery.
+It does not let variable-sized data ride the pooled path, so we reject it as a complete solution while keeping its budget idea for **G2**.
+
+**A2 — One larger or statically configurable buffer size.**
+Widening the fixed size trades internal fragmentation for less unpooled traffic but wastes memory on every small buffer and still cannot serve requests above the chosen size.
+It does not achieve **G1** or **G4** and we reject it. In addition, we do have different requirements by default, input buffers are determined by the source and maybe different sources produce different sizes. In addition, processing buffers are highly specific to the processing as a global window produces one value but a keyed-window one per key (data dependent) and joins are highly unpredictable.
+
+**A3 — A general slab/arena allocator (e.g., jemalloc-style) for all buffers.**
+A generic allocator serves arbitrary sizes but abandons NES's lock-free MPMC-queue pooled recycling and its placement-new'd control blocks, which are the basis of the zero-GC hot path.
+It directly threatens **G7** and we reject it.
+
+**A4 — A VM-assisted buffer manager (vmcache / LeanStore lineage).**
+`mmap`-backed pages with fault-in and pointer swizzling elegantly unify variable sizes and spilling.
+However, this design targets disk-backed paging of a buffer *pool*, not a streaming in-memory data path, and its pinning/swizzling/eviction machinery adds per-access latency that conflicts with **G7**.
+We borrow only its `mmap`-relocation idea, and only for operator-state spilling (G6, NG1), not for the general buffer path.
+
+**A5 — A single fixed block plus external spill for everything (DuckDB style).**
+DuckDB deliberately uses one block size and pushes overflow to temporary disk storage.
+This fits a batch engine but not streaming, which needs variable-sized *in-flight* buffers and *network payloads*, not just spill.
+We reject it as the general model but adopt spilling as one bounded mechanism (G6).
+
+**A6 — Reservation-based liveness (the rejected `#1683`).**
+We first built a scheme that reserves a per-query buffer quota so that no query can starve another (`tryGetReservedBuffer`/`numOfReservedBuffers`).
+In practice reservation wasted buffers that idle queries held and let an over-budget query stall forever without making progress, so it achieved neither **G6** nor **G7**. In general, in streaming we cannot deterministically provide buffers to queries in advance and statically as the workload is unpredictable.
+Victim-query termination (A7-chosen) supersedes it and reservation does not appear in the shipped engine.
+
+**A7 — Compile-time cardinality analysis for emit sizing.**
+Instead of staging output at runtime, the compiler could statically bound each operator's output cardinality and size the buffer at codegen time.
+Output cardinality is unknown for filters and aggregations, so a static bound reduces to the input count (no better than eager for a full input buffer); we choose runtime staging (`StageAndCopy`) for the general case and keep a static `InputSized` mode for the many-to-one case.
+
+We narrow the general allocator decision to **segregated power-of-two size classes** that reuse NES's existing pooled recycling, and we co-design the compiler, network, emit, source, budget, and liveness axes around it.
+This is the consensus design of DuckDB, ClickHouse, Velox, and Umbra for variable-sized allocation, adapted to a streaming, reference-counted, in-memory substrate (see [Solution Background](#solution-background)).
+
+# Solution Background
+
+This design condenses a body of prior work that lives in the repository and in the literature.
+
+**Prior work in NES (issues and PRs).**
+The umbrella is the EPIC #1714 (*Dynamic, variable-sized memory management*), which sequences the axes below.
+- **#1706** — size-class buffer manager (the foundation; implemented on the integration branch).
+- **#1703** — dynamic buffer capacity in Nautilus codegen.
+- **#1704** — carry the buffer size in the network wire protocol.
+- **#1705** — per-size-class page selection for the `PagedVector`.
+- **#1711** — lazy, right-sized emit (selectable allocation modes).
+- **#1712** — retire the unpooled path (route every size through size classes under the budget); subsumes **#1701**.
+- **#1713** — adaptive, AIMD per-source inflight provisioning.
+- **#1699** — disk-backed operator-state spilling.
+- **#1700** — victim-query termination for liveness.
+- **#1701 / #1702** — bound the unpooled path with a budget and clean failure.
+- **#1683** — the rejected reservation scheme (see A6).
+
+**External prior art.**
+Segregated power-of-two size classes are shared by Umbra (variable-size pages in power-of-two classes, the class encoded in the swizzled pointer) and its LeanStore/vmcache lineage, by Velox (a small set of `SizeClass` objects with a malloc fallback), and by ClickHouse (S·2^N blocks).
+DuckDB deliberately uses a single fixed block plus external spill.
+Lasch et al.'s *Cooperative Memory Management for Table and Temporary Data* frames the budget/eviction split between long-lived and temporary allocations.
+Flink 2.0's *Disaggregated State Management* addresses the streaming-state-overflow problem from the state-backend side, which is complementary to our buffer-substrate approach.
+
+# Our Proposed Solution
+
+We make the buffer substrate elastic along every axis — size, capacity, lifetime, distribution, liveness, and overflow — under one bounded global budget, while preserving the reference-counted recycling on the hot path.
+The subsystem is six mechanisms that form one substrate rather than six features.
+
+```mermaid
+flowchart TD
+    R["getBuffer(size)"] --> CI{"classIndexForSize(size)"}
+    CI -->|"size <= max class"| BF["best-fit class pool (FixedSizeClassPool)"]
+    BF -->|"hit"| RET["TupleBuffer (pooled, refcounted)"]
+    BF -->|"empty"| PROMO["promote to larger pooled class"]
+    PROMO -->|"hit"| RET
+    PROMO -->|"all empty, within timeout"| BLOCK["block on best-fit class"]
+    BLOCK --> RET
+    CI -->|"size > max class"| UNP["unpooled tail (bounded by budget)"]
+    UNP -->|"over budget"| FAIL["BufferAllocationFailure (3000)"]
+    RET --> ARB["BufferExhaustionArbiter: keep recovery margin"]
+    ARB -->|"exhausted"| VIC["terminate a victim query (liveness)"]
+```
+
+## Size-class buffer manager (G1, addresses P1)
+
+We generalize the single fixed pool into segregated **power-of-two size classes**.
+A sized request `getBuffer(size)` (`nes-memory/BufferManager.cpp`) rounds up to the smallest fitting class via `classIndexForSize`, serves it in O(1) from that class's own lock-free pool, and **promotes** to a larger pooled class when the best-fit class is momentarily empty; only a request larger than the maximum class falls to the unpooled tail.
+Each class is a `FixedSizeClassPool` (`nes-memory/FixedSizeClassPool.hpp`) — NES's existing MPMC queue plus a `std::deque<MemorySegment>` of stable-address segments — instantiated once per class, so every class keeps the exact zero-GC, lock-free, reference-counted recycling of the current pool (**G7**).
+The `BufferManager` owns a `vector<unique_ptr<FixedSizeClassPool>>` and a `defaultPoolIndex`.
+Provisioning is pluggable via `BufferProvisioningPolicy`: `TotalBudgetSplit` (a fixed total footprint divided across classes), `EagerPerClass` (a fixed count per class), and `LazyElastic` (a small floor that faults in regions on demand up to a cap).
+The design is backward compatible by construction: with no size-class configuration there is exactly one class (the operator buffer size) and the engine behaves byte-for-byte as today (**G8**). The exact and best size class for a given workload or even dynamically is then part of future research work.
+Unlike the size-class allocators of Umbra, Velox, and ClickHouse, ours is a streaming, in-memory substrate — reference-counted, never paged, no pinning or pointer swizzling — so size classes are purely an allocation-latency and fragmentation optimization (**NG1**).
+
+## Size-aware code generation and network (G3, addresses P3)
+
+Variable-sized buffers are insert unless the compiler and the network stop assuming a fixed size.
+For code generation (#1703) we make the per-buffer capacity a **runtime value** carried on the buffer reference (`TupleBufferRef`) instead of the constant-folded `bufferSize / tupleSize`, so one compiled pipeline writes buffers of different sizes; the row layout lands first and columnar follows (**NG3**).
+For the network (#1704) we add the buffer size to the wire header (`SerializedTupleBufferHeader`) so the receiver allocates the fitting size class *before* deserializing, instead of deserializing into a pre-allocated fixed buffer and pushing variable child data onto the unpooled path.
+
+## Lazy, right-sized emit (G4, addresses P4)
+
+We defer output-buffer acquisition and make the emit operator's allocation strategy a selectable mode (#1711, `EmitPhysicalOperator.cpp`, `ExecutionContext::allocateBuffer(size)` / `copyToRightSizedBuffer`).
+- `EagerFull` (baseline): a full buffer up front.
+- `InputSized`: size the output buffer to the input cardinality (an upper bound), capped at the operator buffer size.
+- `StageAndCopy`: write to a staging buffer, then copy the records into an exactly right-sized buffer at flush.
+- `ReuseAcrossRuns`: carry a partially filled buffer across pipeline invocations, flushing only when full.
+Execution memory then tracks the tuples actually emitted: `InputSized` captures the many-to-one case directly, and `StageAndCopy` captures the general case, including selective filters, by sizing to the actual output. Again the best strategy is then evaluated in future research.
+
+## Adaptive source provisioning (G5, addresses P5)
+
+We replace the fixed `counting_semaphore` cap with a resizable throttle (#1713, `InflightThrottle`).
+Each source starts with a small quota and, when it consistently saturates that quota *and* global memory is free, is granted more on an AIMD curve (additive grant, multiplicative backoff), bounded by the configured cap so it never exceeds the static baseline; quotas decay on idle and return to the global pool.
+The control signals already exist: buffer-acquisition stalls in the source retry loop (`SourceThread.cpp`), the `BackpressureChannel` state, and global memory pressure from the budget.
+
+## Bounded budget, clean failure, and liveness (G2, G6, addresses P2, P6)
+
+A single global budget caps total memory and an over-budget request fails cleanly rather than OOM-killing the worker: `getBuffer(size)` (and the unpooled tail) return a recoverable `BufferAllocationFailure` (error 3000) that the caller turns into a per-query failure (#1701/#1702).
+
+For liveness (#1700) a `BufferExhaustionArbiter` interposed on buffer allocation keeps a **recovery margin** of free buffers in reserve (default = worker-thread count, so all workers detect exhaustion together), then selects a victim query, fails it (`QueryCatalog::failQuery` → `QueryBufferExhausted`, 3007), waits briefly for its buffers to drain, and retries; it self-terminates if the caller's own query is the victim, so liveness holds either way (a safety deadline bounds the loop).
+Victim selection is a policy with a design space; the shipped engine implements `TERMINATE_LARGEST` (frees the most per kill) and `TERMINATE_SELF` (trivially local), and the wider space (oldest, over-fair-share, cost-based) is future work (see [Open Questions](#open-questions)).
+Termination supersedes the reservation scheme of A6.
+
+Independently and composably, a query may run with state larger than its resident budget by **spilling** cold operator state to disk (#1699).
+A spillable slice allocates its state over an `ArenaMemoryResource` (`nes-memory/.../Spill/ArenaMemoryResource.hpp`): an anonymous `mmap` region whose eviction is `pwrite` + `madvise(DONTNEED)` and whose reload is `pread` back to the *same virtual address*, so live pointers into the state survive eviction.
+A process-wide `SpillManager` governor evicts the coldest unpinned slices above a high watermark (0.9 of budget) down to a low watermark (0.7); pinning (`pinSliceForBuild`) guarantees a slice in use is never evicted, which requires the no-op slice cache.
+Termination guarantees progress; spilling buys time by relocating state; the two occupy complementary regimes.
+
+## Putting it together
+
+A single global budget caps total memory; allocation is right-sized along four axes — size (size classes), capacity (size-aware codegen), lifetime (lazy emit), and distribution (adaptive sources) — and, under pressure, the engine either relocates state (spilling) or sheds a victim query (termination) to keep running.
+Size, capacity, lifetime, distribution, liveness, and overflow are thus governed coherently by one bounded buffer substrate.
+
+```mermaid
+flowchart LR
+    F["#1706 size classes (foundation)"] --> C["#1703 codegen capacity"]
+    F --> W["#1704 wire size"]
+    F --> PV["#1705 PagedVector per-class"]
+    F --> AS["#1713 adaptive sources"]
+    C --> EM["#1711 lazy emit"]
+    W --> RU["#1712 retire unpooled (⊃ #1701)"]
+    EM --> RU
+    PV --> RU
+    F --> LV["#1700 victim termination + #1699 spilling"]
+```
+
+# Proof of Concept
+
+We implemented all axes in NES and measured them on a single 64-thread server (2×32 cores, 503 GiB RAM), `Benchmark` build.
+We report the outcomes honestly, including where a goal is not yet met, because a design document should record the degree to which the solution reaches its goals.
+
+**G1 (size classes) — met.**
+A microbenchmark (2 M allocate/free per thread) measures the unpooled tax at 1.4–3.4× the pooled path (186 ns fixed vs 596 ns unpooled single-threaded), and size classes track the fixed pool (173 ns vs 186 ns), confirming O(1) pooled-latency service.
+On the variable-sized YSB workload the payloads that the baseline routes off-pool are served from the pooled 256 KiB and 512 KiB classes with byte-identical results.
+
+**G7 (no regression) — met.**
+End-to-end completion time on a 50 M-tuple YSB aggregation is 31.83 s (baseline) vs 31.45 s (size classes) and 31.62 s (`StageAndCopy`), all within the baseline's own 4.0 % run-to-run spread (median of five/three runs).
+
+**G4 (right-sized emit) — met.**
+An emit-bytes counter (`NES_EMIT_STATS`) shows `StageAndCopy` reduces emitted-buffer memory by 3.6–16× (72–94 %) with byte-identical results (e.g. 180 KiB → 11 KiB on a low-cardinality aggregation), and the per-flush copy cost is +0.2 % on an emit-heavy pass-through — effectively free.
+`InputSized` captures the many-to-one case (−46–62 %) but not selective filters (−5 %), exactly the predicted split.
+
+**G2 (clean failure) — met.**
+Under a ~1 KiB unpooled budget a keyed aggregation raises a recoverable `BufferAllocationFailure` (3000) and the worker survives, where the unbounded path would OOM-kill the process.
+
+**G6 (liveness) — met for termination, partially for spilling.**
+On a 16-buffer pool the arbiter terminates a victim query ("selected as victim") instead of deadlocking, and the worker stays live.
+Spilling produces byte-identical results across keyed aggregation (7/7), stacked aggregation (4/4), and a nested-loop join (11/11) at a 16 KiB budget; its overhead at that tight budget exceeds 10× (it did not complete in 150 s vs 15 s in memory), which motivates termination as the backstop but leaves a clean overhead sweep as future work.
+
+**Not yet demonstrated (honest gaps).**
+The *whole-system* memory footprint is **not** reduced by turning all axes on: enabling size classes raises the peak live pooled bytes (5.8 MB → 30–60 MB) because more distinct buffers are concurrently live, and the `TotalBudgetSplit` policy caps only the *reserved* auxiliary-class capacity, not the live peak, while the default pool stays eagerly allocated.
+The adaptive-source benefit (**G5**) is not yet demonstrated: the mechanism is bounded by the static cap and, in this architecture, the inflight cap is rarely the binding backpressure, so a clear throughput/fairness win needs a cap-bound workload and per-source counters.
+The size-aware wire (**G3**) is now measured: the test harness runs every query as a distributed source-node/sink-node plan over the engine's real network channel, and a receive-side counter confirms that variable-sized data crosses the wire as child buffers (50 for YSB, 25 for Nexmark) which the receiver serves from pooled size classes via `getBuffer(child.size())`, with byte-identical results — only the `#1704` *parent* right-sizing branch stays unfired because these payloads fit the receive buffer, so a large-payload two-node throughput sweep would still sharpen it.
+The adaptive-source benefit (**G5**) remains undemonstrated: the generator source hangs at the unlimited emit rate needed to make the inflight cap the binding constraint, and the adaptive quota is bounded by the static cap, so there is no clean throughput win to measure.
+The victim-policy space beyond the two shipped policies is not evaluated.
+
+# Summary
+
+The problem is a single rigidity — a fixed buffer size — that manifests as a slow unbounded unpooled path (**P1**, **P2**), a capacity baked into codegen and the wire format (**P3**), eager full-size emit (**P4**), a static per-source cap (**P5**), and, uniquely for streaming, a circular-wait deadlock under exhaustion (**P6**).
+The proposed subsystem addresses each: segregated power-of-two size classes serve variable sizes at pooled speed (**G1**); a global budget with clean failure bounds memory (**G2**); size-aware codegen and wire let variable data ride the pooled path (**G3**); lazy right-sized emit makes memory proportional to tuples (**G4**); adaptive provisioning replaces the static cap (**G5**); and victim termination plus spilling keep the engine live and bounded (**G6**) — all while preserving the reference-counted hot path (**G7**) and shipping incrementally (**G8**).
+The proof of concept confirms **G1**, **G2**, **G3** (codegen row layout and the size-aware wire), **G4**, **G7**, and the termination half of **G6** with measured, byte-identical results, and it is candid that the whole-system footprint reduction and the adaptive-source benefit (**G5**) remain to be demonstrated.
+We prefer segregated size classes over the alternatives because they alone serve variable sizes at pooled latency without abandoning NES's zero-GC recycling (rejecting A2/A3), without disk-paging machinery a streaming path does not need (rejecting A4/A5), and because victim termination succeeds where the reservation scheme (A6) wasted buffers and stalled progress.
+
+# Open Questions
+
+- **Q1**: Which provisioning policy and budget make the *whole-system* live footprint smaller than the fixed pool, given that the default pool dominates the peak? (relates to #1712)
+- **Q2**: What workload makes the inflight cap the binding backpressure, so the adaptive-source benefit (**G5**) is measurable, and what per-source counters does the benchmark build need for a Jain-fairness metric? (#1713)
+- **Q3**: Should we retire the unpooled path entirely (large/huge `LazyElastic` classes under the budget), and what is the clean over-budget failure at the size-class layer? (#1712, subsumes #1701)
+- **Q4**: Which additional victim-selection policies (oldest, over-fair-share, cost-based) do we implement behind `selectVictim`, and how do we evaluate them on a lopsided workload? (#1700)
+- **Q5**: How do we isolate spill-I/O overhead from the slice-cache-off cost, and expose `SpillManager` evict/reload counters in the benchmark build? (#1699)
+- **Q6**: What is the runtime-capacity design for the *columnar* layout, whose per-column offsets are fixed at lowering time? (#1703, NG3)
+- **Q7**: Maybe we should have a fixed size buffer for sources and the proposed buffer only for processing or alternative just allocate more buffers to the buffer size the sources are using?
+
+# Sources and Further Reading
+
+- Neumann, Freitag. *Umbra: A Disk-Based System with In-Memory Performance.* CIDR 2020.
+- Leis et al. *LeanStore: In-Memory Data Management Beyond Main Memory.* ICDE 2018; and *Virtual-Memory Assisted Buffer Management.* SIGMOD 2023.
+- Kuiper, Boncz, Mühleisen. *Robust External Hash Aggregation in the Solid State Age.* ICDE 2024 (DuckDB).
+- Lasch et al. *Cooperative Memory Management for Table and Temporary Data.* SiMoD @ SIGMOD 2023.
+- Mei et al. *Disaggregated State Management in Apache Flink 2.0.* PVLDB 18(12), 2025.
+- Leis et al. *Morsel-Driven Parallelism.* SIGMOD 2014.
+- NES EPIC #1714 and issues #1699–#1706, #1711–#1713 (and the rejected #1683).
+
+# Appendix
+
+**Configuration keys** (`nes-runtime/interface/Configuration/WorkerConfiguration.hpp`, off by default):
+`enable_buffer_size_classes`, `buffer_size_class_min_bytes` / `_max_bytes` (validated as powers of two), `buffer_size_class_provisioning`, `buffer_size_class_budget_bytes`; `default_query_execution.emit_buffer_allocation_mode`; `enable_adaptive_inflight_buffers`, `default_max_inflight_buffers`; `query_engine.buffer_exhaustion_policy`, `query_engine.buffer_recovery_margin`; `enable_state_spilling`, `state_memory_budget_in_bytes`, `spill_directory`.
+Note: the emit-mode key currently applies only via the worker-config YAML (`-w`), not the CLI override — a usability issue worth a follow-up.
+
+**Instrumentation added for the evaluation** (benchmark-build escape hatches, since logging is compiled out): `NES_BM_STATS` dumps peak pooled occupancy, per-size-class allocation counts, and peak resident pooled bytes; `NES_EMIT_STATS` dumps total emitted-buffer bytes, tuples, and count.

--- a/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
+++ b/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
@@ -165,10 +165,12 @@ refer to another, possibly-spilled buffer through a central table of swizzled po
 tree-like today (parent→child child-buffers), so swizzling is not yet forced; if we move to DAG ownership
 we cannot avoid it.
 
-**Measured comparison.** The size-class buffer manager and this microbenchmark live on the implementation
-branch [`feature/variable-size-buffer-size-classes`](https://github.com/nebulastream/nebulastream/blob/feature/variable-size-buffer-size-classes/nes-memory/benchmarks/BufferManagerBenchmark.cpp),
-not on this doc-only branch; the A2/A3 engine allocators used below are an extension on top of it. All three
-are implemented as an allocator microbenchmark (`nes-memory/benchmarks/BufferManagerBenchmark.cpp`) and run
+**Measured comparison.** The size-class buffer manager lives on
+[`feature/variable-size-buffer-size-classes`](https://github.com/nebulastream/nebulastream/tree/feature/variable-size-buffer-size-classes);
+the A2/A3 allocators and the A2/A3 modes of this microbenchmark are the extension on top, on
+[`feature/variable-size-buffer-size-classes-a2a3`](https://github.com/nebulastream/nebulastream/blob/feature/variable-size-buffer-size-classes-a2a3/nes-memory/benchmarks/BufferManagerBenchmark.cpp)
+(neither is on this doc-only branch). All three are implemented as an allocator microbenchmark
+(`nes-memory/benchmarks/BufferManagerBenchmark.cpp`) and run
 on `sr630-wn-a-11` (Benchmark build, 1M
 `alloc + touch-every-byte + free` per thread). Two request sizes bracket the design: 1 KiB (fits one
 class/block) and 48 KiB (spans many). Latency is ns/op at 8 threads (lower is better); memory is physical
@@ -371,7 +373,7 @@ NES_BM_STATS=1 $S -t $JOIN --data <TESTDATA> -- --worker.query_engine.number_of_
 #   A3: --worker.variable_size_allocator=VmCache
 ```
 
-All commands above run against the implementation branch
-[`feature/variable-size-buffer-size-classes`](https://github.com/nebulastream/nebulastream/tree/feature/variable-size-buffer-size-classes)
-(the A2/A3 `variable_size_allocator` modes are a small extension on top); build that branch to reproduce the
-numbers in this document.
+The size-class runs use [`feature/variable-size-buffer-size-classes`](https://github.com/nebulastream/nebulastream/tree/feature/variable-size-buffer-size-classes);
+the A2/A3 (`variable_size_allocator`) runs use
+[`feature/variable-size-buffer-size-classes-a2a3`](https://github.com/nebulastream/nebulastream/tree/feature/variable-size-buffer-size-classes-a2a3),
+a small extension on top. Build the relevant branch to reproduce the numbers in this document.

--- a/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
+++ b/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
@@ -25,7 +25,7 @@ memory, accounting, and lifecycle. The engine runs two memory subsystems side by
 same machine memory but reasoned about independently: the pool reserves a fixed budget up front; the
 unpooled path grows on demand from anonymous memory. Memory is not exchangeable between them such that the pool can be
 exhausted while the unpooled path has headroom — and each carries its own cap, failure mode, and
-instrumentation. Bounding the unpooled path (#1701/#1702) removed its OOM failure mode but not the split.
+instrumentation. Bounding the unpooled path removed its OOM failure mode but not the split.
 
 The unpooled subsystem is also less predictable than the pool, which matters for an engine targeting
 steady-state latency. Its allocation latency is variable — a heap allocation under a per-thread lock, with

--- a/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
+++ b/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
@@ -1,13 +1,5 @@
 # Variable-sized buffers via size classes
 
-> **Scope note (after review #1792).** This document was originally much broader. Following the review it
-> is narrowed to one question: **how do we serve a variable-sized buffer from the pool instead of the
-> unpooled path**, plus the two consumers that need it (right-sized emit, the network receive path). The
-> two showstoppers it previously bundled are handled elsewhere and are *prerequisites*, not part of this
-> design: bounding the unpooled path is already merged (#1701/#1702, keyseven123), and terminating a query
-> on genuine exhaustion is tracked in #1700. Adaptive source provisioning (#1713) and disk spilling
-> (#1699) are dropped from scope — see Non-Goals.
-
 # The Problem
 
 NebulaStream preallocates a pool of fixed-size `TupleBuffer`s (the operator buffer size — configurable;
@@ -22,28 +14,38 @@ operator buffer size — to hold a `VARSIZED` value, an operator-state page, or 
 
 **P1 — the unpooled path is slower and fragments, and variable-sized data always takes it.**
 A microbenchmark (2 M allocate/free pairs per thread) puts the unpooled path at 596 ns/op single-threaded
-versus 186 ns for the pool (3.2×), narrowing to 1.6× at eight threads (§PoC). It also fragments: chunk
-size is a rolling average of the last 100 requests and a chunk is pinned until its last buffer frees. For a
-`VARSIZED` workload this tax is paid on *every* payload, and none of that memory is pooled or bounded by
-the pool's accounting.
+versus 186 ns for the pool (3.2×), narrowing to 1.6× at eight threads (§PoC). It also fragments: a chunk is
+pinned until its last buffer is released, so one long-lived buffer keeps the whole chunk resident. For a
+`VARSIZED` workload this tax is paid on *every* payload, and none of that memory is bounded by the pool's
+accounting.
 
-**P2 — the unpooled path is unbounded (showstopper, addressed elsewhere).**
-It allocates from anonymous memory with no global cap, so large group-by/join state can exhaust memory and
-the OS OOM-kills the worker. This is the priority the reviewers agree on. Bounding the unpooled byte counter
-and terminating a query when the bounded budget is genuinely reached are prerequisites for retiring the
-unpooled path; both are tracked as their own work (see Non-Goals) and are out of scope here.
+**P2 — variable-sized data forces a second, competing memory subsystem.**
+Because the pool serves one size, every variable-sized request goes to a *separate* allocator with its own
+memory, accounting, and lifecycle. The engine runs two memory subsystems side by side, competing for the
+same machine memory but reasoned about independently: the pool reserves a fixed budget up front; the
+unpooled path grows on demand from anonymous memory. Memory is not exchangeable between them such that the pool can be
+exhausted while the unpooled path has headroom — and each carries its own cap, failure mode, and
+instrumentation. Bounding the unpooled path (#1701/#1702) removed its OOM failure mode but not the split.
 
-**Correction on the network path.** An earlier draft claimed the wire format fixes the buffer size and
-mis-deserializes a right-sized buffer. That was wrong: the wire carries sizes (Rust slices and vectors
-store their length) and does not transmit unused bytes. The only network-side issue is *which allocator the
-receive path uses*: a variable-sized child buffer arriving on a pipeline boundary is served from the
-unpooled path today. §Proposed Solution routes it to a fitting size class instead — an allocator choice,
-not a wire-format change.
+The unpooled subsystem is also less predictable than the pool, which matters for an engine targeting
+steady-state latency. Its allocation latency is variable — a heap allocation under a per-thread lock, with
+occasional chunk creation — rather than the pool's O(1) dequeue, and its chunk size is a rolling average of
+recent requests, so identical requests behave differently depending on history. And two subsystems mean two
+of everything to build and test — control blocks (native vs. heap-wrapped), locking, recycling, budgeting,
+metrics, and any future spilling or NUMA work — each handled twice. Serving variable sizes from the pool
+collapses the common case onto one predictable subsystem, leaving the unpooled path a rare tail for
+requests above the largest class.
+
+**P3 — the network receive path uses the unpooled allocator.** The wire carries buffer sizes (Rust slices
+and vectors store their length) and does not transmit unused bytes, so it needs no change. But a
+variable-sized child buffer arriving on a pipeline boundary is served from the unpooled path today.
+§Proposed Solution routes it to a fitting size class instead — an allocator choice, not a wire-format
+change.
 
 # Goals
 
-- **G1** — Serve a variable-sized buffer request from the pool at pool latency, so most such requests no
-  longer hit the unpooled path (P1).
+- **G1** — Serve a variable-sized buffer request from the pool at pool latency, so the common case no
+  longer hits the unpooled path and the two subsystems collapse to one (P1, P2).
 - **G2** — Keep the existing hot path: lock-free, reference-counted recycling, no per-buffer heap control
   block. The scheme must reuse it, not replace it. (Constrains G1.)
 - **G3** — Bound the *extra* memory the scheme reserves. A workload that uses few sizes must not pay for
@@ -53,21 +55,21 @@ not a wire-format change.
 
 # Non-Goals
 
-- **NG1** — Bounding the unpooled path / OOM query termination. The P2 showstopper; #1701/#1702 (done) and
-  #1700 (open).
-- **NG2** — Disk spilling of operator state. As the review notes, spilling should start from a **pin/unpin
-  API plus accounting** exposed to buffer users (so we can measure pinned vs. floating memory even before a
-  mechanism exists), not from the buffer-manager internals. Separate design; #1699.
-- **NG3** — Adaptive per-source inflight provisioning (#1713). Dropped: we have no measurement showing the
-  static cap is a problem, and source buffers are released promptly under normal pressure. If evidence
-  appears, it is its own design.
+- **NG1** — Bounding the unpooled path and OOM query termination. #1701/#1702 (done) bound the unpooled
+  byte counter; #1700 (open) terminates a query when the bounded budget is reached.
+- **NG2** — Disk spilling of operator state. Spilling should start from a **pin/unpin API plus accounting**
+  exposed to buffer users (so pinned vs. floating memory can be measured before a mechanism exists), not
+  from the buffer-manager internals. Separate design; #1699.
+- **NG3** — Adaptive per-source inflight provisioning (#1713). No measurement shows the static cap is a
+  problem, and source buffers are released promptly under normal pressure; if evidence appears, it is its
+  own design.
 - **NG4** — Columnar runtime capacity, and any cross-node / cluster-wide budget.
 - **NG5** — Changing the reference-counting or ownership model.
 
 # Alternatives
 
 The decision is narrow: how to serve a variable-sized request while keeping the pooled hot path. Three
-options; the review argued for A2 and A3, so we weigh them explicitly.
+options, weighed below.
 
 **A1 — Segregated power-of-two size classes (proposed).** One pool per class, each an instance of the
 existing lock-free machinery; round a request up to the smallest fitting class. *For:* reuses the hot path
@@ -106,7 +108,7 @@ bytes reserved per allocation ÷ bytes requested.
 | **A3** vmcache (reclaim) | 1819 | 5771 | 4.00× | 1.00× |
 | unpooled (baseline) | 1157 | 1143 | ~1× | ~1× |
 
-The numbers sharpen the trade-off the prose describes. **A2** carries *both* 4× internal waste on a small
+**A2** carries *both* 4× internal waste on a small
 buffer *and* 5.5× the latency on a large one, because a 48 KiB request becomes twelve 4 KiB block-pops —
 the composition cost is real and lands on the hot path. **A3** splits on its own budget knob: in *reuse*
 mode (freed slices kept resident) it matches A1's latency, but that discards the resident-budget benefit
@@ -117,12 +119,33 @@ integrated engine: at 48 KiB a memory-bandwidth-bound `memset` dominates every p
 looks competitive there), and A1's single-class queue shows contention under the zero-work alloc/free loop
 that real per-buffer work would mask. It measures the intrinsic allocation cost, not end-to-end throughput.
 
-We propose **A1 now** because it is the smallest step that satisfies G1 while reusing the hot path (G2),
-and because it does not commit us to composition-everywhere (A2) or fault-handling and swizzling (A3)
-before we need them. We do not claim A1 dominates: A2 is the right call if we accept composition across
-consumers, and **A3 is the better long-term target if and when we design spilling** (NG2) and adopt a
-resident-page budget. Recommendation: land A1, and re-open the A1-vs-A3 question as part of the spilling
-design rather than pre-deciding it here.
+**Engine-level comparison.** All three are also implemented as real engine allocation modes — A1 the
+size-class pools, A2 (`variable_size_allocator=ComposeFixed`) and A3 (`variable_size_allocator=VmCache`) as
+memory resources backing the variable-sized path — and run on three queries of increasing state
+(`sr630-wn-a-11`, 8 threads). Memory is the live/resident peak of variable-sized state.
+
+| query (state) | A1 size classes | A2 compose-fixed | A3 vmcache |
+|---|--:|--:|--:|
+| selection — filter+project (none) | ~0 | ~0 | ~0 |
+| window — SUM GROUP BY (aggregation) | **23.7 MB** | 29.2 MB | 29.4 MB |
+| join — Nexmark Q8, 18 M ⋈ (tens of GB) | **22.3 GB** | 35.3 GB | 35.1 GB |
+
+All three complete every query with byte-identical results. **A1 is the most memory-efficient on every
+workload** — power-of-two packing beats A2's 4 KiB block granularity and A3's page granularity (23.7 vs
+~29 MB on the window; **22.3 vs ~35 GB on the join, ~1.6× tighter**). A2's cost surfaces as external
+fragmentation (tens of thousands of free extents on the join); A3's as page-reclaim churn (`madvise` then
+re-fault). The counter-cost is provisioning: to serve the join's large single-class state, A1 needs the
+default class made *elastic* under lazy provisioning **and** a per-class growth ceiling sized between two
+walls — too low and a class exhausts and the query is terminated, too high and the class's lock-free queue
+exceeds its own allocation limit — whereas A2 and A3 take a single flat arena budget and fault in on demand.
+A1 therefore wins on efficiency and loses on operability for unbounded single-class state: the same
+trade-off the recommendation rests on.
+
+**A1 is the choice now.** It is the smallest step that satisfies G1 while reusing the hot path (G2),
+without committing to composition-everywhere (A2) or fault-handling and swizzling (A3) before they are
+needed. A1 does not dominate on every axis: A2 wins where composition across consumers is acceptable, and
+**A3 is the better long-term target once spilling** (NG2) introduces a resident-page budget. The A1-vs-A3
+question re-opens with the spilling design.
 
 # Proposed Solution
 
@@ -143,12 +166,10 @@ floor per class and faults in regions on demand; `EagerPerClass` reserves every 
 divides a fixed total. §PoC shows why `LazyElastic` is the default and `EagerPerClass` is a footgun.
 
 **Emit — one policy.** Size the output buffer to the input record count (an upper bound on output), capped
-at the operator buffer size (`InputSized`, #1711). We deliberately do **not** ship several emit policies;
-per the review, multiple policies make behaviour hard to reason about. If evidence later shows a
-quantile-based size beats the input-count upper bound (trading occasional chunking for space), we add it
-then. The complementary case the review raised — a projection that *grows* the schema so the output no
-longer fits — is the same mechanism from the other side: the emit buffer is sized to the actual output
-schema rather than assumed equal to the input buffer.
+at the operator buffer size (`InputSized`, #1711). A single policy keeps emit behavior easy to reason
+about; a quantile-based size (trading occasional chunking for space) is added only if evidence shows it
+beats the input-count bound. A projection that *grows* the schema is the same mechanism from the other
+side: the emit buffer is sized to the actual output schema rather than assumed equal to the input buffer.
 
 **Network — allocator only.** Serve an arriving variable-sized child from `getBuffer(child.size())` (a
 fitting class) instead of the unpooled path. The wire is unchanged.
@@ -156,10 +177,9 @@ fitting class) instead of the unpooled path. The wire is unchanged.
 # Proof of Concept (reproducible)
 
 All numbers: node `sr630-wn-a-11` (2×32 cores, 503 GiB RAM), `Benchmark` build (`-O3 -DNDEBUG`, no
-logging/asserts). Reproduction commands are in the appendix; raw logs are archived with them. **These are
-measured runs, not estimates** — anyone with cluster access can rerun each line.
+logging/asserts). Reproduction commands are in the appendix.
 
-**Microbench — does the size-class indirection cost anything?** The benchmark does 2 M `getBuffer`/release
+**Microbench — cost of the size-class indirection.** The benchmark does 2 M `getBuffer`/release
 pairs per thread. `getBuffer(size)` adds, over the fixed pool, only `classIndexForSize` (a linear scan over
 the ~14 classes) before the same lock-free pop.
 
@@ -174,14 +194,13 @@ The class index adds **no measurable latency** — SizeClassPooled tracks (in fa
 noise) FixedPooled across 1–8 threads — while both are 1.6–3.2× faster than the unpooled path. So the cost
 of size classes is not the lookup; the win is keeping variable sizes off the unpooled path.
 
-**Placement — does variable-sized data actually pool?** On the variable-sized YSB workload, classes *off*
+**Placement.** On the variable-sized YSB workload, classes *off*
 sends the 256 KiB/512 KiB payloads to the unpooled path (invisible to pool accounting); classes *on* serves
 them from the pooled 256 KiB and 512 KiB classes. Results are byte-identical either way (switching an
 allocation from unpooled to pooled is not expected to change correctness — it is a placement change).
 
-**Memory efficiency — how much is unused classes?** (The review's direct question.) On that workload **3 of
-14 classes are used** and peak *live* pooled memory is ~1 MB. *Reserved* capacity depends entirely on the
-policy:
+**Memory efficiency — reserved vs. used classes.** On that workload **3 of 14 classes are used** and peak
+*live* pooled memory is ~1 MB. *Reserved* capacity depends entirely on the policy:
 
 | provisioning | reserved capacity | of which default 4 KiB pool | peak live | YSB-50M wall |
 |---|--:|--:|--:|--:|
@@ -199,10 +218,35 @@ floors that are faulted lazily, so *resident* memory stays ~1 MB regardless of t
 real cost of A1 and the reason provisioning is a first-class knob: choose `LazyElastic`, and resident
 memory tracks the working set; choose `EagerPerClass`, and you pay for classes you never touch.
 
-**Throughput — is there a regression?** On a 50 M-tuple YSB aggregation, enabling size classes changes
-median completion time by −2.3 % (31.1 s vs 31.8 s), within the baseline's own 4.8 % run-to-run spread. We
-do **not** claim a throughput win on fixed-size pipelines — there is none to claim, and none expected; the
-value is memory placement (variable sizes pooled and bounded) at no throughput cost, not faster queries.
+**Throughput.** On a 50 M-tuple YSB aggregation, enabling size classes changes median completion time by
+−2.3 % (31.1 s vs 31.8 s), within the baseline's own 4.8 % run-to-run spread. Throughput on fixed-size
+pipelines is unchanged; the value is memory placement — variable sizes pooled and bounded — at no
+throughput cost.
+
+**Query shapes — where the second subsystem appears.** Three queries of increasing state, each run with
+classes off and under the three provisioning policies (256 B … 1 MiB classes), measured by peak pooled
+bytes and the classes actually touched (`NES_BM_STATS`).
+
+| query (state) | classes off | classes on (peak pooled, classes used) |
+|---|---|---|
+| selection — filter+project, YSB 50 M (none) | `4096` only, 5.5 MB | identical: `4096` only, 5.5 MB |
+| window — SUM GROUP BY, YSB 50 M (aggregation) | `4096` only, 5.3 MB — state on the unpooled path | pooled, 7–8 classes `256 B–512 K`: Lazy 34 MB / Eager 55 MB / Split 25 MB |
+| join — Nexmark Q8 bid⋈auction, 18 M (hash join) | **hard buffer-allocation failure** at 2 s | pooled across **all 13** classes; runs to pool exhaustion, then cleanly terminated (#1700): Split 245 MB … Lazy 6.4 GB resident |
+
+The stateless selection allocates only operator-size buffers, so size classes are a no-op — every
+configuration is identical. The windowed aggregation allocates variable-sized state (256 B–512 K pages);
+with classes off that state is served by the unpooled path and is invisible to pool accounting (peak pooled
+stays 5.3 MB), while with classes on it is pooled and bounded (25–55 MB by policy). The hash join is the
+sharpest case: with classes off it cannot allocate its `ChainedHashMap` pages at all — a 24-byte
+variable-sized request has no pooled home, exhausts the bounded unpooled path, and the query dies with a
+hard `buffer allocation failure`. With classes on the same pages are pooled across all thirteen classes; the
+join runs until the pool is *genuinely* exhausted and is then terminated cleanly to relieve pool exhaustion
+(#1700) rather than failing on an allocation, and provisioning bounds the resident memory it reaches before
+termination (TotalBudgetSplit 245 MB … LazyElastic 6.4 GB). This is P2 end to end: variable-sized operator
+state either lives in a fragile second subsystem that cannot serve a 24-byte page, or folds into the one
+pooled, bounded, live subsystem. (The join's state exceeds the configured pool budget — not machine memory —
+at every policy, so it does not complete here; the off-vs-on contrast is the placement result, not a
+throughput number.)
 
 # Open Questions
 
@@ -210,9 +254,9 @@ value is memory placement (variable sizes pooled and bounded) at no throughput c
   manager may subsume size classes.
 - **Auxiliary-class floor.** `LazyElastic` reserves ~48 MB of floors here; can the floor be zero (fault the
   first buffer of a class on first use) without a latency cliff?
-- **Interception point for the bounded-budget failure** (#1700): the review notes the arbiter today only
-  sits in `PipelineExecutionContext::allocateBuffer`, which not everyone uses; a `BufferManager` wrapper is
-  cleaner — pending a virtual-call cost check.
+- **Interception point for the bounded-budget failure** (#1700): the arbiter today only sits in
+  `PipelineExecutionContext::allocateBuffer`, which not everyone uses; a `BufferManager` wrapper is cleaner,
+  pending a virtual-call cost check.
 
 # Appendix — reproduction
 
@@ -241,4 +285,18 @@ done
 # throughput (YSB-50M): baseline vs size classes
 $S -b --show-query-performance --data <TESTDATA> -t nes-systests/benchmark/YSB50M_tput.test -- \
   --worker.query_engine.number_of_worker_threads=8 [--worker.enable_buffer_size_classes=true]
+
+# query shapes: stateless selection / stateful window / stateful join, each off + 3 policies
+# (join is measured in correctness mode: -b crashes the harness timer on a query that fails to complete)
+SEL=nes-systests/benchmark/YSB50M_map.test        # filter+project (stateless)
+WIN=nes-systests/benchmark/YSB50M_tput.test       # SUM GROUP BY window (aggregation)
+JOIN=nes-systests/benchmark/Nexmark.test:5        # Q8 variant bid<->auction (hash join)
+CLS="--worker.enable_buffer_size_classes=true --worker.buffer_size_class_min_bytes=256"
+for Q in $SEL $WIN; do for P in "" "$CLS --worker.buffer_size_class_provisioning=LazyElastic" \
+    "$CLS --worker.buffer_size_class_provisioning=EagerPerClass" \
+    "$CLS --worker.buffer_size_class_provisioning=TotalBudgetSplit"; do
+  NES_BM_STATS=1 $S -t $Q -b --show-query-performance --data <TESTDATA> -- \
+    --worker.query_engine.number_of_worker_threads=8 $P
+done; done
+NES_BM_STATS=1 $S -t $JOIN --data <TESTDATA> -- --worker.query_engine.number_of_worker_threads=8 [$CLS ...]
 ```

--- a/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
+++ b/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
@@ -94,8 +94,10 @@ refer to another, possibly-spilled buffer through a central table of swizzled po
 tree-like today (parent→child child-buffers), so swizzling is not yet forced; if we move to DAG ownership
 we cannot avoid it.
 
-**Measured comparison.** All three are implemented as an allocator microbenchmark
-(`nes-memory/benchmarks/BufferManagerBenchmark.cpp`) and run on `sr630-wn-a-11` (Benchmark build, 1M
+**Measured comparison.** The implementation and all files referenced in this document (the size-class
+buffer manager, the A2/A3 allocators, and this microbenchmark) live on the implementation branch
+`mem/integration` (PR #1706), not on this doc-only branch. All three are implemented as an allocator
+microbenchmark (`nes-memory/benchmarks/BufferManagerBenchmark.cpp`) and run on `sr630-wn-a-11` (Benchmark build, 1M
 `alloc + touch-every-byte + free` per thread). Two request sizes bracket the design: 1 KiB (fits one
 class/block) and 48 KiB (spans many). Latency is ns/op at 8 threads (lower is better); memory is physical
 bytes reserved per allocation ÷ bytes requested.
@@ -309,6 +311,5 @@ NES_BM_STATS=1 $S -t $JOIN --data <TESTDATA> -- --worker.query_engine.number_of_
 #   A3: --worker.variable_size_allocator=VmCache
 ```
 
-The A2/A3 allocators and the elastic-default-class change live on the size-class implementation branch
-(`mem/integration`, tracked by #1706), since they depend on the size-class machinery this document proposes;
-build that branch to reproduce the engine-level numbers above.
+All commands above run against the implementation branch `mem/integration` (PR #1706); build that branch to
+reproduce the numbers in this document.

--- a/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
+++ b/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
@@ -133,13 +133,29 @@ O(1) lock-free pop the fixed pool uses (the scan adds no measurable latency, §P
 pooled and bounded. *Against:* there are N classes to provision, most unused on any one workload, so the
 provisioning policy carries real weight (§PoC quantifies this — with eager provisioning it is a footgun).
 
+**What A1 gives up (so the tradeoff is explicit).** A1 is not a general allocator with only upside. It
+deliberately drops the things that make a general allocator complex: it serves ~14 *fixed* power-of-two
+sizes, not arbitrary sizes; it never coalesces or splits blocks; and it keeps O(1) reference-counted
+recycling per class. The price of dropping those is paid in **provisioning**. Because each class is a
+separate lock-free pool, a workload whose state concentrates in one class must have that class provisioned
+large enough — and that is a two-sided knob: too small and the class exhausts and the query is terminated;
+too large and the class's lock-free queue exceeds its own allocation limit (see the join in the engine
+comparison, which needs the default class elastic *and* a per-class ceiling tuned between those two walls).
+A2 and A3 avoid that knob with a single flat budget. So A1 buys memory efficiency and a reused hot path at
+the cost of a per-class provisioning burden that A2/A3 do not carry; that is the trade the recommendation
+accepts.
+
 **A2 — One fixed size, composed (the DuckDB route).** Keep a single buffer size and represent anything
 larger as a chain/tree of fixed buffers. *For:* no size-class provisioning, no internal fragmentation, one
-hot path, nothing new to reason about in the allocator. *Against:* every consumer that needs a *contiguous*
-larger region — a `VARSIZED` value, a hash-map page, a buffer serialized to the network — must handle
-composition and non-contiguity. That pushes chunking logic into operators, code generation, and the wire,
-and it does not help where contiguity is actually required. The complexity is moved, not removed; it is a
-real and defensible choice, but it is not free.
+hot path, nothing new to reason about in the allocator — a genuinely simpler *buffer manager*. *Against:*
+the simplicity is only local; it moves complexity into every consumer that needs a *contiguous* larger
+region. In NES today those are concrete and several: the `ChainedHashMap` pages behind keyed aggregation
+and joins, `PagedVector` segments, `Arena`/`VarVal` `VARSIZED` values, `NLJSlice` state, and a buffer
+serialized to the wire. Each would have to allocate a run of fixed blocks and gather/scatter across the
+non-contiguous boundary itself, and composition does not help where physical contiguity is actually
+required (a hash probe cannot straddle a block boundary for free). So A2 does not remove the complexity — it
+distributes it across those consumers. It is a real and defensible tradeoff *if* the team values a
+dead-simple buffer manager over simple consumers; the measured comparison below is what it costs in memory.
 
 **A3 — Virtual-memory over-allocation with a resident budget (vmcache/Umbra-lite).** Reserve a large
 virtual region, keep a tight budget of *resident* pages, fault in on access. *For:* one unified budget, no

--- a/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
+++ b/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
@@ -269,6 +269,21 @@ memory tracks the working set; choose `EagerPerClass`, and you pay for classes y
 pipelines is unchanged; the value is memory placement — variable sizes pooled and bounded — at no
 throughput cost.
 
+**Emit right-sizing — measured, and workload-dependent.** `InputSized` vs eager emit, `NES_EMIT_STATS`
+(total emit-buffer bytes; deterministic):
+
+| query | eager | InputSized | saved |
+|---|--:|--:|--:|
+| projection — YSB 50 M map (under-filled output) | 14.17 GiB | 10.63 GiB | **25 %** |
+| aggregation — YSB 50 M window (full output) | 5.16 GiB | 5.16 GiB | 0 % |
+
+Both are throughput-neutral (map 17.5 vs 17.4 s). The benefit is real but not universal: it applies exactly
+where output buffers are under-filled — a projection or low-cardinality stage that emits far fewer bytes
+than an operator buffer holds — and is zero when buffers are already full (the aggregation's partial emits
+here). The extreme case (a stage emitting a handful of tuples) saves proportionally more; these two YSB
+queries both fill buffers well, so 25 % is a conservative floor, not the ceiling. This is why emit is scoped
+as one bounded rule (size to the output, capped at the operator buffer) rather than a headline result.
+
 **Query shapes — where the second subsystem appears.** Three queries of increasing state, each run with
 classes off and under the three provisioning policies (256 B … 1 MiB classes), measured by peak pooled
 bytes and the classes actually touched (`NES_BM_STATS`).

--- a/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
+++ b/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
@@ -299,4 +299,16 @@ for Q in $SEL $WIN; do for P in "" "$CLS --worker.buffer_size_class_provisioning
     --worker.query_engine.number_of_worker_threads=8 $P
 done; done
 NES_BM_STATS=1 $S -t $JOIN --data <TESTDATA> -- --worker.query_engine.number_of_worker_threads=8 [$CLS ...]
+
+# A1/A2/A3 as engine allocation modes (A2/A3 select an mmap-arena resource; NES_VARALLOC_STATS=1 dumps
+# arena peak resident / reuse / fragmentation). A1 needs the default class elastic (LazyElastic) plus a
+# per-class ceiling for large single-class state:
+#   A1: --worker.enable_buffer_size_classes=true --worker.buffer_size_class_provisioning=LazyElastic \
+#       --worker.buffer_size_class_buffers_per_class=12000000 --worker.number_of_buffers_in_global_buffer_manager=200000
+#   A2: --worker.variable_size_allocator=ComposeFixed
+#   A3: --worker.variable_size_allocator=VmCache
 ```
+
+The A2/A3 allocators and the elastic-default-class change live on the size-class implementation branch
+(`mem/integration`, tracked by #1706), since they depend on the size-class machinery this document proposes;
+build that branch to reproduce the engine-level numbers above.

--- a/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
+++ b/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
@@ -36,11 +36,11 @@ metrics, and any future spilling or NUMA work — each handled twice. Serving va
 collapses the common case onto one predictable subsystem, leaving the unpooled path a rare tail for
 requests above the largest class.
 
-**P3 — the network receive path uses the unpooled allocator.** The wire carries buffer sizes (Rust slices
-and vectors store their length) and does not transmit unused bytes, so it needs no change. But a
-variable-sized child buffer arriving on a pipeline boundary is served from the unpooled path today.
-§Proposed Solution routes it to a fitting size class instead — an allocator choice, not a wire-format
-change.
+**P3 — variable-sized buffers arriving over the network land on the unpooled path.** A variable-sized child
+buffer received at a pipeline boundary is allocated from the unpooled path today, inheriting P1 and P2 on
+the receive side. (The wire format itself is not the problem — it already carries the buffer size, since
+Rust slices and vectors store their length and unused bytes are not transmitted — so this is purely which
+allocator the receiver uses.)
 
 # Goals
 
@@ -48,10 +48,14 @@ change.
   longer hits the unpooled path and the two subsystems collapse to one (P1, P2).
 - **G2** — Keep the existing hot path: lock-free, reference-counted recycling, no per-buffer heap control
   block. The scheme must reuse it, not replace it. (Constrains G1.)
-- **G3** — Bound the *extra* memory the scheme reserves. A workload that uses few sizes must not pay for
-  many. Reserved capacity and resident memory are separate quantities and both must be controlled.
-- **G4** — Ship incrementally and backward-compatibly: with the feature off, the engine behaves exactly as
-  today; each piece is independently reviewable and testable.
+- **G3** — Bound the extra memory the size-class pools reserve, so a workload that uses only a few sizes
+  does not pay for the classes it never touches. Two quantities must both stay bounded: *reserved capacity*
+  (virtual memory the pools claim up front) and *resident memory* (physical pages actually faulted in) — a
+  class can reserve address space cheaply as long as it stays resident-light until used.
+- **G4** — Ship incrementally: the size-class path lands behind `enable_buffer_size_classes` (default off)
+  so it can be reviewed, tested, and rolled out one piece at a time; with it off the engine behaves exactly
+  as today. The flag is a rollout switch, not a permanent mode — the goal is to make size classes the
+  default once the pieces land, not to keep two code paths forever.
 
 # Non-Goals
 
@@ -66,10 +70,61 @@ change.
 - **NG4** — Columnar runtime capacity, and any cross-node / cluster-wide budget.
 - **NG5** — Changing the reference-counting or ownership model.
 
+# Proposed Solution
+
+Generalize the single pool into segregated power-of-two classes. Each class is a `FixedSizeClassPool` — the
+engine's existing MPMC queue plus a deque of stable-address segments — so the per-class hot path is
+byte-for-byte today's pooled path (G2). `getBuffer(size)` computes the smallest fitting class
+(`classIndexForSize`, a linear scan over the classes), pops from that class's queue, and **promotes** to a
+larger pooled class if the best-fit is momentarily empty. **The unpooled path stays**, but only as the tail
+for a request larger than the maximum class (which #1701/#1702 already bound); everything up to the maximum
+class is now pooled. With no size-class configuration there is exactly one class — the operator buffer
+size — and behaviour is unchanged.
+
+```mermaid
+flowchart LR
+    R["getBuffer(size)"] --> C{"smallest fitting<br/>class?"}
+    C -->|"size ≤ max class"| P["pooled class pop<br/>(promote to next<br/>class if empty)"]
+    C -->|"size &gt; max class"| U["unpooled tail<br/>(bounded, #1701/#1702)"]
+    subgraph Pools["size-class pools (each = today's lock-free pooled path)"]
+      P256["256 B"]
+      P4K["4 KiB<br/>(default / operator size)"]
+      P1M["… 1 MiB"]
+    end
+    P --> Pools
+```
+
+**Interface.** No breaking change to `BufferManager`'s public interface. `getBuffer(size)` already exists;
+this proposal changes what backs it (a fitting size class instead of the unpooled path) and adds
+configuration (`enable_buffer_size_classes`, the class `min`/`max`, and the provisioning policy). The
+`TupleBuffer` handle, reference counting, and recycling are unchanged (NG5).
+
+**Which classes.** Powers of two from a configurable minimum to a maximum (our runs: 256 B … 1 MiB).
+Sub-page classes are pointless for large payloads but useful for small emit outputs (a three-field result
+belongs in a 256 B buffer, not a 4 KiB one), so we expose `min`/`max` and default the minimum to 256 B.
+
+**Classes grow on demand; they are not fully preallocated.** A class is not a fixed slab sized at startup —
+under the default `LazyElastic` policy each class reserves a small floor and *faults in additional regions
+as it is used*, up to a per-class ceiling. This is why the peak footprint tracks the working set rather than
+the sum of every class at full size (the alternative, `EagerPerClass`, does preallocate every class fully —
+and §PoC shows why that is a footgun). `BufferProvisioningPolicy`: `LazyElastic` (default, grows lazily),
+`EagerPerClass` (all classes preallocated), `TotalBudgetSplit` (one byte budget split across classes).
+
+**Emit is a consumer of the small classes, not a provisioning policy.** A pipeline that emits a few tuples
+currently pins a full operator-size output buffer; with sub-page classes available it can instead request a
+buffer sized to the actual output (`InputSized`, #1711) — e.g. a 256 B class for a three-field result. The
+mechanism is one rule (size to the output row count, capped at the operator buffer size), not a menu of
+strategies; a quantile-based size is added only if evidence shows it beats the row-count bound. The
+same rule covers a projection that *grows* the schema: the emit buffer follows the actual output schema.
+
+**Network.** A variable-sized child buffer arriving on a pipeline boundary is served from a fitting size
+class (`getBuffer(child.size())`) instead of the unpooled path. This is purely an allocator choice at the
+receiver; the wire format already carries the size (§P3) and is unchanged.
+
 # Alternatives
 
-The decision is narrow: how to serve a variable-sized request while keeping the pooled hot path. Three
-options, weighed below.
+The proposed solution (A1) is one of three ways to serve a variable-sized request while keeping the pooled
+hot path. This section records why A1 over the other two (A2, A3), with a measured comparison.
 
 **A1 — Segregated power-of-two size classes (proposed).** One pool per class, each an instance of the
 existing lock-free machinery; round a request up to the smallest fitting class. *For:* reuses the hot path
@@ -148,33 +203,6 @@ without committing to composition-everywhere (A2) or fault-handling and swizzlin
 needed. A1 does not dominate on every axis: A2 wins where composition across consumers is acceptable, and
 **A3 is the better long-term target once spilling** (NG2) introduces a resident-page budget. The A1-vs-A3
 question re-opens with the spilling design.
-
-# Proposed Solution
-
-Generalize the single pool into segregated power-of-two classes. Each class is a `FixedSizeClassPool` — the
-engine's existing MPMC queue plus a deque of stable-address segments — so the per-class hot path is
-byte-for-byte today's pooled path (G2). `getBuffer(size)` computes the smallest fitting class
-(`classIndexForSize`, a linear scan over the classes), pops from that class's queue, and **promotes** to a
-larger pooled class if the best-fit is momentarily empty; only a request above the maximum class reaches
-the unpooled tail (which #1701/#1702 already bound). With no size-class configuration there is exactly one
-class — the operator buffer size — and behaviour is unchanged (G4).
-
-**Which classes.** Powers of two from a configurable minimum to a maximum (our runs: 256 B … 1 MiB).
-Sub-page classes are pointless for large payloads but useful for small emit outputs (a three-field result
-belongs in a 256 B buffer, not a 4 KiB one), so we expose `min`/`max` and default the minimum to 256 B.
-
-**Provisioning is the G3 knob** (`BufferProvisioningPolicy`): `LazyElastic` (default) reserves a small
-floor per class and faults in regions on demand; `EagerPerClass` reserves every class fully; `TotalBudgetSplit`
-divides a fixed total. §PoC shows why `LazyElastic` is the default and `EagerPerClass` is a footgun.
-
-**Emit — one policy.** Size the output buffer to the input record count (an upper bound on output), capped
-at the operator buffer size (`InputSized`, #1711). A single policy keeps emit behavior easy to reason
-about; a quantile-based size (trading occasional chunking for space) is added only if evidence shows it
-beats the input-count bound. A projection that *grows* the schema is the same mechanism from the other
-side: the emit buffer is sized to the actual output schema rather than assumed equal to the input buffer.
-
-**Network — allocator only.** Serve an arriving variable-sized child from `getBuffer(child.size())` (a
-fitting class) instead of the unpooled path. The wire is unchanged.
 
 # Proof of Concept (reproducible)
 

--- a/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
+++ b/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
@@ -165,10 +165,11 @@ refer to another, possibly-spilled buffer through a central table of swizzled po
 tree-like today (parent→child child-buffers), so swizzling is not yet forced; if we move to DAG ownership
 we cannot avoid it.
 
-**Measured comparison.** The implementation and all files referenced in this document (the size-class
-buffer manager, the A2/A3 allocators, and this microbenchmark) live on the implementation branch
-`mem/integration` (PR #1706), not on this doc-only branch. All three are implemented as an allocator
-microbenchmark (`nes-memory/benchmarks/BufferManagerBenchmark.cpp`) and run on `sr630-wn-a-11` (Benchmark build, 1M
+**Measured comparison.** The size-class buffer manager and this microbenchmark live on the implementation
+branch [`feature/variable-size-buffer-size-classes`](https://github.com/nebulastream/nebulastream/blob/feature/variable-size-buffer-size-classes/nes-memory/benchmarks/BufferManagerBenchmark.cpp),
+not on this doc-only branch; the A2/A3 engine allocators used below are an extension on top of it. All three
+are implemented as an allocator microbenchmark (`nes-memory/benchmarks/BufferManagerBenchmark.cpp`) and run
+on `sr630-wn-a-11` (Benchmark build, 1M
 `alloc + touch-every-byte + free` per thread). Two request sizes bracket the design: 1 KiB (fits one
 class/block) and 48 KiB (spans many). Latency is ns/op at 8 threads (lower is better); memory is physical
 bytes reserved per allocation ÷ bytes requested.
@@ -370,5 +371,7 @@ NES_BM_STATS=1 $S -t $JOIN --data <TESTDATA> -- --worker.query_engine.number_of_
 #   A3: --worker.variable_size_allocator=VmCache
 ```
 
-All commands above run against the implementation branch `mem/integration` (PR #1706); build that branch to
-reproduce the numbers in this document.
+All commands above run against the implementation branch
+[`feature/variable-size-buffer-size-classes`](https://github.com/nebulastream/nebulastream/tree/feature/variable-size-buffer-size-classes)
+(the A2/A3 `variable_size_allocator` modes are a small extension on top); build that branch to reproduce the
+numbers in this document.

--- a/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
+++ b/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
@@ -15,7 +15,10 @@ our runs use 4 KiB) and hands them out through a lock-free MPMC queue with refer
 no per-buffer heap allocation. Any request for a *different* size — a `VARSIZED` payload, a hash-map page,
 a paged-vector segment — cannot come from that pool and falls to the **unpooled** path
 (`UnpooledChunksManager`): a per-thread allocator that heap-allocates a control block per buffer,
-suballocates from rolling chunks behind a lock, and frees a chunk only once its last buffer is released.
+suballocates from a per-thread chunk behind a lock, and frees a chunk only once its last buffer is released.
+Throughout, a *variable-sized request* means asking the pool for a buffer whose size differs from the
+operator buffer size — to hold a `VARSIZED` value, an operator-state page, or any other payload — not the
+`VARSIZED` column type specifically.
 
 **P1 — the unpooled path is slower and fragments, and variable-sized data always takes it.**
 A microbenchmark (2 M allocate/free pairs per thread) puts the unpooled path at 596 ns/op single-threaded
@@ -24,12 +27,11 @@ size is a rolling average of the last 100 requests and a chunk is pinned until i
 `VARSIZED` workload this tax is paid on *every* payload, and none of that memory is pooled or bounded by
 the pool's accounting.
 
-**P2 — the unpooled path is unbounded (showstopper, already being addressed elsewhere).**
+**P2 — the unpooled path is unbounded (showstopper, addressed elsewhere).**
 It allocates from anonymous memory with no global cap, so large group-by/join state can exhaust memory and
-the OS OOM-kills the worker. This is the priority the reviewers agree on. Bounding the unpooled byte
-counter is **already merged** (#1702); terminating a query when the *bounded* budget is genuinely reached
-is tracked in **#1700**. Both are prerequisites for retiring the unpooled path (#1712) but are out of scope
-here.
+the OS OOM-kills the worker. This is the priority the reviewers agree on. Bounding the unpooled byte counter
+and terminating a query when the bounded budget is genuinely reached are prerequisites for retiring the
+unpooled path; both are tracked as their own work (see Non-Goals) and are out of scope here.
 
 **Correction on the network path.** An earlier draft claimed the wire format fixes the buffer size and
 mis-deserializes a right-sized buffer. That was wrong: the wire carries sizes (Rust slices and vectors
@@ -69,7 +71,8 @@ options; the review argued for A2 and A3, so we weigh them explicitly.
 
 **A1 — Segregated power-of-two size classes (proposed).** One pool per class, each an instance of the
 existing lock-free machinery; round a request up to the smallest fitting class. *For:* reuses the hot path
-verbatim (G2); a request is a bounded index over ~14 classes plus an O(1) queue pop; variable sizes become
+verbatim (G2); a request costs a scan over the ~14 classes to pick the smallest fitting one, then the same
+O(1) lock-free pop the fixed pool uses (the scan adds no measurable latency, §PoC); variable sizes become
 pooled and bounded. *Against:* there are N classes to provision, most unused on any one workload, so the
 provisioning policy carries real weight (§PoC quantifies this — with eager provisioning it is a footgun).
 
@@ -213,7 +216,8 @@ value is memory placement (variable sizes pooled and bounded) at no throughput c
 
 # Appendix — reproduction
 
-On node 11 (`/local-ssd/zeuchste/nes-mem`, `Benchmark` build; run inside `nix develop . --command`):
+On the benchmark node (`sr630-wn-a-11`, 2×32 cores, 503 GiB RAM; tree at `/local-ssd/zeuchste/nes-mem`,
+`Benchmark` build; run inside `nix develop . --command`):
 
 ```bash
 S=cmake-build-release/nes-systests/systest/systest

--- a/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
+++ b/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
@@ -1,284 +1,211 @@
+# Variable-sized buffers via size classes
+
+> **Scope note (after review #1792).** This document was originally much broader. Following the review it
+> is narrowed to one question: **how do we serve a variable-sized buffer from the pool instead of the
+> unpooled path**, plus the two consumers that need it (right-sized emit, the network receive path). The
+> two showstoppers it previously bundled are handled elsewhere and are *prerequisites*, not part of this
+> design: bounding the unpooled path is already merged (#1701/#1702, keyseven123), and terminating a query
+> on genuine exhaustion is tracked in #1700. Adaptive source provisioning (#1713) and disk spilling
+> (#1699) are dropped from scope — see Non-Goals.
+
 # The Problem
 
-NebulaStream (NES) is a compiled stream-processing engine that routes every record through a single unit of memory: a pooled, reference-counted `TupleBuffer` handed out by one `BufferManager` (`nes-memory/include/Runtime/BufferManager.hpp`).
-In a compiled streaming engine this buffer is unusually central.
-It is the unit of data movement, the substrate for operator state (join hash tables, windowed aggregations, paged vectors), the payload of network transfer between pipelines, and — because the engine generates code — a compile-time constant that the code generator folds into the pipeline as `capacity = bufferSize / tupleSize`.
-The buffer is therefore woven into the data path, the state, the network, and the generated program at once.
+NebulaStream preallocates a pool of fixed-size `TupleBuffer`s (the operator buffer size — configurable;
+our runs use 4 KiB) and hands them out through a lock-free MPMC queue with reference-counted recycling and
+no per-buffer heap allocation. Any request for a *different* size — a `VARSIZED` payload, a hash-map page,
+a paged-vector segment — cannot come from that pool and falls to the **unpooled** path
+(`UnpooledChunksManager`): a per-thread allocator that heap-allocates a control block per buffer,
+suballocates from rolling chunks behind a lock, and frees a chunk only once its last buffer is released.
 
-This consolidation is efficient, but today the buffer substrate is *rigid*, and the rigidity shows up at every point where the buffer is woven in.
+**P1 — the unpooled path is slower and fragments, and variable-sized data always takes it.**
+A microbenchmark (2 M allocate/free pairs per thread) puts the unpooled path at 596 ns/op single-threaded
+versus 186 ns for the pool (3.2×), narrowing to 1.6× at eight threads (§PoC). It also fragments: chunk
+size is a rolling average of the last 100 requests and a chunk is pinned until its last buffer frees. For a
+`VARSIZED` workload this tax is paid on *every* payload, and none of that memory is pooled or bounded by
+the pool's accounting.
 
-The `BufferManager` hands out a **single fixed size** (default 8 KiB); any other size falls through to a slow, per-thread *unpooled* path (`nes-memory/include/Runtime/UnpooledChunksManager.hpp`) with a heap-allocated control block and RW-locked chunk maps (**P1**).
-A microbenchmark measures this unpooled path at 1.4–3.4× the latency of the pooled path, and it fragments because it suballocates variable sizes from rolling chunks (**P1**).
+**P2 — the unpooled path is unbounded (showstopper, already being addressed elsewhere).**
+It allocates from anonymous memory with no global cap, so large group-by/join state can exhaust memory and
+the OS OOM-kills the worker. This is the priority the reviewers agree on. Bounding the unpooled byte
+counter is **already merged** (#1702); terminating a query when the *bounded* budget is genuinely reached
+is tracked in **#1700**. Both are prerequisites for retiring the unpooled path (#1712) but are out of scope
+here.
 
-The unpooled path is **unbounded**: a large group-by or join whose state overflows the pool allocates from unpooled memory until it exhausts physical RAM and the OS OOM-kills the entire worker, taking every co-located query down with it (**P2**).
-
-Because the per-buffer capacity is **baked into generated code** and the size is **fixed in the network wire format** (`SerializedTupleBufferHeader`, `nes-network/nes-rust-bindings/network/src/lib.rs:34`), variable-sized data cannot ride the pooled path end to end even if the allocator could serve it: a right-sized buffer would be mis-deserialized at the receiver (**P3**).
-
-Output buffers are acquired **eagerly at full size**: `EmitPhysicalOperator::open` (`nes-physical-operators/src/EmitPhysicalOperator.cpp:54`) grabs a full operator-buffer-size buffer and emits it regardless of occupancy, so a pipeline that produces three tuples still pins a full 8 KiB buffer (**P4**).
-
-Each source is throttled by a **static** inflight cap — a fixed `std::counting_semaphore` sized once at `maxInflightBuffers` (`nes-query-engine/RunningSource.cpp`) — so an idle source is permitted buffers it never uses while a fast source is capped even when memory is free (**P5**).
-
-Finally, there is a consequence specific to *streaming*.
-Because a streaming query never terminates, its state grows monotonically and pins buffers that are not released until a window fires, which itself requires processing more input, which requires more buffers from the same pool.
-When the pool is exhausted a producer waits for a buffer while the only action that would free one also needs a buffer.
-The result is not a slowdown but a **circular wait**: the engine deadlocks (**P6**).
-Batch engines never face this, because query completion is a guaranteed reclamation event; a streaming engine has no such event.
-
-These six problems are not independent.
-They are the same rigidity — a fixed buffer size — viewed from the allocator (**P1**), the budget (**P2**), the compiler and network (**P3**), the emit path (**P4**), the source scheduler (**P5**), and the liveness of a non-terminating query (**P6**).
+**Correction on the network path.** An earlier draft claimed the wire format fixes the buffer size and
+mis-deserializes a right-sized buffer. That was wrong: the wire carries sizes (Rust slices and vectors
+store their length) and does not transmit unused bytes. The only network-side issue is *which allocator the
+receive path uses*: a variable-sized child buffer arriving on a pipeline boundary is served from the
+unpooled path today. §Proposed Solution routes it to a fitting size class instead — an allocator choice,
+not a wire-format change.
 
 # Goals
 
-(**G1**): Serve a variable-sized buffer request from the fast pooled path in O(1), at pooled-path latency, without fragmentation.
-This addresses **P1** by removing the single-size constraint so that most variable-sized requests no longer fall to the slow unpooled path.
-
-(**G2**): Bound total execution memory by a configurable budget, and make an over-budget request fail cleanly with a recoverable error rather than OOM-killing the worker.
-This addresses **P2** by turning an unbounded allocation into a bounded one with a defined failure mode. Essentially, we need to get rid of all unpooled buffers and turn them into a sequence of pooled buffers.
-
-(**G3**): Make code generation and the network wire protocol size-aware, so one generated pipeline handles buffers of any size and the receiver reconstructs the right size.
-This addresses **P3**, which is the part of the design unique to a *compiled* engine.
-
-(**G4**): Defer output-buffer acquisition and size the buffer to the tuples actually produced, making execution memory proportional to live tuples rather than to buffer count.
-This addresses **P4** and is essentially important if the buffer leaves the node to reduce network traffic.
-
-(**G5**): Replace the static per-source inflight cap with an elastic, fair quota drawn from the global budget that grows under load and decays on idle.
-This addresses **P5** and would also allow for a priority based buffer hand-out.
-
-(**G6**): Guarantee progress when the budget is reached: resolve pool exhaustion as a liveness condition rather than a deadlock, and provide disk spilling for state that exceeds the resident budget.
-This addresses **P6** and allows us to decide which buffer should be spilled (the one who guarantee progression) and which not (maybe source buffers that would add new work to an already overloaded systems).
-
-(**G7**): Preserve NES's performance envelope.
-The dynamic substrate must not regress throughput on fixed-size pipelines and must keep the zero-GC, lock-free, reference-counted recycling on the hot path.
-This is a cross-cutting requirement that constrains every other goal.
-
-(**G8**): Deliver the redesign incrementally.
-Each axis must be independently reviewable, mergeable, and backward compatible, so that a partial rollout leaves the engine correct and the default configuration behaves byte-for-byte as today.
+- **G1** — Serve a variable-sized buffer request from the pool at pool latency, so most such requests no
+  longer hit the unpooled path (P1).
+- **G2** — Keep the existing hot path: lock-free, reference-counted recycling, no per-buffer heap control
+  block. The scheme must reuse it, not replace it. (Constrains G1.)
+- **G3** — Bound the *extra* memory the scheme reserves. A workload that uses few sizes must not pay for
+  many. Reserved capacity and resident memory are separate quantities and both must be controlled.
+- **G4** — Ship incrementally and backward-compatibly: with the feature off, the engine behaves exactly as
+  today; each piece is independently reviewable and testable.
 
 # Non-Goals
 
-(**NG1**): We do not build a general-purpose disk-backed buffer manager with page-level eviction and pointer swizzling in the style of Umbra or LeanStore.
-NES's execution memory is in-memory, reference-counted, and latency-critical; page-fault-driven paging and swizzling add machinery and latency that a streaming hot path does not need.
-Disk spilling in this design is scoped to *operator state slices* (G6), not to every buffer as the main purpose is to make the system able to continue processing.
-
-(**NG2**): We do not change the reference-counting and recycling model.
-The `BufferControlBlock` atomic refcount and the recycle callback (`nes-memory/TupleBufferImpl.hpp`) stay exactly as they are; size classes reuse them per class.
-Changing the ownership model is out of scope and would jeopardize **G7**.
-
-(**NG3**): Full runtime capacity for the *columnar* layout is out of scope for the first iteration.
-Columnar capacity fixes per-column offsets at lowering time (`LowerSchemaProvider.cpp:114`) and requires computing offsets at runtime; the row layout lands first and columnar follows in a dedicated change. Anyhow, the columnar layout is not used at all in NES atm.
-
-(**NG4**): We do not coordinate memory across nodes.
-The budget (**G2**) is a single-node budget; a distributed or cluster-wide memory budget is a separate problem.
-
-(**NG5**): We do not redesign the query scheduler or the task queue.
-Liveness (**G6**) interposes on buffer allocation and query termination but leaves the work-distribution model untouched.
+- **NG1** — Bounding the unpooled path / OOM query termination. The P2 showstopper; #1701/#1702 (done) and
+  #1700 (open).
+- **NG2** — Disk spilling of operator state. As the review notes, spilling should start from a **pin/unpin
+  API plus accounting** exposed to buffer users (so we can measure pinned vs. floating memory even before a
+  mechanism exists), not from the buffer-manager internals. Separate design; #1699.
+- **NG3** — Adaptive per-source inflight provisioning (#1713). Dropped: we have no measurement showing the
+  static cap is a problem, and source buffers are released promptly under normal pressure. If evidence
+  appears, it is its own design.
+- **NG4** — Columnar runtime capacity, and any cross-node / cluster-wide budget.
+- **NG5** — Changing the reference-counting or ownership model.
 
 # Alternatives
 
-We evaluate the alternatives per axis, because the redesign spans several loosely coupled decisions.
+The decision is narrow: how to serve a variable-sized request while keeping the pooled hot path. Three
+options; the review argued for A2 and A3, so we weigh them explicitly.
 
-**A1 — Keep the fixed pool and only make the unpooled path faster and bounded.**
-This is the smallest change: cap the unpooled byte counter (which #1701/#1702 already do) and optimize its chunk manager.
-It partially addresses **P2** but leaves **P1** (the pooled path is still single-size), **P3**, and **P4** untouched, and it keeps the fragmenting, RW-locked chunk machinery.
-It does not let variable-sized data ride the pooled path, so we reject it as a complete solution while keeping its budget idea for **G2**.
+**A1 — Segregated power-of-two size classes (proposed).** One pool per class, each an instance of the
+existing lock-free machinery; round a request up to the smallest fitting class. *For:* reuses the hot path
+verbatim (G2); a request is a bounded index over ~14 classes plus an O(1) queue pop; variable sizes become
+pooled and bounded. *Against:* there are N classes to provision, most unused on any one workload, so the
+provisioning policy carries real weight (§PoC quantifies this — with eager provisioning it is a footgun).
 
-**A2 — One larger or statically configurable buffer size.**
-Widening the fixed size trades internal fragmentation for less unpooled traffic but wastes memory on every small buffer and still cannot serve requests above the chosen size.
-It does not achieve **G1** or **G4** and we reject it. In addition, we do have different requirements by default, input buffers are determined by the source and maybe different sources produce different sizes. In addition, processing buffers are highly specific to the processing as a global window produces one value but a keyed-window one per key (data dependent) and joins are highly unpredictable.
+**A2 — One fixed size, composed (the DuckDB route).** Keep a single buffer size and represent anything
+larger as a chain/tree of fixed buffers. *For:* no size-class provisioning, no internal fragmentation, one
+hot path, nothing new to reason about in the allocator. *Against:* every consumer that needs a *contiguous*
+larger region — a `VARSIZED` value, a hash-map page, a buffer serialized to the network — must handle
+composition and non-contiguity. That pushes chunking logic into operators, code generation, and the wire,
+and it does not help where contiguity is actually required. The complexity is moved, not removed; it is a
+real and defensible choice, but it is not free.
 
-**A3 — A general slab/arena allocator (e.g., jemalloc-style) for all buffers.**
-A generic allocator serves arbitrary sizes but abandons NES's lock-free MPMC-queue pooled recycling and its placement-new'd control blocks, which are the basis of the zero-GC hot path.
-It directly threatens **G7** and we reject it.
+**A3 — Virtual-memory over-allocation with a resident budget (vmcache/Umbra-lite).** Reserve a large
+virtual region, keep a tight budget of *resident* pages, fault in on access. *For:* one unified budget, no
+fragmentation, and a natural path to spilling later. *Against:* heavier machinery (fault handling; and
+**pointer swizzling the moment ownership becomes DAG-like** rather than tree-like — needed once a buffer can
+refer to another, possibly-spilled buffer through a central table of swizzled pointers). NES's ownership is
+tree-like today (parent→child child-buffers), so swizzling is not yet forced; if we move to DAG ownership
+we cannot avoid it.
 
-**A4 — A VM-assisted buffer manager (vmcache / LeanStore lineage).**
-`mmap`-backed pages with fault-in and pointer swizzling elegantly unify variable sizes and spilling.
-However, this design targets disk-backed paging of a buffer *pool*, not a streaming in-memory data path, and its pinning/swizzling/eviction machinery adds per-access latency that conflicts with **G7**.
-We borrow only its `mmap`-relocation idea, and only for operator-state spilling (G6, NG1), not for the general buffer path.
+We propose **A1 now** because it is the smallest step that satisfies G1 while reusing the hot path (G2),
+and because it does not commit us to composition-everywhere (A2) or fault-handling and swizzling (A3)
+before we need them. We do not claim A1 dominates: A2 is the right call if we accept composition across
+consumers, and **A3 is the better long-term target if and when we design spilling** (NG2) and adopt a
+resident-page budget. Recommendation: land A1, and re-open the A1-vs-A3 question as part of the spilling
+design rather than pre-deciding it here.
 
-**A5 — A single fixed block plus external spill for everything (DuckDB style).**
-DuckDB deliberately uses one block size and pushes overflow to temporary disk storage.
-This fits a batch engine but not streaming, which needs variable-sized *in-flight* buffers and *network payloads*, not just spill.
-We reject it as the general model but adopt spilling as one bounded mechanism (G6).
+# Proposed Solution
 
-**A6 — Reservation-based liveness (the rejected `#1683`).**
-We first built a scheme that reserves a per-query buffer quota so that no query can starve another (`tryGetReservedBuffer`/`numOfReservedBuffers`).
-In practice reservation wasted buffers that idle queries held and let an over-budget query stall forever without making progress, so it achieved neither **G6** nor **G7**. In general, in streaming we cannot deterministically provide buffers to queries in advance and statically as the workload is unpredictable.
-Victim-query termination (A7-chosen) supersedes it and reservation does not appear in the shipped engine.
+Generalize the single pool into segregated power-of-two classes. Each class is a `FixedSizeClassPool` — the
+engine's existing MPMC queue plus a deque of stable-address segments — so the per-class hot path is
+byte-for-byte today's pooled path (G2). `getBuffer(size)` computes the smallest fitting class
+(`classIndexForSize`, a linear scan over the classes), pops from that class's queue, and **promotes** to a
+larger pooled class if the best-fit is momentarily empty; only a request above the maximum class reaches
+the unpooled tail (which #1701/#1702 already bound). With no size-class configuration there is exactly one
+class — the operator buffer size — and behaviour is unchanged (G4).
 
-**A7 — Compile-time cardinality analysis for emit sizing.**
-Instead of staging output at runtime, the compiler could statically bound each operator's output cardinality and size the buffer at codegen time.
-Output cardinality is unknown for filters and aggregations, so a static bound reduces to the input count (no better than eager for a full input buffer); we choose runtime staging (`StageAndCopy`) for the general case and keep a static `InputSized` mode for the many-to-one case.
+**Which classes.** Powers of two from a configurable minimum to a maximum (our runs: 256 B … 1 MiB).
+Sub-page classes are pointless for large payloads but useful for small emit outputs (a three-field result
+belongs in a 256 B buffer, not a 4 KiB one), so we expose `min`/`max` and default the minimum to 256 B.
 
-We narrow the general allocator decision to **segregated power-of-two size classes** that reuse NES's existing pooled recycling, and we co-design the compiler, network, emit, source, budget, and liveness axes around it.
-This is the consensus design of DuckDB, ClickHouse, Velox, and Umbra for variable-sized allocation, adapted to a streaming, reference-counted, in-memory substrate (see [Solution Background](#solution-background)).
+**Provisioning is the G3 knob** (`BufferProvisioningPolicy`): `LazyElastic` (default) reserves a small
+floor per class and faults in regions on demand; `EagerPerClass` reserves every class fully; `TotalBudgetSplit`
+divides a fixed total. §PoC shows why `LazyElastic` is the default and `EagerPerClass` is a footgun.
 
-# Solution Background
+**Emit — one policy.** Size the output buffer to the input record count (an upper bound on output), capped
+at the operator buffer size (`InputSized`, #1711). We deliberately do **not** ship several emit policies;
+per the review, multiple policies make behaviour hard to reason about. If evidence later shows a
+quantile-based size beats the input-count upper bound (trading occasional chunking for space), we add it
+then. The complementary case the review raised — a projection that *grows* the schema so the output no
+longer fits — is the same mechanism from the other side: the emit buffer is sized to the actual output
+schema rather than assumed equal to the input buffer.
 
-This design condenses a body of prior work that lives in the repository and in the literature.
+**Network — allocator only.** Serve an arriving variable-sized child from `getBuffer(child.size())` (a
+fitting class) instead of the unpooled path. The wire is unchanged.
 
-**Prior work in NES (issues and PRs).**
-The umbrella is the EPIC #1714 (*Dynamic, variable-sized memory management*), which sequences the axes below.
-- **#1706** — size-class buffer manager (the foundation; implemented on the integration branch).
-- **#1703** — dynamic buffer capacity in Nautilus codegen.
-- **#1704** — carry the buffer size in the network wire protocol.
-- **#1705** — per-size-class page selection for the `PagedVector`.
-- **#1711** — lazy, right-sized emit (selectable allocation modes).
-- **#1712** — retire the unpooled path (route every size through size classes under the budget); subsumes **#1701**.
-- **#1713** — adaptive, AIMD per-source inflight provisioning.
-- **#1699** — disk-backed operator-state spilling.
-- **#1700** — victim-query termination for liveness.
-- **#1701 / #1702** — bound the unpooled path with a budget and clean failure.
-- **#1683** — the rejected reservation scheme (see A6).
+# Proof of Concept (reproducible)
 
-**External prior art.**
-Segregated power-of-two size classes are shared by Umbra (variable-size pages in power-of-two classes, the class encoded in the swizzled pointer) and its LeanStore/vmcache lineage, by Velox (a small set of `SizeClass` objects with a malloc fallback), and by ClickHouse (S·2^N blocks).
-DuckDB deliberately uses a single fixed block plus external spill.
-Lasch et al.'s *Cooperative Memory Management for Table and Temporary Data* frames the budget/eviction split between long-lived and temporary allocations.
-Flink 2.0's *Disaggregated State Management* addresses the streaming-state-overflow problem from the state-backend side, which is complementary to our buffer-substrate approach.
+All numbers: node `sr630-wn-a-11` (2×32 cores, 503 GiB RAM), `Benchmark` build (`-O3 -DNDEBUG`, no
+logging/asserts). Reproduction commands are in the appendix; raw logs are archived with them. **These are
+measured runs, not estimates** — anyone with cluster access can rerun each line.
 
-# Our Proposed Solution
+**Microbench — does the size-class indirection cost anything?** The benchmark does 2 M `getBuffer`/release
+pairs per thread. `getBuffer(size)` adds, over the fixed pool, only `classIndexForSize` (a linear scan over
+the ~14 classes) before the same lock-free pop.
 
-We make the buffer substrate elastic along every axis — size, capacity, lifetime, distribution, liveness, and overflow — under one bounded global budget, while preserving the reference-counted recycling on the hot path.
-The subsystem is six mechanisms that form one substrate rather than six features.
+| threads | FixedPooled | SizeClassPooled | Unpooled |
+|--:|--:|--:|--:|
+| 1 | 186 ns | **173 ns** | 596 ns |
+| 2 | 761 | 724 | 1059 |
+| 4 | 774 | 761 | 1130 |
+| 8 | 706 | 691 | 1142 |
 
-```mermaid
-flowchart TD
-    R["getBuffer(size)"] --> CI{"classIndexForSize(size)"}
-    CI -->|"size <= max class"| BF["best-fit class pool (FixedSizeClassPool)"]
-    BF -->|"hit"| RET["TupleBuffer (pooled, refcounted)"]
-    BF -->|"empty"| PROMO["promote to larger pooled class"]
-    PROMO -->|"hit"| RET
-    PROMO -->|"all empty, within timeout"| BLOCK["block on best-fit class"]
-    BLOCK --> RET
-    CI -->|"size > max class"| UNP["unpooled tail (bounded by budget)"]
-    UNP -->|"over budget"| FAIL["BufferAllocationFailure (3000)"]
-    RET --> ARB["BufferExhaustionArbiter: keep recovery margin"]
-    ARB -->|"exhausted"| VIC["terminate a victim query (liveness)"]
-```
+The class index adds **no measurable latency** — SizeClassPooled tracks (in fact slightly beats, within
+noise) FixedPooled across 1–8 threads — while both are 1.6–3.2× faster than the unpooled path. So the cost
+of size classes is not the lookup; the win is keeping variable sizes off the unpooled path.
 
-## Size-class buffer manager (G1, addresses P1)
+**Placement — does variable-sized data actually pool?** On the variable-sized YSB workload, classes *off*
+sends the 256 KiB/512 KiB payloads to the unpooled path (invisible to pool accounting); classes *on* serves
+them from the pooled 256 KiB and 512 KiB classes. Results are byte-identical either way (switching an
+allocation from unpooled to pooled is not expected to change correctness — it is a placement change).
 
-We generalize the single fixed pool into segregated **power-of-two size classes**.
-A sized request `getBuffer(size)` (`nes-memory/BufferManager.cpp`) rounds up to the smallest fitting class via `classIndexForSize`, serves it in O(1) from that class's own lock-free pool, and **promotes** to a larger pooled class when the best-fit class is momentarily empty; only a request larger than the maximum class falls to the unpooled tail.
-Each class is a `FixedSizeClassPool` (`nes-memory/FixedSizeClassPool.hpp`) — NES's existing MPMC queue plus a `std::deque<MemorySegment>` of stable-address segments — instantiated once per class, so every class keeps the exact zero-GC, lock-free, reference-counted recycling of the current pool (**G7**).
-The `BufferManager` owns a `vector<unique_ptr<FixedSizeClassPool>>` and a `defaultPoolIndex`.
-Provisioning is pluggable via `BufferProvisioningPolicy`: `TotalBudgetSplit` (a fixed total footprint divided across classes), `EagerPerClass` (a fixed count per class), and `LazyElastic` (a small floor that faults in regions on demand up to a cap).
-The design is backward compatible by construction: with no size-class configuration there is exactly one class (the operator buffer size) and the engine behaves byte-for-byte as today (**G8**). The exact and best size class for a given workload or even dynamically is then part of future research work.
-Unlike the size-class allocators of Umbra, Velox, and ClickHouse, ours is a streaming, in-memory substrate — reference-counted, never paged, no pinning or pointer swizzling — so size classes are purely an allocation-latency and fragmentation optimization (**NG1**).
+**Memory efficiency — how much is unused classes?** (The review's direct question.) On that workload **3 of
+14 classes are used** and peak *live* pooled memory is ~1 MB. *Reserved* capacity depends entirely on the
+policy:
 
-## Size-aware code generation and network (G3, addresses P3)
+| provisioning | reserved capacity | of which default 4 KiB pool | peak live |
+|---|--:|--:|--:|
+| `EagerPerClass` | **1134 MB** | 128 MB | ~1 MB |
+| `TotalBudgetSplit` | 311 MB | 128 MB | ~1 MB |
+| `LazyElastic` (default) | 176 MB | 128 MB | ~1 MB |
 
-Variable-sized buffers are insert unless the compiler and the network stop assuming a fixed size.
-For code generation (#1703) we make the per-buffer capacity a **runtime value** carried on the buffer reference (`TupleBufferRef`) instead of the constant-folded `bufferSize / tupleSize`, so one compiled pipeline writes buffers of different sizes; the row layout lands first and columnar follows (**NG3**).
-For the network (#1704) we add the buffer size to the wire header (`SerializedTupleBufferHeader`) so the receiver allocates the fitting size class *before* deserializing, instead of deserializing into a pre-allocated fixed buffer and pushing variable child data onto the unpooled path.
+The 128 MB default-class pool is the *same* the fixed-pool engine reserves today. Above it, `EagerPerClass`
+reserves ~1 GB of mostly-unused classes — unacceptable; `LazyElastic` reserves ~48 MB of auxiliary-class
+floors that are faulted lazily, so *resident* memory stays ~1 MB regardless of the class count. This is the
+real cost of A1 and the reason provisioning is a first-class knob: choose `LazyElastic`, and resident
+memory tracks the working set; choose `EagerPerClass`, and you pay for classes you never touch.
 
-## Lazy, right-sized emit (G4, addresses P4)
-
-We defer output-buffer acquisition and make the emit operator's allocation strategy a selectable mode (#1711, `EmitPhysicalOperator.cpp`, `ExecutionContext::allocateBuffer(size)` / `copyToRightSizedBuffer`).
-- `EagerFull` (baseline): a full buffer up front.
-- `InputSized`: size the output buffer to the input cardinality (an upper bound), capped at the operator buffer size.
-- `StageAndCopy`: write to a staging buffer, then copy the records into an exactly right-sized buffer at flush.
-- `ReuseAcrossRuns`: carry a partially filled buffer across pipeline invocations, flushing only when full.
-Execution memory then tracks the tuples actually emitted: `InputSized` captures the many-to-one case directly, and `StageAndCopy` captures the general case, including selective filters, by sizing to the actual output. Again the best strategy is then evaluated in future research.
-
-## Adaptive source provisioning (G5, addresses P5)
-
-We replace the fixed `counting_semaphore` cap with a resizable throttle (#1713, `InflightThrottle`).
-Each source starts with a small quota and, when it consistently saturates that quota *and* global memory is free, is granted more on an AIMD curve (additive grant, multiplicative backoff), bounded by the configured cap so it never exceeds the static baseline; quotas decay on idle and return to the global pool.
-The control signals already exist: buffer-acquisition stalls in the source retry loop (`SourceThread.cpp`), the `BackpressureChannel` state, and global memory pressure from the budget.
-
-## Bounded budget, clean failure, and liveness (G2, G6, addresses P2, P6)
-
-A single global budget caps total memory and an over-budget request fails cleanly rather than OOM-killing the worker: `getBuffer(size)` (and the unpooled tail) return a recoverable `BufferAllocationFailure` (error 3000) that the caller turns into a per-query failure (#1701/#1702).
-
-For liveness (#1700) a `BufferExhaustionArbiter` interposed on buffer allocation keeps a **recovery margin** of free buffers in reserve (default = worker-thread count, so all workers detect exhaustion together), then selects a victim query, fails it (`QueryCatalog::failQuery` → `QueryBufferExhausted`, 3007), waits briefly for its buffers to drain, and retries; it self-terminates if the caller's own query is the victim, so liveness holds either way (a safety deadline bounds the loop).
-Victim selection is a policy with a design space; the shipped engine implements `TERMINATE_LARGEST` (frees the most per kill) and `TERMINATE_SELF` (trivially local), and the wider space (oldest, over-fair-share, cost-based) is future work (see [Open Questions](#open-questions)).
-Termination supersedes the reservation scheme of A6.
-
-Independently and composably, a query may run with state larger than its resident budget by **spilling** cold operator state to disk (#1699).
-A spillable slice allocates its state over an `ArenaMemoryResource` (`nes-memory/.../Spill/ArenaMemoryResource.hpp`): an anonymous `mmap` region whose eviction is `pwrite` + `madvise(DONTNEED)` and whose reload is `pread` back to the *same virtual address*, so live pointers into the state survive eviction.
-A process-wide `SpillManager` governor evicts the coldest unpinned slices above a high watermark (0.9 of budget) down to a low watermark (0.7); pinning (`pinSliceForBuild`) guarantees a slice in use is never evicted, which requires the no-op slice cache.
-Termination guarantees progress; spilling buys time by relocating state; the two occupy complementary regimes.
-
-## Putting it together
-
-A single global budget caps total memory; allocation is right-sized along four axes — size (size classes), capacity (size-aware codegen), lifetime (lazy emit), and distribution (adaptive sources) — and, under pressure, the engine either relocates state (spilling) or sheds a victim query (termination) to keep running.
-Size, capacity, lifetime, distribution, liveness, and overflow are thus governed coherently by one bounded buffer substrate.
-
-```mermaid
-flowchart LR
-    F["#1706 size classes (foundation)"] --> C["#1703 codegen capacity"]
-    F --> W["#1704 wire size"]
-    F --> PV["#1705 PagedVector per-class"]
-    F --> AS["#1713 adaptive sources"]
-    C --> EM["#1711 lazy emit"]
-    W --> RU["#1712 retire unpooled (⊃ #1701)"]
-    EM --> RU
-    PV --> RU
-    F --> LV["#1700 victim termination + #1699 spilling"]
-```
-
-# Proof of Concept
-
-We implemented all axes in NES and measured them on a single 64-thread server (2×32 cores, 503 GiB RAM), `Benchmark` build.
-We report the outcomes honestly, including where a goal is not yet met, because a design document should record the degree to which the solution reaches its goals.
-
-**G1 (size classes) — met.**
-A microbenchmark (2 M allocate/free per thread) measures the unpooled tax at 1.4–3.4× the pooled path (186 ns fixed vs 596 ns unpooled single-threaded), and size classes track the fixed pool (173 ns vs 186 ns), confirming O(1) pooled-latency service.
-On the variable-sized YSB workload the payloads that the baseline routes off-pool are served from the pooled 256 KiB and 512 KiB classes with byte-identical results.
-
-**G7 (no regression) — met.**
-End-to-end completion time on a 50 M-tuple YSB aggregation is 31.83 s (baseline) vs 31.45 s (size classes) and 31.62 s (`StageAndCopy`), all within the baseline's own 4.0 % run-to-run spread (median of five/three runs).
-
-**G4 (right-sized emit) — met.**
-An emit-bytes counter (`NES_EMIT_STATS`) shows `StageAndCopy` reduces emitted-buffer memory by 3.6–16× (72–94 %) with byte-identical results (e.g. 180 KiB → 11 KiB on a low-cardinality aggregation), and the per-flush copy cost is +0.2 % on an emit-heavy pass-through — effectively free.
-`InputSized` captures the many-to-one case (−46–62 %) but not selective filters (−5 %), exactly the predicted split.
-
-**G2 (clean failure) — met.**
-Under a ~1 KiB unpooled budget a keyed aggregation raises a recoverable `BufferAllocationFailure` (3000) and the worker survives, where the unbounded path would OOM-kill the process.
-
-**G6 (liveness) — met for termination, partially for spilling.**
-On a 16-buffer pool the arbiter terminates a victim query ("selected as victim") instead of deadlocking, and the worker stays live.
-Spilling produces byte-identical results across keyed aggregation (7/7), stacked aggregation (4/4), and a nested-loop join (11/11) at a 16 KiB budget; its overhead at that tight budget exceeds 10× (it did not complete in 150 s vs 15 s in memory), which motivates termination as the backstop but leaves a clean overhead sweep as future work.
-
-**Not yet demonstrated (honest gaps).**
-The *whole-system* memory footprint is **not** reduced by turning all axes on: enabling size classes raises the peak live pooled bytes (5.8 MB → 30–60 MB) because more distinct buffers are concurrently live, and the `TotalBudgetSplit` policy caps only the *reserved* auxiliary-class capacity, not the live peak, while the default pool stays eagerly allocated.
-The adaptive-source benefit (**G5**) is not yet demonstrated: the mechanism is bounded by the static cap and, in this architecture, the inflight cap is rarely the binding backpressure, so a clear throughput/fairness win needs a cap-bound workload and per-source counters.
-The size-aware wire (**G3**) is now measured: the test harness runs every query as a distributed source-node/sink-node plan over the engine's real network channel, and a receive-side counter confirms that variable-sized data crosses the wire as child buffers (50 for YSB, 25 for Nexmark) which the receiver serves from pooled size classes via `getBuffer(child.size())`, with byte-identical results — only the `#1704` *parent* right-sizing branch stays unfired because these payloads fit the receive buffer, so a large-payload two-node throughput sweep would still sharpen it.
-The adaptive-source benefit (**G5**) remains undemonstrated: the generator source hangs at the unlimited emit rate needed to make the inflight cap the binding constraint, and the adaptive quota is bounded by the static cap, so there is no clean throughput win to measure.
-The victim-policy space beyond the two shipped policies is not evaluated.
-
-# Summary
-
-The problem is a single rigidity — a fixed buffer size — that manifests as a slow unbounded unpooled path (**P1**, **P2**), a capacity baked into codegen and the wire format (**P3**), eager full-size emit (**P4**), a static per-source cap (**P5**), and, uniquely for streaming, a circular-wait deadlock under exhaustion (**P6**).
-The proposed subsystem addresses each: segregated power-of-two size classes serve variable sizes at pooled speed (**G1**); a global budget with clean failure bounds memory (**G2**); size-aware codegen and wire let variable data ride the pooled path (**G3**); lazy right-sized emit makes memory proportional to tuples (**G4**); adaptive provisioning replaces the static cap (**G5**); and victim termination plus spilling keep the engine live and bounded (**G6**) — all while preserving the reference-counted hot path (**G7**) and shipping incrementally (**G8**).
-The proof of concept confirms **G1**, **G2**, **G3** (codegen row layout and the size-aware wire), **G4**, **G7**, and the termination half of **G6** with measured, byte-identical results, and it is candid that the whole-system footprint reduction and the adaptive-source benefit (**G5**) remain to be demonstrated.
-We prefer segregated size classes over the alternatives because they alone serve variable sizes at pooled latency without abandoning NES's zero-GC recycling (rejecting A2/A3), without disk-paging machinery a streaming path does not need (rejecting A4/A5), and because victim termination succeeds where the reservation scheme (A6) wasted buffers and stalled progress.
+**Throughput — is there a regression?** On a 50 M-tuple YSB aggregation, enabling size classes changes
+median completion time by −2.3 % (31.1 s vs 31.8 s), within the baseline's own 4.8 % run-to-run spread. We
+do **not** claim a throughput win on fixed-size pipelines — there is none to claim, and none expected; the
+value is memory placement (variable sizes pooled and bounded) at no throughput cost, not faster queries.
 
 # Open Questions
 
-- **Q1**: Which provisioning policy and budget make the *whole-system* live footprint smaller than the fixed pool, given that the default pool dominates the peak? (relates to #1712)
-- **Q2**: What workload makes the inflight cap the binding backpressure, so the adaptive-source benefit (**G5**) is measurable, and what per-source counters does the benchmark build need for a Jain-fairness metric? (#1713)
-- **Q3**: Should we retire the unpooled path entirely (large/huge `LazyElastic` classes under the budget), and what is the clean over-budget failure at the size-class layer? (#1712, subsumes #1701)
-- **Q4**: Which additional victim-selection policies (oldest, over-fair-share, cost-based) do we implement behind `selectVictim`, and how do we evaluate them on a lopsided workload? (#1700)
-- **Q5**: How do we isolate spill-I/O overhead from the slice-cache-off cost, and expose `SpillManager` evict/reload counters in the benchmark build? (#1699)
-- **Q6**: What is the runtime-capacity design for the *columnar* layout, whose per-column offsets are fixed at lowering time? (#1703, NG3)
-- **Q7**: Maybe we should have a fixed size buffer for sources and the proposed buffer only for processing or alternative just allocate more buffers to the buffer size the sources are using?
+- **Re-evaluate A3 with the spilling design** (NG2): if we adopt a resident-page budget, a VM-over-allocation
+  manager may subsume size classes.
+- **Auxiliary-class floor.** `LazyElastic` reserves ~48 MB of floors here; can the floor be zero (fault the
+  first buffer of a class on first use) without a latency cliff?
+- **Interception point for the bounded-budget failure** (#1700): the review notes the arbiter today only
+  sits in `PipelineExecutionContext::allocateBuffer`, which not everyone uses; a `BufferManager` wrapper is
+  cleaner — pending a virtual-call cost check.
 
-# Sources and Further Reading
+# Appendix — reproduction
 
-- Neumann, Freitag. *Umbra: A Disk-Based System with In-Memory Performance.* CIDR 2020.
-- Leis et al. *LeanStore: In-Memory Data Management Beyond Main Memory.* ICDE 2018; and *Virtual-Memory Assisted Buffer Management.* SIGMOD 2023.
-- Kuiper, Boncz, Mühleisen. *Robust External Hash Aggregation in the Solid State Age.* ICDE 2024 (DuckDB).
-- Lasch et al. *Cooperative Memory Management for Table and Temporary Data.* SiMoD @ SIGMOD 2023.
-- Mei et al. *Disaggregated State Management in Apache Flink 2.0.* PVLDB 18(12), 2025.
-- Leis et al. *Morsel-Driven Parallelism.* SIGMOD 2014.
-- NES EPIC #1714 and issues #1699–#1706, #1711–#1713 (and the rejected #1683).
+On node 11 (`/local-ssd/zeuchste/nes-mem`, `Benchmark` build; run inside `nix develop . --command`):
 
-# Appendix
+```bash
+S=cmake-build-release/nes-systests/systest/systest
+MB=cmake-build-release/nes-memory/benchmarks/buffer-manager-benchmark
+T=nes-systests/benchmark_small/YahooStreamingBenchmark_with_varsized.test
 
-**Configuration keys** (`nes-runtime/interface/Configuration/WorkerConfiguration.hpp`, off by default):
-`enable_buffer_size_classes`, `buffer_size_class_min_bytes` / `_max_bytes` (validated as powers of two), `buffer_size_class_provisioning`, `buffer_size_class_budget_bytes`; `default_query_execution.emit_buffer_allocation_mode`; `enable_adaptive_inflight_buffers`, `default_max_inflight_buffers`; `query_engine.buffer_exhaustion_policy`, `query_engine.buffer_recovery_margin`; `enable_state_spilling`, `state_memory_budget_in_bytes`, `spill_directory`.
-Note: the emit-mode key currently applies only via the worker-config YAML (`-w`), not the CLI override — a usability issue worth a follow-up.
+# microbench
+$MB
 
-**Instrumentation added for the evaluation** (benchmark-build escape hatches, since logging is compiled out): `NES_BM_STATS` dumps peak pooled occupancy, per-size-class allocation counts, and peak resident pooled bytes; `NES_EMIT_STATS` dumps total emitted-buffer bytes, tuples, and count.
+# placement (classes off vs on) + per-class provisioned/used
+NES_BM_STATS=1 $S -t $T                                             # classes off
+NES_BM_STATS=1 $S -t $T -- --worker.enable_buffer_size_classes=true # classes on
+#   read BM_CLASS lines: "size=<bytes> allocs=<served> buffers=<provisioned>"
+
+# memory efficiency by provisioning policy
+for P in LazyElastic EagerPerClass TotalBudgetSplit; do
+  NES_BM_STATS=1 $S -t $T -- --worker.enable_buffer_size_classes=true \
+    --worker.buffer_size_class_provisioning=$P
+done
+
+# throughput (YSB-50M): baseline vs size classes
+$S -b --show-query-performance --data <TESTDATA> -t nes-systests/benchmark/YSB50M_tput.test -- \
+  --worker.query_engine.number_of_worker_threads=8 [--worker.enable_buffer_size_classes=true]
+```

--- a/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
+++ b/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
@@ -89,6 +89,31 @@ refer to another, possibly-spilled buffer through a central table of swizzled po
 tree-like today (parent→child child-buffers), so swizzling is not yet forced; if we move to DAG ownership
 we cannot avoid it.
 
+**Measured comparison.** All three are implemented as an allocator microbenchmark
+(`nes-memory/benchmarks/BufferManagerBenchmark.cpp`) and run on `sr630-wn-a-11` (Benchmark build, 1M
+`alloc + touch-every-byte + free` per thread). Two request sizes bracket the design: 1 KiB (fits one
+class/block) and 48 KiB (spans many). Latency is ns/op at 8 threads (lower is better); memory is physical
+bytes reserved per allocation ÷ bytes requested.
+
+| approach | 1 KiB ns/op | 48 KiB ns/op | mem 1 KiB | mem 48 KiB |
+|---|--:|--:|--:|--:|
+| **A1** size classes | 701 | **1741** | **1.00×** | 1.33× |
+| **A2** compose-fixed | 676 | 9622 | 4.00× | 1.00× |
+| **A3** vmcache (reuse) | 152 | 1724 | 4.00× | 1.00× |
+| **A3** vmcache (reclaim) | 1819 | 5771 | 4.00× | 1.00× |
+| unpooled (baseline) | 1157 | 1143 | ~1× | ~1× |
+
+The numbers sharpen the trade-off the prose describes. **A2** carries *both* 4× internal waste on a small
+buffer *and* 5.5× the latency on a large one, because a 48 KiB request becomes twelve 4 KiB block-pops —
+the composition cost is real and lands on the hot path. **A3** splits on its own budget knob: in *reuse*
+mode (freed slices kept resident) it matches A1's latency, but that discards the resident-budget benefit
+that motivates it; the mode that actually bounds resident memory (`madvise(DONTNEED)` on every free) puts a
+syscall on the allocation path and costs 3–10×. **A1** pays only a bounded ≤1.33× round-up and a single
+O(1) pop, and is the only pooled path with no per-op syscall. This is an allocator microbenchmark, not the
+integrated engine: at 48 KiB a memory-bandwidth-bound `memset` dominates every pooled path (so unpooled
+looks competitive there), and A1's single-class queue shows contention under the zero-work alloc/free loop
+that real per-buffer work would mask. It measures the intrinsic allocation cost, not end-to-end throughput.
+
 We propose **A1 now** because it is the smallest step that satisfies G1 while reusing the hot path (G2),
 and because it does not commit us to composition-everywhere (A2) or fault-handling and swizzling (A3)
 before we need them. We do not claim A1 dominates: A2 is the right call if we accept composition across

--- a/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
+++ b/docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md
@@ -155,11 +155,15 @@ allocation from unpooled to pooled is not expected to change correctness — it 
 14 classes are used** and peak *live* pooled memory is ~1 MB. *Reserved* capacity depends entirely on the
 policy:
 
-| provisioning | reserved capacity | of which default 4 KiB pool | peak live |
-|---|--:|--:|--:|
-| `EagerPerClass` | **1134 MB** | 128 MB | ~1 MB |
-| `TotalBudgetSplit` | 311 MB | 128 MB | ~1 MB |
-| `LazyElastic` (default) | 176 MB | 128 MB | ~1 MB |
+| provisioning | reserved capacity | of which default 4 KiB pool | peak live | YSB-50M wall |
+|---|--:|--:|--:|--:|
+| `EagerPerClass` | **1134 MB** | 128 MB | ~1 MB | 30.9 s |
+| `TotalBudgetSplit` | 311 MB | 128 MB | ~1 MB | 30.4 s |
+| `LazyElastic` (default) | 176 MB | 128 MB | ~1 MB | 30.4 s |
+
+All three pass identical results and are throughput-equivalent (30.4–30.9 s, within the fixed-pool
+baseline's ~4.8 % run-to-run spread): provisioning is a memory knob, not a speed knob. Only 3 of the 14
+classes are used on this workload.
 
 The 128 MB default-class pool is the *same* the fixed-pool engine reserves today. Above it, `EagerPerClass`
 reserves ~1 GB of mostly-unused classes — unacceptable; `LazyElastic` reserves ~48 MB of auxiliary-class


### PR DESCRIPTION
Adds the design document `docs/design/20260709_Dynamic_Variable_Sized_Memory_Management.md`.

Resolves the design-document issue #1791; tracks the EPIC #1714 workstreams (#1699–#1706, #1711–#1713).

## What
A design document for the redesign of NebulaStream's buffer/memory subsystem, following the `docs/design` template:

- **The Problem** — one rigidity (a fixed buffer size) seen from six angles (P1–P6), including the streaming circular-wait deadlock.
- **Goals / Non-Goals** — G1–G8, NG1–NG5.
- **Alternatives** — A1–A7 (fixed-pool-only, generic slab, VM-assisted/LeanStore, DuckDB single-block+spill, the rejected reservation scheme #1683, …).
- **Proposed Solution** — segregated power-of-two size classes, size-aware codegen + wire, lazy right-sized emit, adaptive source provisioning, bounded budget + clean failure, victim-query termination, and state spilling — one substrate under a single budget.
- **Proof of Concept** — measured results (throughput-neutral size classes; up to 16× less emit memory; variable-sized data on the pooled wire; clean failure; liveness via victim termination; byte-identical spilling), candid about what is not yet demonstrated.

## Review
Per `docs/design/README.md`, this needs two code owners and one additional maintainer. Please assign maintainers as reviewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)