### PR TITLE
chore(sinks/sources) Renaming inline sinks/sources to anonymous sinks/sources

### DIFF
--- a/docs/development/systests.md
+++ b/docs/development/systests.md
@@ -79,10 +79,10 @@ CREATE PHYSICAL SOURCE FOR input TYPE Generator SET(
 );
 ```
 
-#### Inline Sources
+#### Anonymous Sources
 
 Additionally, a source can be defined inline within a SQL query.
-Instead of naming a source, you can create an inline source by writing `[TYPE]([OPTIONS])` (cmp. the example below).
+Instead of naming a source, you can create an anonymous source by writing `[TYPE]([OPTIONS])` (cmp. the example below).
 The accepted options are mostly the same as when creating a source via a `CREATE SOURCE` statement. 
 The only difference is that a schema must be given via the options `SOURCE.SCHEMA` using the `SCHEMA` function.
 
@@ -113,13 +113,13 @@ CREATE SINK output2(id UINT64) TYPE File;
 CREATE SINK output3(new_column UINT64) TYPE Checksum;
 ```
 
-#### Inline Sinks
+#### Anonymous Sinks
 Additionally, sinks can be defined inline within a SQL query. 
-Instead of naming the sink, you can create the inline sink by writing `[TYPE]([options])` (cmp. example below).
+Instead of naming the sink, you can create the anonymous sink by writing `[TYPE]([options])` (cmp. example below).
 The accepted options are mostly the same as when creating a sink via a `CREATE SINK` statement.
 The only difference is that a schema CAN OPTIONALLY be given via the options `SINK.SCHEMA` using the `SCHEMA` function.
 If no schema is given, the schema is inferred automatically.
-Inline sinks are also able to configure the output formatter via `OUTPUT_FORMATTER.*` parameters.
+Anonymous sinks are also able to configure the output formatter via `OUTPUT_FORMATTER.*` parameters.
 
 Because the systest framework automatically sets the sink file paths, `File` and `Generator` sinks can be created
 without any options. 
@@ -256,7 +256,7 @@ This allows tests to be topology-agnostic and run on both single-node and distri
 
 #### Explicit Worker Assignment
 
-Named physical sources and sinks support explicit placement via `SOURCE.HOST` and `SINK.HOST`. Inline sources support `SOURCE.HOST`; inline sinks use topology-based sink placement, so use a named sink when a sink must be pinned to a specific worker.
+Named physical sources and sinks support explicit placement via `SOURCE.HOST` and `SINK.HOST`. Anonymous sources support `SOURCE.HOST`; anonymous sinks use topology-based sink placement, so use a named sink when a sink must be pinned to a specific worker.
 
 **Named Sources and Sinks:**
 
@@ -282,7 +282,7 @@ AliceSmith
 BobJones
 ```
 
-**Inline Sources with Automatically Placed Inline Sinks:**
+**Anonymous Sources with Automatically Placed Anonymous Sinks:**
 
 ```sql
 SELECT id, value, timestamp

--- a/nes-common/include/Identifiers/Identifiers.hpp
+++ b/nes-common/include/Identifiers/Identifiers.hpp
@@ -30,7 +30,7 @@ using OriginId = NESStrongType<uint64_t, struct OriginId_, 0, 1>;
 using LocalQueryId = NESStrongUUIDType<struct LocalQueryId_>;
 using WorkerThreadId = NESStrongType<uint32_t, struct WorkerThreadId_, UINT32_MAX, 0>;
 using PhysicalSourceId = NESStrongType<uint64_t, struct PhysicalSourceId_, 0, 1>;
-using InlineSinkId = NESStrongType<uint64_t, struct InlineSinkId_, 0, 1>;
+using AnonymousSinkId = NESStrongType<uint64_t, struct AnonymousSinkId_, 0, 1>;
 
 /// Local Identifiers: These Identifiers are unique in a local scope. E.g. the PipelineId is unique in regard to a single query plan.
 using PipelineId = NESStrongType<uint64_t, struct PipelineId_, 0, 1>;
@@ -49,8 +49,8 @@ static constexpr OriginId INITIAL_ORIGIN_ID = INITIAL<OriginId>;
 static constexpr PhysicalSourceId INVALID_PHYSICAL_SOURCE_ID = INVALID<PhysicalSourceId>;
 static constexpr PhysicalSourceId INITIAL_PHYSICAL_SOURCE_ID = INITIAL<PhysicalSourceId>;
 
-static constexpr InlineSinkId INVALID_INLINE_SINK_ID = INVALID<InlineSinkId>;
-static constexpr InlineSinkId INITIAL_INLINE_SINK_ID = INITIAL<InlineSinkId>;
+static constexpr AnonymousSinkId INVALID_ANONYMOUS_SINK_ID = INVALID<AnonymousSinkId>;
+static constexpr AnonymousSinkId INITIAL_ANONYMOUS_SINK_ID = INITIAL<AnonymousSinkId>;
 
 static constexpr PipelineId INVALID_PIPELINE_ID = INVALID<PipelineId>;
 static constexpr PipelineId INITIAL_PIPELINE_ID = INITIAL<PipelineId>;

--- a/nes-frontend/apps/repl/tests/embedded.bats
+++ b/nes-frontend/apps/repl/tests/embedded.bats
@@ -102,7 +102,7 @@ setup()         { nes_offline_setup; }
 
   assert_equal "$(extract_explain "${lines[$i_logical_text]}")" "$(cat <<'EOF'
 == Initial Logical Plan ==
-INLINE_SINK(InlineSink)
+ANONYMOUS_SINK(AnonymousSink)
   PROJECTION(fields: [START, END, ID, VALUE, TIMESTAMP, ID2, VALUE2, TIMESTAMP2])
     PROJECTION(fields: [*])
       Join(INNER_JOIN, ID = ID2)
@@ -153,7 +153,7 @@ EOF
   assert_equal "$(extract_explain "${lines[$i_logical_visual]}")" "$(cat <<'EOF'
 == Initial Logical Plan ==
 
-                   INLINE_SINK(InlineSink)
+                ANONYMOUS_SINK(AnonymousSink)
                               │
 PROJECTION(fields: [START, END, ID, VALUE, TIMESTAMP, ID2...
                               │

--- a/nes-logical-operators/include/Operators/Sinks/AnonymousSinkLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Sinks/AnonymousSinkLogicalOperator.hpp
@@ -36,32 +36,32 @@
 namespace NES
 {
 
-/// InlineSinkLogicalOperator objects represent sinks in the logical query plan that are defined within a query as opposed to
-/// sinks defined in separate create statements. The InlineSinkLogicalOperator objects contain all necessary configurations to
-/// build a SinkLogicalOperator within the InlineSinkBindingPhase of the optimizer.
-class InlineSinkLogicalOperator : public ManagedByOperator
+/// AnonymousSinkLogicalOperator objects represent sinks in the logical query plan that are defined within a query as opposed to
+/// sinks defined in separate create statements. The AnonymousSinkLogicalOperator objects contain all necessary configurations to
+/// build a SinkLogicalOperator within the AnonymousSinkBindingPhase of the optimizer.
+class AnonymousSinkLogicalOperator : public ManagedByOperator
 {
 public:
-    explicit InlineSinkLogicalOperator(
+    explicit AnonymousSinkLogicalOperator(
         WeakLogicalOperator self,
         Identifier sinkType,
         std::optional<Schema<UnqualifiedUnboundField, Ordered>> schema,
         std::unordered_map<Identifier, std::string> config,
         std::unordered_map<Identifier, std::string> formatConfig);
 
-    static TypedLogicalOperator<InlineSinkLogicalOperator> create(
+    static TypedLogicalOperator<AnonymousSinkLogicalOperator> create(
         Identifier sinkType,
         std::optional<Schema<UnqualifiedUnboundField, Ordered>> schema,
         std::unordered_map<Identifier, std::string> config,
         std::unordered_map<Identifier, std::string> formatConfig);
 
-    [[nodiscard]] bool operator==(const InlineSinkLogicalOperator& rhs) const;
+    [[nodiscard]] bool operator==(const AnonymousSinkLogicalOperator& rhs) const;
 
-    [[nodiscard]] InlineSinkLogicalOperator withTraitSet(TraitSet traitSet) const;
+    [[nodiscard]] AnonymousSinkLogicalOperator withTraitSet(TraitSet traitSet) const;
     [[nodiscard]] TraitSet getTraitSet() const;
 
-    [[nodiscard]] InlineSinkLogicalOperator withChildrenUnsafe(std::vector<LogicalOperator> children) const;
-    [[nodiscard]] InlineSinkLogicalOperator withChildren(std::vector<LogicalOperator> children) const;
+    [[nodiscard]] AnonymousSinkLogicalOperator withChildrenUnsafe(std::vector<LogicalOperator> children) const;
+    [[nodiscard]] AnonymousSinkLogicalOperator withChildren(std::vector<LogicalOperator> children) const;
     [[nodiscard]] std::vector<LogicalOperator> getChildren() const;
 
     [[nodiscard]] static Schema<Field, Unordered> getOutputSchema();
@@ -69,7 +69,7 @@ public:
     [[nodiscard]] std::string explain(ExplainVerbosity verbosity, OperatorId id) const;
     [[nodiscard]] static std::string_view getName() noexcept;
 
-    [[nodiscard]] static InlineSinkLogicalOperator withInferredSchema();
+    [[nodiscard]] static AnonymousSinkLogicalOperator withInferredSchema();
 
     [[nodiscard]] Identifier getSinkType() const;
     [[nodiscard]] std::unordered_map<Identifier, std::string> getSinkConfig() const;
@@ -77,7 +77,7 @@ public:
     [[nodiscard]] std::unordered_map<Identifier, std::string> getFormatConfig() const;
 
 private:
-    static constexpr std::string_view NAME = "InlineSink";
+    static constexpr std::string_view NAME = "AnonymousSink";
 
     std::vector<LogicalOperator> children;
     TraitSet traitSet;
@@ -87,26 +87,26 @@ private:
     std::unordered_map<Identifier, std::string> sinkConfig;
     std::unordered_map<Identifier, std::string> formatConfig;
 
-    friend Reflector<TypedLogicalOperator<InlineSinkLogicalOperator>>;
+    friend Reflector<TypedLogicalOperator<AnonymousSinkLogicalOperator>>;
 };
 
 template <>
-struct Reflector<TypedLogicalOperator<InlineSinkLogicalOperator>>
+struct Reflector<TypedLogicalOperator<AnonymousSinkLogicalOperator>>
 {
-    Reflected operator()(const TypedLogicalOperator<InlineSinkLogicalOperator>& op, const ReflectionContext& context) const;
+    Reflected operator()(const TypedLogicalOperator<AnonymousSinkLogicalOperator>& op, const ReflectionContext& context) const;
 };
 
 template <>
-struct Unreflector<TypedLogicalOperator<InlineSinkLogicalOperator>>
+struct Unreflector<TypedLogicalOperator<AnonymousSinkLogicalOperator>>
 {
-    TypedLogicalOperator<InlineSinkLogicalOperator> operator()(const Reflected& reflected, const ReflectionContext& context) const;
+    TypedLogicalOperator<AnonymousSinkLogicalOperator> operator()(const Reflected& reflected, const ReflectionContext& context) const;
 };
 
-static_assert(LogicalOperatorConcept<InlineSinkLogicalOperator>);
+static_assert(LogicalOperatorConcept<AnonymousSinkLogicalOperator>);
 }
 
 template <>
-struct std::hash<NES::InlineSinkLogicalOperator>
+struct std::hash<NES::AnonymousSinkLogicalOperator>
 {
-    uint64_t operator()(const NES::InlineSinkLogicalOperator& op) const noexcept;
+    uint64_t operator()(const NES::AnonymousSinkLogicalOperator& op) const noexcept;
 };

--- a/nes-logical-operators/include/Operators/Sources/AnonymousSourceLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Sources/AnonymousSourceLogicalOperator.hpp
@@ -35,33 +35,33 @@
 namespace NES
 {
 
-/// InlineSourceLogicalOperator objects represent physical sources in the logical query plan that are defined within a query as opposed to
-/// sources defined in separate create statements. The InlineSourceLogicalOperator objects contain all necessary configurations to
-/// build a SourceDescriptorLogicalOperator within the InlineSourceBindingPhase of the optimizer.
+/// AnonymousSourceLogicalOperator objects represent physical sources in the logical query plan that are defined within a query as opposed to
+/// sources defined in separate create statements. The AnonymousSourceLogicalOperator objects contain all necessary configurations to
+/// build a SourceDescriptorLogicalOperator within the AnonymousSourceBindingPhase of the optimizer.
 
-class InlineSourceLogicalOperator : public ManagedByOperator
+class AnonymousSourceLogicalOperator : public ManagedByOperator
 {
 public:
-    explicit InlineSourceLogicalOperator(
+    explicit AnonymousSourceLogicalOperator(
         WeakLogicalOperator self,
         Identifier type,
         Schema<UnqualifiedUnboundField, Ordered> sourceSchema,
         std::unordered_map<Identifier, std::string> sourceConfig,
         std::unordered_map<Identifier, std::string> parserConfig);
 
-    static TypedLogicalOperator<InlineSourceLogicalOperator> create(
+    static TypedLogicalOperator<AnonymousSourceLogicalOperator> create(
         Identifier type,
         Schema<UnqualifiedUnboundField, Ordered> sourceSchema,
         std::unordered_map<Identifier, std::string> sourceConfig,
         std::unordered_map<Identifier, std::string> parserConfig);
 
-    [[nodiscard]] bool operator==(const InlineSourceLogicalOperator& rhs) const;
+    [[nodiscard]] bool operator==(const AnonymousSourceLogicalOperator& rhs) const;
 
-    [[nodiscard]] InlineSourceLogicalOperator withTraitSet(TraitSet traitSet) const;
+    [[nodiscard]] AnonymousSourceLogicalOperator withTraitSet(TraitSet traitSet) const;
     [[nodiscard]] TraitSet getTraitSet() const;
 
-    [[nodiscard]] InlineSourceLogicalOperator withChildrenUnsafe(std::vector<LogicalOperator> children) const;
-    [[nodiscard]] InlineSourceLogicalOperator withChildren(std::vector<LogicalOperator> children) const;
+    [[nodiscard]] AnonymousSourceLogicalOperator withChildrenUnsafe(std::vector<LogicalOperator> children) const;
+    [[nodiscard]] AnonymousSourceLogicalOperator withChildren(std::vector<LogicalOperator> children) const;
     [[nodiscard]] std::vector<LogicalOperator> getChildren() const;
 
     [[nodiscard]] static Schema<Field, Unordered> getOutputSchema();
@@ -69,7 +69,7 @@ public:
     [[nodiscard]] std::string explain(ExplainVerbosity verbosity, OperatorId id) const;
     [[nodiscard]] static std::string_view getName() noexcept;
 
-    [[nodiscard]] static InlineSourceLogicalOperator withInferredSchema();
+    [[nodiscard]] static AnonymousSourceLogicalOperator withInferredSchema();
 
     [[nodiscard]] Identifier getSourceType() const;
     [[nodiscard]] std::unordered_map<Identifier, std::string> getSourceConfig() const;
@@ -77,7 +77,7 @@ public:
     [[nodiscard]] Schema<UnqualifiedUnboundField, Ordered> getSourceSchema() const;
 
 private:
-    static constexpr std::string_view NAME = "InlineSource";
+    static constexpr std::string_view NAME = "AnonymousSource";
 
     Schema<UnqualifiedUnboundField, Ordered> sourceSchema;
     Identifier sourceType;
@@ -91,27 +91,27 @@ private:
     /// Set during schema inference
     std::optional<Schema<UnqualifiedUnboundField, Unordered>> outputSchema;
 
-    friend Reflector<TypedLogicalOperator<InlineSourceLogicalOperator>>;
+    friend Reflector<TypedLogicalOperator<AnonymousSourceLogicalOperator>>;
 };
 
 template <>
-struct Reflector<TypedLogicalOperator<InlineSourceLogicalOperator>>
+struct Reflector<TypedLogicalOperator<AnonymousSourceLogicalOperator>>
 {
-    Reflected operator()(const TypedLogicalOperator<InlineSourceLogicalOperator>&, const ReflectionContext& context) const;
+    Reflected operator()(const TypedLogicalOperator<AnonymousSourceLogicalOperator>&, const ReflectionContext& context) const;
 };
 
 template <>
-struct Unreflector<TypedLogicalOperator<InlineSourceLogicalOperator>>
+struct Unreflector<TypedLogicalOperator<AnonymousSourceLogicalOperator>>
 {
-    TypedLogicalOperator<InlineSourceLogicalOperator> operator()(const Reflected&, const ReflectionContext&) const;
+    TypedLogicalOperator<AnonymousSourceLogicalOperator> operator()(const Reflected&, const ReflectionContext&) const;
 };
 
-static_assert(LogicalOperatorConcept<InlineSourceLogicalOperator>);
+static_assert(LogicalOperatorConcept<AnonymousSourceLogicalOperator>);
 
 }
 
 template <>
-struct std::hash<NES::InlineSourceLogicalOperator>
+struct std::hash<NES::AnonymousSourceLogicalOperator>
 {
-    uint64_t operator()(const NES::InlineSourceLogicalOperator& op) const noexcept;
+    uint64_t operator()(const NES::AnonymousSourceLogicalOperator& op) const noexcept;
 };

--- a/nes-logical-operators/include/Plans/LogicalPlanBuilder.hpp
+++ b/nes-logical-operators/include/Plans/LogicalPlanBuilder.hpp
@@ -48,7 +48,7 @@ public:
     static LogicalPlan createLogicalPlan(Identifier logicalSourceName);
 
     static LogicalPlan createLogicalPlan(
-        Identifier inlineSourceType,
+        Identifier anonymousSourceType,
         Schema<UnqualifiedUnboundField, Ordered> schema,
         std::unordered_map<Identifier, std::string> sourceConfig,
         std::unordered_map<Identifier, std::string> parserConfig);
@@ -98,7 +98,7 @@ public:
     static LogicalPlan addInferModel(Identifier modelName, const LogicalPlan& childPlan);
 
     static LogicalPlan addSink(Identifier sinkName, const LogicalPlan& queryPlan);
-    static LogicalPlan addInlineSink(
+    static LogicalPlan addAnonymousSink(
         Identifier type,
         std::optional<Schema<UnqualifiedUnboundField, Ordered>> schema,
         std::unordered_map<Identifier, std::string> sinkConfig,

--- a/nes-logical-operators/src/Operators/Sinks/AnonymousSinkLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Sinks/AnonymousSinkLogicalOperator.cpp
@@ -12,7 +12,7 @@
     limitations under the License.
 */
 
-#include <Operators/Sinks/InlineSinkLogicalOperator.hpp>
+#include <Operators/Sinks/AnonymousSinkLogicalOperator.hpp>
 
 #include <cstdint>
 #include <functional>
@@ -44,7 +44,7 @@
 namespace NES
 {
 
-InlineSinkLogicalOperator::InlineSinkLogicalOperator(
+AnonymousSinkLogicalOperator::AnonymousSinkLogicalOperator(
     WeakLogicalOperator self,
     Identifier sinkType,
     std::optional<Schema<UnqualifiedUnboundField, Ordered>> schema,
@@ -58,75 +58,75 @@ InlineSinkLogicalOperator::InlineSinkLogicalOperator(
 {
 }
 
-TypedLogicalOperator<InlineSinkLogicalOperator> InlineSinkLogicalOperator::create(
+TypedLogicalOperator<AnonymousSinkLogicalOperator> AnonymousSinkLogicalOperator::create(
     Identifier sinkType,
     std::optional<Schema<UnqualifiedUnboundField, Ordered>> schema,
     std::unordered_map<Identifier, std::string> config,
     std::unordered_map<Identifier, std::string> formatConfig)
 {
-    return TypedLogicalOperator<InlineSinkLogicalOperator>{
+    return TypedLogicalOperator<AnonymousSinkLogicalOperator>{
         std::move(sinkType), std::move(schema), std::move(config), std::move(formatConfig)};
 }
 
-InlineSinkLogicalOperator InlineSinkLogicalOperator::withInferredSchema()
+AnonymousSinkLogicalOperator AnonymousSinkLogicalOperator::withInferredSchema()
 {
     PRECONDITION(false, "Schema inference should happen on SinkLogicalOperator");
     std::unreachable();
 }
 
-Identifier InlineSinkLogicalOperator::getSinkType() const
+Identifier AnonymousSinkLogicalOperator::getSinkType() const
 {
     return sinkType;
 }
 
-std::unordered_map<Identifier, std::string> InlineSinkLogicalOperator::getSinkConfig() const
+std::unordered_map<Identifier, std::string> AnonymousSinkLogicalOperator::getSinkConfig() const
 {
     return sinkConfig;
 }
 
-std::optional<Schema<UnqualifiedUnboundField, Ordered>> InlineSinkLogicalOperator::getTargetSchema() const
+std::optional<Schema<UnqualifiedUnboundField, Ordered>> AnonymousSinkLogicalOperator::getTargetSchema() const
 {
     return targetSchema;
 }
 
-std::unordered_map<Identifier, std::string> InlineSinkLogicalOperator::getFormatConfig() const
+std::unordered_map<Identifier, std::string> AnonymousSinkLogicalOperator::getFormatConfig() const
 {
     return formatConfig;
 }
 
-bool InlineSinkLogicalOperator::operator==(const InlineSinkLogicalOperator& rhs) const
+bool AnonymousSinkLogicalOperator::operator==(const AnonymousSinkLogicalOperator& rhs) const
 {
     return this->sinkType == rhs.sinkType && this->targetSchema == rhs.targetSchema && this->sinkConfig == rhs.sinkConfig
         && this->formatConfig == rhs.formatConfig;
 }
 
-std::string InlineSinkLogicalOperator::explain(ExplainVerbosity verbosity, OperatorId id) const
+std::string AnonymousSinkLogicalOperator::explain(ExplainVerbosity verbosity, OperatorId id) const
 {
     if (verbosity == ExplainVerbosity::Debug)
     {
-        return fmt::format("INLINE_SINK(opId: {}, name: {}, traitSet: {})", id, NAME, traitSet.explain(verbosity));
+        return fmt::format("ANONYMOUS_SINK(opId: {}, name: {}, traitSet: {})", id, NAME, traitSet.explain(verbosity));
     }
-    return fmt::format("INLINE_SINK({})", NAME);
+    return fmt::format("ANONYMOUS_SINK({})", NAME);
 }
 
-std::string_view InlineSinkLogicalOperator::getName() noexcept
+std::string_view AnonymousSinkLogicalOperator::getName() noexcept
 {
     return NAME;
 }
 
-InlineSinkLogicalOperator InlineSinkLogicalOperator::withTraitSet(TraitSet traitSet) const
+AnonymousSinkLogicalOperator AnonymousSinkLogicalOperator::withTraitSet(TraitSet traitSet) const
 {
     auto copy = *this;
     copy.traitSet = std::move(traitSet);
     return copy;
 }
 
-TraitSet InlineSinkLogicalOperator::getTraitSet() const
+TraitSet AnonymousSinkLogicalOperator::getTraitSet() const
 {
     return traitSet;
 }
 
-InlineSinkLogicalOperator InlineSinkLogicalOperator::withChildrenUnsafe(std::vector<LogicalOperator> children) const
+AnonymousSinkLogicalOperator AnonymousSinkLogicalOperator::withChildrenUnsafe(std::vector<LogicalOperator> children) const
 {
     auto copy = *this;
     copy.children = std::move(children);
@@ -134,7 +134,7 @@ InlineSinkLogicalOperator InlineSinkLogicalOperator::withChildrenUnsafe(std::vec
 }
 
 /// NOLINTBEGIN(readability-convert-member-functions-to-static, performance-unnecessary-value-param)
-InlineSinkLogicalOperator InlineSinkLogicalOperator::withChildren(std::vector<LogicalOperator>) const
+AnonymousSinkLogicalOperator AnonymousSinkLogicalOperator::withChildren(std::vector<LogicalOperator>) const
 {
     PRECONDITION(false, "Schema inference should happen on SinkLogicalOperator");
     std::unreachable();
@@ -142,34 +142,34 @@ InlineSinkLogicalOperator InlineSinkLogicalOperator::withChildren(std::vector<Lo
 
 /// NOLINTEND(readability-convert-member-functions-to-static, performance-unnecessary-value-param)
 
-Schema<Field, Unordered> InlineSinkLogicalOperator::getOutputSchema()
+Schema<Field, Unordered> AnonymousSinkLogicalOperator::getOutputSchema()
 {
     INVARIANT(false, "SinkLogicalOperator does not define an output schema");
     std::unreachable();
 }
 
-std::vector<LogicalOperator> InlineSinkLogicalOperator::getChildren() const
+std::vector<LogicalOperator> AnonymousSinkLogicalOperator::getChildren() const
 {
     return children;
 }
 
-Reflected Reflector<TypedLogicalOperator<InlineSinkLogicalOperator>>::operator()(
-    const TypedLogicalOperator<InlineSinkLogicalOperator>&, const ReflectionContext&) const
+Reflected Reflector<TypedLogicalOperator<AnonymousSinkLogicalOperator>>::operator()(
+    const TypedLogicalOperator<AnonymousSinkLogicalOperator>&, const ReflectionContext&) const
 {
-    PRECONDITION(false, "no serialize for InlineSinkLogicalOperator defined. Serialization happens with SinkLogicalOperator");
+    PRECONDITION(false, "no serialize for AnonymousSinkLogicalOperator defined. Serialization happens with SinkLogicalOperator");
     std::unreachable();
 }
 
-TypedLogicalOperator<InlineSinkLogicalOperator>
-Unreflector<TypedLogicalOperator<InlineSinkLogicalOperator>>::operator()(const Reflected&, const ReflectionContext&) const
+TypedLogicalOperator<AnonymousSinkLogicalOperator>
+Unreflector<TypedLogicalOperator<AnonymousSinkLogicalOperator>>::operator()(const Reflected&, const ReflectionContext&) const
 {
-    PRECONDITION(false, "no serialize for InlineSinkLogicalOperator defined. Serialization happens with SinkLogicalOperator");
+    PRECONDITION(false, "no serialize for AnonymousSinkLogicalOperator defined. Serialization happens with SinkLogicalOperator");
     std::unreachable();
 }
 
 }
 
-uint64_t std::hash<NES::InlineSinkLogicalOperator>::operator()(const NES::InlineSinkLogicalOperator& op) const noexcept
+uint64_t std::hash<NES::AnonymousSinkLogicalOperator>::operator()(const NES::AnonymousSinkLogicalOperator& op) const noexcept
 {
     return folly::hash::hash_combine_generic(NES::Hash{}, op.getTargetSchema(), op.getSinkType(), op.getSinkConfig());
 }

--- a/nes-logical-operators/src/Operators/Sinks/CMakeLists.txt
+++ b/nes-logical-operators/src/Operators/Sinks/CMakeLists.txt
@@ -11,12 +11,12 @@
 # limitations under the License.
 
 add_source_files(nes-logical-operators
-        InlineSinkLogicalOperator.cpp
+        AnonymousSinkLogicalOperator.cpp
         SinkLogicalOperator.cpp
 )
 
-add_plugin(InlineSink LogicalOperator InlineSinkLogicalOperator.cpp)
+add_plugin(AnonymousSink LogicalOperator AnonymousSinkLogicalOperator.cpp)
 add_plugin(Sink LogicalOperator SinkLogicalOperator.cpp)
 
-add_unreflection_plugin(LogicalOperator InlineSink)
+add_unreflection_plugin(LogicalOperator AnonymousSink)
 add_unreflection_plugin(LogicalOperator Sink)

--- a/nes-logical-operators/src/Operators/Sinks/SinkLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Sinks/SinkLogicalOperator.cpp
@@ -115,7 +115,7 @@ std::string SinkLogicalOperator::explain(ExplainVerbosity verbosity, OperatorId 
         }
         return fmt::format("SINK(opId: {}, sinkName: {})", id, sinkName);
     }
-    if (sinkDescriptor.has_value() && sinkDescriptor->isInline())
+    if (sinkDescriptor.has_value() && sinkDescriptor->isAnonymous())
     {
         return fmt::format("SINK({})", sinkDescriptor->getSinkType());
     }
@@ -136,12 +136,12 @@ void SinkLogicalOperator::inferLocalSchema()
     auto unboundInputSchema = unbind(inputSchema);
     /// Set unordered schema for sinks not declared with a target schema.
     /// Schema<Field, Unordered> order is determined in a stage
-    if (std::holds_alternative<InlineSinkDescriptor>(sinkDescriptor->underlying))
+    if (std::holds_alternative<AnonymousSinkDescriptor>(sinkDescriptor->underlying))
     {
-        auto& inlineSinkDescriptor = std::get<InlineSinkDescriptor>(sinkDescriptor->underlying);
-        if (std::holds_alternative<std::monostate>(inlineSinkDescriptor.getSchema()))
+        auto& anonymousSinkDescriptor = std::get<AnonymousSinkDescriptor>(sinkDescriptor->underlying);
+        if (std::holds_alternative<std::monostate>(anonymousSinkDescriptor.getSchema()))
         {
-            inlineSinkDescriptor.schema = std::make_shared<const Schema<UnqualifiedUnboundField, Unordered>>(
+            anonymousSinkDescriptor.schema = std::make_shared<const Schema<UnqualifiedUnboundField, Unordered>>(
                 unboundInputSchema | std::ranges::to<Schema<UnqualifiedUnboundField, Unordered>>());
         }
     }

--- a/nes-logical-operators/src/Operators/Sources/AnonymousSourceLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Sources/AnonymousSourceLogicalOperator.cpp
@@ -12,7 +12,7 @@
     limitations under the License.
 */
 
-#include <Operators/Sources/InlineSourceLogicalOperator.hpp>
+#include <Operators/Sources/AnonymousSourceLogicalOperator.hpp>
 
 #include <cstdint>
 #include <functional>
@@ -44,65 +44,65 @@ namespace NES
 {
 
 
-InlineSourceLogicalOperator InlineSourceLogicalOperator::withInferredSchema()
+AnonymousSourceLogicalOperator AnonymousSourceLogicalOperator::withInferredSchema()
 {
     PRECONDITION(false, "Schema<Field, Unordered> inference should happen on SourceDescriptorLogicalOperator");
     std::unreachable();
 }
 
-Identifier InlineSourceLogicalOperator::getSourceType() const
+Identifier AnonymousSourceLogicalOperator::getSourceType() const
 {
     return sourceType;
 }
 
-std::unordered_map<Identifier, std::string> InlineSourceLogicalOperator::getSourceConfig() const
+std::unordered_map<Identifier, std::string> AnonymousSourceLogicalOperator::getSourceConfig() const
 {
     return sourceConfig;
 }
 
-std::unordered_map<Identifier, std::string> InlineSourceLogicalOperator::getParserConfig() const
+std::unordered_map<Identifier, std::string> AnonymousSourceLogicalOperator::getParserConfig() const
 {
     return parserConfig;
 }
 
-Schema<UnqualifiedUnboundField, Ordered> InlineSourceLogicalOperator::getSourceSchema() const
+Schema<UnqualifiedUnboundField, Ordered> AnonymousSourceLogicalOperator::getSourceSchema() const
 {
     return sourceSchema;
 }
 
-bool InlineSourceLogicalOperator::operator==(const InlineSourceLogicalOperator& rhs) const
+bool AnonymousSourceLogicalOperator::operator==(const AnonymousSourceLogicalOperator& rhs) const
 {
     return this->sourceType == rhs.sourceType && this->sourceSchema == rhs.sourceSchema && this->parserConfig == rhs.parserConfig
         && this->sourceConfig == rhs.sourceConfig;
 }
 
-std::string InlineSourceLogicalOperator::explain(ExplainVerbosity verbosity, OperatorId id) const
+std::string AnonymousSourceLogicalOperator::explain(ExplainVerbosity verbosity, OperatorId id) const
 {
     if (verbosity == ExplainVerbosity::Debug)
     {
-        return fmt::format("INLINE_SOURCE(opId: {}, type: {} traitSet: {})", id, getSourceType(), traitSet.explain(verbosity));
+        return fmt::format("ANONYMOUS_SOURCE(opId: {}, type: {} traitSet: {})", id, getSourceType(), traitSet.explain(verbosity));
     }
-    return fmt::format("INLINE_SOURCE({})", getSourceType());
+    return fmt::format("ANONYMOUS_SOURCE({})", getSourceType());
 }
 
-std::string_view InlineSourceLogicalOperator::getName() noexcept
+std::string_view AnonymousSourceLogicalOperator::getName() noexcept
 {
     return NAME;
 }
 
-InlineSourceLogicalOperator InlineSourceLogicalOperator::withTraitSet(TraitSet traitSet) const
+AnonymousSourceLogicalOperator AnonymousSourceLogicalOperator::withTraitSet(TraitSet traitSet) const
 {
     auto copy = *this;
     copy.traitSet = std::move(traitSet);
     return copy;
 }
 
-TraitSet InlineSourceLogicalOperator::getTraitSet() const
+TraitSet AnonymousSourceLogicalOperator::getTraitSet() const
 {
     return traitSet;
 }
 
-InlineSourceLogicalOperator InlineSourceLogicalOperator::withChildrenUnsafe(std::vector<LogicalOperator> children) const
+AnonymousSourceLogicalOperator AnonymousSourceLogicalOperator::withChildrenUnsafe(std::vector<LogicalOperator> children) const
 {
     auto copy = *this;
     copy.children = std::move(children);
@@ -110,7 +110,7 @@ InlineSourceLogicalOperator InlineSourceLogicalOperator::withChildrenUnsafe(std:
 }
 
 /// NOLINTBEGIN(readability-convert-member-functions-to-static, performance-unnecessary-value-param)
-InlineSourceLogicalOperator InlineSourceLogicalOperator::withChildren(std::vector<LogicalOperator>) const
+AnonymousSourceLogicalOperator AnonymousSourceLogicalOperator::withChildren(std::vector<LogicalOperator>) const
 {
     PRECONDITION(false, "Schema inference should happen on SourceDescriptorLogicalOperator");
     std::unreachable();
@@ -118,18 +118,18 @@ InlineSourceLogicalOperator InlineSourceLogicalOperator::withChildren(std::vecto
 
 /// NOLINTEND(readability-convert-member-functions-to-static, performance-unnecessary-value-param)
 
-Schema<Field, Unordered> InlineSourceLogicalOperator::getOutputSchema()
+Schema<Field, Unordered> AnonymousSourceLogicalOperator::getOutputSchema()
 {
-    INVARIANT(false, "Convert InlineSourceLogical Operator to SourceDescriptorLogicalOperator before retrieving output schema");
+    INVARIANT(false, "Convert AnonymousSourceLogical Operator to SourceDescriptorLogicalOperator before retrieving output schema");
     std::unreachable();
 }
 
-std::vector<LogicalOperator> InlineSourceLogicalOperator::getChildren() const
+std::vector<LogicalOperator> AnonymousSourceLogicalOperator::getChildren() const
 {
     return children;
 }
 
-InlineSourceLogicalOperator::InlineSourceLogicalOperator(
+AnonymousSourceLogicalOperator::AnonymousSourceLogicalOperator(
     WeakLogicalOperator self,
     Identifier type,
     Schema<UnqualifiedUnboundField, Ordered> sourceSchema,
@@ -143,33 +143,35 @@ InlineSourceLogicalOperator::InlineSourceLogicalOperator(
 {
 }
 
-TypedLogicalOperator<InlineSourceLogicalOperator> InlineSourceLogicalOperator::create(
+TypedLogicalOperator<AnonymousSourceLogicalOperator> AnonymousSourceLogicalOperator::create(
     Identifier type,
     Schema<UnqualifiedUnboundField, Ordered> sourceSchema,
     std::unordered_map<Identifier, std::string> sourceConfig,
     std::unordered_map<Identifier, std::string> parserConfig)
 {
-    return TypedLogicalOperator<InlineSourceLogicalOperator>{
+    return TypedLogicalOperator<AnonymousSourceLogicalOperator>{
         std::move(type), std::move(sourceSchema), std::move(sourceConfig), std::move(parserConfig)};
 }
 
-Reflected Reflector<TypedLogicalOperator<InlineSourceLogicalOperator>>::operator()(
-    const TypedLogicalOperator<InlineSourceLogicalOperator>&, const ReflectionContext&) const
+Reflected Reflector<TypedLogicalOperator<AnonymousSourceLogicalOperator>>::operator()(
+    const TypedLogicalOperator<AnonymousSourceLogicalOperator>&, const ReflectionContext&) const
 {
-    PRECONDITION(false, "no serialize for InlineSourceLogicalOperator defined. Serialization happens with SourceDescriptorLogicalOperator");
+    PRECONDITION(
+        false, "no serialize for AnonymousSourceLogicalOperator defined. Serialization happens with SourceDescriptorLogicalOperator");
     std::unreachable();
 }
 
-TypedLogicalOperator<InlineSourceLogicalOperator>
-Unreflector<TypedLogicalOperator<InlineSourceLogicalOperator>>::operator()(const Reflected&, const ReflectionContext&) const
+TypedLogicalOperator<AnonymousSourceLogicalOperator>
+Unreflector<TypedLogicalOperator<AnonymousSourceLogicalOperator>>::operator()(const Reflected&, const ReflectionContext&) const
 {
-    PRECONDITION(false, "no serialize for InlineSourceLogicalOperator defined. Serialization happens with SourceDescriptorLogicalOperator");
+    PRECONDITION(
+        false, "no serialize for AnonymousSourceLogicalOperator defined. Serialization happens with SourceDescriptorLogicalOperator");
     std::unreachable();
 }
 
 }
 
-uint64_t std::hash<NES::InlineSourceLogicalOperator>::operator()(const NES::InlineSourceLogicalOperator& op) const noexcept
+uint64_t std::hash<NES::AnonymousSourceLogicalOperator>::operator()(const NES::AnonymousSourceLogicalOperator& op) const noexcept
 {
     return folly::hash::hash_combine_generic(
         NES::Hash{}, op.getSourceType(), op.getSourceSchema(), op.getSourceConfig(), op.getParserConfig());

--- a/nes-logical-operators/src/Operators/Sources/CMakeLists.txt
+++ b/nes-logical-operators/src/Operators/Sources/CMakeLists.txt
@@ -13,13 +13,13 @@
 add_source_files(nes-logical-operators
         SourceDescriptorLogicalOperator.cpp
         SourceNameLogicalOperator.cpp
-        InlineSourceLogicalOperator.cpp
+        AnonymousSourceLogicalOperator.cpp
 )
 
 add_plugin(SourceDescriptor LogicalOperator SourceDescriptorLogicalOperator.cpp)
-add_plugin(InlineSource LogicalOperator InlineSourceLogicalOperator.cpp)
+add_plugin(AnonymousSource LogicalOperator AnonymousSourceLogicalOperator.cpp)
 add_plugin(SourceName LogicalOperator SourceNameLogicalOperator.cpp)
 
 add_unreflection_plugin(LogicalOperator SourceDescriptor)
-add_unreflection_plugin(LogicalOperator InlineSource)
+add_unreflection_plugin(LogicalOperator AnonymousSource)
 add_unreflection_plugin(LogicalOperator SourceName)

--- a/nes-logical-operators/src/Plans/LogicalPlanBuilder.cpp
+++ b/nes-logical-operators/src/Plans/LogicalPlanBuilder.cpp
@@ -43,9 +43,9 @@
 #include <Operators/LogicalOperatorFwd.hpp>
 #include <Operators/ProjectionLogicalOperator.hpp>
 #include <Operators/SelectionLogicalOperator.hpp>
-#include <Operators/Sinks/InlineSinkLogicalOperator.hpp>
+#include <Operators/Sinks/AnonymousSinkLogicalOperator.hpp>
 #include <Operators/Sinks/SinkLogicalOperator.hpp>
-#include <Operators/Sources/InlineSourceLogicalOperator.hpp>
+#include <Operators/Sources/AnonymousSourceLogicalOperator.hpp>
 #include <Operators/Sources/SourceNameLogicalOperator.hpp>
 #include <Operators/UnionLogicalOperator.hpp>
 #include <Operators/Windows/Aggregations/WindowAggregationLogicalFunction.hpp>
@@ -79,15 +79,15 @@ LogicalPlan LogicalPlanBuilder::createLogicalPlan(Identifier logicalSourceName)
 }
 
 LogicalPlan LogicalPlanBuilder::createLogicalPlan(
-    Identifier inlineSourceType,
+    Identifier anonymousSourceType,
     Schema<UnqualifiedUnboundField, Ordered> schema,
     std::unordered_map<Identifier, std::string> sourceConfig,
     std::unordered_map<Identifier, std::string> parserConfig)
 {
     return LogicalPlan(
         INVALID_QUERY_ID,
-        {InlineSourceLogicalOperator::create(
-            std::move(inlineSourceType), std::move(schema), std::move(sourceConfig), std::move(parserConfig))});
+        {AnonymousSourceLogicalOperator::create(
+            std::move(anonymousSourceType), std::move(schema), std::move(sourceConfig), std::move(parserConfig))});
 }
 
 LogicalPlan LogicalPlanBuilder::addProjection(
@@ -207,7 +207,7 @@ LogicalPlan LogicalPlanBuilder::addSink(Identifier sinkName, const LogicalPlan& 
     return promoteOperatorToRoot(queryPlan, SinkLogicalOperator::create(std::move(sinkName)));
 }
 
-LogicalPlan LogicalPlanBuilder::addInlineSink(
+LogicalPlan LogicalPlanBuilder::addAnonymousSink(
     Identifier type,
     std::optional<Schema<UnqualifiedUnboundField, Ordered>> schema,
     std::unordered_map<Identifier, std::string> sinkConfig,
@@ -215,7 +215,8 @@ LogicalPlan LogicalPlanBuilder::addInlineSink(
     const LogicalPlan& queryPlan)
 {
     return promoteOperatorToRoot(
-        queryPlan, InlineSinkLogicalOperator::create(std::move(type), std::move(schema), std::move(sinkConfig), std::move(formatConfig)));
+        queryPlan,
+        AnonymousSinkLogicalOperator::create(std::move(type), std::move(schema), std::move(sinkConfig), std::move(formatConfig)));
 }
 
 LogicalPlan LogicalPlanBuilder::checkAndAddWatermarkAssigner(LogicalPlan queryPlan, const Windowing::TimeCharacteristic& timeCharacteristic)

--- a/nes-query-compiler/tests/UnitTests/PhysicalPlanBuilderFlipTest.cpp
+++ b/nes-query-compiler/tests/UnitTests/PhysicalPlanBuilderFlipTest.cpp
@@ -73,7 +73,7 @@ public:
     std::shared_ptr<PhysicalOperatorWrapper> makeSourceWrapper()
     {
         auto schema = createSchema();
-        auto descriptor = sourceCatalog.getInlineSource(
+        auto descriptor = sourceCatalog.getAnonymousSource(
             Identifier::parse("File"),
             schema,
             Host("localhost"),
@@ -91,7 +91,7 @@ public:
     std::shared_ptr<PhysicalOperatorWrapper> makeSinkWrapper() const
     {
         auto schema = createSchema();
-        auto descriptor = sinkCatalog.getInlineSink(
+        auto descriptor = sinkCatalog.getAnonymousSink(
             schema, Identifier::parse("Print"), Host("localhost"), {{Identifier::parse("output_format"), "CSV"}}, {});
         EXPECT_TRUE(descriptor.has_value());
         auto sinkOp = SinkPhysicalOperator(descriptor.value()); /// NOLINT(bugprone-unchecked-optional-access)

--- a/nes-query-optimizer/include/Rules/Semantic/AnonymousSinkBindingRule.hpp
+++ b/nes-query-optimizer/include/Rules/Semantic/AnonymousSinkBindingRule.hpp
@@ -27,26 +27,25 @@
 namespace NES
 {
 
-/// The InlineSinkBindingPhase replaces all sink that are defined within the query itself (InlineSinkLogicalOperators), as opposed to
-/// sinks that are created in separate CREATE statements, with SinkLogicalOperators based on the given inline sink configuration.
+/// The AnonymousSinkBindingPhase creates SinkLogicalOperators for all AnonymousSinkOperators based on the given configuration.
 
-class InlineSinkBindingRule
+class AnonymousSinkBindingRule
 {
 public:
-    explicit InlineSinkBindingRule(std::shared_ptr<const SinkCatalog> sinkCatalog) : sinkCatalog(std::move(sinkCatalog)) { }
+    explicit AnonymousSinkBindingRule(std::shared_ptr<const SinkCatalog> sinkCatalog) : sinkCatalog(std::move(sinkCatalog)) { }
 
-    static constexpr std::string_view NAME = "InlineSinkBindingRule";
+    static constexpr std::string_view NAME = "AnonymousSinkBindingRule";
 
     [[nodiscard]] static const std::type_info& getType();
     [[nodiscard]] static std::string_view getName();
     [[nodiscard]] std::set<std::type_index> dependsOn() const;
     [[nodiscard]] std::set<std::type_index> requiredBy() const;
     [[nodiscard]] LogicalPlan apply(const LogicalPlan& queryPlan) const;
-    bool operator==(const InlineSinkBindingRule& other) const;
+    bool operator==(const AnonymousSinkBindingRule& other) const;
 
 private:
     std::shared_ptr<const SinkCatalog> sinkCatalog;
 };
 
-static_assert(RuleConcept<InlineSinkBindingRule, LogicalPlan>);
+static_assert(RuleConcept<AnonymousSinkBindingRule, LogicalPlan>);
 }

--- a/nes-query-optimizer/include/Rules/Semantic/AnonymousSourceBindingRule.hpp
+++ b/nes-query-optimizer/include/Rules/Semantic/AnonymousSourceBindingRule.hpp
@@ -28,27 +28,26 @@
 namespace NES
 {
 
-/// The InlineSourceBindingPhase replaces all sources that are defined within the query itself (InlineSourceLogicalOperators), as opposed to
-/// sources that are created in separate CREATE statements, with physical sources based on the given inline source configuration.
+/// The AnonymousSourceBindingPhase replaces all anonymously defined sources with physical sources based on the given source configuration.
 
-class InlineSourceBindingRule
+class AnonymousSourceBindingRule
 {
 public:
-    explicit InlineSourceBindingRule(std::shared_ptr<const SourceCatalog> sourceCatalog) : sourceCatalog(std::move(sourceCatalog)) { }
+    explicit AnonymousSourceBindingRule(std::shared_ptr<const SourceCatalog> sourceCatalog) : sourceCatalog(std::move(sourceCatalog)) { }
 
-    static constexpr std::string_view NAME = "InlineSourceBindingRule";
+    static constexpr std::string_view NAME = "AnonymousSourceBindingRule";
 
     [[nodiscard]] static const std::type_info& getType();
     [[nodiscard]] static std::string_view getName();
     [[nodiscard]] std::set<std::type_index> dependsOn() const;
     [[nodiscard]] std::set<std::type_index> requiredBy() const;
     [[nodiscard]] LogicalPlan apply(const LogicalPlan& queryPlan) const;
-    bool operator==(const InlineSourceBindingRule& other) const;
+    bool operator==(const AnonymousSourceBindingRule& other) const;
 
 private:
-    [[nodiscard]] LogicalOperator bindInlineSourceLogicalOperators(const LogicalOperator& current) const;
+    [[nodiscard]] LogicalOperator bindAnonymousSourceLogicalOperators(const LogicalOperator& current) const;
     std::shared_ptr<const SourceCatalog> sourceCatalog;
 };
 
-static_assert(RuleConcept<InlineSourceBindingRule, LogicalPlan>);
+static_assert(RuleConcept<AnonymousSourceBindingRule, LogicalPlan>);
 }

--- a/nes-query-optimizer/include/Rules/Semantic/CalcTargetOrderRule.hpp
+++ b/nes-query-optimizer/include/Rules/Semantic/CalcTargetOrderRule.hpp
@@ -22,7 +22,7 @@
 
 namespace NES
 {
-/// Calculates the schema of inline sinks if no schema was specified deterministically.
+/// Calculates the schema of anonymous sinks if no schema was specified deterministically.
 /// The default behavior for every operator is the following:
 /// 1. For any child (in the order of the children): For any of its output fields (In the output order determined for the child):
 ///     If the current operator outputs a fields that has the same name, append it to the list of fields

--- a/nes-query-optimizer/src/Phases/SemanticAnalyzer.cpp
+++ b/nes-query-optimizer/src/Phases/SemanticAnalyzer.cpp
@@ -20,10 +20,10 @@
 
 #include <Plans/LogicalPlan.hpp>
 #include <Rules/RuleManager.hpp>
+#include <Rules/Semantic/AnonymousSinkBindingRule.hpp>
+#include <Rules/Semantic/AnonymousSourceBindingRule.hpp>
 #include <Rules/Semantic/CalcTargetOrderRule.hpp>
 #include <Rules/Semantic/InferModelResolutionRule.hpp>
-#include <Rules/Semantic/InlineSinkBindingRule.hpp>
-#include <Rules/Semantic/InlineSourceBindingRule.hpp>
 #include <Rules/Semantic/LogicalSourceExpansionRule.hpp>
 #include <Rules/Semantic/SinkBindingRule.hpp>
 #include <Rules/Semantic/TypeInferenceRule.hpp>
@@ -40,9 +40,9 @@ SemanticAnalyzer::SemanticAnalyzer(
     : sourceCatalog(std::move(sourceCatalog)), sinkCatalog(std::move(sinkCatalog)), modelCatalog(std::move(modelCatalog))
 {
     RuleManager<LogicalPlan> ruleManager;
-    ruleManager.addRule(InlineSinkBindingRule{this->sinkCatalog});
+    ruleManager.addRule(AnonymousSinkBindingRule{this->sinkCatalog});
     ruleManager.addRule(SinkBindingRule{this->sinkCatalog});
-    ruleManager.addRule(InlineSourceBindingRule{this->sourceCatalog});
+    ruleManager.addRule(AnonymousSourceBindingRule{this->sourceCatalog});
     ruleManager.addRule(LogicalSourceExpansionRule{this->sourceCatalog});
     ruleManager.addRule(InferModelResolutionRule{this->modelCatalog});
     ruleManager.addRule(TypeInferenceRule{});

--- a/nes-query-optimizer/src/Placement/QueryDecomposition.cpp
+++ b/nes-query-optimizer/src/Placement/QueryDecomposition.cpp
@@ -125,7 +125,7 @@ Bridge connect(const DecompositionContext& context, const NetworkChannel& channe
     }
 
     auto orderedUpstreamSchema = channel.upstreamOp->getTraitSet().get<FieldOrderingTrait>()->getOrderedFields();
-    const auto networkSourceDescriptorOpt = context.sourceCatalog->getInlineSource(
+    const auto networkSourceDescriptorOpt = context.sourceCatalog->getAnonymousSource(
         Identifier::parse("Network"),
         orderedUpstreamSchema,
         Host(channel.downstreamNode.getRawValue()),
@@ -134,7 +134,7 @@ Bridge connect(const DecompositionContext& context, const NetworkChannel& channe
     INVARIANT(networkSourceDescriptorOpt.has_value(), "Failed to add physical source for network channel");
     const auto& networkSourceDescriptor = networkSourceDescriptorOpt.value();
 
-    auto networkSinkDescriptor = context.sinkCatalog->getInlineSink(
+    auto networkSinkDescriptor = context.sinkCatalog->getAnonymousSink(
         orderedUpstreamSchema, Identifier::parse("Network"), Host(channel.upstreamNode.getRawValue()), sinkConfig, {});
     INVARIANT(networkSinkDescriptor.has_value(), "Invalid sink descriptor config for network sink");
 

--- a/nes-query-optimizer/src/Rules/Semantic/AnonymousSinkBindingRule.cpp
+++ b/nes-query-optimizer/src/Rules/Semantic/AnonymousSinkBindingRule.cpp
@@ -12,7 +12,7 @@
     limitations under the License.
 */
 
-#include <Rules/Semantic/InlineSinkBindingRule.hpp>
+#include <Rules/Semantic/AnonymousSinkBindingRule.hpp>
 
 #include <set>
 #include <string_view>
@@ -22,7 +22,7 @@
 #include <Identifiers/Identifier.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Operators/LogicalOperator.hpp>
-#include <Operators/Sinks/InlineSinkLogicalOperator.hpp>
+#include <Operators/Sinks/AnonymousSinkLogicalOperator.hpp>
 #include <Operators/Sinks/SinkLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <ErrorHandling.hpp>
@@ -30,39 +30,39 @@
 namespace NES
 {
 
-const std::type_info& InlineSinkBindingRule::getType()
+const std::type_info& AnonymousSinkBindingRule::getType()
 {
-    return typeid(InlineSinkBindingRule);
+    return typeid(AnonymousSinkBindingRule);
 }
 
-std::string_view InlineSinkBindingRule::getName()
+std::string_view AnonymousSinkBindingRule::getName()
 {
     return NAME;
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-std::set<std::type_index> InlineSinkBindingRule::dependsOn() const
+std::set<std::type_index> AnonymousSinkBindingRule::dependsOn() const
 {
     return {};
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-std::set<std::type_index> InlineSinkBindingRule::requiredBy() const
+std::set<std::type_index> AnonymousSinkBindingRule::requiredBy() const
 {
     return {};
 }
 
-bool InlineSinkBindingRule::operator==(const InlineSinkBindingRule& other) const
+bool AnonymousSinkBindingRule::operator==(const AnonymousSinkBindingRule& other) const
 {
     return sinkCatalog == other.sinkCatalog;
 }
 
-LogicalPlan InlineSinkBindingRule::apply(const LogicalPlan& queryPlan) const
+LogicalPlan AnonymousSinkBindingRule::apply(const LogicalPlan& queryPlan) const
 {
     std::vector<LogicalOperator> newRootOperators;
     for (const auto& rootOperator : queryPlan.getRootOperators())
     {
-        if (auto sink = rootOperator.tryGetAs<InlineSinkLogicalOperator>(); sink.has_value())
+        if (auto sink = rootOperator.tryGetAs<AnonymousSinkLogicalOperator>(); sink.has_value())
         {
             const auto schema = sink.value()->getTargetSchema();
             const auto type = sink.value()->getSinkType();
@@ -70,7 +70,7 @@ LogicalPlan InlineSinkBindingRule::apply(const LogicalPlan& queryPlan) const
             const auto formatConfig = sink.value()->getFormatConfig();
 
             /// "host" is not part of the sink config — it determines placement, not sink behavior.
-            /// It is stored in the config map only because InlineSinkLogicalOperator lacks a dedicated host field.
+            /// It is stored in the config map only because AnonymousSinkLogicalOperator lacks a dedicated host field.
             auto hostIt = config.find(Identifier::parse("host"));
             if (hostIt == config.end())
             {
@@ -79,11 +79,11 @@ LogicalPlan InlineSinkBindingRule::apply(const LogicalPlan& queryPlan) const
             auto host = Host(hostIt->second);
             config.erase(hostIt);
 
-            const auto sinkDescriptor = sinkCatalog->getInlineSink(schema, type, host, config, formatConfig);
+            const auto sinkDescriptor = sinkCatalog->getAnonymousSink(schema, type, host, config, formatConfig);
 
             if (!sinkDescriptor.has_value())
             {
-                throw InvalidConfigParameter("Failed to create inline sink descriptor");
+                throw InvalidConfigParameter("Failed to create anonymous sink descriptor");
             }
 
             TypedLogicalOperator<SinkLogicalOperator> sinkOperator = SinkLogicalOperator::create(sinkDescriptor.value());

--- a/nes-query-optimizer/src/Rules/Semantic/AnonymousSourceBindingRule.cpp
+++ b/nes-query-optimizer/src/Rules/Semantic/AnonymousSourceBindingRule.cpp
@@ -11,7 +11,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-#include <Rules/Semantic/InlineSourceBindingRule.hpp>
+#include <Rules/Semantic/AnonymousSourceBindingRule.hpp>
 
 #include <ranges>
 #include <set>
@@ -23,7 +23,8 @@
 #include <Identifiers/Identifier.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Operators/LogicalOperator.hpp>
-#include <Operators/Sources/InlineSourceLogicalOperator.hpp>
+#include <Operators/LogicalOperatorFwd.hpp>
+#include <Operators/Sources/AnonymousSourceLogicalOperator.hpp>
 #include <Operators/Sources/SourceDescriptorLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <ErrorHandling.hpp>
@@ -31,51 +32,51 @@
 namespace NES
 {
 
-const std::type_info& InlineSourceBindingRule::getType()
+const std::type_info& AnonymousSourceBindingRule::getType()
 {
-    return typeid(InlineSourceBindingRule);
+    return typeid(AnonymousSourceBindingRule);
 }
 
-std::string_view InlineSourceBindingRule::getName()
+std::string_view AnonymousSourceBindingRule::getName()
 {
     return NAME;
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-std::set<std::type_index> InlineSourceBindingRule::dependsOn() const
+std::set<std::type_index> AnonymousSourceBindingRule::dependsOn() const
 {
     return {};
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-std::set<std::type_index> InlineSourceBindingRule::requiredBy() const
+std::set<std::type_index> AnonymousSourceBindingRule::requiredBy() const
 {
     return {};
 };
 
-bool InlineSourceBindingRule::operator==(const InlineSourceBindingRule& other) const
+bool AnonymousSourceBindingRule::operator==(const AnonymousSourceBindingRule& other) const
 {
     return sourceCatalog == other.sourceCatalog;
 }
 
-LogicalOperator InlineSourceBindingRule::bindInlineSourceLogicalOperators(const LogicalOperator& current) const
+LogicalOperator AnonymousSourceBindingRule::bindAnonymousSourceLogicalOperators(const LogicalOperator& current) const
 {
     std::vector<LogicalOperator> newChildren;
     for (const auto& child : current.getChildren())
     {
-        newChildren.emplace_back(bindInlineSourceLogicalOperators(child));
+        newChildren.emplace_back(bindAnonymousSourceLogicalOperators(child));
     }
 
-    if (const auto inlineSource = current.tryGetAs<InlineSourceLogicalOperator>())
+    if (const auto anonymousSource = current.tryGetAs<AnonymousSourceLogicalOperator>())
     {
-        PRECONDITION(std::ranges::empty(inlineSource->getChildren()), "Inline source operator must have no children");
-        const auto type = inlineSource.value()->getSourceType();
-        const auto schema = inlineSource.value()->getSourceSchema();
-        const auto parserConfig = inlineSource.value()->getParserConfig();
-        auto sourceConfig = inlineSource.value()->getSourceConfig();
+        PRECONDITION(std::ranges::empty(anonymousSource->getChildren()), "Anonymous source operator must have no children");
+        const auto type = anonymousSource.value()->getSourceType();
+        const auto schema = anonymousSource.value()->getSourceSchema();
+        const auto parserConfig = anonymousSource.value()->getParserConfig();
+        auto sourceConfig = anonymousSource.value()->getSourceConfig();
 
         /// "host" is not part of the source config — it determines placement, not source behavior.
-        /// It is stored in the config map only because InlineSourceLogicalOperator lacks a dedicated host field.
+        /// It is stored in the config map only because AnonymousSourceLogicalOperator lacks a dedicated host field.
         auto hostIt = sourceConfig.find(Identifier::parse("host"));
         if (hostIt == sourceConfig.end())
         {
@@ -84,11 +85,11 @@ LogicalOperator InlineSourceBindingRule::bindInlineSourceLogicalOperators(const 
         auto host = Host(hostIt->second);
         sourceConfig.erase(hostIt);
 
-        const auto descriptorOpt = sourceCatalog->getInlineSource(type, schema, host, parserConfig, sourceConfig);
+        const auto descriptorOpt = sourceCatalog->getAnonymousSource(type, schema, host, parserConfig, sourceConfig);
 
         if (!descriptorOpt.has_value())
         {
-            throw InvalidConfigParameter("Could not create an inline source descriptor because of invalid config parameters");
+            throw InvalidConfigParameter("Could not create an anonymous source descriptor because of invalid config parameters");
         }
         const auto& descriptor = descriptorOpt.value();
         return SourceDescriptorLogicalOperator::create(descriptor);
@@ -97,12 +98,12 @@ LogicalOperator InlineSourceBindingRule::bindInlineSourceLogicalOperators(const 
     return current.withChildrenUnsafe(newChildren);
 }
 
-LogicalPlan InlineSourceBindingRule::apply(const LogicalPlan& queryPlan) const
+LogicalPlan AnonymousSourceBindingRule::apply(const LogicalPlan& queryPlan) const
 {
     std::vector<LogicalOperator> newRoots;
     for (const auto& root : queryPlan.getRootOperators())
     {
-        newRoots.emplace_back(bindInlineSourceLogicalOperators(root));
+        newRoots.emplace_back(bindAnonymousSourceLogicalOperators(root));
     }
     return queryPlan.withRootOperators(newRoots);
 }

--- a/nes-query-optimizer/src/Rules/Semantic/CMakeLists.txt
+++ b/nes-query-optimizer/src/Rules/Semantic/CMakeLists.txt
@@ -11,8 +11,8 @@
 # limitations under the License.
 
 add_source_files(nes-query-optimizer
-        InlineSinkBindingRule.cpp
-        InlineSourceBindingRule.cpp
+        AnonymousSinkBindingRule.cpp
+        AnonymousSourceBindingRule.cpp
         LogicalSourceExpansionRule.cpp
         TypeInferenceRule.cpp
         SinkBindingRule.cpp

--- a/nes-query-optimizer/src/Rules/Semantic/CalcTargetOrderRule.cpp
+++ b/nes-query-optimizer/src/Rules/Semantic/CalcTargetOrderRule.cpp
@@ -32,7 +32,7 @@
 #include <Operators/Reorderer.hpp>
 #include <Operators/Sinks/SinkLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
-#include <Rules/Semantic/InlineSinkBindingRule.hpp>
+#include <Rules/Semantic/AnonymousSinkBindingRule.hpp>
 #include <Rules/Semantic/LogicalSourceExpansionRule.hpp>
 #include <Rules/Semantic/SinkBindingRule.hpp>
 #include <Rules/Semantic/TypeInferenceRule.hpp>
@@ -111,7 +111,7 @@ std::string_view CalcTargetOrderRule::getName()
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 std::set<std::type_index> CalcTargetOrderRule::dependsOn() const
 {
-    return {typeid(SinkBindingRule), typeid(InlineSinkBindingRule), typeid(LogicalSourceExpansionRule), typeid(TypeInferenceRule)};
+    return {typeid(SinkBindingRule), typeid(AnonymousSinkBindingRule), typeid(LogicalSourceExpansionRule), typeid(TypeInferenceRule)};
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
@@ -157,9 +157,9 @@ LogicalPlan CalcTargetOrderRule::apply(NES::LogicalPlan plan) const
         = outputOrder | std::views::transform(Unbinder<Field>{}) | std::ranges::to<Schema<UnqualifiedUnboundField, Ordered>>();
     auto sinkDescriptorOpt = root->getSinkDescriptor();
     PRECONDITION(sinkDescriptorOpt.has_value(), "Sink operator must have a descriptor to infer target schema order");
-    const auto oldDescriptor = NES::get<InlineSinkDescriptor>(sinkDescriptorOpt->getUnderlying());
-    auto newInlineSinkDescriptor = SinkDescriptor{oldDescriptor.withSchemaOrder(newTargetSchema)};
-    auto newSinkRoot = root->withSinkDescriptor(newInlineSinkDescriptor);
+    const auto oldDescriptor = NES::get<AnonymousSinkDescriptor>(sinkDescriptorOpt->getUnderlying());
+    auto newAnonymousSinkDescriptor = SinkDescriptor{oldDescriptor.withSchemaOrder(newTargetSchema)};
+    auto newSinkRoot = root->withSinkDescriptor(newAnonymousSinkDescriptor);
     return plan.withRootOperators({newSinkRoot});
 }
 };

--- a/nes-query-optimizer/src/Rules/Semantic/InferModelResolutionRule.cpp
+++ b/nes-query-optimizer/src/Rules/Semantic/InferModelResolutionRule.cpp
@@ -27,7 +27,7 @@
 #include <Operators/LogicalOperator.hpp>
 #include <Operators/LogicalOperatorFwd.hpp>
 #include <Plans/LogicalPlan.hpp>
-#include <Rules/Semantic/InlineSinkBindingRule.hpp>
+#include <Rules/Semantic/AnonymousSinkBindingRule.hpp>
 #include <Rules/Semantic/LogicalSourceExpansionRule.hpp>
 #include <Rules/Semantic/OriginIdInferenceRule.hpp>
 #include <Rules/Semantic/SinkBindingRule.hpp>
@@ -81,7 +81,7 @@ std::string_view InferModelResolutionRule::getName()
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 std::set<std::type_index> InferModelResolutionRule::dependsOn() const
 {
-    return {typeid(LogicalSourceExpansionRule), typeid(SinkBindingRule), typeid(InlineSinkBindingRule)};
+    return {typeid(LogicalSourceExpansionRule), typeid(SinkBindingRule), typeid(AnonymousSinkBindingRule)};
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Semantic/SinkBindingRule.cpp
+++ b/nes-query-optimizer/src/Rules/Semantic/SinkBindingRule.cpp
@@ -24,7 +24,7 @@
 #include <Operators/LogicalOperator.hpp>
 #include <Operators/Sinks/SinkLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
-#include <Rules/Semantic/InlineSinkBindingRule.hpp>
+#include <Rules/Semantic/AnonymousSinkBindingRule.hpp>
 
 #include <ErrorHandling.hpp>
 
@@ -44,7 +44,7 @@ std::string_view SinkBindingRule::getName()
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 std::set<std::type_index> SinkBindingRule::dependsOn() const
 {
-    return {typeid(InlineSinkBindingRule)};
+    return {typeid(AnonymousSinkBindingRule)};
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Semantic/TypeInferenceRule.cpp
+++ b/nes-query-optimizer/src/Rules/Semantic/TypeInferenceRule.cpp
@@ -22,7 +22,7 @@
 
 #include <Operators/LogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
-#include <Rules/Semantic/InlineSinkBindingRule.hpp>
+#include <Rules/Semantic/AnonymousSinkBindingRule.hpp>
 #include <Rules/Semantic/LogicalSourceExpansionRule.hpp>
 #include <Rules/Semantic/SinkBindingRule.hpp>
 
@@ -55,7 +55,7 @@ std::string_view TypeInferenceRule::getName()
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 std::set<std::type_index> TypeInferenceRule::dependsOn() const
 {
-    return {typeid(LogicalSourceExpansionRule), typeid(SinkBindingRule), typeid(InlineSinkBindingRule)};
+    return {typeid(LogicalSourceExpansionRule), typeid(SinkBindingRule), typeid(AnonymousSinkBindingRule)};
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Static/DecideFieldOrder.cpp
+++ b/nes-query-optimizer/src/Rules/Static/DecideFieldOrder.cpp
@@ -47,7 +47,7 @@ namespace NES
 /// Currently, we use the same algorithm that CalcTargetOrderRule uses, to determine which field order to use at each operator.
 /// In the future, this might be something we want to optimize over more aggressively.
 /// Analogue to CalcTargetOrderRule:
-/// Calculates the schema of inline sinks if no schema was specified deterministically.
+/// Calculates the schema of anonymous sinks if no schema was specified deterministically.
 /// The default behavior for every operator is the following:
 /// 1. For any child (in the order of the children): For any of its output fields (In the output order determined for the child):
 ///     If the current operator outputs a fields that has the same name, append it to the list of fields

--- a/nes-query-optimizer/src/Rules/Static/OriginIdInferenceRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/OriginIdInferenceRule.cpp
@@ -31,7 +31,6 @@
 #include <Operators/Sources/SourceDescriptorLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <Rules/Barriers/FixedPlanStructureBarrier.hpp>
-#include <Rules/Semantic/InlineSourceBindingRule.hpp>
 #include <Rules/Semantic/LogicalSourceExpansionRule.hpp>
 #include <Traits/OutputOriginIdsTrait.hpp>
 #include <Traits/Trait.hpp>

--- a/nes-query-optimizer/tests/Rules/Static/CalcTargetOrderTest.cpp
+++ b/nes-query-optimizer/tests/Rules/Static/CalcTargetOrderTest.cpp
@@ -78,7 +78,7 @@ SinkDescriptor createTestSinkDescriptor(SinkCatalog& sinkCatalog)
     const std::unordered_map<Identifier, std::string> sinkConfig{
         {Identifier::parse("file_path"), "/dev/null"}, {Identifier::parse("output_format"), "CSV"}};
 
-    return sinkCatalog.getInlineSink(std::nullopt, Identifier::parse("file"), Host("localhost"), sinkConfig, {}).value();
+    return sinkCatalog.getAnonymousSink(std::nullopt, Identifier::parse("file"), Host("localhost"), sinkConfig, {}).value();
 }
 }
 

--- a/nes-query-optimizer/tests/Rules/Static/DecideJoinTypesTest.cpp
+++ b/nes-query-optimizer/tests/Rules/Static/DecideJoinTypesTest.cpp
@@ -130,7 +130,7 @@ public:
     }
 };
 
-/// A simple Selection → InlineSource plan. Verify all operators get CHOICELESS.
+/// A simple Selection → AnonymousSource plan. Verify all operators get CHOICELESS.
 TEST_F(DecideJoinTypesTest, NonJoinPlanGetChoicelessTrait)
 {
     SourceCatalog sourceCatalog;

--- a/nes-query-optimizer/tests/Rules/Static/DecideMemoryLayoutTest.cpp
+++ b/nes-query-optimizer/tests/Rules/Static/DecideMemoryLayoutTest.cpp
@@ -81,7 +81,7 @@ SinkDescriptor createTestSinkDescriptor(SinkCatalog& sinkCatalog)
 {
     const std::unordered_map<Identifier, std::string> sinkConfig{
         {Identifier::parse("file_path"), "/dev/null"}, {Identifier::parse("output_format"), "CSV"}};
-    return sinkCatalog.getInlineSink(std::nullopt, Identifier::parse("file"), Host("localhost"), sinkConfig, {}).value();
+    return sinkCatalog.getAnonymousSink(std::nullopt, Identifier::parse("file"), Host("localhost"), sinkConfig, {}).value();
 }
 }
 

--- a/nes-sinks/include/Sinks/SinkCatalog.hpp
+++ b/nes-sinks/include/Sinks/SinkCatalog.hpp
@@ -44,7 +44,7 @@ public:
 
     std::optional<SinkDescriptor> getSinkDescriptor(const Identifier& sinkName) const;
 
-    [[nodiscard]] std::optional<SinkDescriptor> getInlineSink(
+    [[nodiscard]] std::optional<SinkDescriptor> getAnonymousSink(
         const std::optional<Schema<UnqualifiedUnboundField, Ordered>>& schema,
         const Identifier& sinkType,
         Host host,
@@ -60,7 +60,7 @@ public:
     std::vector<SinkDescriptor> getAllSinkDescriptors() const;
 
 private:
-    mutable std::atomic<InlineSinkId::Underlying> nextInlineSinkId{INITIAL_INLINE_SINK_ID.getRawValue()};
+    mutable std::atomic<AnonymousSinkId::Underlying> nextAnonymousSinkId{INITIAL_ANONYMOUS_SINK_ID.getRawValue()};
     folly::Synchronized<std::unordered_map<Identifier, SinkDescriptor>> sinks;
 };
 }

--- a/nes-sinks/include/Sinks/SinkDescriptor.hpp
+++ b/nes-sinks/include/Sinks/SinkDescriptor.hpp
@@ -80,7 +80,7 @@ private:
     friend Unreflector<NamedSinkDescriptor>;
 };
 
-class InlineSinkDescriptor final : public Descriptor
+class AnonymousSinkDescriptor final : public Descriptor
 {
     friend SinkCatalog;
     friend OperatorSerializationUtil;
@@ -88,11 +88,11 @@ class InlineSinkDescriptor final : public Descriptor
     friend class CalcTargetOrderRule;
 
 public:
-    ~InlineSinkDescriptor() = default;
+    ~AnonymousSinkDescriptor() = default;
 
 
-    friend std::ostream& operator<<(std::ostream& out, const InlineSinkDescriptor& sinkDescriptor);
-    friend bool operator==(const InlineSinkDescriptor& lhs, const InlineSinkDescriptor& rhs);
+    friend std::ostream& operator<<(std::ostream& out, const AnonymousSinkDescriptor& sinkDescriptor);
+    friend bool operator==(const AnonymousSinkDescriptor& lhs, const AnonymousSinkDescriptor& rhs);
 
     [[nodiscard]] std::string getFormatType() const;
     [[nodiscard]] std::string getSinkType() const;
@@ -106,7 +106,7 @@ public:
     [[nodiscard]] std::unordered_map<Identifier, std::string> getOutputFormatterConfig() const;
 
 private:
-    explicit InlineSinkDescriptor(
+    explicit AnonymousSinkDescriptor(
         uint64_t sinkId,
         std::variant<std::monostate, Schema<UnqualifiedUnboundField, Unordered>, Schema<UnqualifiedUnboundField, Ordered>> schema,
         std::string_view sinkType,
@@ -114,7 +114,7 @@ private:
         std::unordered_map<Identifier, std::string> formatConfig,
         DescriptorConfig::Config config);
 
-    [[nodiscard]] InlineSinkDescriptor withSchemaOrder(const Schema<UnqualifiedUnboundField, Ordered>& newSchema) const;
+    [[nodiscard]] AnonymousSinkDescriptor withSchemaOrder(const Schema<UnqualifiedUnboundField, Ordered>& newSchema) const;
 
     uint64_t sinkId;
     std::variant<
@@ -126,7 +126,7 @@ private:
     Host host;
     std::unordered_map<Identifier, std::string> formatConfig;
 
-    friend Unreflector<InlineSinkDescriptor>;
+    friend Unreflector<AnonymousSinkDescriptor>;
 };
 
 class SinkDescriptor final : public Descriptor
@@ -151,14 +151,14 @@ public:
         std::shared_ptr<const Schema<UnqualifiedUnboundField, Unordered>>,
         std::shared_ptr<const Schema<UnqualifiedUnboundField, Ordered>>> getSchema() const;
     [[nodiscard]] Identifier getSinkName() const;
-    [[nodiscard]] bool isInline() const;
+    [[nodiscard]] bool isAnonymous() const;
     [[nodiscard]] Host getHost() const;
     [[nodiscard]] std::unordered_map<Identifier, std::string> getOutputFormatterConfig() const;
-    [[nodiscard]] const std::variant<NamedSinkDescriptor, InlineSinkDescriptor>& getUnderlying() const;
+    [[nodiscard]] const std::variant<NamedSinkDescriptor, AnonymousSinkDescriptor>& getUnderlying() const;
 
 private:
-    explicit SinkDescriptor(std::variant<NamedSinkDescriptor, InlineSinkDescriptor> underlying);
-    std::variant<NamedSinkDescriptor, InlineSinkDescriptor> underlying;
+    explicit SinkDescriptor(std::variant<NamedSinkDescriptor, AnonymousSinkDescriptor> underlying);
+    std::variant<NamedSinkDescriptor, AnonymousSinkDescriptor> underlying;
 
     friend Reflector<SinkDescriptor>;
 
@@ -215,7 +215,7 @@ struct Unreflector<SinkDescriptor>
 
 namespace detail
 {
-struct ReflectedInlineSinkDescriptor
+struct ReflectedAnonymousSinkDescriptor
 {
     uint64_t sinkId;
     std::variant<std::monostate, Schema<UnqualifiedUnboundField, Unordered>, Schema<UnqualifiedUnboundField, Ordered>> schema;
@@ -249,15 +249,15 @@ struct Unreflector<NamedSinkDescriptor>
 };
 
 template <>
-struct Reflector<InlineSinkDescriptor>
+struct Reflector<AnonymousSinkDescriptor>
 {
-    Reflected operator()(const InlineSinkDescriptor& descriptor, const ReflectionContext& context) const;
+    Reflected operator()(const AnonymousSinkDescriptor& descriptor, const ReflectionContext& context) const;
 };
 
 template <>
-struct Unreflector<InlineSinkDescriptor>
+struct Unreflector<AnonymousSinkDescriptor>
 {
-    InlineSinkDescriptor operator()(const Reflected& reflected, const ReflectionContext& context) const;
+    AnonymousSinkDescriptor operator()(const Reflected& reflected, const ReflectionContext& context) const;
 };
 
 }

--- a/nes-sinks/src/SinkCatalog.cpp
+++ b/nes-sinks/src/SinkCatalog.cpp
@@ -77,7 +77,7 @@ std::optional<SinkDescriptor> SinkCatalog::getSinkDescriptor(const Identifier& s
     return sinkDescriptorOpt->second;
 }
 
-std::optional<SinkDescriptor> SinkCatalog::getInlineSink(
+std::optional<SinkDescriptor> SinkCatalog::getAnonymousSink(
     const std::optional<Schema<UnqualifiedUnboundField, Ordered>>& schema,
     const Identifier& sinkType,
     Host host,
@@ -86,7 +86,7 @@ std::optional<SinkDescriptor> SinkCatalog::getInlineSink(
 {
     auto descriptorConfigOpt = SinkDescriptor::validateAndFormatConfig(sinkType.asCanonicalString(), std::move(config));
 
-    const auto inlineSinkId = InlineSinkId{nextInlineSinkId.fetch_add(1)};
+    const auto anonymousSinkId = AnonymousSinkId{nextAnonymousSinkId.fetch_add(1)};
 
     if (not descriptorConfigOpt.has_value())
     {
@@ -98,8 +98,8 @@ std::optional<SinkDescriptor> SinkCatalog::getInlineSink(
         ? std::variant<std::monostate, Schema<UnqualifiedUnboundField, Unordered>, Schema<UnqualifiedUnboundField, Ordered>>{schema.value()}
         : std::monostate{};
 
-    auto sinkDescriptor = SinkDescriptor{InlineSinkDescriptor{
-        inlineSinkId.getRawValue(),
+    auto sinkDescriptor = SinkDescriptor{AnonymousSinkDescriptor{
+        anonymousSinkId.getRawValue(),
         schemaVar,
         sinkType.asCanonicalString(),
         std::move(host),

--- a/nes-sinks/src/SinkDescriptor.cpp
+++ b/nes-sinks/src/SinkDescriptor.cpp
@@ -111,7 +111,7 @@ NamedSinkDescriptor::NamedSinkDescriptor(
 {
 }
 
-InlineSinkDescriptor::InlineSinkDescriptor(
+AnonymousSinkDescriptor::AnonymousSinkDescriptor(
     uint64_t sinkId,
     std::variant<std::monostate, Schema<UnqualifiedUnboundField, Unordered>, Schema<UnqualifiedUnboundField, Ordered>> schema,
     const std::string_view sinkType,
@@ -143,7 +143,7 @@ InlineSinkDescriptor::InlineSinkDescriptor(
 {
 }
 
-std::ostream& operator<<(std::ostream& out, const InlineSinkDescriptor& sinkDescriptor)
+std::ostream& operator<<(std::ostream& out, const AnonymousSinkDescriptor& sinkDescriptor)
 {
     out << fmt::format(
         "SinkDescriptor: (name: {}, type: {}, host: {}, Config: {})",
@@ -154,12 +154,12 @@ std::ostream& operator<<(std::ostream& out, const InlineSinkDescriptor& sinkDesc
     return out;
 }
 
-bool operator==(const InlineSinkDescriptor& lhs, const InlineSinkDescriptor& rhs)
+bool operator==(const AnonymousSinkDescriptor& lhs, const AnonymousSinkDescriptor& rhs)
 {
     return lhs.sinkId == rhs.sinkId;
 }
 
-std::string InlineSinkDescriptor::getFormatType() const
+std::string AnonymousSinkDescriptor::getFormatType() const
 {
     try
     {
@@ -171,7 +171,7 @@ std::string InlineSinkDescriptor::getFormatType() const
     }
 }
 
-std::string InlineSinkDescriptor::getSinkType() const
+std::string AnonymousSinkDescriptor::getSinkType() const
 {
     return sinkType;
 }
@@ -180,27 +180,27 @@ std::variant<
     std::monostate,
     std::shared_ptr<const Schema<UnqualifiedUnboundField, Unordered>>,
     std::shared_ptr<const Schema<UnqualifiedUnboundField, Ordered>>>
-InlineSinkDescriptor::getSchema() const
+AnonymousSinkDescriptor::getSchema() const
 {
     return schema;
 }
 
-uint64_t InlineSinkDescriptor::getSinkId() const
+uint64_t AnonymousSinkDescriptor::getSinkId() const
 {
     return sinkId;
 }
 
-Host InlineSinkDescriptor::getHost() const
+Host AnonymousSinkDescriptor::getHost() const
 {
     return host;
 }
 
-std::unordered_map<Identifier, std::string> InlineSinkDescriptor::getOutputFormatterConfig() const
+std::unordered_map<Identifier, std::string> AnonymousSinkDescriptor::getOutputFormatterConfig() const
 {
     return formatConfig;
 }
 
-SinkDescriptor::SinkDescriptor(std::variant<NamedSinkDescriptor, InlineSinkDescriptor> underlying)
+SinkDescriptor::SinkDescriptor(std::variant<NamedSinkDescriptor, AnonymousSinkDescriptor> underlying)
     : Descriptor(std::visit([](const auto& var) { return var.getConfig(); }, underlying)), underlying(std::move(underlying))
 {
 }
@@ -222,7 +222,7 @@ SinkDescriptor::getSchema() const
         underlying);
 }
 
-InlineSinkDescriptor InlineSinkDescriptor::withSchemaOrder(const Schema<UnqualifiedUnboundField, Ordered>& newSchema) const
+AnonymousSinkDescriptor AnonymousSinkDescriptor::withSchemaOrder(const Schema<UnqualifiedUnboundField, Ordered>& newSchema) const
 {
     PRECONDITION(!std::holds_alternative<std::monostate>(this->schema), "Cannot set ordered schema directly from empty");
     const auto alreadyOrderSet = std::holds_alternative<std::shared_ptr<const Schema<UnqualifiedUnboundField, Ordered>>>(this->schema);
@@ -256,8 +256,8 @@ Identifier SinkDescriptor::getSinkName() const
     return std::visit(
         Overloaded{
             [](const NamedSinkDescriptor& namedDescriptor) { return namedDescriptor.getSinkName(); },
-            [](const InlineSinkDescriptor& inlineDescriptor)
-            { return Identifier::parse(fmt::format("{}", inlineDescriptor.getSinkId())); }},
+            [](const AnonymousSinkDescriptor& anonymousDescriptor)
+            { return Identifier::parse(fmt::format("{}", anonymousDescriptor.getSinkId())); }},
         underlying);
 }
 
@@ -266,9 +266,9 @@ std::unordered_map<Identifier, std::string> SinkDescriptor::getOutputFormatterCo
     return std::visit([](const auto& var) { return var.getOutputFormatterConfig(); }, underlying);
 }
 
-bool SinkDescriptor::isInline() const
+bool SinkDescriptor::isAnonymous() const
 {
-    return std::holds_alternative<InlineSinkDescriptor>(this->underlying);
+    return std::holds_alternative<AnonymousSinkDescriptor>(this->underlying);
 }
 
 Host SinkDescriptor::getHost() const
@@ -297,7 +297,8 @@ bool operator==(const SinkDescriptor& lhs, const SinkDescriptor& rhs)
     return std::visit(
         Overloaded{
             [](const NamedSinkDescriptor& namedLhs, const NamedSinkDescriptor& namedRhs) { return namedLhs == namedRhs; },
-            [](const InlineSinkDescriptor& inlineLhs, const InlineSinkDescriptor& inlineRhs) { return inlineLhs == inlineRhs; },
+            [](const AnonymousSinkDescriptor& anonymousLhs, const AnonymousSinkDescriptor& anonymousRhs)
+            { return anonymousLhs == anonymousRhs; },
             [](const auto&, const auto&) { return false; }},
         lhs.underlying,
         rhs.underlying);
@@ -321,16 +322,16 @@ NamedSinkDescriptor Unreflector<NamedSinkDescriptor>::operator()(const Reflected
     return NamedSinkDescriptor{name, schema, sinkType, host, unreflectedFormatConfig, Descriptor::unreflectConfig(config, context)};
 }
 
-Reflected Reflector<InlineSinkDescriptor>::operator()(const InlineSinkDescriptor& descriptor, const ReflectionContext& context) const
+Reflected Reflector<AnonymousSinkDescriptor>::operator()(const AnonymousSinkDescriptor& descriptor, const ReflectionContext& context) const
 {
-    using SchemaType = decltype(std::declval<detail::ReflectedInlineSinkDescriptor>().schema);
+    using SchemaType = decltype(std::declval<detail::ReflectedAnonymousSinkDescriptor>().schema);
     auto schema = std::visit(
         Overloaded{
             [](const std::monostate&) { return SchemaType{std::monostate{}}; },
             [](const auto& schemaPtr) { return SchemaType{*schemaPtr}; }},
         descriptor.getSchema());
 
-    return context.reflect(detail::ReflectedInlineSinkDescriptor{
+    return context.reflect(detail::ReflectedAnonymousSinkDescriptor{
         .sinkId = descriptor.getSinkId(),
         .schema = std::move(schema),
         .sinkType = descriptor.getSinkType(),
@@ -339,11 +340,11 @@ Reflected Reflector<InlineSinkDescriptor>::operator()(const InlineSinkDescriptor
         .config = descriptor.getReflectedConfig(context)});
 }
 
-InlineSinkDescriptor Unreflector<InlineSinkDescriptor>::operator()(const Reflected& reflected, const ReflectionContext& context) const
+AnonymousSinkDescriptor Unreflector<AnonymousSinkDescriptor>::operator()(const Reflected& reflected, const ReflectionContext& context) const
 {
-    auto [sinkId, schema, sinkType, host, formatConfig, config] = context.unreflect<detail::ReflectedInlineSinkDescriptor>(reflected);
+    auto [sinkId, schema, sinkType, host, formatConfig, config] = context.unreflect<detail::ReflectedAnonymousSinkDescriptor>(reflected);
     auto unreflectedFormatConfig = context.unreflect<std::unordered_map<Identifier, std::string>>(formatConfig);
-    return InlineSinkDescriptor{sinkId, schema, sinkType, host, unreflectedFormatConfig, Descriptor::unreflectConfig(config, context)};
+    return AnonymousSinkDescriptor{sinkId, schema, sinkType, host, unreflectedFormatConfig, Descriptor::unreflectConfig(config, context)};
 }
 
 Reflected Reflector<SinkDescriptor>::operator()(const SinkDescriptor& descriptor, const ReflectionContext& context) const
@@ -357,7 +358,7 @@ SinkDescriptor Unreflector<SinkDescriptor>::operator()(const Reflected& reflecte
     return SinkDescriptor{context.unreflect<UnderlyingType>(reflected)};
 }
 
-const std::variant<NamedSinkDescriptor, InlineSinkDescriptor>& SinkDescriptor::getUnderlying() const
+const std::variant<NamedSinkDescriptor, AnonymousSinkDescriptor>& SinkDescriptor::getUnderlying() const
 {
     return underlying;
 }

--- a/nes-sources/include/Sources/SourceCatalog.hpp
+++ b/nes-sources/include/Sources/SourceCatalog.hpp
@@ -79,7 +79,7 @@ public:
 
     [[nodiscard]] std::optional<SourceDescriptor> getPhysicalSource(PhysicalSourceId physicalSourceId) const;
 
-    [[nodiscard]] std::optional<SourceDescriptor> getInlineSource(
+    [[nodiscard]] std::optional<SourceDescriptor> getAnonymousSource(
         const Identifier& sourceType,
         const Schema<UnqualifiedUnboundField, Ordered>& schema,
         Host host,

--- a/nes-sources/include/Sources/SourceDescriptor.hpp
+++ b/nes-sources/include/Sources/SourceDescriptor.hpp
@@ -65,7 +65,7 @@ public:
     [[nodiscard]] Host getHost() const;
     [[nodiscard]] PhysicalSourceId getPhysicalSourceId() const;
 
-    [[nodiscard]] bool isInlineSource() const;
+    [[nodiscard]] bool isAnonymousSource() const;
 
     [[nodiscard]] std::string explain(ExplainVerbosity verbosity) const;
 
@@ -80,7 +80,7 @@ private:
     std::string sourceType;
     Host host;
     InputFormatterDescriptor inputFormatterDescriptor;
-    bool isInline = false;
+    bool isAnonymous = false;
 
 
     /// Used by Sources to create a valid SourceDescriptor.
@@ -91,7 +91,7 @@ private:
         Host host,
         DescriptorConfig::Config config,
         const InputFormatterDescriptor& inputFormatterDescriptor,
-        bool isInline);
+        bool isAnonymous);
 
 public:
     /// Per default, we set an 'invalid' number of max inflight buffers. We choose zero as an invalid number as giving zero buffers to a source would make it unusable.
@@ -141,7 +141,7 @@ struct ReflectedSourceDescriptor
     std::string type;
     Host host;
     InputFormatterDescriptor inputFormatterDescriptor;
-    bool isInline;
+    bool isAnonymous;
     Reflected config;
 };
 }

--- a/nes-sources/src/SourceCatalog.cpp
+++ b/nes-sources/src/SourceCatalog.cpp
@@ -158,7 +158,7 @@ std::optional<SourceDescriptor> SourceCatalog::getPhysicalSource(const PhysicalS
     return std::nullopt;
 }
 
-std::optional<SourceDescriptor> SourceCatalog::getInlineSource(
+std::optional<SourceDescriptor> SourceCatalog::getAnonymousSource(
     const Identifier& sourceType,
     const Schema<UnqualifiedUnboundField, Ordered>& schema,
     Host host,

--- a/nes-sources/src/SourceDescriptor.cpp
+++ b/nes-sources/src/SourceDescriptor.cpp
@@ -42,14 +42,14 @@ SourceDescriptor::SourceDescriptor(
     Host host,
     DescriptorConfig::Config config,
     const InputFormatterDescriptor& inputFormatterDescriptor,
-    bool isInline)
+    bool isAnonymous)
     : Descriptor(std::move(config))
     , physicalSourceId(physicalSourceId)
     , logicalSource(std::move(logicalSource))
     , sourceType(std::move(sourceType))
     , host(std::move(host))
     , inputFormatterDescriptor(inputFormatterDescriptor)
-    , isInline(isInline)
+    , isAnonymous(isAnonymous)
 {
 }
 
@@ -83,9 +83,9 @@ PhysicalSourceId SourceDescriptor::getPhysicalSourceId() const
     return physicalSourceId;
 }
 
-bool SourceDescriptor::isInlineSource() const
+bool SourceDescriptor::isAnonymousSource() const
 {
-    return isInline;
+    return isAnonymous;
 }
 
 std::weak_ordering operator<=>(const SourceDescriptor& lhs, const SourceDescriptor& rhs)
@@ -102,7 +102,7 @@ std::string SourceDescriptor::explain(ExplainVerbosity verbosity) const
     }
     else if (verbosity == ExplainVerbosity::Short)
     {
-        if (isInlineSource())
+        if (isAnonymousSource())
         {
             stringstream << sourceType;
         }
@@ -133,7 +133,7 @@ Reflected Reflector<SourceDescriptor>::operator()(const SourceDescriptor& source
         .type = sourceDescriptor.sourceType,
         .host = sourceDescriptor.host,
         .inputFormatterDescriptor = sourceDescriptor.inputFormatterDescriptor,
-        .isInline = sourceDescriptor.isInline,
+        .isAnonymous = sourceDescriptor.isAnonymous,
         .config = sourceDescriptor.getReflectedConfig(context)};
 
     return context.reflect(descriptor);
@@ -150,6 +150,6 @@ SourceDescriptor Unreflector<SourceDescriptor>::operator()(const Reflected& rfl,
         reflectedSourceDescriptor.host,
         Descriptor::unreflectConfig(reflectedSourceDescriptor.config, context),
         reflectedSourceDescriptor.inputFormatterDescriptor,
-        reflectedSourceDescriptor.isInline};
+        reflectedSourceDescriptor.isAnonymous};
 }
 }

--- a/nes-sql-parser/AntlrSQL.g4
+++ b/nes-sql-parser/AntlrSQL.g4
@@ -165,7 +165,7 @@ relationPrimary
     | '(' query ')'                           #aliasedQuery
     | '(' relation ')'                        #aliasedRelation
     | inlineTable                             #inlineTableDefault2
-    | inlineSource                            #inlineDefinedSource
+    | anonymousSource                         #anonymousDefinedSource
     | modelInferenceSource                    #modelInferenceRelation
     ;
 
@@ -179,7 +179,7 @@ modelInferenceInput
     | modelInferenceSource                    #modelInferenceNested
     ;
 
-inlineSource
+anonymousSource
     : type=identifier '(' parameters=namedConfigExpressionSeq ')'
     ;
 
@@ -335,9 +335,9 @@ functionName:  IDENTIFIER | AVG | MAX | MIN | SUM | COUNT | MEDIAN;
 
 sinkClause: INTO sink (',' sink)*;
 
-sink: identifier | inlineSink;
+sink: identifier | anonymousSink;
 
-inlineSink
+anonymousSink
     : type=identifier '(' parameters=namedConfigExpressionSeq ')'
     ;
 

--- a/nes-sql-parser/private/AntlrSQLParser/AntlrSQLHelper.hpp
+++ b/nes-sql-parser/private/AntlrSQLParser/AntlrSQLHelper.hpp
@@ -43,7 +43,7 @@ class AntlrSQLHelper
     std::vector<LogicalFunction> whereClauses; ///where and having clauses need to be accessed in reverse
     std::vector<LogicalFunction> havingClauses;
     std::optional<Identifier> source;
-    std::optional<std::pair<Identifier, ConfigMap>> inlineSourceConfig;
+    std::optional<std::pair<Identifier, ConfigMap>> anonymousSourceConfig;
     std::vector<Projection> projectionBuilder;
 
 public:
@@ -112,8 +112,8 @@ public:
     void addHavingClause(LogicalFunction expressionNode);
     void setSource(Identifier sourceName);
     [[nodiscard]] std::optional<Identifier> getSource() const;
-    void setInlineSource(const Identifier& type, const ConfigMap& parameters);
-    [[nodiscard]] std::optional<std::pair<Identifier, ConfigMap>> getInlineSourceConfig();
+    void setAnonymousSource(const Identifier& type, const ConfigMap& parameters);
+    [[nodiscard]] std::optional<std::pair<Identifier, ConfigMap>> getAnonymousSourceConfig();
     void addProjection(std::optional<Identifier>, LogicalFunction);
 };
 }

--- a/nes-sql-parser/private/AntlrSQLParser/AntlrSQLQueryPlanCreator.hpp
+++ b/nes-sql-parser/private/AntlrSQLParser/AntlrSQLQueryPlanCreator.hpp
@@ -87,7 +87,7 @@ public:
     void exitLogicalNot(AntlrSQLParser::LogicalNotContext* context) override;
     void exitConstantDefault(AntlrSQLParser::ConstantDefaultContext* context) override;
     void exitThresholdMinSizeParameter(AntlrSQLParser::ThresholdMinSizeParameterContext* context) override;
-    void enterInlineSource(AntlrSQLParser::InlineSourceContext* context) override;
+    void enterAnonymousSource(AntlrSQLParser::AnonymousSourceContext* context) override;
 };
 
 }

--- a/nes-sql-parser/src/AntlrSQLHelper.cpp
+++ b/nes-sql-parser/src/AntlrSQLHelper.cpp
@@ -46,14 +46,14 @@ void AntlrSQLHelper::setSource(Identifier sourceName)
     this->source = std::move(sourceName);
 }
 
-void AntlrSQLHelper::setInlineSource(const Identifier& type, const ConfigMap& parameters)
+void AntlrSQLHelper::setAnonymousSource(const Identifier& type, const ConfigMap& parameters)
 {
-    this->inlineSourceConfig = std::make_pair(type, parameters);
+    this->anonymousSourceConfig = std::make_pair(type, parameters);
 }
 
-std::optional<std::pair<Identifier, ConfigMap>> AntlrSQLHelper::getInlineSourceConfig()
+std::optional<std::pair<Identifier, ConfigMap>> AntlrSQLHelper::getAnonymousSourceConfig()
 {
-    return this->inlineSourceConfig;
+    return this->anonymousSourceConfig;
 }
 
 void AntlrSQLHelper::addWhereClause(LogicalFunction expressionNode)

--- a/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
+++ b/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
@@ -96,13 +96,13 @@ LogicalPlan AntlrSQLQueryPlanCreator::getQueryPlan() const
     return std::visit(
         Overloaded{
             [&](const Identifier& sinkName) { return LogicalPlanBuilder::addSink(sinkName, queryPlans.top()); },
-            [&](const std::pair<Identifier, ConfigMap>& inlineSink)
+            [&](const std::pair<Identifier, ConfigMap>& anonymousSink)
             {
-                const auto& [type, configOptions] = inlineSink;
+                const auto& [type, configOptions] = anonymousSink;
                 const auto sinkConfig = getSinkConfig(configOptions);
                 const auto formatConfig = parseOutputFormatterConfig(configOptions);
                 const auto schemaOpt = getSinkSchema(configOptions);
-                return LogicalPlanBuilder::addInlineSink(type, schemaOpt, sinkConfig, formatConfig, queryPlans.top());
+                return LogicalPlanBuilder::addAnonymousSink(type, schemaOpt, sinkConfig, formatConfig, queryPlans.top());
             }},
         sinks.front());
 }
@@ -284,12 +284,12 @@ void AntlrSQLQueryPlanCreator::enterSinkClause(AntlrSQLParser::SinkClauseContext
         {
             sinks.emplace_back(bindIdentifier(sink->identifier()));
         }
-        else if (sink->inlineSink() != nullptr)
+        else if (sink->anonymousSink() != nullptr)
         {
-            const auto& sinkInlineSink = sink->inlineSink();
+            const auto& anonymousSink = sink->anonymousSink();
 
-            const auto type = bindIdentifier(sinkInlineSink->type);
-            const auto configOptions = bindConfigOptions(sinkInlineSink->parameters->namedConfigExpression());
+            const auto type = bindIdentifier(anonymousSink->type);
+            const auto configOptions = bindConfigOptions(anonymousSink->parameters->namedConfigExpression());
 
             sinks.emplace_back(std::make_pair(type, configOptions));
         }
@@ -665,18 +665,18 @@ void AntlrSQLQueryPlanCreator::exitPrimaryQuery(AntlrSQLParser::PrimaryQueryCont
         }
         if (!helpers.top().getSource().has_value())
         {
-            const auto inlineSourceConfig = helpers.top().getInlineSourceConfig();
-            if (!inlineSourceConfig.has_value())
+            const auto anonymousSourceConfig = helpers.top().getAnonymousSourceConfig();
+            if (!anonymousSourceConfig.has_value())
             {
-                throw InvalidQuerySyntax("Neither named source or inline source specified");
+                throw InvalidQuerySyntax("Neither named source or anonymous source specified");
             }
-            const auto [type, configOptions] = inlineSourceConfig.value();
+            const auto [type, configOptions] = anonymousSourceConfig.value();
             const auto parserConfig = parseInputFormatterConfig(configOptions);
             const auto sourceConfig = getSourceConfig(configOptions);
             const auto schema = getSourceSchema(configOptions);
             if (!schema.has_value())
             {
-                throw InvalidConfigParameter("Inline Source is missing schema definition");
+                throw InvalidConfigParameter("Anonymous Source is missing schema definition");
             }
 
             return LogicalPlanBuilder::createLogicalPlan(type, schema.value(), sourceConfig, parserConfig);
@@ -1265,13 +1265,13 @@ void AntlrSQLQueryPlanCreator::exitThresholdMinSizeParameter(AntlrSQLParser::Thr
     helpers.top().minimumCount = std::stoi(context->getText());
 }
 
-void AntlrSQLQueryPlanCreator::enterInlineSource(AntlrSQLParser::InlineSourceContext* context)
+void AntlrSQLQueryPlanCreator::enterAnonymousSource(AntlrSQLParser::AnonymousSourceContext* context)
 {
     const auto type = bindIdentifier(context->type);
 
     const auto parameters = bindConfigOptions(context->parameters->namedConfigExpression());
 
-    helpers.top().setInlineSource(type, parameters);
+    helpers.top().setAnonymousSource(type, parameters);
 }
 
 void AntlrSQLQueryPlanCreator::enterSetOperation(AntlrSQLParser::SetOperationContext*)

--- a/nes-sql-parser/tests/StatementBinderTest.cpp
+++ b/nes-sql-parser/tests/StatementBinderTest.cpp
@@ -30,8 +30,8 @@
 #include <Identifiers/Identifier.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Operators/SelectionLogicalOperator.hpp>
-#include <Operators/Sinks/InlineSinkLogicalOperator.hpp>
-#include <Operators/Sources/InlineSourceLogicalOperator.hpp>
+#include <Operators/Sinks/AnonymousSinkLogicalOperator.hpp>
+#include <Operators/Sources/AnonymousSourceLogicalOperator.hpp>
 #include <Operators/Windows/JoinLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <SQLQueryParser/AntlrSQLQueryParser.hpp>
@@ -329,7 +329,7 @@ TEST_F(StatementBinderTest, Nullable)
     ASSERT_EQ(*actualSource.getSchema(), expectedSchema);
 }
 
-TEST_F(StatementBinderTest, InlineSinkQuery)
+TEST_F(StatementBinderTest, AnonymousSinkQuery)
 {
     const std::string query = "SELECT id, text \n"
                               "FROM input\n"
@@ -343,26 +343,26 @@ TEST_F(StatementBinderTest, InlineSinkQuery)
 
     const auto plan = std::get<QueryStatement>(*statement).plan;
 
-    const auto inlineSinkOperatorList = getOperatorByType<InlineSinkLogicalOperator>(plan);
-    ASSERT_EQ(1, inlineSinkOperatorList.size());
+    const auto anonymousSinkOperatorList = getOperatorByType<AnonymousSinkLogicalOperator>(plan);
+    ASSERT_EQ(1, anonymousSinkOperatorList.size());
 
-    const auto& inlineSinkOperator = inlineSinkOperatorList.at(0);
+    const auto& anonymousSinkOperator = anonymousSinkOperatorList.at(0);
 
-    ASSERT_EQ(Identifier::parse("FILE"), inlineSinkOperator->getSinkType());
+    ASSERT_EQ(Identifier::parse("FILE"), anonymousSinkOperator->getSinkType());
 
     const std::unordered_map<Identifier, std::string> expectedSinkConfig
         = {{Identifier::parse("file_path"), "out.csv"}, {Identifier::parse("output_format"), "CSV"}};
-    ASSERT_EQ(expectedSinkConfig, inlineSinkOperator->getSinkConfig());
+    ASSERT_EQ(expectedSinkConfig, anonymousSinkOperator->getSinkConfig());
 
     const Schema<UnqualifiedUnboundField, Ordered> schema{
         UnqualifiedUnboundField{
             Identifier::parse("ID"), DataTypeProvider::provideDataType(DataType::Type::UINT64, DataType::NULLABLE::IS_NULLABLE)},
         UnqualifiedUnboundField{
             Identifier::parse("TEXT"), DataTypeProvider::provideDataType(DataType::Type::VARSIZED, DataType::NULLABLE::IS_NULLABLE)}};
-    ASSERT_EQ(schema, inlineSinkOperator->getTargetSchema());
+    ASSERT_EQ(schema, anonymousSinkOperator->getTargetSchema());
 }
 
-TEST_F(StatementBinderTest, InlineSourceQuery)
+TEST_F(StatementBinderTest, AnonymousSourceQuery)
 {
     const std::string query = "SELECT id, text \n"
                               "FROM File(\n"
@@ -376,25 +376,25 @@ TEST_F(StatementBinderTest, InlineSourceQuery)
 
     const auto plan = std::get<QueryStatement>(*statement).plan;
 
-    const auto inlineSourceOperatorList = getOperatorByType<InlineSourceLogicalOperator>(plan);
-    ASSERT_EQ(1, inlineSourceOperatorList.size());
+    const auto anonymousSourceOperatorList = getOperatorByType<AnonymousSourceLogicalOperator>(plan);
+    ASSERT_EQ(1, anonymousSourceOperatorList.size());
 
-    const auto& inlineSourceOperator = inlineSourceOperatorList.at(0);
+    const auto& anonymousSourceOperator = anonymousSourceOperatorList.at(0);
 
-    ASSERT_EQ(Identifier::parse("FILE"), inlineSourceOperator->getSourceType());
+    ASSERT_EQ(Identifier::parse("FILE"), anonymousSourceOperator->getSourceType());
 
     const std::unordered_map<Identifier, std::string> expectedSourceConfig = {{Identifier::parse("file_path"), "input.csv"}};
-    ASSERT_EQ(expectedSourceConfig, inlineSourceOperator->getSourceConfig());
+    ASSERT_EQ(expectedSourceConfig, anonymousSourceOperator->getSourceConfig());
 
     const std::unordered_map<Identifier, std::string> expectedParserConfig = {{Identifier::parse("type"), "CSV"}};
-    ASSERT_EQ(expectedParserConfig, inlineSourceOperator->getParserConfig());
+    ASSERT_EQ(expectedParserConfig, anonymousSourceOperator->getParserConfig());
 
     const Schema<UnqualifiedUnboundField, Ordered> schema{
         UnqualifiedUnboundField{
             Identifier::parse("ID"), DataTypeProvider::provideDataType(DataType::Type::UINT64, DataType::NULLABLE::IS_NULLABLE)},
         UnqualifiedUnboundField{
             Identifier::parse("TEXT"), DataTypeProvider::provideDataType(DataType::Type::VARSIZED, DataType::NULLABLE::IS_NULLABLE)}};
-    ASSERT_EQ(schema, inlineSourceOperator->getSourceSchema());
+    ASSERT_EQ(schema, anonymousSourceOperator->getSourceSchema());
 }
 
 TEST_F(StatementBinderTest, BindQuotedIdentifiers)

--- a/nes-systests/sinks/AnonymousSink.test
+++ b/nes-systests/sinks/AnonymousSink.test
@@ -1,5 +1,5 @@
-# name: sinks/InlineSink.test
-# description: Creating sink inline
+# name: sinks/AnonymousSink.test
+# description: Creating anonymous sinks within queries
 # groups: [Sources]
 
 SELECT ID, VALUE, TIMESTAMP

--- a/nes-systests/sources/AnonymousSource.test
+++ b/nes-systests/sources/AnonymousSource.test
@@ -1,5 +1,5 @@
-# name: sources/InlineSource.test
-# description: Creating sources inline
+# name: sources/AnonymousSource.test
+# description: Creating anonymous sources within queries
 # groups: [Sources]
 
 

--- a/nes-systests/systest/src/SystestBinder.cpp
+++ b/nes-systests/systest/src/SystestBinder.cpp
@@ -46,9 +46,9 @@
 #include <Identifiers/Identifiers.hpp>
 #include <Identifiers/NESStrongType.hpp>
 #include <Operators/LogicalOperator.hpp>
-#include <Operators/Sinks/InlineSinkLogicalOperator.hpp>
+#include <Operators/Sinks/AnonymousSinkLogicalOperator.hpp>
 #include <Operators/Sinks/SinkLogicalOperator.hpp>
-#include <Operators/Sources/InlineSourceLogicalOperator.hpp>
+#include <Operators/Sources/AnonymousSourceLogicalOperator.hpp>
 #include <Operators/Sources/SourceDescriptorLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <SQLQueryParser/AntlrSQLQueryParser.hpp>
@@ -160,7 +160,7 @@ public:
         return success;
     }
 
-    std::optional<SinkDescriptor> getInlineSink(
+    std::optional<SinkDescriptor> getAnonymousSink(
         const std::optional<Schema<UnqualifiedUnboundField, Ordered>>& schema,
         const Identifier& sinkType,
         std::unordered_map<Identifier, std::string> config,
@@ -168,8 +168,8 @@ public:
     {
         PRECONDITION(
             not possibleSinkPlacements.empty(),
-            "Topology must list at least one worker in allow_sink_placement to assign a default inline sink host");
-        return sinkCatalog->getInlineSink(
+            "Topology must list at least one worker in allow_sink_placement to assign a default anonymous sink host");
+        return sinkCatalog->getAnonymousSink(
             schema, std::move(sinkType), Host(possibleSinkPlacements.at(0).getRawValue()), std::move(config), formatConfig);
     }
 
@@ -752,25 +752,25 @@ struct SystestBinder::Impl
         }
     }
 
-    [[nodiscard]] LogicalOperator updateInlineSource(const LogicalOperator& current) const
+    [[nodiscard]] LogicalOperator updateAnonymousSource(const LogicalOperator& current) const
     {
         std::vector<LogicalOperator> newChildren;
         for (const auto& child : current.getChildren())
         {
-            newChildren.emplace_back(updateInlineSource(child));
+            newChildren.emplace_back(updateAnonymousSource(child));
         }
 
-        if (const auto inlineSource = current.tryGetAs<InlineSourceLogicalOperator>())
+        if (const auto anonymousSource = current.tryGetAs<AnonymousSourceLogicalOperator>())
         {
-            auto sourceConfig = inlineSource.value()->getSourceConfig();
-            auto parserConfig = inlineSource.value()->getParserConfig();
+            auto sourceConfig = anonymousSource.value()->getSourceConfig();
+            auto parserConfig = anonymousSource.value()->getParserConfig();
 
             parserConfig.try_emplace(Identifier::parse("type"), "CSV");
 
             /// By default, all relative paths are relative to the testDataDir.
             if (sourceConfig.contains(Identifier::parse("file_path")) && !sourceConfig.at(Identifier::parse("file_path")).starts_with("/"))
             {
-                auto filePath = inlineSource.value()->getSourceConfig().at(Identifier::parse("file_path"));
+                auto filePath = anonymousSource.value()->getSourceConfig().at(Identifier::parse("file_path"));
                 filePath = testDataDir / filePath;
                 sourceConfig.erase(Identifier::parse("file_path"));
                 sourceConfig.emplace(Identifier::parse("file_path"), filePath);
@@ -778,13 +778,13 @@ struct SystestBinder::Impl
 
             PRECONDITION(
                 not clusterConfiguration.allowSourcePlacement.empty(),
-                "Topology must list at least one worker in allow_source_placement to assign a default inline source host");
+                "Topology must list at least one worker in allow_source_placement to assign a default anonymous source host");
             sourceConfig.try_emplace(Identifier::parse("host"), clusterConfiguration.allowSourcePlacement.at(0).getRawValue());
 
-            if (sourceConfig != inlineSource.value()->getSourceConfig() || parserConfig != inlineSource.value()->getParserConfig())
+            if (sourceConfig != anonymousSource.value()->getSourceConfig() || parserConfig != anonymousSource.value()->getParserConfig())
             {
-                const auto newOperator = InlineSourceLogicalOperator::create(
-                    inlineSource.value()->getSourceType(), inlineSource.value()->getSourceSchema(), sourceConfig, parserConfig);
+                const auto newOperator = AnonymousSourceLogicalOperator::create(
+                    anonymousSource.value()->getSourceType(), anonymousSource.value()->getSourceSchema(), sourceConfig, parserConfig);
 
                 return newOperator.withChildrenUnsafe(newChildren);
             }
@@ -793,21 +793,21 @@ struct SystestBinder::Impl
         return current.withChildrenUnsafe(std::move(newChildren));
     }
 
-    void setInlineSources(LogicalPlan& plan) const
+    void setAnonymousSources(LogicalPlan& plan) const
     {
         std::vector<LogicalOperator> newRoots;
         for (const auto& root : plan.getRootOperators())
         {
-            newRoots.emplace_back(updateInlineSource(root));
+            newRoots.emplace_back(updateAnonymousSource(root));
         }
         plan = plan.withRootOperators(newRoots);
     }
 
-    LogicalOperator setInlineSink(
+    LogicalOperator setAnonymousSink(
         const std::string_view& testFileName,
         SLTSinkFactory& sltSinkProvider,
         const SystestQueryId& currentQueryNumberInTest,
-        const TypedLogicalOperator<InlineSinkLogicalOperator>& sinkOperator) const
+        const TypedLogicalOperator<AnonymousSinkLogicalOperator>& sinkOperator) const
     {
         const auto resultFile = SystestQuery::resultFile(workingDir, testFileName, currentQueryNumberInTest);
 
@@ -830,10 +830,10 @@ struct SystestBinder::Impl
             formatConfig[Identifier::parse("quote_strings")] = "true";
         }
 
-        auto sinkDescriptor = sltSinkProvider.getInlineSink(schema, sinkOperator->getSinkType(), sinkConfig, formatConfig);
+        auto sinkDescriptor = sltSinkProvider.getAnonymousSink(schema, sinkOperator->getSinkType(), sinkConfig, formatConfig);
         if (not sinkDescriptor.has_value())
         {
-            throw InvalidConfigParameter("Failed to create inline sink of type {}", sinkOperator->getSinkType());
+            throw InvalidConfigParameter("Failed to create anonymous sink of type {}", sinkOperator->getSinkType());
         }
         const auto newOperator = SinkLogicalOperator::create(sinkDescriptor.value());
 
@@ -877,9 +877,9 @@ struct SystestBinder::Impl
         std::vector<LogicalOperator> newRoots;
         for (const auto& rootOperator : plan.getRootOperators())
         {
-            if (auto inlineSink = rootOperator.tryGetAs<InlineSinkLogicalOperator>(); inlineSink.has_value())
+            if (auto anonymousSink = rootOperator.tryGetAs<AnonymousSinkLogicalOperator>(); anonymousSink.has_value())
             {
-                newRoots.emplace_back(setInlineSink(testFileName, sltSinkProvider, currentQueryNumberInTest, inlineSink.value()));
+                newRoots.emplace_back(setAnonymousSink(testFileName, sltSinkProvider, currentQueryNumberInTest, anonymousSink.value()));
             }
             else if (auto namedSink = rootOperator.tryGetAs<SinkLogicalOperator>(); namedSink.has_value())
             {
@@ -889,14 +889,14 @@ struct SystestBinder::Impl
             else
             {
                 throw UnsupportedQuery(
-                    "Invalid root operator \"{}\". Root operators must be SinkLogicalOperators or InlineSinksLogicalOperators.",
+                    "Invalid root operator \"{}\". Root operators must be SinkLogicalOperators or AnonymousSinkLogicalOperators.",
                     rootOperator.getName());
             }
             plan = plan.withRootOperators(newRoots);
         }
     }
 
-    void setInlineSinks(
+    void setAnonymousSinks(
         LogicalPlan& plan,
         const std::string_view& testFileName,
         SLTSinkFactory& sltSinkProvider,
@@ -907,9 +907,9 @@ struct SystestBinder::Impl
 
         for (const auto& rootOperator : plan.getRootOperators())
         {
-            if (auto inlineSink = rootOperator.tryGetAs<InlineSinkLogicalOperator>(); inlineSink.has_value())
+            if (auto anonymousSink = rootOperator.tryGetAs<AnonymousSinkLogicalOperator>(); anonymousSink.has_value())
             {
-                newRoots.emplace_back(setInlineSink(testFileName, sltSinkProvider, currentQueryNumberInTest, inlineSink.value()));
+                newRoots.emplace_back(setAnonymousSink(testFileName, sltSinkProvider, currentQueryNumberInTest, anonymousSink.value()));
             }
             else
             {
@@ -940,7 +940,7 @@ struct SystestBinder::Impl
             auto plan = AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString(query);
             setSinks(plan, currentBuilder, testFileName, sltSinkProvider, currentQueryNumberInTest);
             plan.setQueryId(QueryId::createDistributed(DistributedQueryId(fmt::format("{}:{}", testFileName, currentQueryNumberInTest))));
-            setInlineSources(plan);
+            setAnonymousSources(plan);
             currentBuilder.setBoundPlan(std::move(plan));
         }
         catch (Exception& e)
@@ -982,10 +982,10 @@ struct SystestBinder::Impl
                 throw UnsupportedQuery("expected an EXPLAIN statement, but got: \"{}\"", replaceAll(statementString, "\n", " "));
             }
 
-            /// The inner query plan needs the same rewrites as a regular systest query, so that its sinks and inline
+            /// The inner query plan needs the same rewrites as a regular systest query, so that its anonymous sinks and
             /// sources resolve during optimization (the OPTIMIZED, DISTRIBUTED and ALL stages run the optimizer).
-            setInlineSinks(explainStatement->plan, testFileName, sltSinkProvider, currentQueryNumberInTest);
-            setInlineSources(explainStatement->plan);
+            setAnonymousSinks(explainStatement->plan, testFileName, sltSinkProvider, currentQueryNumberInTest);
+            setAnonymousSources(explainStatement->plan);
             currentBuilder.setExplainStatement(std::move(*explainStatement));
         }
         catch (Exception& e)
@@ -1040,8 +1040,8 @@ struct SystestBinder::Impl
             setSinks(leftPlan, currentTest, testFileName, sltSinkProvider, currentQueryNumberInTest);
             setSinks(rightPlan, currentTest, differentialTestResultFileName, sltSinkProvider, currentQueryNumberInTest);
 
-            setInlineSources(leftPlan);
-            setInlineSources(rightPlan);
+            setAnonymousSources(leftPlan);
+            setAnonymousSources(rightPlan);
 
             leftPlan.setQueryId(
                 QueryId::createDistributed(DistributedQueryId(fmt::format("{}:{}", testFileName, currentQueryNumberInTest))));


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR renamed inline sinks/sources to anonymous sinks/sources to better reflect what they actually do, since they are used both for defining sinks/sources within queries, and for creating unregistered network sinks/sources for internal communication in distributed plans. 

## Verifying this change
All existing tests continue to run

## What components does this pull request potentially affect?
* query parser
* query optimizer
* logical operators
* systests
* Sink/Source descriptors    

## Documentation
The documentation is updated accordingly 
