### PR TITLE
Implement Median as Nautilus Function

### DIFF
--- a/nes-physical-operators/include/Aggregation/Function/AggregationPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Aggregation/Function/AggregationPhysicalFunction.hpp
@@ -44,24 +44,40 @@ public:
     AggregationPhysicalFunction(
         DataType inputType, DataType resultType, PhysicalFunction inputFunction, Record::RecordFieldIdentifier resultFieldIdentifier);
 
+    /// All four methods below are called while the pipeline is traced and receive its compilation context, so that
+    /// an aggregation can put an expensive body into a shared nautilus function instead of inlining it once per
+    /// aggregation (see CompilationContext::getOrRegisterNautilusFunction).
+
     /// Adds the incoming record to the existing aggregation state
-    virtual void
-    lift(const nautilus::val<AggregationState*>& aggregationState, PipelineMemoryProvider& bufferProvider, const Record& record)
+    virtual void lift(
+        const nautilus::val<AggregationState*>& aggregationState,
+        PipelineMemoryProvider& bufferProvider,
+        CompilationContext& compilationContext,
+        const Record& record)
         = 0;
 
     /// Combines two aggregation states into one. After calling this method, aggregationState1 contains the combined state
     virtual void combine(
         nautilus::val<AggregationState*> aggregationState1,
         nautilus::val<AggregationState*> aggregationState2,
-        PipelineMemoryProvider& pipelineMemoryProvider)
+        PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext)
         = 0;
 
     /// Returns the aggregation state as a nautilus record. The record will contain the aggregation state in the field specified by resultFieldIdentifier
     /// It will NOT contain any other metadata fields, e.g., window start and end fields
-    virtual Record lower(nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider& pipelineMemoryProvider) = 0;
+    virtual Record lower(
+        nautilus::val<AggregationState*> aggregationState,
+        PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext)
+        = 0;
 
     /// Resets the aggregation state to its initial state. For a sum, this would be 0, for a min aggregation, this would be the maximum possible value, etc.
-    virtual void reset(nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider& pipelineMemoryProvider) = 0;
+    virtual void reset(
+        nautilus::val<AggregationState*> aggregationState,
+        PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext)
+        = 0;
 
     /// Destroys the aggregation state. This is used to free up memory when the aggregation state is no longer needed.
     virtual void cleanup(nautilus::val<AggregationState*> aggregationState) = 0;

--- a/nes-physical-operators/include/Aggregation/Function/AvgAggregationPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Aggregation/Function/AvgAggregationPhysicalFunction.hpp
@@ -38,13 +38,21 @@ public:
     void lift(
         const nautilus::val<AggregationState*>& aggregationState,
         PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext,
         const Record& record) override;
     void combine(
         nautilus::val<AggregationState*> aggregationState1,
         nautilus::val<AggregationState*> aggregationState2,
-        PipelineMemoryProvider& pipelineMemoryProvider) override;
-    Record lower(nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider& pipelineMemoryProvider) override;
-    void reset(nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider& pipelineMemoryProvider) override;
+        PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext) override;
+    Record lower(
+        nautilus::val<AggregationState*> aggregationState,
+        PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext) override;
+    void reset(
+        nautilus::val<AggregationState*> aggregationState,
+        PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext) override;
     void cleanup(nautilus::val<AggregationState*> aggregationState) override;
     [[nodiscard]] size_t getSizeOfStateInBytes() const override;
     ~AvgAggregationPhysicalFunction() override = default;

--- a/nes-physical-operators/include/Aggregation/Function/CountAggregationPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Aggregation/Function/CountAggregationPhysicalFunction.hpp
@@ -38,13 +38,21 @@ public:
     void lift(
         const nautilus::val<AggregationState*>& aggregationState,
         PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext,
         const Record& record) override;
     void combine(
         nautilus::val<AggregationState*> aggregationState1,
         nautilus::val<AggregationState*> aggregationState2,
-        PipelineMemoryProvider& pipelineMemoryProvider) override;
-    Record lower(nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider& pipelineMemoryProvider) override;
-    void reset(nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider& pipelineMemoryProvider) override;
+        PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext) override;
+    Record lower(
+        nautilus::val<AggregationState*> aggregationState,
+        PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext) override;
+    void reset(
+        nautilus::val<AggregationState*> aggregationState,
+        PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext) override;
     void cleanup(nautilus::val<AggregationState*> aggregationState) override;
     [[nodiscard]] size_t getSizeOfStateInBytes() const override;
     ~CountAggregationPhysicalFunction() override = default;

--- a/nes-physical-operators/include/Aggregation/Function/MaxAggregationPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Aggregation/Function/MaxAggregationPhysicalFunction.hpp
@@ -34,13 +34,21 @@ public:
     void lift(
         const nautilus::val<AggregationState*>& aggregationState,
         PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext,
         const Record& record) override;
     void combine(
         nautilus::val<AggregationState*> aggregationState1,
         nautilus::val<AggregationState*> aggregationState2,
-        PipelineMemoryProvider& pipelineMemoryProvider) override;
-    Record lower(nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider& pipelineMemoryProvider) override;
-    void reset(nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider& pipelineMemoryProvider) override;
+        PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext) override;
+    Record lower(
+        nautilus::val<AggregationState*> aggregationState,
+        PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext) override;
+    void reset(
+        nautilus::val<AggregationState*> aggregationState,
+        PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext) override;
     void cleanup(nautilus::val<AggregationState*> aggregationState) override;
     [[nodiscard]] size_t getSizeOfStateInBytes() const override;
     ~MaxAggregationPhysicalFunction() override = default;

--- a/nes-physical-operators/include/Aggregation/Function/MedianAggregationPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Aggregation/Function/MedianAggregationPhysicalFunction.hpp
@@ -27,6 +27,9 @@
 namespace NES
 {
 
+/// Median aggregation. The values seen so far are stored in a paged vector, one value per row, and the median is
+/// computed over them when the window closes. lift stays in the pipeline because it is short; the expensive
+/// lower, along with combine and reset, is called as a shared nautilus function (see MedianNautilusFunctions).
 class MedianAggregationPhysicalFunction : public AggregationPhysicalFunction
 {
 public:
@@ -39,19 +42,31 @@ public:
     void lift(
         const nautilus::val<AggregationState*>& aggregationState,
         PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext,
         const Record& record) override;
     void combine(
         nautilus::val<AggregationState*> aggregationState1,
         nautilus::val<AggregationState*> aggregationState2,
-        PipelineMemoryProvider& pipelineMemoryProvider) override;
-    Record lower(nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider& pipelineMemoryProvider) override;
-    void reset(nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider& pipelineMemoryProvider) override;
+        PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext) override;
+    Record lower(
+        nautilus::val<AggregationState*> aggregationState,
+        PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext) override;
+    void reset(
+        nautilus::val<AggregationState*> aggregationState,
+        PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext) override;
     void cleanup(nautilus::val<AggregationState*> aggregationState) override;
     [[nodiscard]] size_t getSizeOfStateInBytes() const override;
     ~MedianAggregationPhysicalFunction() override = default;
 
 private:
+    /// A single column holding the aggregated field, laid out by the lowering rule. Storing only that value is
+    /// what lets the median body be shared: it reads the value by name instead of applying this median's
+    /// column-specific input function.
     std::shared_ptr<PagedVectorTupleLayout> tupleLayout;
+    Record::RecordFieldIdentifier valueFieldName;
 };
 
 }

--- a/nes-physical-operators/include/Aggregation/Function/MedianNautilusFunctions.hpp
+++ b/nes-physical-operators/include/Aggregation/Function/MedianNautilusFunctions.hpp
@@ -1,0 +1,58 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <Aggregation/Function/AggregationPhysicalFunction.hpp>
+#include <Interface/PagedVector/PagedVectorRef.hpp>
+#include <Interface/Record.hpp>
+#include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/TupleBuffer.hpp>
+#include <val_arith.hpp>
+#include <val_base.hpp>
+#include <val_ptr.hpp>
+
+namespace NES
+{
+
+/// The bodies that MedianAggregationPhysicalFunction registers as shared nautilus functions instead of inlining
+/// them at every aggregation. medianOf is the expensive one: it is a doubly-nested loop, so a query with many
+/// MEDIANs would otherwise inline that loop once per aggregation.
+///
+/// They are free functions over a runtime layout and nullability rather than members, so that one traced instance
+/// can serve every median of the same shape in a pipeline. medianOf reads the stored value by name instead of
+/// applying the column-specific input function, which is what makes it shareable at all.
+nautilus::val<double> medianOf(
+    const nautilus::val<TupleBuffer*>& pagedVectorBuffer,
+    const std::shared_ptr<PagedVectorTupleLayout>& tupleLayout,
+    const Record::RecordFieldIdentifier& valueFieldName);
+
+/// Merges the pages of the second state into the first. Null flag semantics follow the SQL standard: the state
+/// stays null only while neither side has seen a non-null value.
+void medianCombineStates(
+    const nautilus::val<AggregationState*>& aggregationState1,
+    const nautilus::val<AggregationState*>& aggregationState2,
+    const nautilus::val<AbstractBufferProvider*>& bufferProvider,
+    bool nullable);
+
+/// Allocates a fresh paged vector for the state and marks it as "no value seen yet".
+void medianResetState(
+    const nautilus::val<AggregationState*>& aggregationState,
+    const nautilus::val<AbstractBufferProvider*>& bufferProvider,
+    const nautilus::val<uint64_t>& tupleSize,
+    bool nullable);
+
+}

--- a/nes-physical-operators/include/Aggregation/Function/MinAggregationPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Aggregation/Function/MinAggregationPhysicalFunction.hpp
@@ -34,13 +34,21 @@ public:
     void lift(
         const nautilus::val<AggregationState*>& aggregationState,
         PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext,
         const Record& record) override;
     void combine(
         nautilus::val<AggregationState*> aggregationState1,
         nautilus::val<AggregationState*> aggregationState2,
-        PipelineMemoryProvider& pipelineMemoryProvider) override;
-    Record lower(nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider& pipelineMemoryProvider) override;
-    void reset(nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider& pipelineMemoryProvider) override;
+        PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext) override;
+    Record lower(
+        nautilus::val<AggregationState*> aggregationState,
+        PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext) override;
+    void reset(
+        nautilus::val<AggregationState*> aggregationState,
+        PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext) override;
     void cleanup(nautilus::val<AggregationState*> aggregationState) override;
     [[nodiscard]] size_t getSizeOfStateInBytes() const override;
     ~MinAggregationPhysicalFunction() override = default;

--- a/nes-physical-operators/include/Aggregation/Function/SumAggregationPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Aggregation/Function/SumAggregationPhysicalFunction.hpp
@@ -34,13 +34,21 @@ public:
     void lift(
         const nautilus::val<AggregationState*>& aggregationState,
         PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext,
         const Record& record) override;
     void combine(
         nautilus::val<AggregationState*> aggregationState1,
         nautilus::val<AggregationState*> aggregationState2,
-        PipelineMemoryProvider& pipelineMemoryProvider) override;
-    Record lower(nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider& pipelineMemoryProvider) override;
-    void reset(nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider& pipelineMemoryProvider) override;
+        PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext) override;
+    Record lower(
+        nautilus::val<AggregationState*> aggregationState,
+        PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext) override;
+    void reset(
+        nautilus::val<AggregationState*> aggregationState,
+        PipelineMemoryProvider& pipelineMemoryProvider,
+        CompilationContext& compilationContext) override;
     void cleanup(nautilus::val<AggregationState*> aggregationState) override;
     [[nodiscard]] size_t getSizeOfStateInBytes() const override;
     ~SumAggregationPhysicalFunction() override = default;

--- a/nes-physical-operators/src/Aggregation/AggregationBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Aggregation/AggregationBuildPhysicalOperator.cpp
@@ -117,7 +117,7 @@ void AggregationBuildPhysicalOperator::execute(ExecutionContext& ctx, Record& re
             auto state = static_cast<nautilus::val<AggregationState*>>(entryRefReset.getValueMemArea());
             for (const auto& aggFunction : nautilus::static_iterable(aggregationPhysicalFunctions))
             {
-                aggFunction->reset(state, ctx.pipelineMemoryProvider);
+                aggFunction->reset(state, ctx.pipelineMemoryProvider, ctx.getCompilationContext());
                 state = state + aggFunction->getSizeOfStateInBytes();
             }
         },
@@ -129,7 +129,7 @@ void AggregationBuildPhysicalOperator::execute(ExecutionContext& ctx, Record& re
     auto state = static_cast<nautilus::val<AggregationState*>>(entryRef.getValueMemArea());
     for (const auto& aggFunction : nautilus::static_iterable(aggregationPhysicalFunctions))
     {
-        aggFunction->lift(state, ctx.pipelineMemoryProvider, record);
+        aggFunction->lift(state, ctx.pipelineMemoryProvider, ctx.getCompilationContext(), record);
         state = state + aggFunction->getSizeOfStateInBytes();
     }
 }

--- a/nes-physical-operators/src/Aggregation/AggregationProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/Aggregation/AggregationProbePhysicalOperator.cpp
@@ -99,7 +99,8 @@ void AggregationProbePhysicalOperator::open(ExecutionContext& executionCtx, Reco
                     auto entryRefState = static_cast<nautilus::val<AggregationState*>>(entryRef.getValueMemArea());
                     for (const auto& aggFunction : nautilus::static_iterable(aggregationPhysicalFunctions))
                     {
-                        aggFunction->combine(globalState, entryRefState, executionCtx.pipelineMemoryProvider);
+                        aggFunction->combine(
+                            globalState, entryRefState, executionCtx.pipelineMemoryProvider, executionCtx.getCompilationContext());
                         globalState = globalState + aggFunction->getSizeOfStateInBytes();
                         entryRefState = entryRefState + aggFunction->getSizeOfStateInBytes();
                     }
@@ -119,8 +120,9 @@ void AggregationProbePhysicalOperator::open(ExecutionContext& executionCtx, Reco
                     for (const auto& aggFunction : nautilus::static_iterable(aggregationPhysicalFunctions))
                     {
                         /// In contrast to the lambda method above, we have to reset the aggregation state before combining it with the other state
-                        aggFunction->reset(globalState, executionCtx.pipelineMemoryProvider);
-                        aggFunction->combine(globalState, entryRefStatePtr, executionCtx.pipelineMemoryProvider);
+                        aggFunction->reset(globalState, executionCtx.pipelineMemoryProvider, executionCtx.getCompilationContext());
+                        aggFunction->combine(
+                            globalState, entryRefStatePtr, executionCtx.pipelineMemoryProvider, executionCtx.getCompilationContext());
                         globalState = globalState + aggFunction->getSizeOfStateInBytes();
                         entryRefStatePtr = entryRefStatePtr + aggFunction->getSizeOfStateInBytes();
                     }
@@ -138,7 +140,8 @@ void AggregationProbePhysicalOperator::open(ExecutionContext& executionCtx, Reco
         for (auto finalStatePtr = static_cast<nautilus::val<AggregationState*>>(entryRef.getValueMemArea());
              const auto& aggFunction : nautilus::static_iterable(aggregationPhysicalFunctions))
         {
-            outputRecord.reassignFields(aggFunction->lower(finalStatePtr, executionCtx.pipelineMemoryProvider));
+            outputRecord.reassignFields(
+                aggFunction->lower(finalStatePtr, executionCtx.pipelineMemoryProvider, executionCtx.getCompilationContext()));
             finalStatePtr = finalStatePtr + aggFunction->getSizeOfStateInBytes();
         }
 

--- a/nes-physical-operators/src/Aggregation/Function/AvgAggregationPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Aggregation/Function/AvgAggregationPhysicalFunction.cpp
@@ -48,7 +48,10 @@ AvgAggregationPhysicalFunction::AvgAggregationPhysicalFunction(
 }
 
 void AvgAggregationPhysicalFunction::lift(
-    const nautilus::val<AggregationState*>& aggregationState, PipelineMemoryProvider& pipelineMemoryProvider, const Record& record)
+    const nautilus::val<AggregationState*>& aggregationState,
+    PipelineMemoryProvider& pipelineMemoryProvider,
+    CompilationContext&,
+    const Record& record)
 {
     const auto value = inputFunction.execute(record, pipelineMemoryProvider.arena);
     if (inputType.nullable)
@@ -96,7 +99,8 @@ void AvgAggregationPhysicalFunction::lift(
 void AvgAggregationPhysicalFunction::combine(
     const nautilus::val<AggregationState*> aggregationState1,
     const nautilus::val<AggregationState*> aggregationState2,
-    PipelineMemoryProvider&)
+    PipelineMemoryProvider&,
+    CompilationContext&)
 {
     if (inputType.nullable)
     {
@@ -149,7 +153,8 @@ void AvgAggregationPhysicalFunction::combine(
     }
 }
 
-Record AvgAggregationPhysicalFunction::lower(const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&)
+Record
+AvgAggregationPhysicalFunction::lower(const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&, CompilationContext&)
 {
     if (inputType.nullable)
     {
@@ -184,7 +189,8 @@ Record AvgAggregationPhysicalFunction::lower(const nautilus::val<AggregationStat
     return Record({{resultFieldIdentifier, avg}});
 }
 
-void AvgAggregationPhysicalFunction::reset(const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&)
+void AvgAggregationPhysicalFunction::reset(
+    const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&, CompilationContext&)
 {
     /// Resetting the isNull, sum, and count to 0
     const auto memArea = static_cast<nautilus::val<int8_t*>>(aggregationState);

--- a/nes-physical-operators/src/Aggregation/Function/CMakeLists.txt
+++ b/nes-physical-operators/src/Aggregation/Function/CMakeLists.txt
@@ -14,7 +14,7 @@ add_plugin(Avg AggregationPhysicalFunction AvgAggregationPhysicalFunction.cpp)
 add_plugin(Count AggregationPhysicalFunction CountAggregationPhysicalFunction.cpp)
 add_plugin(Max AggregationPhysicalFunction MaxAggregationPhysicalFunction.cpp)
 add_plugin(Min AggregationPhysicalFunction MinAggregationPhysicalFunction.cpp)
-add_plugin(Median AggregationPhysicalFunction MedianAggregationPhysicalFunction.cpp)
+add_plugin(Median AggregationPhysicalFunction MedianAggregationPhysicalFunction.cpp MedianNautilusFunctions.cpp)
 add_plugin(Sum AggregationPhysicalFunction SumAggregationPhysicalFunction.cpp)
 
 add_source_files(nes-physical-operators

--- a/nes-physical-operators/src/Aggregation/Function/CountAggregationPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Aggregation/Function/CountAggregationPhysicalFunction.cpp
@@ -46,7 +46,10 @@ CountAggregationPhysicalFunction::CountAggregationPhysicalFunction(
 }
 
 void CountAggregationPhysicalFunction::lift(
-    const nautilus::val<AggregationState*>& aggregationState, PipelineMemoryProvider& pipelineMemoryProvider, const Record& record)
+    const nautilus::val<AggregationState*>& aggregationState,
+    PipelineMemoryProvider& pipelineMemoryProvider,
+    CompilationContext&,
+    const Record& record)
 {
     /// Reading the old count from the aggregation state.
     const auto value = inputFunction.execute(record, pipelineMemoryProvider.arena);
@@ -64,7 +67,8 @@ void CountAggregationPhysicalFunction::lift(
 void CountAggregationPhysicalFunction::combine(
     const nautilus::val<AggregationState*> aggregationState1,
     const nautilus::val<AggregationState*> aggregationState2,
-    PipelineMemoryProvider&)
+    PipelineMemoryProvider&,
+    CompilationContext&)
 {
     /// Reading the count from the first aggregation state
     const auto memAreaCount1 = static_cast<nautilus::val<int8_t*>>(aggregationState1);
@@ -81,7 +85,8 @@ void CountAggregationPhysicalFunction::combine(
     newCount.writeToMemory(memAreaCount1);
 }
 
-Record CountAggregationPhysicalFunction::lower(const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&)
+Record CountAggregationPhysicalFunction::lower(
+    const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&, CompilationContext&)
 {
     /// Reading the count from the aggregation state
     const auto memAreaCount = static_cast<nautilus::val<int8_t*>>(aggregationState);
@@ -94,7 +99,8 @@ Record CountAggregationPhysicalFunction::lower(const nautilus::val<AggregationSt
     return record;
 }
 
-void CountAggregationPhysicalFunction::reset(const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&)
+void CountAggregationPhysicalFunction::reset(
+    const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&, CompilationContext&)
 {
     /// Resetting the count and count to 0
     const auto memArea = static_cast<nautilus::val<int8_t*>>(aggregationState);

--- a/nes-physical-operators/src/Aggregation/Function/MaxAggregationPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Aggregation/Function/MaxAggregationPhysicalFunction.cpp
@@ -40,7 +40,10 @@ MaxAggregationPhysicalFunction::MaxAggregationPhysicalFunction(
 }
 
 void MaxAggregationPhysicalFunction::lift(
-    const nautilus::val<AggregationState*>& aggregationState, PipelineMemoryProvider& pipelineMemoryProvider, const Record& record)
+    const nautilus::val<AggregationState*>& aggregationState,
+    PipelineMemoryProvider& pipelineMemoryProvider,
+    CompilationContext&,
+    const Record& record)
 {
     const auto value = inputFunction.execute(record, pipelineMemoryProvider.arena);
 
@@ -76,7 +79,8 @@ void MaxAggregationPhysicalFunction::lift(
 void MaxAggregationPhysicalFunction::combine(
     const nautilus::val<AggregationState*> aggregationState1,
     const nautilus::val<AggregationState*> aggregationState2,
-    PipelineMemoryProvider&)
+    PipelineMemoryProvider&,
+    CompilationContext&)
 {
     if (not inputType.nullable)
     {
@@ -111,7 +115,8 @@ void MaxAggregationPhysicalFunction::combine(
     }
 }
 
-Record MaxAggregationPhysicalFunction::lower(const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&)
+Record
+MaxAggregationPhysicalFunction::lower(const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&, CompilationContext&)
 {
     if (not inputType.nullable)
     {
@@ -136,7 +141,8 @@ Record MaxAggregationPhysicalFunction::lower(const nautilus::val<AggregationStat
     return record;
 }
 
-void MaxAggregationPhysicalFunction::reset(const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&)
+void MaxAggregationPhysicalFunction::reset(
+    const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&, CompilationContext&)
 {
     /// Initialize the null flag to "no value seen yet" so the first non-null input becomes the running max
     if (inputType.nullable)

--- a/nes-physical-operators/src/Aggregation/Function/MedianAggregationPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Aggregation/Function/MedianAggregationPhysicalFunction.cpp
@@ -17,9 +17,11 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <ranges>
 #include <utility>
 
 #include <Aggregation/Function/AggregationPhysicalFunction.hpp>
+#include <Aggregation/Function/MedianNautilusFunctions.hpp>
 #include <DataTypes/DataType.hpp>
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/NautilusBuffer.hpp>
@@ -30,8 +32,11 @@
 
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
+#include <fmt/format.h>
+#include <magic_enum/magic_enum.hpp>
 #include <nautilus/std/cstring.h>
 #include <AggregationPhysicalFunctionRegistry.hpp>
+#include <CompilationContext.hpp>
 #include <ErrorHandling.hpp>
 #include <ExecutionContext.hpp>
 #include <val.hpp>
@@ -50,11 +55,21 @@ MedianAggregationPhysicalFunction::MedianAggregationPhysicalFunction(
     std::shared_ptr<PagedVectorTupleLayout> tupleLayout)
     : AggregationPhysicalFunction(std::move(inputType), std::move(resultType), std::move(inputFunction), std::move(resultFieldIdentifier))
     , tupleLayout(std::move(tupleLayout))
+    /// The lowering rule lays the paged vector out as the single column being aggregated, so the name the value
+    /// is stored under is the one and only field of that layout.
+    , valueFieldName(this->tupleLayout->getSchema()[0].value().getFullyQualifiedName())
 {
+    PRECONDITION(
+        std::ranges::size(this->tupleLayout->getSchema()) == 1,
+        "Median stores a single value per row, but its layout has {} fields",
+        std::ranges::size(this->tupleLayout->getSchema()));
 }
 
 void MedianAggregationPhysicalFunction::lift(
-    const nautilus::val<AggregationState*>& aggregationState, PipelineMemoryProvider& pipelineMemoryProvider, const Record& record)
+    const nautilus::val<AggregationState*>& aggregationState,
+    PipelineMemoryProvider& pipelineMemoryProvider,
+    CompilationContext&,
+    const Record& record)
 {
     const auto value = inputFunction.execute(record, pipelineMemoryProvider.arena);
     if (inputType.nullable)
@@ -83,39 +98,23 @@ void MedianAggregationPhysicalFunction::lift(
 void MedianAggregationPhysicalFunction::combine(
     const nautilus::val<AggregationState*> aggregationState1,
     const nautilus::val<AggregationState*> aggregationState2,
-    PipelineMemoryProvider& pipelineMemoryProvider)
+    PipelineMemoryProvider& pipelineMemoryProvider,
+    CompilationContext& compilationContext)
 {
-    /// Getting the paged vectors from the aggregation states
-    auto memArea1 = static_cast<nautilus::val<int8_t*>>(aggregationState1);
-    auto memArea2 = static_cast<nautilus::val<int8_t*>>(aggregationState2);
-
-    if (inputType.nullable)
-    {
-        /// SQL-standard: only stay null when both partitions are still empty (no non-null value seen on either side)
-        const auto containsNull1 = readNull(aggregationState1);
-        const auto containsNull2 = readNull(aggregationState2);
-        storeNull(aggregationState1, containsNull1 and containsNull2);
-
-        /// Skipping the first byte (null)
-        memArea1 += nautilus::val<uint64_t>{1};
-        memArea2 += nautilus::val<uint64_t>{1};
-    }
-
-    /// Calling the copyFrom function of the paged vector to combine the two paged vectors by copying the content of the second paged vector to the first paged vector
-    nautilus::invoke(
-        +[](AbstractBufferProvider* bufferProvider, TupleBuffer* vector1Buffer, const TupleBuffer* vector2Buffer) -> void
-        {
-            auto vector1 = PagedVector::load(*vector1Buffer);
-            const auto vector2 = PagedVector::load(*vector2Buffer);
-            vector1.copyPagesFrom(*bufferProvider, vector2);
-        },
-        pipelineMemoryProvider.bufferProvider,
-        memArea1,
-        memArea2);
+    using CombineSignature
+        = void(nautilus::val<AggregationState*>, nautilus::val<AggregationState*>, nautilus::val<AbstractBufferProvider*>);
+    auto& combineFunction = compilationContext.getOrRegisterNautilusFunction<CombineSignature>(
+        fmt::format("Median_combine_{}", inputType.nullable ? "N" : "X"),
+        [nullable = inputType.nullable](
+            const nautilus::val<AggregationState*>& state1,
+            const nautilus::val<AggregationState*>& state2,
+            const nautilus::val<AbstractBufferProvider*>& bufferProvider)
+        { medianCombineStates(state1, state2, bufferProvider, nullable); });
+    combineFunction(aggregationState1, aggregationState2, pipelineMemoryProvider.bufferProvider);
 }
 
 Record MedianAggregationPhysicalFunction::lower(
-    const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider& pipelineMemoryProvider)
+    const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&, CompilationContext& compilationContext)
 {
     /// SQL-standard: if no non-null value was observed, the null flag is still set and the paged vector is empty,
     /// so we return NULL. The early skip below also guards the numberOfEntries > 0 invariant.
@@ -125,92 +124,27 @@ Record MedianAggregationPhysicalFunction::lower(
         containsNull = readNull(aggregationState);
     }
 
-    const VarVal zero{nautilus::val<uint64_t>(0), true, true};
-    VarVal medianValue = zero.castToType(resultType.type);
-
-    if (!containsNull)
+    /// The shared function can only hand back a plain value: VarVal's nullability is a C++-level property that
+    /// would not survive the call, and assigning a non-nullable VarVal inside the traced branch below would drop
+    /// the null flag of the other branch. So only the value crosses the branch, and the VarVal is built once
+    /// afterwards with the traced null flag.
+    nautilus::val<double> rawMedian = 0.0;
+    if (not containsNull)
     {
-        /// Getting the paged vector from the aggregation state
         const auto pagedVectorBufferPtr = static_cast<nautilus::val<NES::TupleBuffer*>>(
             aggregationState + nautilus::val<uint64_t>{static_cast<uint64_t>(inputType.nullable)});
-        const auto numberOfEntries = invoke(
-            +[](const TupleBuffer* pagedVectorBuffer)
-            {
-                const auto pagedVector = PagedVector::load(*pagedVectorBuffer);
-                const auto numberOfEntriesVal = pagedVector.getTotalNumberOfRecords();
-                INVARIANT(numberOfEntriesVal > 0, "The number of entries in the paged vector must be greater than 0");
-                return numberOfEntriesVal;
-            },
-            pagedVectorBufferPtr);
-
-        /// Iterating in two nested loops over all the records in the paged vector to get the median.
-        /// We pick a candidate and then count for each item, if the candidate is smaller and also if the candidate is less than the item.
-        const nautilus::val<int64_t> medianPos1 = (numberOfEntries - 1) / 2;
-        const nautilus::val<int64_t> medianPos2 = numberOfEntries / 2;
-        nautilus::val<uint64_t> medianItemPos1 = 0;
-        nautilus::val<uint64_t> medianItemPos2 = 0;
-        nautilus::val<bool> medianFound1(false);
-        nautilus::val<bool> medianFound2(false);
-
-
-        /// Picking a candidate and counting how many items are smaller or equal to the candidate.
-        /// Iterator-based scan: the page lookup is amortized per page-crossing instead of paid per access,
-        /// which matters here because the outer/inner pair is O(N^2) over the paged vector.
-        const PagedVectorRef pagedVectorRef(BorrowedNautilusBuffer::from(pagedVectorBufferPtr), tupleLayout);
-        const auto pagedVectorEnd = pagedVectorRef.end();
-        nautilus::val<uint64_t> candidatePos = 0;
-        for (auto candidateIt = pagedVectorRef.begin(); candidateIt != pagedVectorEnd; ++candidateIt)
-        {
-            nautilus::val<int64_t> countLessThan = 0;
-            nautilus::val<int64_t> countEqual = 0;
-            const auto candidateRecord = *candidateIt;
-            const auto candidateValue = inputFunction.execute(candidateRecord, pipelineMemoryProvider.arena);
-
-            /// Counting how many items are smaller or equal for the current candidate
-            for (const auto& itemRecord : pagedVectorRef)
-            {
-                const auto itemValue = inputFunction.execute(itemRecord, pipelineMemoryProvider.arena);
-                if (itemValue < candidateValue)
-                {
-                    countLessThan = countLessThan + 1;
-                }
-                if (itemValue == candidateValue)
-                {
-                    countEqual = countEqual + 1;
-                }
-            }
-
-            /// Checking if the current candidate is the median, and if so, storing the position of the median
-            /// The current candidate is the median if the number of items that are smaller or equal to the candidate is larger than the median position
-            if (not medianFound1 && countLessThan <= medianPos1 && medianPos1 < countLessThan + countEqual)
-            {
-                medianItemPos1 = candidatePos;
-                medianFound1 = true;
-            }
-            if (not medianFound2 && countLessThan <= medianPos2 && medianPos2 < countLessThan + countEqual)
-            {
-                medianItemPos2 = candidatePos;
-                medianFound2 = true;
-            }
-            candidatePos = candidatePos + 1;
-        }
-
-        if (medianFound1 and medianFound2)
-        {
-            /// Calculating the median value. Regardless if the number of entries is odd or even, we calculate the median as the average of the two middle values.
-            /// For even numbers of entries, this is its natural definition.
-            /// For odd numbers of entries, both positions are pointing to the same item and thus, we are calculating the average of the same item, which is the item itself.
-            const auto medianRecord1 = pagedVectorRef.at(medianItemPos1);
-            const auto medianRecord2 = pagedVectorRef.at(medianItemPos2);
-
-            const auto medianValue1 = inputFunction.execute(medianRecord1, pipelineMemoryProvider.arena);
-            const auto medianValue2 = inputFunction.execute(medianRecord2, pipelineMemoryProvider.arena);
-            const VarVal two = nautilus::val<uint64_t>(2);
-            medianValue
-                = (medianValue1.castToType(resultType.type) + medianValue2.castToType(resultType.type)) / two.castToType(resultType.type);
-        }
+        /// The name must carry everything the generated code depends on, because a second median of the same name
+        /// reuses this body and drops its own, captured layout. That is the stored column's type: page geometry is
+        /// resolved at runtime, and the captured field name resolves to offset 0 of a single-column layout no
+        /// matter which column it names.
+        const auto& storedType = tupleLayout->getSchema()[0].value().getDataType();
+        auto& lowerFunction = compilationContext.getOrRegisterNautilusFunction<nautilus::val<double>(nautilus::val<TupleBuffer*>)>(
+            fmt::format("Median_lower_{}_{}", magic_enum::enum_name(storedType.type), storedType.nullable ? "N" : "X"),
+            [layout = tupleLayout, field = valueFieldName](const nautilus::val<TupleBuffer*>& pagedVectorBuffer)
+            { return medianOf(pagedVectorBuffer, layout, field); });
+        rawMedian = lowerFunction(pagedVectorBufferPtr);
     }
-
+    const VarVal medianValue = VarVal{rawMedian, true, containsNull}.castToType(resultType.type);
 
     /// Adding the median to the result record
     Record resultRecord;
@@ -220,33 +154,19 @@ Record MedianAggregationPhysicalFunction::lower(
 }
 
 void MedianAggregationPhysicalFunction::reset(
-    const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider& pipelineMemoryProvider)
+    const nautilus::val<AggregationState*> aggregationState,
+    PipelineMemoryProvider& pipelineMemoryProvider,
+    CompilationContext& compilationContext)
 {
-    const nautilus::val<uint64_t> tupleSize = tupleLayout->getSchema().getSizeInBytes();
-    nautilus::invoke(
-        +[](AggregationState* pagedVectorMemArea, AbstractBufferProvider* bufferProvider, uint64_t tupleSize) -> void
-        {
-            /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): aggregation state stores a TupleBuffer at this slot.
-            auto* pagedVectorBufferMemArea = reinterpret_cast<TupleBuffer*>(pagedVectorMemArea);
-            if (auto pagedVectorBuffer = bufferProvider->getUnpooledBuffer(PagedVector::getMainBufferSize()))
-            {
-                /// initialize paged vector buffer
-                PagedVector::init(pagedVectorBuffer.value(), bufferProvider->getBufferSize(), tupleSize);
-                /// @warning: this will be refactored again during the ChainedHashMap refactor
-                new (pagedVectorBufferMemArea) TupleBuffer(pagedVectorBuffer.value());
-                return;
-            }
-            throw BufferAllocationFailure("No unpooled TupleBuffer available for median aggregation paged vector!");
-        },
-        aggregationState + nautilus::val<uint64_t>{static_cast<uint64_t>(inputType.nullable)},
-        pipelineMemoryProvider.bufferProvider,
-        tupleSize);
-
-    if (inputType.nullable)
-    {
-        /// Initialize the null flag to "no value seen yet" so all-NULL windows correctly emit NULL
-        storeNull(aggregationState, true);
-    }
+    using ResetSignature = void(nautilus::val<AggregationState*>, nautilus::val<AbstractBufferProvider*>, nautilus::val<uint64_t>);
+    auto& resetFunction = compilationContext.getOrRegisterNautilusFunction<ResetSignature>(
+        fmt::format("Median_reset_{}", inputType.nullable ? "N" : "X"),
+        [nullable = inputType.nullable](
+            const nautilus::val<AggregationState*>& state,
+            const nautilus::val<AbstractBufferProvider*>& bufferProvider,
+            const nautilus::val<uint64_t>& tupleSize) { medianResetState(state, bufferProvider, tupleSize, nullable); });
+    resetFunction(
+        aggregationState, pipelineMemoryProvider.bufferProvider, nautilus::val<uint64_t>{tupleLayout->getSchema().getSizeInBytes()});
 }
 
 void MedianAggregationPhysicalFunction::cleanup(nautilus::val<AggregationState*> aggregationState)

--- a/nes-physical-operators/src/Aggregation/Function/MedianNautilusFunctions.cpp
+++ b/nes-physical-operators/src/Aggregation/Function/MedianNautilusFunctions.cpp
@@ -1,0 +1,184 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Aggregation/Function/MedianNautilusFunctions.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <Aggregation/Function/AggregationPhysicalFunction.hpp>
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/VarVal.hpp>
+#include <Interface/NautilusBuffer.hpp>
+#include <Interface/PagedVector/PagedVector.hpp>
+#include <Interface/PagedVector/PagedVectorRef.hpp>
+#include <Interface/Record.hpp>
+#include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/TupleBuffer.hpp>
+#include <nautilus/function.hpp>
+#include <ErrorHandling.hpp>
+#include <val_arith.hpp>
+#include <val_bool.hpp>
+#include <val_ptr.hpp>
+
+namespace NES
+{
+
+namespace
+{
+uint64_t medianNumberOfRecords(const TupleBuffer* buffer)
+{
+    const auto pagedVector = PagedVector::load(*buffer);
+    const auto numberOfEntries = pagedVector.getTotalNumberOfRecords();
+    INVARIANT(numberOfEntries > 0, "The number of entries in the paged vector must be greater than 0");
+    return numberOfEntries;
+}
+
+void medianCombinePagedVectors(AbstractBufferProvider* provider, TupleBuffer* vector1Buffer, const TupleBuffer* vector2Buffer)
+{
+    auto vector1 = PagedVector::load(*vector1Buffer);
+    const auto vector2 = PagedVector::load(*vector2Buffer);
+    vector1.copyPagesFrom(*provider, vector2);
+}
+
+void medianInitPagedVectorState(AggregationState* pagedVectorMemArea, AbstractBufferProvider* provider, uint64_t sizeOfTuple)
+{
+    /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): aggregation state stores a TupleBuffer at this slot.
+    auto* pagedVectorBufferMemArea = reinterpret_cast<TupleBuffer*>(pagedVectorMemArea);
+    if (auto pagedVectorBuffer = provider->getUnpooledBuffer(PagedVector::getMainBufferSize()))
+    {
+        /// initialize paged vector buffer
+        PagedVector::init(pagedVectorBuffer.value(), provider->getBufferSize(), sizeOfTuple);
+        /// @warning: this will be refactored again during the ChainedHashMap refactor
+        new (pagedVectorBufferMemArea) TupleBuffer(pagedVectorBuffer.value());
+        return;
+    }
+    throw BufferAllocationFailure("No unpooled TupleBuffer available for median aggregation paged vector!");
+}
+
+}
+
+nautilus::val<double> medianOf(
+    const nautilus::val<TupleBuffer*>& pagedVectorBuffer,
+    const std::shared_ptr<PagedVectorTupleLayout>& tupleLayout,
+    const Record::RecordFieldIdentifier& valueFieldName)
+{
+    const auto numberOfEntries = nautilus::invoke(medianNumberOfRecords, pagedVectorBuffer);
+
+    /// Iterating in two nested loops over all the records in the paged vector to get the median.
+    /// We pick a candidate and then count for each item, if the candidate is smaller and also if the candidate is less than the item.
+    const nautilus::val<int64_t> medianPos1 = (numberOfEntries - 1) / 2;
+    const nautilus::val<int64_t> medianPos2 = numberOfEntries / 2;
+    nautilus::val<uint64_t> medianItemPos1 = 0;
+    nautilus::val<uint64_t> medianItemPos2 = 0;
+    nautilus::val<bool> medianFound1(false);
+    nautilus::val<bool> medianFound2(false);
+
+    /// Picking a candidate and counting how many items are smaller or equal to the candidate.
+    /// Iterator-based scan: the page lookup is amortized per page-crossing instead of paid per access,
+    /// which matters here because the outer/inner pair is O(N^2) over the paged vector.
+    const PagedVectorRef pagedVectorRef(BorrowedNautilusBuffer::from(pagedVectorBuffer), tupleLayout);
+    const auto pagedVectorEnd = pagedVectorRef.end();
+    nautilus::val<uint64_t> candidatePos = 0;
+    for (auto candidateIt = pagedVectorRef.begin(); candidateIt != pagedVectorEnd; ++candidateIt)
+    {
+        nautilus::val<int64_t> countLessThan = 0;
+        nautilus::val<int64_t> countEqual = 0;
+        const auto candidateValue = (*candidateIt).read(valueFieldName);
+
+        /// Counting how many items are smaller or equal for the current candidate
+        for (const auto& itemRecord : pagedVectorRef)
+        {
+            const auto itemValue = itemRecord.read(valueFieldName);
+            if (itemValue < candidateValue)
+            {
+                countLessThan = countLessThan + 1;
+            }
+            if (itemValue == candidateValue)
+            {
+                countEqual = countEqual + 1;
+            }
+        }
+
+        /// Checking if the current candidate is the median, and if so, storing the position of the median
+        /// The current candidate is the median if the number of items that are smaller or equal to the candidate is larger than the median position
+        if (not medianFound1 and countLessThan <= medianPos1 and medianPos1 < countLessThan + countEqual)
+        {
+            medianItemPos1 = candidatePos;
+            medianFound1 = true;
+        }
+        if (not medianFound2 and countLessThan <= medianPos2 and medianPos2 < countLessThan + countEqual)
+        {
+            medianItemPos2 = candidatePos;
+            medianFound2 = true;
+        }
+        candidatePos = candidatePos + 1;
+    }
+
+    VarVal medianValue = VarVal(nautilus::val<double>(0));
+    if (medianFound1 and medianFound2)
+    {
+        /// Calculating the median value. Regardless if the number of entries is odd or even, we calculate the median as the average of the two middle values.
+        /// For even numbers of entries, this is its natural definition.
+        /// For odd numbers of entries, both positions are pointing to the same item and thus, we are calculating the average of the same item, which is the item itself.
+        const auto medianValue1 = pagedVectorRef.at(medianItemPos1).read(valueFieldName);
+        const auto medianValue2 = pagedVectorRef.at(medianItemPos2).read(valueFieldName);
+        const VarVal two = nautilus::val<double>(2);
+        medianValue = (medianValue1.castToType(DataType::Type::FLOAT64) + medianValue2.castToType(DataType::Type::FLOAT64)) / two;
+    }
+    return medianValue.getRawValueAs<nautilus::val<double>>();
+}
+
+void medianCombineStates(
+    const nautilus::val<AggregationState*>& aggregationState1,
+    const nautilus::val<AggregationState*>& aggregationState2,
+    const nautilus::val<AbstractBufferProvider*>& bufferProvider,
+    const bool nullable)
+{
+    /// Getting the paged vectors from the aggregation states
+    auto memArea1 = static_cast<nautilus::val<int8_t*>>(aggregationState1);
+    auto memArea2 = static_cast<nautilus::val<int8_t*>>(aggregationState2);
+
+    if (nullable)
+    {
+        /// SQL-standard: only stay null when both partitions are still empty (no non-null value seen on either side)
+        const auto containsNull1 = AggregationPhysicalFunction::readNull(aggregationState1);
+        const auto containsNull2 = AggregationPhysicalFunction::readNull(aggregationState2);
+        AggregationPhysicalFunction::storeNull(aggregationState1, containsNull1 and containsNull2);
+
+        /// Skipping the first byte (null)
+        memArea1 += nautilus::val<uint64_t>{1};
+        memArea2 += nautilus::val<uint64_t>{1};
+    }
+
+    /// Calling the copyFrom function of the paged vector to combine the two paged vectors by copying the content of the second paged vector to the first paged vector
+    nautilus::invoke(medianCombinePagedVectors, bufferProvider, memArea1, memArea2);
+}
+
+void medianResetState(
+    const nautilus::val<AggregationState*>& aggregationState,
+    const nautilus::val<AbstractBufferProvider*>& bufferProvider,
+    const nautilus::val<uint64_t>& tupleSize,
+    const bool nullable)
+{
+    nautilus::invoke(
+        medianInitPagedVectorState, aggregationState + nautilus::val<uint64_t>{static_cast<uint64_t>(nullable)}, bufferProvider, tupleSize);
+
+    if (nullable)
+    {
+        /// Initialize the null flag to "no value seen yet" so all-NULL windows correctly emit NULL
+        AggregationPhysicalFunction::storeNull(aggregationState, true);
+    }
+}
+
+}

--- a/nes-physical-operators/src/Aggregation/Function/MinAggregationPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Aggregation/Function/MinAggregationPhysicalFunction.cpp
@@ -40,7 +40,10 @@ MinAggregationPhysicalFunction::MinAggregationPhysicalFunction(
 }
 
 void MinAggregationPhysicalFunction::lift(
-    const nautilus::val<AggregationState*>& aggregationState, PipelineMemoryProvider& pipelineMemoryProvider, const Record& record)
+    const nautilus::val<AggregationState*>& aggregationState,
+    PipelineMemoryProvider& pipelineMemoryProvider,
+    CompilationContext&,
+    const Record& record)
 {
     const auto value = inputFunction.execute(record, pipelineMemoryProvider.arena);
 
@@ -76,7 +79,8 @@ void MinAggregationPhysicalFunction::lift(
 void MinAggregationPhysicalFunction::combine(
     const nautilus::val<AggregationState*> aggregationState1,
     const nautilus::val<AggregationState*> aggregationState2,
-    PipelineMemoryProvider&)
+    PipelineMemoryProvider&,
+    CompilationContext&)
 {
     if (not inputType.nullable)
     {
@@ -111,7 +115,8 @@ void MinAggregationPhysicalFunction::combine(
     }
 }
 
-Record MinAggregationPhysicalFunction::lower(const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&)
+Record
+MinAggregationPhysicalFunction::lower(const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&, CompilationContext&)
 {
     if (not inputType.nullable)
     {
@@ -136,7 +141,8 @@ Record MinAggregationPhysicalFunction::lower(const nautilus::val<AggregationStat
     return record;
 }
 
-void MinAggregationPhysicalFunction::reset(const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&)
+void MinAggregationPhysicalFunction::reset(
+    const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&, CompilationContext&)
 {
     /// Initialize the null flag to "no value seen yet" so the first non-null input becomes the running min
     if (inputType.nullable)

--- a/nes-physical-operators/src/Aggregation/Function/SumAggregationPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Aggregation/Function/SumAggregationPhysicalFunction.cpp
@@ -41,7 +41,10 @@ SumAggregationPhysicalFunction::SumAggregationPhysicalFunction(
 }
 
 void SumAggregationPhysicalFunction::lift(
-    const nautilus::val<AggregationState*>& aggregationState, PipelineMemoryProvider& pipelineMemoryProvider, const Record& record)
+    const nautilus::val<AggregationState*>& aggregationState,
+    PipelineMemoryProvider& pipelineMemoryProvider,
+    CompilationContext&,
+    const Record& record)
 {
     const auto value = inputFunction.execute(record, pipelineMemoryProvider.arena);
     if (inputType.nullable)
@@ -72,7 +75,8 @@ void SumAggregationPhysicalFunction::lift(
 void SumAggregationPhysicalFunction::combine(
     const nautilus::val<AggregationState*> aggregationState1,
     const nautilus::val<AggregationState*> aggregationState2,
-    PipelineMemoryProvider&)
+    PipelineMemoryProvider&,
+    CompilationContext&)
 {
     if (inputType.nullable)
     {
@@ -109,7 +113,8 @@ void SumAggregationPhysicalFunction::combine(
     }
 }
 
-Record SumAggregationPhysicalFunction::lower(const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&)
+Record
+SumAggregationPhysicalFunction::lower(const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&, CompilationContext&)
 {
     if (inputType.nullable)
     {
@@ -136,7 +141,8 @@ Record SumAggregationPhysicalFunction::lower(const nautilus::val<AggregationStat
     return record;
 }
 
-void SumAggregationPhysicalFunction::reset(const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&)
+void SumAggregationPhysicalFunction::reset(
+    const nautilus::val<AggregationState*> aggregationState, PipelineMemoryProvider&, CompilationContext&)
 {
     /// Resetting the sum to 0
     const auto memArea = static_cast<nautilus::val<int8_t*>>(aggregationState);

--- a/nes-query-compiler/src/LoweringRules/LowerToPhysical/LowerToPhysicalWindowedAggregation.cpp
+++ b/nes-query-compiler/src/LoweringRules/LowerToPhysical/LowerToPhysicalWindowedAggregation.cpp
@@ -58,6 +58,8 @@
 #include <WindowTypes/Types/TimeBasedWindowType.hpp>
 #include <magic_enum/magic_enum.hpp>
 
+#include <DataTypes/Schema.hpp>
+#include <DataTypes/SchemaFwd.hpp>
 #include <DataTypes/UnboundField.hpp>
 #include <Functions/FieldAccessLogicalFunction.hpp>
 #include <Functions/LogicalFunction.hpp>
@@ -86,7 +88,6 @@ getAggregationPhysicalFunctions(const WindowedAggregationLogicalOperator& logica
     PRECONDITION(memoryLayoutTypeTrait.has_value(), "Expected a memory layout type trait");
     const auto memoryLayoutType = memoryLayoutTypeTrait.value()->memoryLayout;
     const auto physicalInputSchema = createPhysicalOutputSchema(logicalOperator.getChild()->getTraitSet());
-    auto tupleLayout = std::make_shared<DefaultPagedVectorTupleLayout>(physicalInputSchema);
     auto bufferRef = LowerSchemaProvider::lowerSchema(configuration.pageSize.getValue(), physicalInputSchema, memoryLayoutType);
 
     for (const auto& descriptor : aggregationDescriptors)
@@ -98,17 +99,29 @@ getAggregationPhysicalFunctions(const WindowedAggregationLogicalOperator& logica
 
         auto physicalInputType = fieldAccessFunction->getDataType();
         auto physicalFinalType = descriptor.function->getAggregateType();
-        auto aggregationInputFunction = QueryCompilation::FunctionProvider::lowerFunction(
-            fieldAccessFunction, *logicalOperator.getChild().getTraitSet().get<FieldMappingTrait>());
+        const auto& fieldMapping = *logicalOperator.getChild().getTraitSet().get<FieldMappingTrait>();
+        auto aggregationInputFunction = QueryCompilation::FunctionProvider::lowerFunction(fieldAccessFunction, fieldMapping);
         const auto resultFieldIdentifier = descriptor.name;
         auto name = descriptor.function->getName();
+
+        /// Layout under which an aggregation that keeps the individual values around (median) stores them: the
+        /// single column it aggregates, rather than the whole input record. writeRecord skips schema fields the
+        /// record does not carry, so lift can still push the whole record. Narrowing it is what lets the median
+        /// body be shared across aggregations: it reads the stored value by name instead of applying this
+        /// aggregation's column-specific input function.
+        const auto mappedName = fieldMapping.getMapping(fieldAccessFunction->getField().unbound());
+        PRECONDITION(mappedName.has_value(), "Can not find mapping for {}", fieldAccessFunction->getField());
+        const auto aggregatedField = physicalInputSchema.getFieldByName(mappedName.value());
+        PRECONDITION(aggregatedField.has_value(), "Physical input schema has no field {}", mappedName.value());
+        auto aggregatedValueLayout
+            = std::make_shared<DefaultPagedVectorTupleLayout>(Schema<QualifiedUnboundField, Ordered>{aggregatedField.value()});
 
         auto aggregationArguments = AggregationPhysicalFunctionRegistryArguments(
             std::move(physicalInputType),
             std::move(physicalFinalType),
             std::move(aggregationInputFunction),
             resultFieldIdentifier,
-            tupleLayout,
+            aggregatedValueLayout,
             descriptor.function.shallIncludeNullValues());
         if (auto aggregationPhysicalFunction
             = AggregationPhysicalFunctionRegistry::instance().create(std::string{name}, std::move(aggregationArguments)))

--- a/nes-runtime/include/CompilationContext.hpp
+++ b/nes-runtime/include/CompilationContext.hpp
@@ -19,9 +19,12 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 #include <fmt/format.h>
+#include <folly/Synchronized.h>
+#include <nautilus/nautilus_function.hpp>
 #include <Engine.hpp>
 #include <ErrorHandling.hpp>
 #include <Module.hpp>
@@ -74,6 +77,11 @@ class CompilationContext
     /// We assume that a compilation context never outlives the module; both live in CompiledExecutablePipelineStage::start()
     nautilus::engine::NautilusModule& module; /// NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     std::vector<std::function<void(nautilus::engine::CompiledModule&)>> pendingResolvers;
+    /// Type-erased owners of the functions handed out by getOrRegisterNautilusFunction(), keyed by their name.
+    /// In interpreted mode this map is looked up at runtime by every worker thread executing the pipeline, so it
+    /// is guarded. The map is node-based, hence the references handed out stay valid past the lock.
+    /// The name needs to be unique per pipeline.
+    folly::Synchronized<std::unordered_map<std::string, std::shared_ptr<void>>> nautilusFunctions;
     uint64_t functionNameCounter = 0;
     /// Set once resolveAfterCompilation() has run; registering further functions afterwards would append a resolver
     /// that never runs, leaving its handle permanently unresolved, so it is a precondition violation.
@@ -115,6 +123,32 @@ public:
     auto registerFunction(R (*fnptr)(nautilus::val<FunctionArguments>...))
     {
         return registerFunction(std::function<R(nautilus::val<FunctionArguments>...)>(fnptr), "operatorFunction");
+    }
+
+    /// Returns the pipeline's nautilus function of the given name, creating it from body on first use.
+    /// In contrast to registerFunction(), the returned function is called from *inside* traced code: its body is
+    /// traced once into the pipeline's module and called instead of being inlined at every call site. Operators
+    /// that would otherwise inline the same body N times per pipeline (N aggregations, N joins, ...) derive a
+    /// name from the shape of the body and share the single instantiation this hands out.
+    ///
+    /// The functions live as long as this context, i.e. as long as the pipeline stage: in interpreted mode the
+    /// bodies are not compiled but invoked directly, every time the pipeline runs. That is also why, unlike
+    /// registerFunction(), this may be called after the module has been compiled -- it hands out nothing that
+    /// would still need resolving, and why it must be safe to call from several worker threads at once.
+    template <typename Signature>
+    nautilus::NautilusFunction<std::function<Signature>>&
+    getOrRegisterNautilusFunction(const std::string& name, std::function<Signature> body)
+    {
+        using Function = nautilus::NautilusFunction<std::function<Signature>>;
+        auto locked = nautilusFunctions.wlock();
+        auto& stored = (*locked)[name];
+        if (stored == nullptr)
+        {
+            /// NautilusFunction is neither copyable nor movable, so it is constructed in place and kept behind a
+            /// type-erased shared_ptr, which retains the deleter of the concrete type.
+            stored = std::make_shared<Function>(name, std::move(body));
+        }
+        return *std::static_pointer_cast<Function>(stored);
     }
 
     /// Called by CompiledExecutablePipelineStage once, directly after compiling the pipeline's module.

--- a/nes-runtime/include/ExecutionContext.hpp
+++ b/nes-runtime/include/ExecutionContext.hpp
@@ -44,6 +44,8 @@
 namespace NES
 {
 
+class CompilationContext;
+
 /// Struct that combines the arena and the buffer provider. This struct combines the functionality of the arena and the buffer provider,
 /// allowing the operator to allocate two different types of memory, in regard to their lifetime.
 /// 1. Memory for a pipeline invocation: Arena
@@ -103,6 +105,11 @@ struct ExecutionContext final
 
     void setOpenReturnState(OpenReturnState openReturnState);
     [[nodiscard]] OpenReturnState getOpenReturnState() const;
+
+    /// The context compiling this pipeline, so that operators can register shared nautilus functions from their
+    /// traced code. Only set while the pipeline is being set up and traced, which is the only time it is needed.
+    [[nodiscard]] CompilationContext& getCompilationContext() const;
+    CompilationContext* compilationContext = nullptr;
 
     const nautilus::val<PipelineExecutionContext*> pipelineContext;
     nautilus::val<WorkerThreadId> workerThreadId;

--- a/nes-runtime/include/Pipelines/CompiledExecutablePipelineStage.hpp
+++ b/nes-runtime/include/Pipelines/CompiledExecutablePipelineStage.hpp
@@ -23,6 +23,7 @@
 #include <Runtime/TupleBuffer.hpp>
 #include <nautilus/Engine.hpp>
 #include <nautilus/Module.hpp>
+#include <CompilationContext.hpp>
 #include <ExecutablePipelineStage.hpp>
 #include <ExecutionContext.hpp>
 #include <Pipeline.hpp>
@@ -53,10 +54,14 @@ private:
     static constexpr std::string_view PIPELINE_FUNCTION_NAME = "execute";
 
     /// Registers the pipeline's main traced function in the pipeline's module.
-    void registerPipelineFunction(nautilus::engine::NautilusModule& module) const;
+    void registerPipelineFunction(nautilus::engine::NautilusModule& module, CompilationContext& compilationContext) const;
 
     nautilus::engine::NautilusEngine engine;
-    /// Both are created lazily in start(); neither type is default-constructible.
+    /// All created lazily in start(); none of the types is default-constructible. The module and its compilation
+    /// context outlive start() because in interpreted mode the pipeline function is not compiled but invoked
+    /// through the traced lambdas themselves, which still resolve shared nautilus functions out of the context.
+    std::optional<nautilus::engine::NautilusModule> module;
+    std::optional<CompilationContext> compilationContext;
     std::optional<nautilus::engine::CompiledModule> compiledModule;
     std::optional<nautilus::engine::ModuleFunction<PipelineSignature>> compiledPipelineFunction;
     std::unordered_map<OperatorHandlerId, std::shared_ptr<OperatorHandler>> operatorHandlers;

--- a/nes-runtime/src/ExecutionContext.cpp
+++ b/nes-runtime/src/ExecutionContext.cpp
@@ -31,6 +31,7 @@
 #include <Util/Logger/Logger.hpp>
 #include <Util/StdInt.hpp>
 #include <nautilus/function.hpp>
+#include <CompilationContext.hpp>
 #include <ErrorHandling.hpp>
 #include <OperatorState.hpp>
 #include <PipelineExecutionContext.hpp>
@@ -113,6 +114,12 @@ void ExecutionContext::setOpenReturnState(const OpenReturnState openReturnState)
 OpenReturnState ExecutionContext::getOpenReturnState() const
 {
     return this->openReturnState;
+}
+
+CompilationContext& ExecutionContext::getCompilationContext() const
+{
+    INVARIANT(compilationContext != nullptr, "The compilation context is only available while the pipeline is compiled");
+    return *compilationContext;
 }
 
 OperatorState* ExecutionContext::getLocalState(const OperatorId operatorId)

--- a/nes-runtime/src/Pipelines/CompiledExecutablePipelineStage.cpp
+++ b/nes-runtime/src/Pipelines/CompiledExecutablePipelineStage.cpp
@@ -57,7 +57,8 @@ void CompiledExecutablePipelineStage::execute(const TupleBuffer& inputTupleBuffe
     (*compiledPipelineFunction)(std::addressof(pipelineExecutionContext), std::addressof(inputTupleBuffer), std::addressof(arena));
 }
 
-void CompiledExecutablePipelineStage::registerPipelineFunction(nautilus::engine::NautilusModule& module) const
+void CompiledExecutablePipelineStage::registerPipelineFunction(
+    nautilus::engine::NautilusModule& module, CompilationContext& compilationContext) const
 {
     /// Capture the stage by pointer rather than the pipeline shared_ptr: this compiled function is only ever invoked
     /// through execute()/start()/stop() on the owning stage, so the stage (and thus its pipeline) outlives every call.
@@ -67,12 +68,15 @@ void CompiledExecutablePipelineStage::registerPipelineFunction(nautilus::engine:
     /// Additionally, we can NOT use const or const references for the parameters of the lambda function
     /// NOLINTBEGIN(performance-unnecessary-value-param)
     const std::function<void(nautilus::val<PipelineExecutionContext*>, nautilus::val<const TupleBuffer*>, nautilus::val<const Arena*>)>
-        compiledFunction = [this](
+        compiledFunction = [this, &compilationContext](
                                nautilus::val<PipelineExecutionContext*> pipelineExecutionContext,
                                nautilus::val<const TupleBuffer*> recordBufferRef,
                                nautilus::val<const Arena*> arenaRef)
     {
         auto ctx = ExecutionContext(pipelineExecutionContext, arenaRef);
+        /// The compilation context is a member of the stage, so it stays valid for every invocation of this
+        /// lambda: in interpreted mode that is not only the tracing run inside compile(), but every execute().
+        ctx.compilationContext = std::addressof(compilationContext);
         RecordBuffer recordBuffer(recordBufferRef);
 
         pipeline->getRootOperator().open(ctx, recordBuffer);
@@ -119,11 +123,12 @@ void CompiledExecutablePipelineStage::start(PipelineExecutionContext& pipelineEx
     /// all of them together. Only afterwards do the handles handed out during setup() become invocable.
     CPPTRACE_TRY
     {
-        auto module = engine.createModule();
-        CompilationContext compilationCtx{module};
+        auto& newModule = module.emplace(engine.createModule());
+        auto& compilationCtx = compilationContext.emplace(newModule);
+        ctx.compilationContext = std::addressof(compilationCtx);
         pipeline->getRootOperator().setup(ctx, compilationCtx);
-        registerPipelineFunction(module);
-        compiledModule = module.compile();
+        registerPipelineFunction(newModule, compilationCtx);
+        compiledModule = newModule.compile();
         compilationCtx.resolveAfterCompilation(*compiledModule);
         compiledPipelineFunction = compiledModule->getFunction<PipelineSignature>(std::string{PIPELINE_FUNCTION_NAME});
 

--- a/nes-systests/differential/AggregationEquiValence.test
+++ b/nes-systests/differential/AggregationEquiValence.test
@@ -1,6 +1,6 @@
 # name: differential/AggregationEquivalence.test
 # description: Ensure differential queries agree for logically equivalent aggregation
-# groups: [Differential, Aggregation, CompilationIntensive] TODO #1272
+# groups: [Differential, Aggregation]
 
 CREATE LOGICAL SOURCE stream(id UINT64 NOT NULL, value UINT64 NOT NULL, timestamp UINT64 NOT NULL);
 CREATE PHYSICAL SOURCE FOR stream TYPE Generator SET(

--- a/nes-systests/operator/aggregation/WindowAggregationDifferentDataTypes.test
+++ b/nes-systests/operator/aggregation/WindowAggregationDifferentDataTypes.test
@@ -2,6 +2,10 @@
 # description: Test window aggregations over different data types
 # groups: [Aggregation, WindowOperators, CompilationIntensive] TODO #1272
 
+# The last query aggregates 100 medians, each keeping a TupleBuffer of its own in the aggregation state, which
+# does not fit a hash map entry at the default page size of 1024 bytes.
+GlobalConfiguration worker.default_query_execution.page_size: [16384]
+
 
 CREATE LOGICAL SOURCE stream(i8 INT8 NOT NULL, i16 INT16 NOT NULL, i32 INT32 NOT NULL, i64 INT64 NOT NULL, u8 UINT8 NOT NULL, u16 UINT16 NOT NULL, u32 UINT32 NOT NULL, u64 UINT64 NOT NULL, f32 FLOAT32 NOT NULL, f64 FLOAT64 NOT NULL, c CHAR NOT NULL, ts UINT64 NOT NULL);
 CREATE PHYSICAL SOURCE FOR stream TYPE File;
@@ -201,3 +205,42 @@ FROM stream WINDOW SLIDING(ts, size 100 ms, advance by 50 ms) INTO sinkStreamAll
 250,350,-42,-126,-10921.6666666667,4,3,263,3,8,23,10
 300,400,-42,-124,-10920.6666666667,5,3,269,3,9,23,11
 350,450,2,3,4,5,1,7,1,9,10,11
+
+
+# Checking that many medians in one query still produce the correct result for each of them, as all medians
+# of the same data type share a single compiled function. The first three rounds cover every type, the rest
+# pick their input field at random so the types are unevenly distributed.
+SELECT start, end, MEDIAN(i8) as i8_out, MEDIAN(i16) as i16_out, MEDIAN(i32) as i32_out, MEDIAN(i64) as i64_out,
+       MEDIAN(u8) as u8_out, MEDIAN(u16) as u16_out, MEDIAN(u32) as u32_out, MEDIAN(u64) as u64_out,
+       MEDIAN(f32) as f32_out, MEDIAN(f64) as f64_out, MEDIAN(i8) as i8_out1, MEDIAN(i16) as i16_out1,
+       MEDIAN(i32) as i32_out1, MEDIAN(i64) as i64_out1, MEDIAN(u8) as u8_out1, MEDIAN(u16) as u16_out1,
+       MEDIAN(u32) as u32_out1, MEDIAN(u64) as u64_out1, MEDIAN(f32) as f32_out1, MEDIAN(f64) as f64_out1,
+       MEDIAN(i8) as i8_out2, MEDIAN(i16) as i16_out2, MEDIAN(i32) as i32_out2, MEDIAN(i64) as i64_out2,
+       MEDIAN(u8) as u8_out2, MEDIAN(u16) as u16_out2, MEDIAN(u32) as u32_out2, MEDIAN(u64) as u64_out2,
+       MEDIAN(f32) as f32_out2, MEDIAN(f64) as f64_out2, MEDIAN(f64) as f64_out3, MEDIAN(u8) as u8_out4,
+       MEDIAN(u16) as u16_out5, MEDIAN(i16) as i16_out6, MEDIAN(f32) as f32_out7, MEDIAN(i8) as i8_out8,
+       MEDIAN(u32) as u32_out9, MEDIAN(i16) as i16_out10, MEDIAN(i32) as i32_out11, MEDIAN(u32) as u32_out12,
+       MEDIAN(f64) as f64_out13, MEDIAN(f32) as f32_out14, MEDIAN(i8) as i8_out15, MEDIAN(i8) as i8_out16,
+       MEDIAN(u32) as u32_out17, MEDIAN(u8) as u8_out18, MEDIAN(u64) as u64_out19, MEDIAN(f64) as f64_out20,
+       MEDIAN(u16) as u16_out21, MEDIAN(u16) as u16_out22, MEDIAN(i32) as i32_out23, MEDIAN(u8) as u8_out24,
+       MEDIAN(u8) as u8_out25, MEDIAN(i64) as i64_out26, MEDIAN(f32) as f32_out27, MEDIAN(f64) as f64_out28,
+       MEDIAN(i32) as i32_out29, MEDIAN(f32) as f32_out30, MEDIAN(u16) as u16_out31, MEDIAN(i16) as i16_out32,
+       MEDIAN(u16) as u16_out33, MEDIAN(i32) as i32_out34, MEDIAN(u16) as u16_out35, MEDIAN(u8) as u8_out36,
+       MEDIAN(i8) as i8_out37, MEDIAN(u16) as u16_out38, MEDIAN(i32) as i32_out39, MEDIAN(u8) as u8_out40,
+       MEDIAN(i64) as i64_out41, MEDIAN(f64) as f64_out42, MEDIAN(i64) as i64_out43, MEDIAN(i16) as i16_out44,
+       MEDIAN(i32) as i32_out45, MEDIAN(u64) as u64_out46, MEDIAN(u8) as u8_out47, MEDIAN(f32) as f32_out48,
+       MEDIAN(u64) as u64_out49, MEDIAN(i16) as i16_out50, MEDIAN(i16) as i16_out51, MEDIAN(u64) as u64_out52,
+       MEDIAN(u64) as u64_out53, MEDIAN(f64) as f64_out54, MEDIAN(u8) as u8_out55, MEDIAN(i8) as i8_out56,
+       MEDIAN(u32) as u32_out57, MEDIAN(u16) as u16_out58, MEDIAN(i64) as i64_out59, MEDIAN(i16) as i16_out60,
+       MEDIAN(i16) as i16_out61, MEDIAN(i16) as i16_out62, MEDIAN(u16) as u16_out63, MEDIAN(i32) as i32_out64,
+       MEDIAN(f64) as f64_out65, MEDIAN(u16) as u16_out66, MEDIAN(u32) as u32_out67, MEDIAN(u32) as u32_out68,
+       MEDIAN(u64) as u64_out69, MEDIAN(u64) as u64_out70, MEDIAN(u8) as u8_out71, MEDIAN(u8) as u8_out72
+FROM stream WINDOW SLIDING(ts, size 100 ms, advance by 50 ms) INTO File();
+----
+50,150,1.5,2.5,3.5,4.5,5.5,6.5,7.5,8.5,9.5,10.5,1.5,2.5,3.5,4.5,5.5,6.5,7.5,8.5,9.5,10.5,1.5,2.5,3.5,4.5,5.5,6.5,7.5,8.5,9.5,10.5,10.5,5.5,6.5,2.5,9.5,1.5,7.5,2.5,3.5,7.5,10.5,9.5,1.5,1.5,7.5,5.5,8.5,10.5,6.5,6.5,3.5,5.5,5.5,4.5,9.5,10.5,3.5,9.5,6.5,2.5,6.5,3.5,6.5,5.5,1.5,6.5,3.5,5.5,4.5,10.5,4.5,2.5,3.5,8.5,5.5,9.5,8.5,2.5,2.5,8.5,8.5,10.5,5.5,1.5,7.5,6.5,4.5,2.5,2.5,2.5,6.5,3.5,10.5,6.5,7.5,7.5,8.5,8.5,5.5,5.5
+100,200,1,2,3,4,5,6,7,8,9,10,1,2,3,4,5,6,7,8,9,10,1,2,3,4,5,6,7,8,9,10,10,5,6,2,9,1,7,2,3,7,10,9,1,1,7,5,8,10,6,6,3,5,5,4,9,10,3,9,6,2,6,3,6,5,1,6,3,5,4,10,4,2,3,8,5,9,8,2,2,8,8,10,5,1,7,6,4,2,2,2,6,3,10,6,7,7,8,8,5,5
+150,250,-21,-64.5,-16384.5,-1073741824.5,21,128,32768,2147483648,11.5,11.5,-21,-64.5,-16384.5,-1073741824.5,21,128,32768,2147483648,11.5,11.5,-21,-64.5,-16384.5,-1073741824.5,21,128,32768,2147483648,11.5,11.5,11.5,21,128,-64.5,11.5,-21,32768,-64.5,-16384.5,32768,11.5,11.5,-21,-21,32768,21,2147483648,11.5,128,128,-16384.5,21,21,-1073741824.5,11.5,11.5,-16384.5,11.5,128,-64.5,128,-16384.5,128,21,-21,128,-16384.5,21,-1073741824.5,11.5,-1073741824.5,-64.5,-16384.5,2147483648,21,11.5,2147483648,-64.5,-64.5,2147483648,2147483648,11.5,21,-21,32768,128,-1073741824.5,-64.5,-64.5,-64.5,128,-16384.5,11.5,128,32768,32768,2147483648,2147483648,21,21
+200,300,-20.5,-64,-16384,-1073741824,21.5,128.5,32768.5,2147483648.5,12,12,-20.5,-64,-16384,-1073741824,21.5,128.5,32768.5,2147483648.5,12,12,-20.5,-64,-16384,-1073741824,21.5,128.5,32768.5,2147483648.5,12,12,12,21.5,128.5,-64,12,-20.5,32768.5,-64,-16384,32768.5,12,12,-20.5,-20.5,32768.5,21.5,2147483648.5,12,128.5,128.5,-16384,21.5,21.5,-1073741824,12,12,-16384,12,128.5,-64,128.5,-16384,128.5,21.5,-20.5,128.5,-16384,21.5,-1073741824,12,-1073741824,-64,-16384,2147483648.5,21.5,12,2147483648.5,-64,-64,2147483648.5,2147483648.5,12,21.5,-20.5,32768.5,128.5,-1073741824,-64,-64,-64,128.5,-16384,12,128.5,32768.5,32768.5,2147483648.5,2147483648.5,21.5,21.5
+250,350,1,1,1,1,5,6,7,8,9,10,1,1,1,1,5,6,7,8,9,10,1,1,1,1,5,6,7,8,9,10,10,5,6,1,9,1,7,1,1,7,10,9,1,1,7,5,8,10,6,6,1,5,5,1,9,10,1,9,6,1,6,1,6,5,1,6,1,5,1,10,1,1,1,8,5,9,8,1,1,8,8,10,5,1,7,6,1,1,1,1,6,1,10,6,7,7,8,8,5,5
+300,400,1,2,3,4,6,7,8,9,10,11,1,2,3,4,6,7,8,9,10,11,1,2,3,4,6,7,8,9,10,11,11,6,7,2,10,1,8,2,3,8,11,10,1,1,8,6,9,11,7,7,3,6,6,4,10,11,3,10,7,2,7,3,7,6,1,7,3,6,4,11,4,2,3,9,6,10,9,2,2,9,9,11,6,1,8,7,4,2,2,2,7,3,11,7,8,8,9,9,6,6
+350,450,2,3,4,5,6,7,8,9,10,11,2,3,4,5,6,7,8,9,10,11,2,3,4,5,6,7,8,9,10,11,11,6,7,3,10,2,8,3,4,8,11,10,2,2,8,6,9,11,7,7,4,6,6,5,10,11,4,10,7,3,7,4,7,6,2,7,4,6,5,11,5,3,4,9,6,10,9,3,3,9,9,11,6,2,8,7,5,3,3,3,7,4,11,7,8,8,9,9,6,6

--- a/nes-systests/operator/aggregation/WindowAggregationDifferentDataTypes.test
+++ b/nes-systests/operator/aggregation/WindowAggregationDifferentDataTypes.test
@@ -1,6 +1,6 @@
 # name: window/WindowAggregationDifferentDataTypes.test
 # description: Test window aggregations over different data types
-# groups: [Aggregation, WindowOperators, CompilationIntensive] TODO #1272
+# groups: [Aggregation, WindowOperators]
 
 # The last query aggregates 100 medians, each keeping a TupleBuffer of its own in the aggregation state, which
 # does not fit a hash map entry at the default page size of 1024 bytes.

--- a/nes-systests/operator/aggregation/WindowAggregationDifferentDataTypesKeyed.test
+++ b/nes-systests/operator/aggregation/WindowAggregationDifferentDataTypesKeyed.test
@@ -1,6 +1,6 @@
 # name: window/WindowAggregationDifferentDataTypesKeyed.test
 # description: Test window aggregations over different data types for keyed windows
-# groups: [Aggregation, WindowOperators, CompilationIntensive] TODO #1272
+# groups: [Aggregation, WindowOperators]
 
 
 CREATE LOGICAL SOURCE stream(keyI8 INT8 NOT NULL, keyI16 INT16 NOT NULL, keyU64 UINT64 NOT NULL, i8 INT8 NOT NULL, i16 INT16 NOT NULL, i32 INT32 NOT NULL, i64 INT64 NOT NULL, u8 UINT8 NOT NULL, u16 UINT16 NOT NULL, u32 UINT32 NOT NULL, u64 UINT64 NOT NULL, f32 FLOAT32 NOT NULL, f64 FLOAT64 NOT NULL, ts UINT64 NOT NULL, c CHAR NOT NULL);

--- a/nes-systests/operator/aggregation/WindowAggregationDifferentDataTypesKeyedVarSized.test
+++ b/nes-systests/operator/aggregation/WindowAggregationDifferentDataTypesKeyedVarSized.test
@@ -1,6 +1,6 @@
 # name: window/WindowAggregationDifferentDataTypesKeyed.test
 # description: Test window aggregations over different data types for keyed windows with the key being a varsized
-# groups: [Aggregation, WindowOperators, CompilationIntensive] TODO #1272
+# groups: [Aggregation, WindowOperators]
 
 
 CREATE LOGICAL SOURCE stream(keyI8 VARSIZED NOT NULL, keyI16 VARSIZED NOT NULL, keyU64 VARSIZED NOT NULL, i8 INT8 NOT NULL, i16 INT16 NOT NULL, i32 INT32 NOT NULL, i64 INT64 NOT NULL, u8 UINT8 NOT NULL, u16 UINT16 NOT NULL, u32 UINT32 NOT NULL, u64 UINT64 NOT NULL, f32 FLOAT32 NOT NULL, f64 FLOAT64 NOT NULL, ts UINT64 NOT NULL);

--- a/nes-systests/operator/aggregation/WindowAggregationProjection.test
+++ b/nes-systests/operator/aggregation/WindowAggregationProjection.test
@@ -1,6 +1,6 @@
 # name: window/WindowAggregationProjection.test
 # description: Test projection over window operators
-# groups: [Aggregation, WindowOperators, Projection, CompilationIntensive] TODO #1272
+# groups: [Aggregation, WindowOperators, Projection]
 
 # Source definitions
 CREATE LOGICAL SOURCE stream(id UINT64 NOT NULL, value UINT64 NOT NULL, timestamp UINT64 NOT NULL);

--- a/nes-systests/operator/aggregation/WindowAggregationStackedAggregations.test
+++ b/nes-systests/operator/aggregation/WindowAggregationStackedAggregations.test
@@ -1,6 +1,6 @@
 # name: window/WindowAggregationStackedAggregations.test
 # description: Test window aggregations over different data types for (keyed) windows with stacked aggregations
-# groups: [Aggregation, WindowOperators, CompilationIntensive] TODO #1272
+# groups: [Aggregation, WindowOperators]
 
 # Source definitions
 CREATE LOGICAL SOURCE stream(id UINT64 NOT NULL, value UINT64 NOT NULL, timestamp UINT64 NOT NULL);

--- a/nes-systests/windows/SlidingWindowsWithGap.test
+++ b/nes-systests/windows/SlidingWindowsWithGap.test
@@ -1,6 +1,6 @@
 # name: windows/SlidingWindowsWithGap.test
 # description: Tests windowed operators with sliding windows that have a gap, i.e., size >= slide
-# groups: [WindowOperators, Join, Aggregation, CompilationIntensive] TODO #1272
+# groups: [WindowOperators, Join, Aggregation]
 
 # Source definitions
 CREATE LOGICAL SOURCE stream(id UINT64 NOT NULL, value UINT64 NOT NULL, timestamp1 UINT64 NOT NULL);


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

The compilation of physical aggregation functions is expensive because each aggregation's `lift`/`combine`/`lower` body is traced and **inlined** into the build/probe pipeline functions. For median this is the worst case: its `lower` is a doubly-nested loop, and a query with many `MEDIAN` aggregations inlines that loop once per aggregation, blowing up the traced pipeline and slowing compilation.

This PR extracts the median bodies into dedicated **nautilus functions** (`NautilusFunction`, i.e. cross-calls compiled once and called from the pipeline) so they are no longer inlined. Since nautilus deduplicates functions by name, naming them purely by data type means all medians of the same type in a pipeline share a single compiled instantiation.

Change log:
- Added a global, statically-allocated templated table `MedianFunctionTable<InputT, ResultT, Nullable>` holding the four extracted nautilus functions (`lift`, `combine`, `lower`, `reset`) with clear, type-derived names (e.g. `Median_lower_INT64_FLOAT64_X`). `combine`/`reset` depend only on nullability and are named/shared accordingly.
- The bodies are free, type-parametric function templates (no per-instance capture) so they can be global statics shared across all medians of the same type.
- The virtual `lift`/`combine`/`lower`/`reset` are now thin wrappers that keep the column-specific work in the main pipeline trace (compute the input value via `inputFunction` into a scratch slot; read the lowered result from a scratch slot before writing the result field) and forward to the selected functions via a `MedianFunctions` pointer struct.
- The paged vector now stores **only the single aggregated value** per row (a one-column buffer derived from the input type) instead of the whole input record, so `lower` reads that value directly rather than re-applying `inputFunction`. `getSizeOfStateInBytes()` is unchanged, so the hash-map layout and the lowering rule are untouched.
- Scope is **median only**; the same pattern can be applied to Sum/Min/Max/Count/Avg later. The change is self-contained in `MedianAggregationPhysicalFunction.hpp/.cpp`.

## Verifying this change

This change should be covered by the existing aggregation systests (no behavior change intended):
- `nes-systests/operator/aggregation/WindowAggregationNull.test`, `WindowAggregationDifferentDataTypes*.test`, `WindowAggregationStackedAggregations.test`, `ExpressionInsideAggregation.test`, `ColumnNames.test`, `AggregationOfUnion.test`
- `nes-systests/differential/AggregationEquiValence.test`, `nes-systests/guide/guide8.test`

The intended win can be confirmed by compiling a query with many `MEDIAN`s and checking that the probe module emits a single `Median_lower_*` per distinct type instead of one inlined copy per aggregation.

## What components does this pull request potentially affect?

- ExecutionEngine (physical aggregation functions / nautilus code generation)
- QueryCompiler (only indirectly; the windowed-aggregation lowering rule is unchanged)

## Documentation

- The change is reflected in in-code documentation (class and helper comments in `MedianAggregationPhysicalFunction`).