### PR TITLE
Fixes SLT Benchmarking Mode

### DIFF
--- a/nes-systests/regression/2026-07-23_BenchmarkModeIgnoresGlobalConfiguration.test
+++ b/nes-systests/regression/2026-07-23_BenchmarkModeIgnoresGlobalConfiguration.test
@@ -1,0 +1,37 @@
+# description: Benchmarking mode (-b) must apply a test's GlobalConfiguration to the worker. It used to pass the
+# base worker configuration straight to runQueriesAndBenchmark while still printing the override in the query
+# label, so the override silently had no effect and only surfaced as an unrelated crash deep inside a query.
+#
+# This query keeps one paged vector per median in the aggregation state, so its hash map entry does not fit a
+# page at the default size of 1024 bytes: without the page size below, lowering aborts on the entriesPerPage
+# invariant instead of running. Run it with -b, where the regression lived.
+# groups: [regression]
+
+GlobalConfiguration worker.default_query_execution.page_size: [16384]
+
+CREATE LOGICAL SOURCE stream(value INT64 NOT NULL, ts UINT64 NOT NULL);
+CREATE PHYSICAL SOURCE FOR stream TYPE File;
+ATTACH INLINE
+1,100
+3,150
+5,200
+
+SELECT start, end, MEDIAN(value) as out0, MEDIAN(value) as out1, MEDIAN(value) as out2, MEDIAN(value) as out3,
+       MEDIAN(value) as out4, MEDIAN(value) as out5, MEDIAN(value) as out6, MEDIAN(value) as out7,
+       MEDIAN(value) as out8, MEDIAN(value) as out9, MEDIAN(value) as out10, MEDIAN(value) as out11,
+       MEDIAN(value) as out12, MEDIAN(value) as out13, MEDIAN(value) as out14, MEDIAN(value) as out15,
+       MEDIAN(value) as out16, MEDIAN(value) as out17, MEDIAN(value) as out18, MEDIAN(value) as out19,
+       MEDIAN(value) as out20, MEDIAN(value) as out21, MEDIAN(value) as out22, MEDIAN(value) as out23,
+       MEDIAN(value) as out24, MEDIAN(value) as out25, MEDIAN(value) as out26, MEDIAN(value) as out27,
+       MEDIAN(value) as out28, MEDIAN(value) as out29, MEDIAN(value) as out30, MEDIAN(value) as out31,
+       MEDIAN(value) as out32, MEDIAN(value) as out33, MEDIAN(value) as out34, MEDIAN(value) as out35,
+       MEDIAN(value) as out36, MEDIAN(value) as out37, MEDIAN(value) as out38, MEDIAN(value) as out39,
+       MEDIAN(value) as out40, MEDIAN(value) as out41, MEDIAN(value) as out42, MEDIAN(value) as out43,
+       MEDIAN(value) as out44, MEDIAN(value) as out45, MEDIAN(value) as out46, MEDIAN(value) as out47,
+       MEDIAN(value) as out48, MEDIAN(value) as out49, MEDIAN(value) as out50, MEDIAN(value) as out51,
+       MEDIAN(value) as out52, MEDIAN(value) as out53, MEDIAN(value) as out54, MEDIAN(value) as out55,
+       MEDIAN(value) as out56, MEDIAN(value) as out57, MEDIAN(value) as out58, MEDIAN(value) as out59,
+       MEDIAN(value) as out60, MEDIAN(value) as out61, MEDIAN(value) as out62, MEDIAN(value) as out63
+FROM stream WINDOW TUMBLING(ts, size 1000 ms) INTO File();
+----
+0,1000,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3

--- a/nes-systests/sinks/AnonymousSink.test
+++ b/nes-systests/sinks/AnonymousSink.test
@@ -71,3 +71,15 @@ FROM File(
 	'CSV' AS INPUT_FORMATTER."TYPE",
 	SCHEMA(id UINT64 NOT NULL, value UINT64 NOT NULL, timestamp UINT64 NOT NULL) AS "SOURCE"."SCHEMA")
 INTO Checksum();
+
+
+# The sink type is looked up as written, so "FileSink" does not resolve to the registered "File" sink and the
+# query must be rejected with an error instead of being silently accepted.
+SELECT ID, VALUE, TIMESTAMP
+FROM File(
+	'small/stream8.csv' AS "SOURCE".FILE_PATH,
+	'CSV' AS INPUT_FORMATTER."TYPE",
+	SCHEMA(id UINT64 NOT NULL, value UINT64 NOT NULL, timestamp UINT64 NOT NULL) AS "SOURCE"."SCHEMA")
+INTO FileSink();
+----
+ERROR 1000

--- a/nes-systests/systest/CMakeLists.txt
+++ b/nes-systests/systest/CMakeLists.txt
@@ -124,6 +124,13 @@ if (NOT CODE_COVERAGE)
                 COMMAND systest -n 20 --show-query-performance --workingDir=${CMAKE_CURRENT_BINARY_DIR}/compiler_sliceCache_${enableSliceCache} --exclude-groups ${SYSTEST_EXCLUDE_GROUPS_COMPILER} --data ${EXPANDED_TEST_DATA_PATH} -- --worker.query_engine.number_of_worker_threads=4 --worker.default_query_execution.execution_mode=COMPILER --enable_event_trace=true --worker.total_memory_in_bytes=${SYSTEST_JOIN_TOTAL_MEMORY_BYTES} --worker.unpooled_memory_fraction=${SYSTEST_JOIN_UNPOOLED_FRACTION} --worker.default_query_execution.slice_cache.enable_slice_cache=${enableSliceCache})
         set_tests_properties(systest_compiler_sliceCache_${enableSliceCache} PROPERTIES LABELS "Systest" PROCESSORS 4)
     endforeach ()
+
+    # Benchmarking mode (-b) drives the runner sequentially and writes BenchmarkResults.json. Without this target the only -b
+    # coverage is systest_large_benchmark_*, which is gated behind ENABLE_LARGE_TESTS.
+    ExternalData_Add_Test(test-data
+            NAME systest_benchmark_small
+            COMMAND systest -b --show-query-performance --workingDir=${CMAKE_CURRENT_BINARY_DIR}/benchmark_small --exclude-groups ${SYSTEST_EXCLUDE_GROUPS_COMPILER} --data ${EXPANDED_TEST_DATA_PATH} -- --worker.query_engine.number_of_worker_threads=4 --worker.default_query_execution.execution_mode=COMPILER --worker.total_memory_in_bytes=${SYSTEST_JOIN_TOTAL_MEMORY_BYTES} --worker.unpooled_memory_fraction=${SYSTEST_JOIN_UNPOOLED_FRACTION} --worker.default_query_execution.slice_cache.enable_slice_cache=true)
+    set_tests_properties(systest_benchmark_small PROPERTIES LABELS "Systest" PROCESSORS 4)
 endif (NOT CODE_COVERAGE)
 
 

--- a/nes-systests/systest/src/SystestExecutor.cpp
+++ b/nes-systests/systest/src/SystestExecutor.cpp
@@ -372,11 +372,27 @@ SystestExecutorResult SystestExecutor::executeSystests()
                     benchmarkQueries.push_back(query);
                 }
 
+                /// Benchmarked queries honour their configuration override just like the regular path does: queries
+                /// are grouped by override and each group runs against a worker configured with it.
+                std::unordered_map<Systest::ConfigurationOverride, std::vector<Systest::SystestQuery>> benchmarkQueriesByOverride;
+                for (const auto& query : benchmarkQueries)
+                {
+                    benchmarkQueriesByOverride[query.configurationOverride].push_back(query);
+                }
+
                 progressTracker.reset();
                 progressTracker.setTotalQueries(benchmarkQueries.size());
-                auto failed = runQueriesAndBenchmark(
-                    benchmarkQueries, singleNodeWorkerConfiguration, benchmarkResults, config.clusterConfig, progressTracker);
-                failedQueries.insert(failedQueries.end(), failed.begin(), failed.end());
+                for (const auto& [overrideConfig, queriesForConfig] : benchmarkQueriesByOverride)
+                {
+                    auto configCopy = singleNodeWorkerConfiguration;
+                    for (const auto& [key, value] : overrideConfig.overrideParameters)
+                    {
+                        configCopy.overwriteConfigWithCommandLineInput({{key, value}});
+                    }
+                    auto failed
+                        = runQueriesAndBenchmark(queriesForConfig, configCopy, benchmarkResults, config.clusterConfig, progressTracker);
+                    failedQueries.insert(failedQueries.end(), failed.begin(), failed.end());
+                }
                 const auto serializedResults = rfl::json::write(benchmarkResults, rfl::json::pretty);
                 std::cout << serializedResults;
                 const auto outputPath = std::filesystem::path(config.workingDir.getValue()) / "BenchmarkResults.json";

--- a/nes-systests/systest/src/SystestRunner.cpp
+++ b/nes-systests/systest/src/SystestRunner.cpp
@@ -26,6 +26,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <iterator>
 #include <memory>
 #include <optional>
 #include <ostream>
@@ -430,115 +431,6 @@ std::vector<RunningQuery> runQueries(
 
 /// NOLINTEND(readability-function-cognitive-complexity)
 
-namespace
-{
-std::vector<RunningQuery>
-serializeExecutionResults(const std::vector<RunningQuery>& queries, std::vector<BenchmarkResult>& benchmarkResults)
-{
-    std::vector<RunningQuery> failedQueries;
-    for (const auto& queryRan : queries)
-    {
-        if (!queryRan.passed)
-        {
-            failedQueries.emplace_back(queryRan);
-        }
-        const auto executionTimeInSeconds = queryRan.getElapsedTime().count();
-        benchmarkResults.push_back(
-            {.queryName = queryRan.systestQuery.testName,
-             .time = executionTimeInSeconds,
-             .bytesPerSecond = static_cast<double>(queryRan.bytesProcessed.value_or(NAN)) / executionTimeInSeconds,
-             .tuplesPerSecond = static_cast<double>(queryRan.tuplesProcessed.value_or(NAN)) / executionTimeInSeconds});
-    }
-    return failedQueries;
-}
-}
-
-std::vector<RunningQuery> runQueriesAndBenchmark(
-    const std::vector<SystestQuery>& queries,
-    const SingleNodeWorkerConfiguration& configuration,
-    std::vector<BenchmarkResult>& benchmarkResults,
-    const SystestClusterConfiguration& clusterConfig,
-    SystestProgressTracker& progressTracker)
-{
-    auto catalog = std::make_shared<WorkerCatalog>(clusterConfig.workers);
-
-    auto worker = std::make_unique<QueryManager>(std::move(catalog), createEmbeddedBackend(configuration));
-    QuerySubmitter submitter(std::move(worker));
-    std::vector<std::shared_ptr<RunningQuery>> ranQueries;
-    progressTracker.reset();
-    progressTracker.setTotalQueries(queries.size());
-    for (auto it = queries.rbegin(); it != queries.rend(); ++it)
-    {
-        const auto& queryToRun = *it;
-        if (not queryToRun.planInfoOrException.has_value())
-        {
-            NES_ERROR("skip failing query: {}", queryToRun.testName);
-            continue;
-        }
-
-        const auto startResult = submitter.startQuery(queryToRun.planInfoOrException.value().queryPlan);
-        if (not startResult.has_value())
-        {
-            NES_ERROR("skip failing query: {}", queryToRun.testName);
-            continue;
-        }
-        auto queryId = startResult.value();
-
-        auto runningQueryPtr = std::make_shared<RunningQuery>(queryToRun, queryId);
-        runningQueryPtr->passed = false;
-        ranQueries.emplace_back(runningQueryPtr);
-        const auto summary = submitter.finishedQueries().at(0);
-
-        if (summary.getGlobalQueryStatus() == DistributedQueryStatus::Failed)
-        {
-            NES_ERROR("Query {} has failed with: {}", queryId, summary.coalesceException());
-            continue;
-        }
-
-        if (summary.getGlobalQueryStatus() != DistributedQueryStatus::Stopped)
-        {
-            NES_ERROR("Query {} terminated in unexpected state {}", queryId, summary.getGlobalQueryStatus());
-            continue;
-        }
-
-        runningQueryPtr->queryStatus = summary;
-
-        /// Getting the size and no. tuples of all input files to pass this information to currentRunningQuery.bytesProcessed
-        size_t bytesProcessed = 0;
-        size_t tuplesProcessed = 0;
-        for (const auto& [sourcePath, sourceOccurrencesInQuery] :
-             queryToRun.planInfoOrException.value().sourcesToFilePathsAndCounts | std::views::values)
-        {
-            if (not(std::filesystem::exists(sourcePath.getRawValue()) and sourcePath.getRawValue().has_filename()))
-            {
-                NES_ERROR("Source path is empty or does not exist.");
-                bytesProcessed = 0;
-                tuplesProcessed = 0;
-                break;
-            }
-
-            bytesProcessed += (std::filesystem::file_size(sourcePath.getRawValue()) * sourceOccurrencesInQuery);
-
-            /// Counting the lines, i.e., \n in the sourcePath
-            std::ifstream inFile(sourcePath.getRawValue());
-            tuplesProcessed
-                += std::count(std::istreambuf_iterator(inFile), std::istreambuf_iterator<char>(), '\n') * sourceOccurrencesInQuery;
-        }
-        ranQueries.back()->bytesProcessed = bytesProcessed;
-        ranQueries.back()->tuplesProcessed = tuplesProcessed;
-
-        auto errorMessage = checkResult(*ranQueries.back());
-        ranQueries.back()->passed = not errorMessage.has_value();
-        const auto queryPerformanceMessage
-            = fmt::format(" in {} ({})", ranQueries.back()->getElapsedTime(), ranQueries.back()->getThroughput());
-        progressTracker.incrementQueryCounter();
-        printQueryResultToStdOut(*ranQueries.back(), errorMessage.value_or(""), progressTracker, queryPerformanceMessage);
-    }
-
-    return serializeExecutionResults(
-        ranQueries | std::views::transform([](const auto& query) { return *query; }) | std::ranges::to<std::vector>(), benchmarkResults);
-}
-
 void printQueryResultToStdOut(
     const RunningQuery& runningQuery,
     const std::string& errorMessage,
@@ -602,6 +494,60 @@ std::vector<RunningQuery> runQueriesAtLocalWorker(
 
     QuerySubmitter submitter(std::make_unique<QueryManager>(std::move(catalog), createEmbeddedBackend(configuration)));
     return runQueries(queries, numConcurrentQueries, submitter, progressTracker, queryPerformanceMessage);
+}
+
+namespace
+{
+/// Size and no. tuples of all input files of the query, so that the throughput can be derived from the elapsed time.
+void recordProcessedInput(RunningQuery& runningQuery)
+{
+    size_t bytesProcessed = 0;
+    size_t tuplesProcessed = 0;
+    for (const auto& [sourcePath, sourceOccurrencesInQuery] :
+         runningQuery.systestQuery.planInfoOrException.value().sourcesToFilePathsAndCounts | std::views::values)
+    {
+        if (not(std::filesystem::exists(sourcePath.getRawValue()) and sourcePath.getRawValue().has_filename()))
+        {
+            NES_ERROR("Source path is empty or does not exist.");
+            bytesProcessed = 0;
+            tuplesProcessed = 0;
+            break;
+        }
+
+        bytesProcessed += (std::filesystem::file_size(sourcePath.getRawValue()) * sourceOccurrencesInQuery);
+
+        /// Counting the lines, i.e., \n in the sourcePath
+        std::ifstream inFile(sourcePath.getRawValue());
+        tuplesProcessed += std::count(std::istreambuf_iterator(inFile), std::istreambuf_iterator<char>(), '\n') * sourceOccurrencesInQuery;
+    }
+    runningQuery.bytesProcessed = bytesProcessed;
+    runningQuery.tuplesProcessed = tuplesProcessed;
+}
+}
+
+std::vector<RunningQuery> runQueriesAndBenchmark(
+    const std::vector<SystestQuery>& queries,
+    const SingleNodeWorkerConfiguration& configuration,
+    std::vector<BenchmarkResult>& benchmarkResults,
+    const SystestClusterConfiguration& clusterConfig,
+    SystestProgressTracker& progressTracker)
+{
+    /// The performance message builder is invoked exactly once per query that reached the stopped state, which is exactly the set of
+    /// queries that can be timed. That makes it the hook for collecting the benchmark results.
+    const QueryPerformanceMessageBuilder benchmarkQuery = [&benchmarkResults](RunningQuery& runningQuery)
+    {
+        recordProcessedInput(runningQuery);
+        const auto executionTimeInSeconds = runningQuery.getElapsedTime().count();
+        benchmarkResults.push_back(
+            {.queryName = runningQuery.systestQuery.testName,
+             .time = executionTimeInSeconds,
+             .bytesPerSecond = static_cast<double>(runningQuery.bytesProcessed.value_or(NAN)) / executionTimeInSeconds,
+             .tuplesPerSecond = static_cast<double>(runningQuery.tuplesProcessed.value_or(NAN)) / executionTimeInSeconds});
+        return fmt::format(" in {} ({})", runningQuery.getElapsedTime(), runningQuery.getThroughput());
+    };
+
+    /// Benchmarking runs one query at a time so that the timings are not skewed by concurrently running queries.
+    return runQueriesAtLocalWorker(queries, 1, clusterConfig, configuration, progressTracker, benchmarkQuery);
 }
 
 std::vector<RunningQuery> runQueriesAtRemoteWorker(


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR includes two fixes for the benchmarking mode `-b` of our system level test. 
1. Passing exceptions to cout
2. Passing GlobalConfiguration in `.test`files to the worker

## Verifying this change
This change is tested by existing and newly added tests.

## What components does this pull request potentially affect?
- System Level Tests
