### PR TITLE
fix(CI): harden sccache in large tests

### DIFF
--- a/.github/workflows/large_test.yml
+++ b/.github/workflows/large_test.yml
@@ -42,12 +42,6 @@ jobs:
         - /var/run/docker.sock:/var/run/docker.sock
       env:
         MOLD_JOBS: 1
-        SCCACHE_BUCKET: ${{ secrets.SCCACHE_CACHE_BUCKET }}
-        SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_CACHE_ENDPOINT }}
-        SCCACHE_REGION: auto
-        SCCACHE_S3_USE_SSL: "true"
-        AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_CACHE_ACCESS_KEY }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_CACHE_SECRET_KEY }}
       # TODO #401 Investigate rootless docker containers
       options: --user root
     timeout-minutes: 40
@@ -63,10 +57,23 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.head_sha }}
+      - uses: ./.github/steps/setup-sccache
+        with:
+          bucket: ${{ secrets.SCCACHE_CACHE_BUCKET }}
+          endpoint: ${{ secrets.SCCACHE_CACHE_ENDPOINT }}
+          access_key: ${{ secrets.SCCACHE_CACHE_ACCESS_KEY }}
+          secret_key: ${{ secrets.SCCACHE_CACHE_SECRET_KEY }}
       - name: Configure NebulaStream
-        run: cmake -GNinja -B build -DUSE_SANITIZER=${{ matrix.sanitizer }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_LARGE_TESTS=ON -DExternalData_OBJECT_STORES=/test-file-cache -DNES_LOG_LEVEL=DEBUG
+        run: |
+          sccache --start-server
+          sccache --show-stats
+          cmake -GNinja -B build -DUSE_SANITIZER=${{ matrix.sanitizer }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_LARGE_TESTS=ON -DExternalData_OBJECT_STORES=/test-file-cache -DNES_LOG_LEVEL=DEBUG
       - name: Build NebulaStream
-        run: cmake --build build --target systest -j
+        run: |
+          sccache --show-stats
+          cmake --build build --target systest -j
+          sccache --show-stats
+          sccache --stop-server
       - name: Run large System Level Tests
         run: |
           echo "Running all large tests with: "
@@ -120,10 +127,23 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.head_sha }}
+      - uses: ./.github/steps/setup-sccache
+        with:
+          bucket: ${{ secrets.SCCACHE_CACHE_BUCKET }}
+          endpoint: ${{ secrets.SCCACHE_CACHE_ENDPOINT }}
+          access_key: ${{ secrets.SCCACHE_CACHE_ACCESS_KEY }}
+          secret_key: ${{ secrets.SCCACHE_CACHE_SECRET_KEY }}
       - name: Configure NebulaStream
-        run: cmake -GNinja -B build -DUSE_SANITIZER=${{ matrix.sanitizer }} -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_LARGE_TESTS=ON -DExternalData_OBJECT_STORES=/test-file-cache -DLARGE_TEST_TOTAL_MEMORY_BYTES=76911476736
+        run: |
+          sccache --start-server
+          sccache --show-stats
+          cmake -GNinja -B build -DUSE_SANITIZER=${{ matrix.sanitizer }} -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_LARGE_TESTS=ON -DExternalData_OBJECT_STORES=/test-file-cache -DLARGE_TEST_TOTAL_MEMORY_BYTES=76911476736
       - name: Build NebulaStream
-        run: cmake --build build --target systest nes-single-node-worker -j
+        run: |
+          sccache --show-stats
+          cmake --build build --target systest nes-single-node-worker -j
+          sccache --show-stats
+          sccache --stop-server
       - name: Run systest remote test
         run: ctest --test-dir build --output-on-failure --timeout 2400 -R systest-remote-test
       - name: Upload Test Logs on Failure


### PR DESCRIPTION
## Summary

- configure both large-test build jobs through the shared `setup-sccache` action
- start the sccache daemon before CMake configuration
- check daemon health immediately before each parallel build and report final cache statistics

## Why

Large-scale CI builds occasionally fail when multiple Ninja compiler invocations race to start sccache, producing `Timed out waiting for server startup`. Unlike the main build-and-test workflow, the large-test workflow bypassed the shared setup action and therefore missed its increased startup and idle timeouts as well as explicit daemon startup.

This change applies the existing build-and-test hardening to both the regular large-scale test job and the remote systest job. Fork builds also gain the shared action's local-cache fallback when remote-cache credentials are unavailable.

## Validation

- parsed `.github/workflows/large_test.yml` successfully with Ruby YAML
- `git diff --check`
