### PR TITLE
fix(CI): harden sccache in log level tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -162,13 +162,18 @@ jobs:
         with:
           image_name: nebulastream/nes-ci:${{ inputs.dev_image_tag }}-libcxx-none
           run: |
+            sccache --start-server
+            sccache --show-stats
             for LOG_LEVEL in TRACE DEBUG INFO WARN ERROR LEVEL_NONE; do
               echo "=== ${{ matrix.build_type }} / ${LOG_LEVEL} ==="
               cmake -GNinja -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DNES_LOG_LEVEL=$LOG_LEVEL
+              sccache --show-stats
               cmake --build build --target nes-common-tests -j -- -k 0
               ctest --test-dir build -j --output-on-failure --output-junit build/junit-log-${{ matrix.build_type }}-${LOG_LEVEL}.xml --timeout 600 -R "testLogLevel"
               cmake --build build --target clean
             done
+            sccache --show-stats
+            sccache --stop-server
 
   clean-build-and-test-linux:
     # Ensures the build works from a clean build directory and that the dev image


### PR DESCRIPTION
## Summary

- start the sccache daemon before the log-level build loop
- check daemon health before every parallel build
- report final cache statistics and stop the daemon after the matrix shard completes

## Why

The log-level test job already uses the shared `setup-sccache` action and receives its increased startup and idle timeouts, but it still relied on compiler invocations to start the daemon implicitly. Under Ninja's parallel launch, that can race and fail with `Timed out waiting for server startup`.

This applies the explicit startup and pre-build heartbeat pattern already used by the main build-and-test workflow.

## Validation

- parsed `.github/workflows/build_and_test.yml` successfully with Ruby YAML
- `git diff --check`
