### PR TITLE
ci: require large-memory runner for remote systests

### DIFF
--- a/.github/workflows/large_test.yml
+++ b/.github/workflows/large_test.yml
@@ -116,7 +116,7 @@ jobs:
         MOLD_JOBS: 1
       options: --user root
     timeout-minutes: 40
-    runs-on: [ self-hosted, linux, Build, "${{matrix.arch}}" ]
+    runs-on: [ self-hosted, linux, Build, "${{matrix.arch}}", large-memory ]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What changed

- Require the `large-memory` runner label for the remote system-test job.

## Why

The remote large-scale topology starts two workers with a combined declared memory budget of 153,822,953,472 bytes (about 144 GiB). The generic x64 runner pool includes machines with only about 126 GiB, causing the test to fail during its memory preflight before the workload starts.

This routes the job to the runner set that has sufficient physical memory while leaving the single-process large-test matrix unchanged.

## Validation

- Parsed `.github/workflows/large_test.yml` successfully with `yq`.
- `git diff --check` passes.
- Confirmed the label is applied only to `systest-remote-test`.