### PR TITLE
feat(QueryOptimizer): handle multi-sink plans in optimization rules 

### DIFF
--- a/nes-logical-operators/include/Plans/LogicalPlan.hpp
+++ b/nes-logical-operators/include/Plans/LogicalPlan.hpp
@@ -66,22 +66,18 @@ private:
 /// Get all parent operators of the target operator
 [[nodiscard]] std::vector<LogicalOperator> getParents(const LogicalPlan& plan, const LogicalOperator& target);
 
+/// All operators reachable from any root, each one exactly once. BFSRange alone yields a shared operator once per path.
+[[nodiscard]] std::vector<LogicalOperator> planOperators(const LogicalPlan& plan);
+
 [[nodiscard]] LogicalPlan addRootOperators(const LogicalPlan& plan, const std::vector<LogicalOperator>& rootsToAdd);
 
+/// Every operator of the given type, each one exactly once even if it is shared between sink roots.
 template <LogicalOperatorConcept T>
 [[nodiscard]] std::vector<TypedLogicalOperator<T>> getOperatorByType(const LogicalPlan& plan)
 {
-    std::vector<TypedLogicalOperator<T>> operators;
-    std::ranges::for_each(
-        plan.getRootOperators(),
-        [&operators](const auto& rootOperator)
-        {
-            auto typedOps = BFSRange(rootOperator)
-                | std::views::filter([&](const LogicalOperator& op) { return op.tryGetAs<T>().has_value(); })
-                | std::views::transform([](const LogicalOperator& op) { return op.getAs<T>(); });
-            std::ranges::copy(typedOps, std::back_inserter(operators));
-        });
-    return operators;
+    return planOperators(plan) | std::views::filter([](const LogicalOperator& op) { return op.tryGetAs<T>().has_value(); })
+        | std::views::transform([](const LogicalOperator& op) { return op.getAs<T>(); })
+        | std::ranges::to<std::vector<TypedLogicalOperator<T>>>();
 }
 
 [[nodiscard]] std::optional<LogicalOperator> getOperatorById(const LogicalPlan& plan, OperatorId operatorId);

--- a/nes-logical-operators/src/Plans/LogicalPlan.cpp
+++ b/nes-logical-operators/src/Plans/LogicalPlan.cpp
@@ -137,24 +137,57 @@ std::vector<LogicalOperator> getParents(const LogicalPlan& plan, const LogicalOp
     return parents;
 }
 
+std::vector<LogicalOperator> planOperators(const LogicalPlan& plan)
+{
+    std::vector<LogicalOperator> operators;
+    std::unordered_set<OperatorId> visited;
+    for (const auto& root : plan.getRootOperators())
+    {
+        for (const auto& op : BFSRange(root))
+        {
+            if (visited.insert(op.getId()).second)
+            {
+                operators.push_back(op);
+            }
+        }
+    }
+    return operators;
+}
+
+namespace
+{
+/// Marks an operator an earlier sink already rendered; repeating its sub-plan would read as if each sink had a copy.
+constexpr std::string_view SharedOperatorMarker = " [shared]";
+
+void dumpOperator( /// NOLINT(misc-no-recursion)
+    const LogicalOperator& op,
+    const std::size_t level,
+    std::ostream& out,
+    const ExplainVerbosity verbosity,
+    std::unordered_set<OperatorId>& alreadyDumped)
+{
+    const std::string indent(level * 2, ' ');
+    if (not alreadyDumped.insert(op.getId()).second)
+    {
+        out << indent << op.explain(verbosity) << SharedOperatorMarker << '\n';
+        return;
+    }
+
+    out << indent << op.explain(verbosity) << '\n';
+    for (const auto& child : op.getChildren())
+    {
+        dumpOperator(child, level + 1, out, verbosity, alreadyDumped);
+    }
+}
+}
+
 std::string explain(const LogicalPlan& plan, ExplainVerbosity verbosity)
 {
     std::stringstream stringstream;
-    if (verbosity == ExplainVerbosity::Short)
+    std::unordered_set<OperatorId> alreadyDumped;
+    for (const auto& rootOperator : plan.getRootOperators())
     {
-        auto dumpHandler = QueryConsoleDumpHandler<LogicalPlan, LogicalOperator>(stringstream, false, ExplainVerbosity::Short);
-        for (const auto& rootOperator : plan.getRootOperators())
-        {
-            dumpHandler.dump({rootOperator});
-        }
-    }
-    else
-    {
-        auto dumpHandler = QueryConsoleDumpHandler<LogicalPlan, LogicalOperator>(stringstream, false, ExplainVerbosity::Debug);
-        for (const auto& rootOperator : plan.getRootOperators())
-        {
-            dumpHandler.dump({rootOperator});
-        }
+        dumpOperator(rootOperator, 0, stringstream, verbosity, alreadyDumped);
     }
     return stringstream.str();
 }

--- a/nes-logical-operators/src/Serialization/QueryPlanSerializationUtil.cpp
+++ b/nes-logical-operators/src/Serialization/QueryPlanSerializationUtil.cpp
@@ -22,7 +22,6 @@
 #include <vector>
 
 #include <Identifiers/Identifiers.hpp>
-#include <Iterators/BFSIterator.hpp>
 #include <Operators/LogicalOperator.hpp>
 #include <Operators/Sinks/SinkLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
@@ -44,24 +43,16 @@ namespace NES
 
 SerializableQueryPlan QueryPlanSerializationUtil::serializeQueryPlan(const LogicalPlan& queryPlan)
 {
-    INVARIANT(queryPlan.getRootOperators().size() == 1, "Query plan should currently have only one root operator");
-    auto rootOperator = queryPlan.getRootOperators().front();
+    INVARIANT(not queryPlan.getRootOperators().empty(), "Query plan should have at least one root operator");
 
     SerializableQueryPlan serializableQueryPlan;
     if (queryPlan.getQueryId().isValid())
     {
         *serializableQueryPlan.mutable_queryid() = serializeQueryId(queryPlan.getQueryId());
     }
-    /// Serialize Query Plan operators
-    std::set<OperatorId> alreadySerialized;
-    for (auto itr : BFSRange(rootOperator))
+    /// Serialize Query Plan operators. Shared operators are serialized once; the children ids restore the sharing.
+    for (const auto& itr : planOperators(queryPlan))
     {
-        if (alreadySerialized.contains(itr.getId()))
-        {
-            /// Skip rest of the steps as the operator is already serialized
-            continue;
-        }
-        alreadySerialized.insert(itr.getId());
         NES_TRACE("QueryPlan: Inserting operator in collection of already visited node.");
 
         auto childrenIds = itr->getChildren() | std::views::transform([](const auto& child) { return child->getOperatorId(); })
@@ -78,8 +69,10 @@ SerializableQueryPlan QueryPlanSerializationUtil::serializeQueryPlan(const Logic
     }
 
     /// Serialize the root operator ids
-    auto rootOperatorId = rootOperator.getId();
-    serializableQueryPlan.add_rootoperatorids(rootOperatorId.getRawValue());
+    for (const auto& rootOperator : queryPlan.getRootOperators())
+    {
+        serializableQueryPlan.add_rootoperatorids(rootOperator.getId().getRawValue());
+    }
     return serializableQueryPlan;
 }
 
@@ -152,29 +145,25 @@ LogicalPlan QueryPlanSerializationUtil::deserializeQueryPlan(const SerializableQ
         }
     }
 
-    if (rootOperators.size() != 1)
+    for (const auto& rootOperator : rootOperators)
     {
-        throw CannotDeserialize("Plan contains multiple root operators!");
-    }
+        const auto sinkOpt = rootOperator.tryGetAs<SinkLogicalOperator>();
+        if (!sinkOpt)
+        {
+            throw CannotDeserialize("Plan root has to be a sink, but got {} from\n{}", rootOperator, serializedQueryPlan.DebugString());
+        }
+        const auto& sink = sinkOpt.value();
 
-    auto sinkOpt = rootOperators.at(0).tryGetAs<SinkLogicalOperator>();
-    if (!sinkOpt)
-    {
-        throw CannotDeserialize("Plan root has to be a sink, but got {} from\n{}", rootOperators.at(0), serializedQueryPlan.DebugString());
-    }
-    auto sink = std::move(sinkOpt).value();
+        if (sink->getChildren().empty())
+        {
+            throw CannotDeserialize("Sink has no children! From\n{}", serializedQueryPlan.DebugString());
+        }
 
-    if (sink->getChildren().empty())
-    {
-        throw CannotDeserialize("Sink has no children! From\n{}", serializedQueryPlan.DebugString());
+        if (not sink->getSinkDescriptor())
+        {
+            throw CannotDeserialize("Sink has no descriptor!");
+        }
     }
-
-    if (not sink->getSinkDescriptor())
-    {
-        throw CannotDeserialize("Sink has no descriptor!");
-    }
-
-    rootOperators = std::vector<LogicalOperator>{sink};
 
     /// 4) Finalize plan
     auto queryId = INVALID_QUERY_ID;

--- a/nes-logical-operators/tests/LogicalPlanTest.cpp
+++ b/nes-logical-operators/tests/LogicalPlanTest.cpp
@@ -143,6 +143,20 @@ TEST_F(LogicalPlanTest, GetOperatorByType)
     EXPECT_EQ(LogicalOperator{sourceOperators[0]}, sourceOp);
 }
 
+TEST_F(LogicalPlanTest, PlanOperatorsVisitsSharedOperatorsOnce)
+{
+    /// Two sinks reading one sub-plan, as a multi-sink query produces it.
+    const auto sourceOp = SourceNameLogicalOperator::create(Identifier::parse("source"));
+    const auto selectionOp = SelectionLogicalOperator::create(UnboundFieldAccessLogicalFunction{Identifier::parse("field")})
+                                 .withChildrenUnsafe(std::vector<LogicalOperator>{sourceOp});
+    const LogicalOperator sinkA{SinkLogicalOperator::create(Identifier::parse("sinkA")).withChildrenUnsafe({selectionOp})};
+    const LogicalOperator sinkB{SinkLogicalOperator::create(Identifier::parse("sinkB")).withChildrenUnsafe({selectionOp})};
+    const LogicalPlan plan(INVALID_QUERY_ID, {sinkA, sinkB});
+
+    EXPECT_EQ(planOperators(plan).size(), 4);
+    EXPECT_EQ(getOperatorByType<SourceNameLogicalOperator>(plan).size(), 1);
+}
+
 TEST_F(LogicalPlanTest, GetOperatorsById)
 {
     const auto sourceOp = SourceNameLogicalOperator::create(Identifier::parse("TestSource"));

--- a/nes-plugins/Rules/RedundantUnionRemovalRule/RedundantUnionRemovalRule.cpp
+++ b/nes-plugins/Rules/RedundantUnionRemovalRule/RedundantUnionRemovalRule.cpp
@@ -14,7 +14,6 @@
 
 #include <RedundantUnionRemovalRule.hpp>
 
-#include <ranges>
 #include <set>
 #include <string_view>
 #include <typeindex>
@@ -30,32 +29,29 @@
 #include <Rules/Barriers/SemanticAnalysisBarrier.hpp>
 
 #include <ErrorHandling.hpp>
+#include <PlanRewriteUtils.hpp>
 #include <PlanRuleRegistry.hpp>
 
 namespace NES
 {
 
 
-namespace
-{
-LogicalOperator recur(const LogicalOperator& op)
-{
-    auto newChildren = op.getChildren() | std::views::transform(recur) | std::ranges::to<std::vector>();
-
-    if (op.tryGetAs<UnionLogicalOperator>().has_value() && newChildren.size() == 1)
-    {
-        return newChildren.front();
-    }
-    return op.withChildren(std::move(newChildren));
-}
-}
-
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 LogicalPlan RedundantUnionRemovalRule::apply(LogicalPlan queryPlan) const
 {
-    PRECONDITION(queryPlan.getRootOperators().size() == 1, "Query plan must have exactly one root operator");
-    queryPlan = queryPlan.withRootOperators({recur(queryPlan.getRootOperators().front().withInferredSchema())});
-    return queryPlan;
+    PRECONDITION(not queryPlan.getRootOperators().empty(), "Query must have a sink root operator");
+    /// No upfront deep schema inference: withChildren re-infers each operator's local schema bottom-up,
+    /// while a recursive withInferredSchema would copy shared subtrees per parent.
+    return rewritePlanBottomUp(
+        queryPlan,
+        [](const LogicalOperator& op, std::vector<LogicalOperator> newChildren) -> LogicalOperator
+        {
+            if (op.tryGetAs<UnionLogicalOperator>().has_value() && newChildren.size() == 1)
+            {
+                return newChildren.front();
+            }
+            return op.withChildren(std::move(newChildren));
+        });
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-plugins/Rules/RedundantUnionRemovalRule/RedundantUnionRemovalRuleTest.cpp
+++ b/nes-plugins/Rules/RedundantUnionRemovalRule/RedundantUnionRemovalRuleTest.cpp
@@ -131,5 +131,22 @@ TEST_F(RedundantUnionRemovalRuleTest, LeaveUnionWithMultipleChildren)
     ASSERT_TRUE(op21.tryGetAs<SourceDescriptorLogicalOperator>());
 }
 
+/// A union shared by two sinks must be removed once, leaving both sinks reading one instance of the sub-plan below it.
+TEST_F(RedundantUnionRemovalRuleTest, RemovesSharedUnionOnce)
+{
+    auto source = utils.createSource("redundant_union_src", {"a", "b"});
+    auto unionOp = UnionLogicalOperator::create(std::vector<LogicalOperator>{source});
+    auto sink1 = utils.createSink(unionOp, "redundant_union_sink1", {"a", "b"});
+    auto sink2 = utils.createSink(unionOp, "redundant_union_sink2", {"a", "b"});
+
+    const auto result = RedundantUnionRemovalRule{}.apply(utils.createPlan({sink1, sink2}));
+
+    const auto roots = result.getRootOperators();
+    ASSERT_EQ(roots.size(), 2);
+    EXPECT_EQ(roots.at(0).getChildren().at(0).getId(), roots.at(1).getChildren().at(0).getId());
+    EXPECT_TRUE(roots.at(0).getChildren().at(0).tryGetAs<SourceDescriptorLogicalOperator>().has_value());
+    EXPECT_EQ(OptimizerTestUtils::collectOperators(result).size(), 3);
+}
+
 /// NOLINTEND(bugprone-unchecked-optional-access)
 }

--- a/nes-query-optimizer/include/PlanRewriteUtils.hpp
+++ b/nes-query-optimizer/include/PlanRewriteUtils.hpp
@@ -14,9 +14,15 @@
 
 #pragma once
 
+#include <functional>
 #include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 #include <Functions/LogicalFunction.hpp>
+#include <Identifiers/Identifiers.hpp>
+#include <Operators/LogicalOperatorFwd.hpp>
+#include <Plans/LogicalPlan.hpp>
 #include <Schema/Field.hpp>
 
 namespace NES
@@ -24,5 +30,18 @@ namespace NES
 
 /// recursively replaces field accesses of given LogicalFunction if they are a key in given field map with the field the key points to
 LogicalFunction replaceFieldAccesses(const LogicalFunction& function, const std::unordered_map<Field, Field>& fields);
+
+/// Returns the ids of all operators that are reachable through more than one parent edge in the (possibly DAG-shaped) plan.
+/// Duplicate edges from the same parent (e.g. a union reading the same input twice) count as sharing as well.
+[[nodiscard]] std::unordered_set<OperatorId> getSharedOperatorIds(const LogicalPlan& plan);
+
+/// Rewrites all operators of a (possibly DAG-shaped) plan bottom-up.
+/// The rewrite function is invoked exactly once per unique operator (identified by the input plan's OperatorId) with the original
+/// operator and its already-rewritten children. The result is memoized and reused for every additional parent, so operators shared
+/// between multiple parents stay shared in the rewritten plan. Children are rewritten left-to-right and roots in order, making the
+/// invocation order deterministic for stateful rewrite functions.
+[[nodiscard]] LogicalPlan rewritePlanBottomUp(
+    const LogicalPlan& plan,
+    const std::function<LogicalOperator(const LogicalOperator& original, std::vector<LogicalOperator> rewrittenChildren)>& rewrite);
 
 }

--- a/nes-query-optimizer/include/PlanRewriteUtils.hpp
+++ b/nes-query-optimizer/include/PlanRewriteUtils.hpp
@@ -17,10 +17,12 @@
 #include <functional>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include <Functions/LogicalFunction.hpp>
 #include <Identifiers/Identifiers.hpp>
+#include <Operators/LogicalOperator.hpp>
 #include <Operators/LogicalOperatorFwd.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <Schema/Field.hpp>
@@ -35,11 +37,37 @@ LogicalFunction replaceFieldAccesses(const LogicalFunction& function, const std:
 /// Duplicate edges from the same parent (e.g. a union reading the same input twice) count as sharing as well.
 [[nodiscard]] std::unordered_set<OperatorId> getSharedOperatorIds(const LogicalPlan& plan);
 
-/// Rewrites all operators of a (possibly DAG-shaped) plan bottom-up.
-/// The rewrite function is invoked exactly once per unique operator (identified by the input plan's OperatorId) with the original
-/// operator and its already-rewritten children. The result is memoized and reused for every additional parent, so operators shared
-/// between multiple parents stay shared in the rewritten plan. Children are rewritten left-to-right and roots in order, making the
-/// invocation order deterministic for stateful rewrite functions.
+/// Shared state for one pushdown-rule invocation over a (possibly DAG-shaped) plan. A shared operator (reachable through
+/// more than one parent, see getSharedOperatorIds) is a pushdown barrier: it is rewritten once with empty pending state
+/// and reused by every parent, which re-introduces its own pending state above the barrier — so one parent's pushdown
+/// cannot corrupt what a sibling parent reads through the same shared subtree.
+struct PushdownBarrier
+{
+    std::unordered_set<OperatorId> sharedOperatorIds;
+    std::unordered_map<OperatorId, LogicalOperator> rewrittenSharedOperators;
+
+    explicit PushdownBarrier(const LogicalPlan& plan) : sharedOperatorIds(getSharedOperatorIds(plan)) { }
+
+    [[nodiscard]] bool isShared(const LogicalOperator& op) const { return sharedOperatorIds.contains(op.getId()); }
+
+    /// Rewrites a shared operator at most once (memoized) and reuses it for every parent. `rewriteWithoutPending()`
+    /// produces the canonical rewrite; `materializeAbove(rewritten)` re-introduces the calling parent's pending state.
+    template <typename RewriteWithoutPending, typename MaterializeAbove>
+    LogicalOperator
+    rewriteShared(const LogicalOperator& op, RewriteWithoutPending&& rewriteWithoutPending, MaterializeAbove&& materializeAbove)
+    {
+        auto rewritten = rewrittenSharedOperators.find(op.getId());
+        if (rewritten == rewrittenSharedOperators.end())
+        {
+            rewritten = rewrittenSharedOperators.emplace(op.getId(), std::forward<RewriteWithoutPending>(rewriteWithoutPending)()).first;
+        }
+        return std::forward<MaterializeAbove>(materializeAbove)(rewritten->second);
+    }
+};
+
+/// Rewrites all operators of a (possibly DAG-shaped) plan bottom-up. `rewrite` is invoked once per unique operator (keyed
+/// on the input OperatorId) with the original operator and its already-rewritten children; the result is memoized and reused
+/// for every parent, so shared operators stay shared. Deterministic order: children left-to-right, roots in order.
 [[nodiscard]] LogicalPlan rewritePlanBottomUp(
     const LogicalPlan& plan,
     const std::function<LogicalOperator(const LogicalOperator& original, std::vector<LogicalOperator> rewrittenChildren)>& rewrite);

--- a/nes-query-optimizer/include/Rules/Semantic/AnonymousSourceBindingRule.hpp
+++ b/nes-query-optimizer/include/Rules/Semantic/AnonymousSourceBindingRule.hpp
@@ -19,6 +19,7 @@
 #include <typeindex>
 #include <typeinfo>
 #include <utility>
+#include <vector>
 
 #include <Operators/LogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
@@ -41,7 +42,8 @@ public:
     [[nodiscard]] std::set<std::type_index> neededBy() const;
 
 private:
-    [[nodiscard]] LogicalOperator bindAnonymousSourceLogicalOperators(const LogicalOperator& current) const;
+    [[nodiscard]] LogicalOperator
+    bindAnonymousSourceLogicalOperators(const LogicalOperator& current, std::vector<LogicalOperator> children) const;
     std::shared_ptr<const SourceCatalog> sourceCatalog;
 };
 

--- a/nes-query-optimizer/include/Rules/Static/DecideFieldMappings.hpp
+++ b/nes-query-optimizer/include/Rules/Static/DecideFieldMappings.hpp
@@ -17,6 +17,7 @@
 #include <string_view>
 #include <typeindex>
 #include <typeinfo>
+#include <vector>
 #include <Operators/LogicalOperatorFwd.hpp>
 #include <Plans/LogicalPlan.hpp>
 
@@ -45,6 +46,6 @@ public:
     [[nodiscard]] std::set<std::type_index> needs() const;
 
 private:
-    [[nodiscard]] LogicalOperator apply(const LogicalOperator& logicalOperator) const;
+    [[nodiscard]] LogicalOperator apply(const LogicalOperator& logicalOperator, std::vector<LogicalOperator> children) const;
 };
 }

--- a/nes-query-optimizer/include/Rules/Static/DecideJoinTypesRule.hpp
+++ b/nes-query-optimizer/include/Rules/Static/DecideJoinTypesRule.hpp
@@ -17,6 +17,7 @@
 #include <string_view>
 #include <typeindex>
 #include <typeinfo>
+#include <vector>
 #include <Operators/LogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <Rules/Rule.hpp>
@@ -40,7 +41,7 @@ public:
 
 
 private:
-    [[nodiscard]] LogicalOperator apply(const LogicalOperator& logicalOperator) const;
+    [[nodiscard]] LogicalOperator apply(const LogicalOperator& logicalOperator, std::vector<LogicalOperator> children) const;
     StreamJoinStrategy joinStrategy;
 };
 

--- a/nes-query-optimizer/include/Rules/Static/DecideMemoryLayoutRule.hpp
+++ b/nes-query-optimizer/include/Rules/Static/DecideMemoryLayoutRule.hpp
@@ -17,6 +17,7 @@
 #include <string_view>
 #include <typeindex>
 #include <typeinfo>
+#include <vector>
 #include <Operators/LogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <Rules/Rule.hpp>
@@ -34,7 +35,7 @@ public:
     [[nodiscard]] std::set<std::type_index> needs() const;
 
 private:
-    [[nodiscard]] LogicalOperator apply(const LogicalOperator& logicalOperator) const;
+    [[nodiscard]] LogicalOperator apply(const LogicalOperator& logicalOperator, std::vector<LogicalOperator> children) const;
 };
 
 static_assert(RuleConcept<DecideMemoryLayoutRule, LogicalPlan>);

--- a/nes-query-optimizer/src/Placement/BottomUpPlacement.cpp
+++ b/nes-query-optimizer/src/Placement/BottomUpPlacement.cpp
@@ -63,8 +63,18 @@ size_t operatorCapacityDemand(const LogicalOperator& op)
     return 1;
 }
 
-LogicalOperator addPlacementTrait(const LogicalOperator& op, const std::unordered_map<OperatorId, NetworkTopology::NodeId>& placement)
+/// @param placed operators already placed, keyed by their id before the assignment. An operator shared between sinks is placed
+/// once and every parent must end up with that same instance.
+LogicalOperator addPlacementTrait(
+    const LogicalOperator& op,
+    const std::unordered_map<OperatorId, NetworkTopology::NodeId>& placement,
+    std::unordered_map<OperatorId, LogicalOperator>& placed)
 {
+    if (const auto alreadyPlaced = placed.find(op.getId()); alreadyPlaced != placed.end())
+    {
+        return alreadyPlaced->second;
+    }
+
     auto oldTraitSet = op.getTraitSet();
     /// USED_IN_DEBUG suppresses "unused variable" warnings when NO_ASSERT is defined.
     /// addedTrait is only referenced by the INVARIANT below; when NO_ASSERT is active,
@@ -72,12 +82,14 @@ LogicalOperator addPlacementTrait(const LogicalOperator& op, const std::unordere
     USED_IN_DEBUG auto addedTrait = oldTraitSet.tryInsert(PlacementTrait(placement.at(op.getId())));
     INVARIANT(addedTrait, "There should not have been a placement trait");
 
-    return op.withTraitSet(oldTraitSet)
-        .withChildren(
-            op.getChildren()
-            | std::views::transform(
-                [&placement](const LogicalOperator& child) -> LogicalOperator { return addPlacementTrait(child, placement); })
-            | std::ranges::to<std::vector>());
+    auto placedOperator
+        = op.withTraitSet(oldTraitSet)
+              .withChildren(
+                  op.getChildren()
+                  | std::views::transform([&](const LogicalOperator& child) { return addPlacementTrait(child, placement, placed); })
+                  | std::ranges::to<std::vector>());
+    placed.emplace(op.getId(), placedOperator);
+    return placedOperator;
 }
 
 constexpr auto MODEL_STATUS_STRINGS = std::to_array<std::string_view>(
@@ -161,23 +173,26 @@ void validatePlan(const NetworkTopology& topology, const LogicalPlan& plan)
     NES_DEBUG("Performing Operator Placement on: {}", os.str());
 }
 
-/// Verify that every source can reach the sink via the network topology.
+/// Verify that every source can reach every sink via the network topology.
 /// This check runs before the ILP solver so that missing paths produce a clear error
 /// instead of a generic "placement is not possible" from the solver.
 void validateConnectivity(const NetworkTopology& topology, const LogicalPlan& plan)
 {
-    auto sinkOperator = plan.getRootOperators().front().getAs<SinkLogicalOperator>().get();
-    const auto& sinkDescriptorOpt = sinkOperator.getSinkDescriptor();
-    INVARIANT(sinkDescriptorOpt, "BUG: sink operator must have a sink descriptor");
-    auto sinkHost = sinkDescriptorOpt->getHost();
-
     std::vector<std::string> errors;
-    for (const auto& sourceOperator : getOperatorByType<SourceDescriptorLogicalOperator>(plan))
+    for (const auto& rootOperator : plan.getRootOperators())
     {
-        auto sourceHost = sourceOperator->getSourceDescriptor().getHost();
-        if (topology.findPaths(sinkHost, sourceHost, NetworkTopology::Upstream).empty())
+        auto sinkOperator = rootOperator.getAs<SinkLogicalOperator>().get();
+        const auto& sinkDescriptorOpt = sinkOperator.getSinkDescriptor();
+        INVARIANT(sinkDescriptorOpt, "BUG: sink operator must have a sink descriptor");
+        auto sinkHost = sinkDescriptorOpt->getHost();
+
+        for (const auto& sourceOperator : getOperatorByType<SourceDescriptorLogicalOperator>(plan))
         {
-            errors.emplace_back(fmt::format("No path from source worker '{}' to sink worker '{}'", sourceHost, sinkHost));
+            auto sourceHost = sourceOperator->getSourceDescriptor().getHost();
+            if (topology.findPaths(sinkHost, sourceHost, NetworkTopology::Upstream).empty())
+            {
+                errors.emplace_back(fmt::format("No path from source worker '{}' to sink worker '{}'", sourceHost, sinkHost));
+            }
         }
     }
 
@@ -232,7 +247,7 @@ PlacementModel createPlacementModel()
 /// If an operator o is placed on a node n then placementMatrix[o][n] = true
 void addPlacementVariables(PlacementModel& model, const LogicalPlan& logicalPlan, const NetworkTopology& topology)
 {
-    for (const LogicalOperator& op : BFSRange(logicalPlan.getRootOperators().front()))
+    for (const LogicalOperator& op : planOperators(logicalPlan))
     {
         for (const NetworkTopology::NodeId& node : topology | std::views::keys)
         {
@@ -250,7 +265,7 @@ void addPlacementVariables(PlacementModel& model, const LogicalPlan& logicalPlan
 /// Constraint: Each operator assigned to exactly one node
 void addExactlyOneNodeConstraint(PlacementModel& model, const LogicalPlan& logicalPlan, const NetworkTopology& topology)
 {
-    for (const LogicalOperator& op : BFSRange(logicalPlan.getRootOperators().front()))
+    for (const LogicalOperator& op : planOperators(logicalPlan))
     {
         std::vector<int> index;
         std::vector<double> value;
@@ -282,7 +297,7 @@ void addCapacityConstraints(
                 {
                     std::vector<int> index;
                     std::vector<double> value;
-                    for (const LogicalOperator& op : BFSRange(logicalPlan.getRootOperators().front()))
+                    for (const LogicalOperator& op : planOperators(logicalPlan))
                     {
                         index.push_back(model.operatorPlacementMatrix.at({op.getId(), nodeId}));
                         value.push_back(static_cast<double>(operatorCapacityDemand(op)));
@@ -304,7 +319,7 @@ void addCapacityConstraints(
 /// Constraint: Fix source operators to their host nodes
 void addSourcePlacementConstraints(PlacementModel& model, const LogicalPlan& logicalPlan)
 {
-    for (const LogicalOperator& op : BFSRange(logicalPlan.getRootOperators().front()))
+    for (const LogicalOperator& op : planOperators(logicalPlan))
     {
         if (auto sourceOperator = op.tryGetAs<SourceDescriptorLogicalOperator>())
         {
@@ -315,23 +330,25 @@ void addSourcePlacementConstraints(PlacementModel& model, const LogicalPlan& log
     }
 }
 
-/// Constraint: Fix sink operator to its host node
+/// Constraint: Fix every sink operator to its host node
 void addSinkPlacementConstraint(PlacementModel& model, const LogicalPlan& logicalPlan)
 {
-    auto rootOperatorId = logicalPlan.getRootOperators().front().getId();
-    auto sinkOperator = logicalPlan.getRootOperators().front().getAs<SinkLogicalOperator>().get();
-    const auto& sinkDescriptorOpt = sinkOperator.getSinkDescriptor();
-    INVARIANT(sinkDescriptorOpt, "BUG: sink operator must have a sink descriptor");
-    auto sinkPlacement = sinkDescriptorOpt->getHost();
+    for (const auto& rootOperator : logicalPlan.getRootOperators())
+    {
+        auto sinkOperator = rootOperator.getAs<SinkLogicalOperator>().get();
+        const auto& sinkDescriptorOpt = sinkOperator.getSinkDescriptor();
+        INVARIANT(sinkDescriptorOpt, "BUG: sink operator must have a sink descriptor");
+        auto sinkPlacement = sinkDescriptorOpt->getHost();
 
-    const auto sinkVar = model.operatorPlacementMatrix.at({rootOperatorId, sinkPlacement});
-    checkError(Highs_changeColBounds(model.highs, sinkVar, 1.0, 1.0), model.highs);
+        const auto sinkVar = model.operatorPlacementMatrix.at({rootOperator.getId(), sinkPlacement});
+        checkError(Highs_changeColBounds(model.highs, sinkVar, 1.0, 1.0), model.highs);
+    }
 }
 
 /// Constraint: Parent-child placement must respect network connectivity
 void addConnectivityConstraints(PlacementModel& model, const LogicalPlan& logicalPlan, const NetworkTopology& topology)
 {
-    for (const LogicalOperator& op : BFSRange(logicalPlan.getRootOperators().front()))
+    for (const LogicalOperator& op : planOperators(logicalPlan))
     {
         for (const LogicalOperator& child : op.getChildren())
         {
@@ -357,7 +374,7 @@ void addConnectivityConstraints(PlacementModel& model, const LogicalPlan& logica
 /// Objective: minimize the sum of distances for all operator placements to their descendant sources
 void addDistanceObjective(PlacementModel& model, const LogicalPlan& logicalPlan, const NetworkTopology& topology)
 {
-    for (const LogicalOperator& op : BFSRange(logicalPlan.getRootOperators().front()))
+    for (const LogicalOperator& op : planOperators(logicalPlan))
     {
         for (const auto& nodeId : topology | std::views::keys)
         {
@@ -449,7 +466,11 @@ void BottomUpOperatorPlacer::apply(LogicalPlan& logicalPlan)
     {
         throw PlacementFailure("Placement is not possible under the given capacity constraints");
     }
-    logicalPlan = LogicalPlan(logicalPlan.getQueryId(), {addPlacementTrait(logicalPlan.getRootOperators().front(), *placement)});
+    std::unordered_map<OperatorId, LogicalOperator> placed;
+    logicalPlan = logicalPlan.withRootOperators(
+        logicalPlan.getRootOperators()
+        | std::views::transform([&](const LogicalOperator& root) { return addPlacementTrait(root, *placement, placed); })
+        | std::ranges::to<std::vector>());
 }
 
 }

--- a/nes-query-optimizer/src/Placement/QueryDecomposition.cpp
+++ b/nes-query-optimizer/src/Placement/QueryDecomposition.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <map>
 #include <optional>
 #include <ranges>
 #include <string>
@@ -44,6 +45,7 @@
 #include <ErrorHandling.hpp>
 #include <InputFormatterDescriptor.hpp>
 #include <NetworkTopology.hpp>
+#include <PlanRewriteUtils.hpp>
 #include <QueryId.hpp>
 #include <QueryOptimizerNetworkConfiguration.hpp>
 #include <WorkerCatalog.hpp>
@@ -57,6 +59,8 @@ namespace
 struct DecompositionContext
 {
     std::unordered_map<NetworkTopology::NodeId, std::vector<LogicalPlan>> plansByNode;
+    /// Network source per (operator, consuming node): an operator shared by sinks is sent to a node once, not once per consumer.
+    std::map<std::pair<OperatorId, NetworkTopology::NodeId>, LogicalOperator> networkChannels;
     /// NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members) deliberate const-ref in local helper struct
     const QueryOptimizerNetworkConfiguration& config;
     SharedPtr<const SourceCatalog> sourceCatalog;
@@ -186,7 +190,8 @@ LogicalOperator createNetworkChannel(
     return currentOp;
 }
 
-LogicalOperator decomposePlanRecursive(DecompositionContext& context, const LogicalOperator& op);
+LogicalOperator decomposePlanRecursive(
+    DecompositionContext& context, const LogicalOperator& op, std::unordered_map<OperatorId, LogicalOperator>& decomposed);
 
 NetworkTopology::NodeId getPlacementFor(const LogicalOperator& op)
 {
@@ -194,9 +199,13 @@ NetworkTopology::NodeId getPlacementFor(const LogicalOperator& op)
     return placementTrait->onNode;
 }
 
-LogicalOperator assignOperator(DecompositionContext& context, const LogicalOperator& op, const LogicalOperator& child)
+LogicalOperator assignOperator(
+    DecompositionContext& context,
+    const LogicalOperator& op,
+    const LogicalOperator& child,
+    std::unordered_map<OperatorId, LogicalOperator>& decomposed)
 {
-    auto assignedChild = decomposePlanRecursive(context, child);
+    auto assignedChild = decomposePlanRecursive(context, child, decomposed);
 
     const auto opNode = getPlacementFor(op);
     const auto childNode = getPlacementFor(child);
@@ -205,20 +214,38 @@ LogicalOperator assignOperator(DecompositionContext& context, const LogicalOpera
     {
         return assignedChild;
     }
-    return createNetworkChannel(context, assignedChild, childNode, opNode);
+
+    const auto channelKey = std::pair{child.getId(), opNode};
+    if (const auto existingChannel = context.networkChannels.find(channelKey); existingChannel != context.networkChannels.end())
+    {
+        return existingChannel->second;
+    }
+    auto networkSource = createNetworkChannel(context, assignedChild, childNode, opNode);
+    context.networkChannels.emplace(channelKey, networkSource);
+    return networkSource;
 }
 
-LogicalOperator decomposePlanRecursive(DecompositionContext& context, const LogicalOperator& op)
+/// @param decomposed operators that were already decomposed, keyed by their id before the decomposition. An operator shared between
+/// sinks is reached through more than one parent, but must be decomposed only once so that all parents keep reading one instance of it.
+LogicalOperator decomposePlanRecursive(
+    DecompositionContext& context, const LogicalOperator& op, std::unordered_map<OperatorId, LogicalOperator>& decomposed)
 {
+    if (const auto alreadyDecomposed = decomposed.find(op.getId()); alreadyDecomposed != decomposed.end())
+    {
+        return alreadyDecomposed->second;
+    }
+
     std::vector<LogicalOperator> assignedChildren;
     assignedChildren.reserve(op.getChildren().size());
 
     for (const auto& child : op.getChildren())
     {
-        assignedChildren.emplace_back(assignOperator(context, op, child));
+        assignedChildren.emplace_back(assignOperator(context, op, child, decomposed));
     }
 
-    return op.withChildren({std::move(assignedChildren)});
+    auto decomposedOperator = op.withChildren({std::move(assignedChildren)});
+    decomposed.emplace(op.getId(), decomposedOperator);
+    return decomposedOperator;
 }
 }
 
@@ -230,21 +257,50 @@ QueryDecomposer::QueryDecomposer(
 
 DistributedLogicalPlan QueryDecomposer::decompose(const LogicalPlan& placedPlan, const QueryOptimizerNetworkConfiguration& configuration)
 {
-    PRECONDITION(placedPlan.getRootOperators().size() == 1, "BUG: query decomposition requires a single root operator");
+    PRECONDITION(not placedPlan.getRootOperators().empty(), "BUG: query decomposition requires at least one root operator");
     PRECONDITION(
-        std::ranges::all_of(
-            BFSRange(placedPlan.getRootOperators().front()), [](const auto& op) { return hasTrait<PlacementTrait>(op.getTraitSet()); }),
+        std::ranges::all_of(planOperators(placedPlan), [](const auto& op) { return hasTrait<PlacementTrait>(op.getTraitSet()); }),
         "BUG: query decomposition requires placement of all operators");
+
+    /// An operator shared between sinks lives on exactly one node. Sending it to a second node means duplicating it there, sources
+    /// included, so a plan that would require that is rejected instead of silently reading its sources twice.
+    for (const auto& op : planOperators(placedPlan))
+    {
+        const auto parents = getParents(placedPlan, op);
+        if (parents.size() > 1
+            and not std::ranges::all_of(
+                parents, [&](const auto& parent) { return getPlacementFor(parent) == getPlacementFor(parents.front()); }))
+        {
+            throw PlacementFailure(
+                "Operator {} is shared by sinks that were placed on different workers", op.explain(ExplainVerbosity::Short));
+        }
+    }
 
     DecompositionContext context{
         .plansByNode = {},
+        .networkChannels = {},
         .config = configuration,
         .sourceCatalog = copyPtr(sourceCatalog),
         .sinkCatalog = copyPtr(sinkCatalog),
         .workerCatalog = copyPtr(workerCatalog)};
 
-    auto root = decomposePlanRecursive(context, placedPlan.getRootOperators().front()).withInferredSchema();
-    context.addPlanToNode(root, getPlacementFor(root));
+    /// All sinks that end up on the same node form one plan for that node, so that the part they share is deployed once.
+    std::unordered_map<OperatorId, LogicalOperator> decomposed;
+    std::unordered_map<NetworkTopology::NodeId, std::vector<LogicalOperator>> rootsByNode;
+    for (const auto& rootOperator : placedPlan.getRootOperators())
+    {
+        auto root = decomposePlanRecursive(context, rootOperator, decomposed);
+        rootsByNode[getPlacementFor(root)].push_back(root);
+    }
+    for (auto& [node, roots] : rootsByNode)
+    {
+        /// Decomposition inserts network sources and sinks, so the operators above them need their schema inferred again. Setting
+        /// the children re-infers it locally, which keeps the part the sinks share shared.
+        context.plansByNode[node].emplace_back(rewritePlanBottomUp(
+            LogicalPlan{INVALID_QUERY_ID, std::move(roots)},
+            [](const LogicalOperator& original, std::vector<LogicalOperator> children)
+            { return original.withChildren(std::move(children)); }));
+    }
 
     for (const auto& [node, plans] : context.plansByNode)
     {

--- a/nes-query-optimizer/src/PlanRewriteUtils.cpp
+++ b/nes-query-optimizer/src/PlanRewriteUtils.cpp
@@ -13,11 +13,18 @@
 */
 #include <PlanRewriteUtils.hpp>
 
+#include <cstddef>
+#include <deque>
+#include <functional>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <Functions/FieldAccessLogicalFunction.hpp>
 #include <Functions/LogicalFunction.hpp>
+#include <Identifiers/Identifiers.hpp>
+#include <Operators/LogicalOperator.hpp>
+#include <Plans/LogicalPlan.hpp>
 #include <Schema/Field.hpp>
 
 namespace NES
@@ -42,5 +49,81 @@ LogicalFunction replaceFieldAccesses(const LogicalFunction& function, const std:
     }
 
     return function.withChildren(newChildren);
+}
+
+std::unordered_set<OperatorId> getSharedOperatorIds(const LogicalPlan& plan)
+{
+    /// Operator hashing/equality is structural, so visited-tracking must use operator ids.
+    std::unordered_map<OperatorId, std::size_t> parentEdgeCounts;
+    std::unordered_set<OperatorId> visited;
+    std::deque<LogicalOperator> pending;
+    for (const auto& root : plan.getRootOperators())
+    {
+        if (visited.insert(root.getId()).second)
+        {
+            pending.push_back(root);
+        }
+    }
+    while (!pending.empty())
+    {
+        const auto current = pending.front();
+        pending.pop_front();
+        for (const auto& child : current.getChildren())
+        {
+            ++parentEdgeCounts[child.getId()];
+            if (visited.insert(child.getId()).second)
+            {
+                pending.push_back(child);
+            }
+        }
+    }
+
+    std::unordered_set<OperatorId> sharedIds;
+    for (const auto& [operatorId, parentEdges] : parentEdgeCounts)
+    {
+        if (parentEdges > 1)
+        {
+            sharedIds.insert(operatorId);
+        }
+    }
+    return sharedIds;
+}
+
+namespace
+{
+LogicalOperator rewriteOperatorBottomUp(
+    const LogicalOperator& original,
+    const std::function<LogicalOperator(const LogicalOperator&, std::vector<LogicalOperator>)>& rewrite,
+    std::unordered_map<OperatorId, LogicalOperator>& rewritten)
+{
+    if (const auto found = rewritten.find(original.getId()); found != rewritten.end())
+    {
+        return found->second;
+    }
+
+    std::vector<LogicalOperator> rewrittenChildren;
+    for (const auto& child : original.getChildren())
+    {
+        rewrittenChildren.push_back(rewriteOperatorBottomUp(child, rewrite, rewritten));
+    }
+
+    auto result = rewrite(original, std::move(rewrittenChildren));
+    rewritten.emplace(original.getId(), result);
+    return result;
+}
+}
+
+LogicalPlan rewritePlanBottomUp(
+    const LogicalPlan& plan,
+    const std::function<LogicalOperator(const LogicalOperator& original, std::vector<LogicalOperator> rewrittenChildren)>& rewrite)
+{
+    std::unordered_map<OperatorId, LogicalOperator> rewritten;
+    std::vector<LogicalOperator> newRoots;
+    newRoots.reserve(plan.getRootOperators().size());
+    for (const auto& root : plan.getRootOperators())
+    {
+        newRoots.push_back(rewriteOperatorBottomUp(root, rewrite, rewritten));
+    }
+    return plan.withRootOperators(newRoots);
 }
 }

--- a/nes-query-optimizer/src/Rules/Semantic/AnonymousSourceBindingRule.cpp
+++ b/nes-query-optimizer/src/Rules/Semantic/AnonymousSourceBindingRule.cpp
@@ -18,6 +18,7 @@
 #include <string_view>
 #include <typeindex>
 #include <typeinfo>
+#include <utility>
 #include <vector>
 
 #include <Identifiers/Identifier.hpp>
@@ -29,19 +30,15 @@
 #include <Plans/LogicalPlan.hpp>
 #include <Rules/Barriers/SemanticAnalysisBarrier.hpp>
 #include <ErrorHandling.hpp>
+#include <PlanRewriteUtils.hpp>
 #include <PlanRuleRegistry.hpp>
 
 namespace NES
 {
 
-LogicalOperator AnonymousSourceBindingRule::bindAnonymousSourceLogicalOperators(const LogicalOperator& current) const
+LogicalOperator AnonymousSourceBindingRule::bindAnonymousSourceLogicalOperators(
+    const LogicalOperator& current, std::vector<LogicalOperator> newChildren) const
 {
-    std::vector<LogicalOperator> newChildren;
-    for (const auto& child : current.getChildren())
-    {
-        newChildren.emplace_back(bindAnonymousSourceLogicalOperators(child));
-    }
-
     if (const auto anonymousSource = current.tryGetAs<AnonymousSourceLogicalOperator>())
     {
         PRECONDITION(std::ranges::empty(anonymousSource->getChildren()), "Anonymous source operator must have no children");
@@ -70,17 +67,15 @@ LogicalOperator AnonymousSourceBindingRule::bindAnonymousSourceLogicalOperators(
         return SourceDescriptorLogicalOperator::create(descriptor);
     }
 
-    return current.withChildrenUnsafe(newChildren);
+    return current.withChildrenUnsafe(std::move(newChildren));
 }
 
 LogicalPlan AnonymousSourceBindingRule::apply(const LogicalPlan& queryPlan) const
 {
-    std::vector<LogicalOperator> newRoots;
-    for (const auto& root : queryPlan.getRootOperators())
-    {
-        newRoots.emplace_back(bindAnonymousSourceLogicalOperators(root));
-    }
-    return queryPlan.withRootOperators(newRoots);
+    return rewritePlanBottomUp(
+        queryPlan,
+        [this](const LogicalOperator& current, std::vector<LogicalOperator> children)
+        { return bindAnonymousSourceLogicalOperators(current, std::move(children)); });
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Semantic/CalcTargetOrderRule.cpp
+++ b/nes-query-optimizer/src/Rules/Semantic/CalcTargetOrderRule.cpp
@@ -125,17 +125,28 @@ LogicalPlan CalcTargetOrderRule::apply(NES::LogicalPlan plan) const
         return plan;
     }
 
-    PRECONDITION(std::ranges::size(plan.getRootOperators()) == 1, "Can only infer target schema order for plans with exactly one root");
-    const auto root = plan.getRootOperators()[0].getAs<SinkLogicalOperator>();
-    auto outputOrder = applyRecursive(root->getChild());
-    const auto newTargetSchema
-        = outputOrder | std::views::transform(Unbinder<Field>{}) | std::ranges::to<Schema<UnqualifiedUnboundField, Ordered>>();
-    auto sinkDescriptorOpt = root->getSinkDescriptor();
-    PRECONDITION(sinkDescriptorOpt.has_value(), "Sink operator must have a descriptor to infer target schema order");
-    const auto oldDescriptor = NES::get<AnonymousSinkDescriptor>(sinkDescriptorOpt->getUnderlying());
-    auto newAnonymousSinkDescriptor = SinkDescriptor{oldDescriptor.withSchemaOrder(newTargetSchema)};
-    auto newSinkRoot = root->withSinkDescriptor(newAnonymousSinkDescriptor);
-    return plan.withRootOperators({newSinkRoot});
+    /// Infer the target schema order for every sink that does not have one yet. The traversal below is read-only,
+    /// so operators shared between multiple sinks stay shared.
+    std::vector<LogicalOperator> newRoots;
+    newRoots.reserve(plan.getRootOperators().size());
+    for (const auto& rootOperator : plan.getRootOperators())
+    {
+        if (hasOrder(rootOperator))
+        {
+            newRoots.push_back(rootOperator);
+            continue;
+        }
+        const auto root = rootOperator.getAs<SinkLogicalOperator>();
+        auto outputOrder = applyRecursive(root->getChild());
+        const auto newTargetSchema
+            = outputOrder | std::views::transform(Unbinder<Field>{}) | std::ranges::to<Schema<UnqualifiedUnboundField, Ordered>>();
+        auto sinkDescriptorOpt = root->getSinkDescriptor();
+        PRECONDITION(sinkDescriptorOpt.has_value(), "Sink operator must have a descriptor to infer target schema order");
+        const auto oldDescriptor = NES::get<AnonymousSinkDescriptor>(sinkDescriptorOpt->getUnderlying());
+        auto newAnonymousSinkDescriptor = SinkDescriptor{oldDescriptor.withSchemaOrder(newTargetSchema)};
+        newRoots.push_back(root->withSinkDescriptor(newAnonymousSinkDescriptor));
+    }
+    return plan.withRootOperators(newRoots);
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Semantic/InferModelResolutionRule.cpp
+++ b/nes-query-optimizer/src/Rules/Semantic/InferModelResolutionRule.cpp
@@ -34,6 +34,7 @@
 #include <Rules/Semantic/TypeInferenceRule.hpp>
 #include <ErrorHandling.hpp>
 #include <ModelCatalog.hpp>
+#include <PlanRewriteUtils.hpp>
 #include <PlanRuleRegistry.hpp>
 
 namespace NES
@@ -41,11 +42,8 @@ namespace NES
 
 namespace
 {
-LogicalOperator recur(const LogicalOperator& op, const ModelCatalog& modelCatalog)
+LogicalOperator resolveInferModel(const LogicalOperator& op, std::vector<LogicalOperator> newChildren, const ModelCatalog& modelCatalog)
 {
-    auto newChildren = op.getChildren() | std::views::transform([&](const auto& child) { return recur(child, modelCatalog); })
-        | std::ranges::to<std::vector>();
-
     if (const auto inferModelName = op.tryGetAs<InferModelNameLogicalOperator>())
     {
         const auto& modelName = inferModelName->get().getModelName();
@@ -65,8 +63,11 @@ LogicalOperator recur(const LogicalOperator& op, const ModelCatalog& modelCatalo
 
 LogicalPlan InferModelResolutionRule::apply(const LogicalPlan& queryPlan) const
 {
-    PRECONDITION(queryPlan.getRootOperators().size() == 1, "Query plan must have exactly one root operator");
-    return queryPlan.withRootOperators({recur(queryPlan.getRootOperators().front(), *modelCatalog)});
+    PRECONDITION(not queryPlan.getRootOperators().empty(), "Query must have a sink root operator");
+    return rewritePlanBottomUp(
+        queryPlan,
+        [this](const LogicalOperator& op, std::vector<LogicalOperator> children)
+        { return resolveInferModel(op, std::move(children), *modelCatalog); });
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Semantic/LogicalSourceExpansionRule.cpp
+++ b/nes-query-optimizer/src/Rules/Semantic/LogicalSourceExpansionRule.cpp
@@ -32,6 +32,7 @@
 #include <Sources/SourceCatalog.hpp>
 #include <Util/PlanRenderer.hpp>
 #include <ErrorHandling.hpp>
+#include <PlanRewriteUtils.hpp>
 #include <PlanRuleRegistry.hpp>
 
 namespace NES
@@ -39,11 +40,9 @@ namespace NES
 
 namespace
 {
-LogicalOperator applyRecursive(const LogicalOperator& visiting, const SourceCatalog& sourceCatalog)
+LogicalOperator
+expandLogicalSource(const LogicalOperator& visiting, std::vector<LogicalOperator> children, const SourceCatalog& sourceCatalog)
 {
-    auto children = visiting.getChildren()
-        | std::views::transform([&sourceCatalog](const auto& child) { return applyRecursive(child, sourceCatalog); })
-        | std::ranges::to<std::vector>();
     if (const auto sourceNameOperator = visiting.tryGetAs<SourceNameLogicalOperator>())
     {
         const auto logicalSourceOpt = sourceCatalog.getLogicalSource(sourceNameOperator.value()->getLogicalSourceName());
@@ -82,8 +81,11 @@ LogicalOperator applyRecursive(const LogicalOperator& visiting, const SourceCata
 
 LogicalPlan LogicalSourceExpansionRule::apply(const LogicalPlan& queryPlan) const
 {
-    PRECONDITION(queryPlan.getRootOperators().size() == 1, "Query plan must have exactly one root operator");
-    return queryPlan.withRootOperators({applyRecursive(queryPlan.getRootOperators().at(0), *sourceCatalog)});
+    PRECONDITION(not queryPlan.getRootOperators().empty(), "Query must have a sink root operator");
+    return rewritePlanBottomUp(
+        queryPlan,
+        [this](const LogicalOperator& visiting, std::vector<LogicalOperator> children)
+        { return expandLogicalSource(visiting, std::move(children), *sourceCatalog); });
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Semantic/TypeInferenceRule.cpp
+++ b/nes-query-optimizer/src/Rules/Semantic/TypeInferenceRule.cpp
@@ -18,6 +18,7 @@
 #include <string_view>
 #include <typeindex>
 #include <typeinfo>
+#include <utility>
 #include <vector>
 
 #include <Operators/LogicalOperator.hpp>
@@ -26,6 +27,7 @@
 #include <Rules/Semantic/AnonymousSinkBindingRule.hpp>
 #include <Rules/Semantic/LogicalSourceExpansionRule.hpp>
 #include <Rules/Semantic/SinkBindingRule.hpp>
+#include <PlanRewriteUtils.hpp>
 
 #include <PlanRuleRegistry.hpp>
 
@@ -36,13 +38,19 @@ namespace NES
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 LogicalPlan TypeInferenceRule::apply(const LogicalPlan& queryPlan) const
 {
-    std::vector<LogicalOperator> newRoots;
-    for (const auto& sink : queryPlan.getRootOperators())
-    {
-        const LogicalOperator inferredRoot = sink->withInferredSchema();
-        newRoots.push_back(inferredRoot);
-    }
-    return queryPlan.withRootOperators(newRoots);
+    /// Infer bottom-up instead of calling withInferredSchema on each root: the recursive withInferredSchema
+    /// would copy operators shared between multiple parents once per parent. withChildren re-infers the local
+    /// schema, which is equivalent once all children are already inferred.
+    return rewritePlanBottomUp(
+        queryPlan,
+        [](const LogicalOperator& op, std::vector<LogicalOperator> children) -> LogicalOperator
+        {
+            if (children.empty())
+            {
+                return op.withInferredSchema();
+            }
+            return op.withChildren(std::move(children));
+        });
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Static/DecideFieldMappings.cpp
+++ b/nes-query-optimizer/src/Rules/Static/DecideFieldMappings.cpp
@@ -40,6 +40,7 @@
 #include <Traits/FieldMappingTrait.hpp>
 #include <Traits/TraitSet.hpp>
 #include <ErrorHandling.hpp>
+#include <PlanRewriteUtils.hpp>
 #include <PlanRuleRegistry.hpp>
 
 namespace NES
@@ -178,11 +179,8 @@ defaultMapping(const LogicalOperator& logicalOperator, const std::vector<Logical
 }
 }
 
-LogicalOperator DecideFieldMappings::apply(const LogicalOperator& logicalOperator) const
+LogicalOperator DecideFieldMappings::apply(const LogicalOperator& logicalOperator, std::vector<LogicalOperator> children) const
 {
-    const auto children = logicalOperator->getChildren() | std::views::transform([this](const auto& child) { return apply(child); })
-        | std::ranges::to<std::vector>();
-
     const auto mapping = [&]
     {
         if (const auto& reprojecter = logicalOperator.tryGetAs<Reprojecter>())
@@ -207,14 +205,16 @@ LogicalOperator DecideFieldMappings::apply(const LogicalOperator& logicalOperato
     const auto success = tryInsert(traitSet, std::move(fieldMappingTrait));
     /// If there is a good reason why we would want to run this multiple times we can also disable this check and replace the trait instance.
     PRECONDITION(success, "Field mapping trait already set");
-    return logicalOperator.withTraitSet(std::move(traitSet)).withChildren(children);
+    return logicalOperator.withTraitSet(std::move(traitSet)).withChildren(std::move(children));
 }
 
 LogicalPlan DecideFieldMappings::apply(const LogicalPlan& queryPlan) const
 {
-    PRECONDITION(std::ranges::size(queryPlan.getRootOperators()) == 1, "Currently only one root operator is supported");
-    auto newRootOperator = apply(queryPlan.getRootOperators().at(0));
-    return queryPlan.withRootOperators({newRootOperator});
+    PRECONDITION(not queryPlan.getRootOperators().empty(), "Query must have a sink root operator");
+    return rewritePlanBottomUp(
+        queryPlan,
+        [this](const LogicalOperator& logicalOperator, std::vector<LogicalOperator> children)
+        { return apply(logicalOperator, std::move(children)); });
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Static/DecideFieldOrder.cpp
+++ b/nes-query-optimizer/src/Rules/Static/DecideFieldOrder.cpp
@@ -63,16 +63,10 @@ namespace
 Schema<Field, Ordered> heuristicOutputOrder(const LogicalOperator& visiting, const std::vector<LogicalOperator>& newChildren)
 {
     /// For now we reuse the semantic field order of the operators as a heuristic for deciding the FieldOrdering trait
-    /// Other strategies may be explored for better physical optimization
-    const auto oldChildren = visiting.getChildren();
-    std::vector<std::pair<LogicalOperator, LogicalOperator>> oldWithNewChildren;
-    oldWithNewChildren.reserve(oldChildren.size());
-    for (std::size_t i = 0; i < oldChildren.size(); ++i)
-    {
-        oldWithNewChildren.emplace_back(oldChildren[i], newChildren[i]);
-    }
-
-    const auto childrenMap = oldWithNewChildren | std::ranges::to<std::unordered_map>();
+    /// Other strategies may be explored for better physical optimization.
+    /// A child's ordering trait is read below. In a DAG a shared child may carry a target order imposed by another sink
+    /// (see apply): a shared operator has a single physical output order that all of its parents -- across sink branches --
+    /// must consume, so deriving this operator's order from that child is intentional, not an accidental cross-sink leak.
     const std::unordered_map<TypedLogicalOperator<>, Schema<Field, Ordered>> childrenWithOutputOrder
         = newChildren
         | std::views::transform(
@@ -87,6 +81,15 @@ Schema<Field, Ordered> heuristicOutputOrder(const LogicalOperator& visiting, con
 
     if (const auto reorderer = visiting.tryGetAs<Reorderer>())
     {
+        /// The Reorderer callback is keyed by the original child, so map each original child to its rewritten counterpart.
+        const auto oldChildren = visiting.getChildren();
+        std::vector<std::pair<LogicalOperator, LogicalOperator>> oldWithNewChildren;
+        oldWithNewChildren.reserve(oldChildren.size());
+        for (std::size_t i = 0; i < oldChildren.size(); ++i)
+        {
+            oldWithNewChildren.emplace_back(oldChildren[i], newChildren[i]);
+        }
+        const auto childrenMap = oldWithNewChildren | std::ranges::to<std::unordered_map>();
         return reorderer.value()->get().getOrderedOutputSchema([&childrenWithOutputOrder, &childrenMap](const LogicalOperator& child)
                                                                { return childrenWithOutputOrder.at(childrenMap.at(child)); });
     }

--- a/nes-query-optimizer/src/Rules/Static/DecideFieldOrder.cpp
+++ b/nes-query-optimizer/src/Rules/Static/DecideFieldOrder.cpp
@@ -15,6 +15,7 @@
 #include <Rules/Static/DecideFieldOrder.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <memory>
 #include <ranges>
 #include <set>
@@ -28,6 +29,7 @@
 #include <DataTypes/Schema.hpp>
 #include <DataTypes/SchemaFwd.hpp>
 #include <DataTypes/UnboundField.hpp>
+#include <Identifiers/Identifiers.hpp>
 #include <Operators/LogicalOperator.hpp>
 #include <Operators/LogicalOperatorFwd.hpp>
 #include <Operators/Reorderer.hpp>
@@ -40,6 +42,7 @@
 #include <Traits/TraitSet.hpp>
 #include <Util/Variant.hpp>
 #include <ErrorHandling.hpp>
+#include <PlanRewriteUtils.hpp>
 #include <PlanRuleRegistry.hpp>
 
 namespace NES
@@ -57,73 +60,68 @@ namespace NES
 /// Concrete operators can overwrite this behavior by overwriting Reorderer
 namespace
 {
-LogicalOperator applyRecur(const LogicalOperator& visiting)
+Schema<Field, Ordered> heuristicOutputOrder(const LogicalOperator& visiting, const std::vector<LogicalOperator>& newChildren)
 {
     /// For now we reuse the semantic field order of the operators as a heuristic for deciding the FieldOrdering trait
     /// Other strategies may be explored for better physical optimization
-    const auto oldWithNewChildren = visiting.getChildren()
-        | std::views::transform([&](const auto& child) { return std::pair{child, applyRecur(child)}; }) | std::ranges::to<std::vector>();
-    const auto newChildren
-        = oldWithNewChildren | std::views::transform(&std::pair<LogicalOperator, LogicalOperator>::second) | std::ranges::to<std::vector>();
-
-
-    const Schema<Field, Ordered> outputOrder = [&]
+    const auto oldChildren = visiting.getChildren();
+    std::vector<std::pair<LogicalOperator, LogicalOperator>> oldWithNewChildren;
+    oldWithNewChildren.reserve(oldChildren.size());
+    for (std::size_t i = 0; i < oldChildren.size(); ++i)
     {
-        const auto childrenMap = oldWithNewChildren | std::ranges::to<std::unordered_map>();
-        const std::unordered_map<TypedLogicalOperator<>, Schema<Field, Ordered>> childrenWithOutputOrder
-            = newChildren
-            | std::views::transform(
-                  [](const auto& child) -> std::pair<TypedLogicalOperator<>, Schema<Field, Ordered>>
-                  {
-                      return std::pair{
-                          child,
-                          child->getTraitSet().template get<FieldOrderingTrait>()->getOrderedFields() | RangeBinder{child}
-                              | std::ranges::to<Schema<Field, Ordered>>()};
-                  })
-            | std::ranges::to<std::unordered_map>();
+        oldWithNewChildren.emplace_back(oldChildren[i], newChildren[i]);
+    }
 
-        if (const auto reorderer = visiting.tryGetAs<Reorderer>())
+    const auto childrenMap = oldWithNewChildren | std::ranges::to<std::unordered_map>();
+    const std::unordered_map<TypedLogicalOperator<>, Schema<Field, Ordered>> childrenWithOutputOrder
+        = newChildren
+        | std::views::transform(
+              [](const auto& child) -> std::pair<TypedLogicalOperator<>, Schema<Field, Ordered>>
+              {
+                  return std::pair{
+                      child,
+                      child->getTraitSet().template get<FieldOrderingTrait>()->getOrderedFields() | RangeBinder{child}
+                          | std::ranges::to<Schema<Field, Ordered>>()};
+              })
+        | std::ranges::to<std::unordered_map>();
+
+    if (const auto reorderer = visiting.tryGetAs<Reorderer>())
+    {
+        return reorderer.value()->get().getOrderedOutputSchema([&childrenWithOutputOrder, &childrenMap](const LogicalOperator& child)
+                                                               { return childrenWithOutputOrder.at(childrenMap.at(child)); });
+    }
+    std::vector<Field> outputOrder;
+    std::vector<Field> rest;
+    const auto outputSchema = visiting.getOutputSchema();
+    const auto orderedBoundInputSchema = newChildren
+        | std::views::transform([&](const auto& child) { return childrenWithOutputOrder.at(child); }) | std::views::join
+        | std::ranges::to<Schema<Field, Ordered>>();
+    for (const auto& inputField : orderedBoundInputSchema)
+    {
+        if (const auto& outputFieldOpt = outputSchema[inputField.getFullyQualifiedName()])
         {
-            return reorderer.value()->get().getOrderedOutputSchema([&childrenWithOutputOrder, &childrenMap](const LogicalOperator& child)
-                                                                   { return childrenWithOutputOrder.at(childrenMap.at(child)); });
+            outputOrder.push_back(outputFieldOpt.value());
         }
-        std::vector<Field> outputOrder;
-        std::vector<Field> rest;
-        const auto outputSchema = visiting.getOutputSchema();
-        const auto orderedBoundInputSchema = newChildren
-            | std::views::transform([&](const auto& child) { return childrenWithOutputOrder.at(child); }) | std::views::join
-            | std::ranges::to<Schema<Field, Ordered>>();
-        for (const auto& inputField : orderedBoundInputSchema)
+    }
+
+    for (const auto& outputField : outputSchema)
+    {
+        if (!orderedBoundInputSchema.contains(outputField.getFullyQualifiedName()))
         {
-            if (const auto& outputFieldOpt = outputSchema[inputField.getFullyQualifiedName()])
-            {
-                outputOrder.push_back(outputFieldOpt.value());
-            }
+            rest.push_back(outputField);
         }
+    }
 
-        for (const auto& outputField : outputSchema)
-        {
-            if (!orderedBoundInputSchema.contains(outputField.getFullyQualifiedName()))
-            {
-                rest.push_back(outputField);
-            }
-        }
+    std::ranges::sort(
+        rest,
+        [](const auto& lhs, const auto& rhs)
+        { return fmt::format("{}", lhs.getFullyQualifiedName()) < fmt::format("{}", rhs.getFullyQualifiedName()); });
 
-        std::ranges::sort(
-            rest,
-            [](const auto& lhs, const auto& rhs)
-            { return fmt::format("{}", lhs.getFullyQualifiedName()) < fmt::format("{}", rhs.getFullyQualifiedName()); });
-
-        for (const auto& field : rest)
-        {
-            outputOrder.push_back(field);
-        }
-        return outputOrder | std::ranges::to<Schema<Field, Ordered>>();
-    }();
-
-    auto traitSet = visiting.getTraitSet();
-    traitSet.insert(FieldOrderingTrait{unbind(outputOrder)});
-    return visiting.withTraitSet(std::move(traitSet)).withChildren(newChildren);
+    for (const auto& field : rest)
+    {
+        outputOrder.push_back(field);
+    }
+    return outputOrder | std::ranges::to<Schema<Field, Ordered>>();
 }
 
 }
@@ -137,44 +135,54 @@ std::set<std::type_index> DecideFieldOrder::needs() const
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 LogicalPlan DecideFieldOrder::apply(const LogicalPlan& queryPlan) const
 {
-    PRECONDITION(
-        std::ranges::size(queryPlan.getRootOperators()) == 1,
-        "query plan must have exactly one root operator but has {}",
-        std::ranges::size(queryPlan.getRootOperators()));
+    PRECONDITION(not queryPlan.getRootOperators().empty(), "Query must have a sink root operator");
 
-    auto rootSink = queryPlan.getRootOperators()[0].getAs<SinkLogicalOperator>();
-    auto oldRootChild = rootSink->getChild();
-
-    const auto newRootChild = [&]
+    /// Each sink imposes its target schema order on its child. A child shared between multiple sinks can only carry one
+    /// field order, so all sinks sharing it must agree on the order.
+    std::unordered_map<OperatorId, Schema<UnqualifiedUnboundField, Ordered>> targetOrders;
+    for (const auto& rootOperator : queryPlan.getRootOperators())
     {
-        if (std::ranges::size(oldRootChild->getChildren()) > 0)
+        auto rootSink = rootOperator.getAs<SinkLogicalOperator>();
+        auto sinkDescriptorOpt = rootSink->getSinkDescriptor();
+        PRECONDITION(sinkDescriptorOpt.has_value(), "Root sink must have a sink descriptor");
+        auto targetSchema = *NES::get<std::shared_ptr<const Schema<UnqualifiedUnboundField, Ordered>>>(sinkDescriptorOpt->getSchema());
+        const auto child = rootSink->getChild();
+        for (const auto& targetField : targetSchema)
         {
-            auto newGrandchildren = oldRootChild->getChildren()
-                | std::views::transform([](const auto& grandchild) { return applyRecur(grandchild); }) | std::ranges::to<std::vector>();
-            return oldRootChild.withChildren(std::move(newGrandchildren));
+            PRECONDITION(
+                child.getOutputSchema().contains(targetField.getFullyQualifiedName()),
+                "Field {} not present in root child output schema",
+                targetField.getFullyQualifiedName());
         }
-        return oldRootChild;
-    }();
-
-    auto sinkDescriptorOpt = rootSink->getSinkDescriptor();
-    PRECONDITION(sinkDescriptorOpt.has_value(), "Root sink must have a sink descriptor");
-    auto targetSchema = *NES::get<std::shared_ptr<const Schema<UnqualifiedUnboundField, Ordered>>>(sinkDescriptorOpt->getSchema());
-    for (const auto& targetField : targetSchema)
-    {
-        PRECONDITION(
-            newRootChild.getOutputSchema().contains(targetField.getFullyQualifiedName()),
-            "Field {} not present in root child output schema",
-            targetField.getFullyQualifiedName());
+        if (const auto [existing, inserted] = targetOrders.try_emplace(child.getId(), targetSchema); !inserted)
+        {
+            if (existing->second != targetSchema)
+            {
+                throw UnsupportedQuery(
+                    "sinks sharing the operator {} require conflicting field orders", child.explain(ExplainVerbosity::Short));
+            }
+        }
     }
-    TraitSet rootChildTraitSet = newRootChild.getTraitSet();
-    rootChildTraitSet.insert(FieldOrderingTrait{targetSchema});
-    const auto rootChildWithTargetOrder = newRootChild.withTraitSet(TraitSet{rootChildTraitSet});
 
-    auto rootTraitSet = rootSink->getTraitSet();
-    rootTraitSet.insert(FieldOrderingTrait{Schema<UnqualifiedUnboundField, Ordered>{}});
-
-    auto newRoot = rootSink.withChildren({rootChildWithTargetOrder}).withTraitSet(rootTraitSet);
-    return queryPlan.withRootOperators({std::move(newRoot)});
+    return rewritePlanBottomUp(
+        queryPlan,
+        [&targetOrders](const LogicalOperator& visiting, std::vector<LogicalOperator> newChildren) -> LogicalOperator
+        {
+            auto traitSet = visiting.getTraitSet();
+            if (visiting.tryGetAs<SinkLogicalOperator>().has_value())
+            {
+                traitSet.insert(FieldOrderingTrait{Schema<UnqualifiedUnboundField, Ordered>{}});
+            }
+            else if (const auto targetOrder = targetOrders.find(visiting.getId()); targetOrder != targetOrders.end())
+            {
+                traitSet.insert(FieldOrderingTrait{targetOrder->second});
+            }
+            else
+            {
+                traitSet.insert(FieldOrderingTrait{unbind(heuristicOutputOrder(visiting, newChildren))});
+            }
+            return visiting.withTraitSet(std::move(traitSet)).withChildren(std::move(newChildren));
+        });
 }
 
 /// NOLINTNEXTLINE(performance-unnecessary-value-param)

--- a/nes-query-optimizer/src/Rules/Static/DecideJoinTypesRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/DecideJoinTypesRule.cpp
@@ -14,12 +14,12 @@
 #include <Rules/Static/DecideJoinTypesRule.hpp>
 
 #include <algorithm>
-#include <ranges>
 #include <set>
 #include <string_view>
 #include <typeindex>
 #include <typeinfo>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include <Functions/BooleanFunctions/AndLogicalFunction.hpp>
@@ -37,6 +37,7 @@
 #include <Traits/TraitSet.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <ErrorHandling.hpp>
+#include <PlanRewriteUtils.hpp>
 #include <PlanRuleRegistry.hpp>
 #include <QueryOptimizerConfiguration.hpp>
 
@@ -93,9 +94,11 @@ std::set<std::type_index> DecideJoinTypesRule::needs() const
 
 LogicalPlan DecideJoinTypesRule::apply(const LogicalPlan& queryPlan) const
 {
-    PRECONDITION(queryPlan.getRootOperators().size() == 1, "Only single root operators are supported for now");
     PRECONDITION(not queryPlan.getRootOperators().empty(), "Query must have a sink root operator");
-    return LogicalPlan{queryPlan.getQueryId(), {apply(queryPlan.getRootOperators()[0])}};
+    return rewritePlanBottomUp(
+        queryPlan,
+        [this](const LogicalOperator& logicalOperator, std::vector<LogicalOperator> children)
+        { return apply(logicalOperator, std::move(children)); });
 }
 
 bool DecideJoinTypesRule::operator==(const DecideJoinTypesRule& other) const
@@ -103,10 +106,8 @@ bool DecideJoinTypesRule::operator==(const DecideJoinTypesRule& other) const
     return this->joinStrategy == other.joinStrategy;
 }
 
-LogicalOperator DecideJoinTypesRule::apply(const LogicalOperator& logicalOperator) const
+LogicalOperator DecideJoinTypesRule::apply(const LogicalOperator& logicalOperator, std::vector<LogicalOperator> children) const
 {
-    const auto children = logicalOperator.getChildren()
-        | std::views::transform([this](const LogicalOperator& child) { return apply(child); }) | std::ranges::to<std::vector>();
     auto traitSet = logicalOperator.getTraitSet();
     if (const auto joinOperator = logicalOperator.tryGetAs<JoinLogicalOperator>())
     {
@@ -134,7 +135,7 @@ LogicalOperator DecideJoinTypesRule::apply(const LogicalOperator& logicalOperato
     {
         tryInsert(traitSet, JoinImplementationTypeTrait{JoinImplementation::CHOICELESS});
     }
-    return logicalOperator.withChildren(children).withTraitSet(traitSet);
+    return logicalOperator.withChildren(std::move(children)).withTraitSet(traitSet);
 }
 
 /// NOLINTNEXTLINE(performance-unnecessary-value-param)

--- a/nes-query-optimizer/src/Rules/Static/DecideMemoryLayoutRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/DecideMemoryLayoutRule.cpp
@@ -13,11 +13,12 @@
 */
 #include <Rules/Static/DecideMemoryLayoutRule.hpp>
 
-#include <ranges>
 #include <set>
 #include <string_view>
 #include <typeindex>
 #include <typeinfo>
+#include <utility>
+#include <vector>
 
 #include <Interface/BufferRef/LowerSchemaProvider.hpp>
 #include <Operators/LogicalOperator.hpp>
@@ -26,6 +27,7 @@
 #include <Traits/MemoryLayoutTypeTrait.hpp>
 #include <Traits/TraitSet.hpp>
 #include <ErrorHandling.hpp>
+#include <PlanRewriteUtils.hpp>
 #include <PlanRuleRegistry.hpp>
 
 namespace NES
@@ -39,19 +41,19 @@ std::set<std::type_index> DecideMemoryLayoutRule::needs() const
 
 LogicalPlan DecideMemoryLayoutRule::apply(const LogicalPlan& queryPlan) const
 {
-    PRECONDITION(queryPlan.getRootOperators().size() == 1, "Only single root operators are supported for now");
     PRECONDITION(not queryPlan.getRootOperators().empty(), "Query must have a sink root operator");
-    return LogicalPlan{queryPlan.getQueryId(), {apply(queryPlan.getRootOperators()[0])}};
+    return rewritePlanBottomUp(
+        queryPlan,
+        [this](const LogicalOperator& logicalOperator, std::vector<LogicalOperator> children)
+        { return apply(logicalOperator, std::move(children)); });
 }
 
-LogicalOperator DecideMemoryLayoutRule::apply(const LogicalOperator& logicalOperator) const
+LogicalOperator DecideMemoryLayoutRule::apply(const LogicalOperator& logicalOperator, std::vector<LogicalOperator> children) const
 {
     /// Iterating over all operators and setting the memory layout trait to row
-    const auto children = logicalOperator.getChildren()
-        | std::views::transform([this](const LogicalOperator& child) { return apply(child); }) | std::ranges::to<std::vector>();
     auto traitSet = logicalOperator.getTraitSet();
     tryInsert(traitSet, MemoryLayoutTypeTrait{MemoryLayoutType::ROW_LAYOUT});
-    return logicalOperator.withChildren(children).withTraitSet(traitSet);
+    return logicalOperator.withChildren(std::move(children)).withTraitSet(traitSet);
 }
 
 /// NOLINTNEXTLINE(performance-unnecessary-value-param)

--- a/nes-query-optimizer/src/Rules/Static/OriginIdInferenceRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/OriginIdInferenceRule.cpp
@@ -36,6 +36,7 @@
 #include <Traits/Trait.hpp>
 #include <Traits/TraitSet.hpp>
 #include <ErrorHandling.hpp>
+#include <PlanRewriteUtils.hpp>
 #include <PlanRuleRegistry.hpp>
 
 namespace NES
@@ -43,14 +44,12 @@ namespace NES
 
 namespace
 {
-LogicalOperator propagateOriginIds(const LogicalOperator& visitingOperator, OriginId& lastOriginId)
+LogicalOperator
+propagateOriginIds(const LogicalOperator& visitingOperator, std::vector<LogicalOperator> newChildren, OriginId& lastOriginId)
 {
-    std::vector<LogicalOperator> newChildren;
     std::vector<OutputOriginIdsTrait> childOriginIds;
-    for (const auto& child : visitingOperator.getChildren())
+    for (const auto& newChild : newChildren)
     {
-        auto newChild = propagateOriginIds(child, lastOriginId);
-        newChildren.push_back(newChild);
         const auto childOriginIdsOpt = getTrait<OutputOriginIdsTrait>(newChild.getTraitSet());
         INVARIANT(childOriginIdsOpt.has_value(), "Child operator must have origin ids trait");
         childOriginIds.push_back(childOriginIdsOpt.value().get());
@@ -73,7 +72,7 @@ LogicalOperator propagateOriginIds(const LogicalOperator& visitingOperator, Orig
         INVARIANT(success, "Failed to insert origin id trait, did another phase already assign them?");
     }
 
-    return visitingOperator.withTraitSet(traitSet).withChildren(newChildren);
+    return visitingOperator.withTraitSet(traitSet).withChildren(std::move(newChildren));
 }
 }
 
@@ -88,14 +87,11 @@ LogicalPlan OriginIdInferenceRule::apply(const LogicalPlan& queryPlan) const
 {
     /// origin ids, always start from 1 to n, whereby n is the number of operators that assign new orin ids
     auto originIdCounter = OriginId{INITIAL_ORIGIN_ID.getRawValue()};
-    /// propagate origin ids through the complete query plan
-    std::vector<LogicalOperator> newSinks;
-    newSinks.reserve(queryPlan.getRootOperators().size());
-    for (auto& sinkOperator : queryPlan.getRootOperators())
-    {
-        newSinks.push_back(propagateOriginIds(sinkOperator, originIdCounter));
-    }
-    return queryPlan.withRootOperators(newSinks);
+    /// propagate origin ids through the complete query plan; shared operators are visited once, so they assign one origin id
+    return rewritePlanBottomUp(
+        queryPlan,
+        [&originIdCounter](const LogicalOperator& visitingOperator, std::vector<LogicalOperator> children)
+        { return propagateOriginIds(visitingOperator, std::move(children), originIdCounter); });
 }
 
 /// NOLINTNEXTLINE(performance-unnecessary-value-param)

--- a/nes-query-optimizer/src/Rules/Static/PredicatePushdownRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/PredicatePushdownRule.cpp
@@ -54,18 +54,8 @@ namespace NES
 
 namespace
 {
-/// Tracks operators reachable through more than one parent during pushdown. Predicates from one parent must not be
-/// pushed into a subtree another parent also reads, so shared operators act as pushdown barriers: pending predicates
-/// are materialized above them, while the shared subtree itself is rewritten exactly once (with an empty predicate
-/// set) and the rewritten instance is reused by every parent, preserving sharing.
-struct PushdownContext
-{
-    std::unordered_set<OperatorId> sharedOperatorIds;
-    std::unordered_map<OperatorId, LogicalOperator> rewrittenSharedOperators;
-};
-
 [[nodiscard]] LogicalOperator predicatePushdown(
-    PushdownContext& ctx, LogicalOperator op, std::vector<LogicalFunction> predicateSet, std::unordered_map<Field, Field> fields);
+    PushdownBarrier& ctx, LogicalOperator op, std::vector<LogicalFunction> predicateSet, std::unordered_map<Field, Field> fields);
 
 std::vector<LogicalFunction> splitPredicate(LogicalFunction function)
 {
@@ -134,7 +124,7 @@ std::unordered_map<Field, Field> fieldsWithNewOperator(const LogicalOperator& ba
 }
 
 LogicalOperator applyToAllChildren(
-    PushdownContext& ctx,
+    PushdownBarrier& ctx,
     const LogicalOperator& op,
     const std::vector<LogicalFunction>& predicateSet,
     const std::unordered_map<Field, Field>& fields)
@@ -154,7 +144,7 @@ LogicalOperator applyToAllChildren(
 }
 
 LogicalOperator pushBeyondSelection(
-    PushdownContext& ctx,
+    PushdownBarrier& ctx,
     const TypedLogicalOperator<SelectionLogicalOperator>& op,
     std::vector<LogicalFunction> predicateSet,
     std::unordered_map<Field, Field> fields)
@@ -180,7 +170,7 @@ LogicalOperator pushBeyondSelection(
 }
 
 LogicalOperator pushBeyondUnion(
-    PushdownContext& ctx,
+    PushdownBarrier& ctx,
     const TypedLogicalOperator<UnionLogicalOperator>& op,
     const std::vector<LogicalFunction>& predicateSet,
     const std::unordered_map<Field, Field>& fields)
@@ -198,7 +188,7 @@ LogicalOperator pushBeyondUnion(
 }
 
 LogicalOperator pushBeyondProjection(
-    PushdownContext& ctx,
+    PushdownBarrier& ctx,
     const TypedLogicalOperator<ProjectionLogicalOperator>& op,
     const std::vector<LogicalFunction>& predicateSet,
     const std::unordered_map<Field, Field>& fields)
@@ -262,7 +252,7 @@ LogicalOperator pushBeyondProjection(
 }
 
 LogicalOperator pushBeyondJoin(
-    PushdownContext& ctx,
+    PushdownBarrier& ctx,
     const TypedLogicalOperator<JoinLogicalOperator>& op,
     const std::vector<LogicalFunction>& predicateSet,
     const std::unordered_map<Field, Field>& fields)
@@ -313,7 +303,7 @@ LogicalOperator pushBeyondJoin(
 }
 
 LogicalOperator pushBeyondWatermarkAssigner(
-    PushdownContext& ctx,
+    PushdownBarrier& ctx,
     const LogicalOperator& op,
     const std::vector<LogicalFunction>& predicateSet,
     const std::unordered_map<Field, Field>& fields)
@@ -326,7 +316,7 @@ LogicalOperator pushBeyondWatermarkAssigner(
 }
 
 LogicalOperator pushBeyondWindowedAggregation(
-    PushdownContext& ctx,
+    PushdownBarrier& ctx,
     const TypedLogicalOperator<WindowedAggregationLogicalOperator>& op,
     const std::vector<LogicalFunction>& predicateSet,
     std::unordered_map<Field, Field> fields)
@@ -377,7 +367,7 @@ LogicalOperator pushBeyondWindowedAggregation(
 }
 
 LogicalOperator predicatePushdownDispatch(
-    PushdownContext& ctx, LogicalOperator op, std::vector<LogicalFunction> predicateSet, std::unordered_map<Field, Field> fields)
+    PushdownBarrier& ctx, LogicalOperator op, std::vector<LogicalFunction> predicateSet, std::unordered_map<Field, Field> fields)
 {
     if (op.tryGetAs<SourceDescriptorLogicalOperator>())
     {
@@ -417,16 +407,17 @@ LogicalOperator predicatePushdownDispatch(
 }
 
 LogicalOperator predicatePushdown(
-    PushdownContext& ctx, LogicalOperator op, std::vector<LogicalFunction> predicateSet, std::unordered_map<Field, Field> fields)
+    PushdownBarrier& ctx, LogicalOperator op, std::vector<LogicalFunction> predicateSet, std::unordered_map<Field, Field> fields)
 {
-    if (ctx.sharedOperatorIds.contains(op.getId()))
+    /// A shared operator is a pushdown barrier: pending predicates must not enter a subtree another parent also reads, so
+    /// they are materialized above it while the shared subtree itself is rewritten once with an empty predicate set.
+    if (ctx.isShared(op))
     {
-        auto rewritten = ctx.rewrittenSharedOperators.find(op.getId());
-        if (rewritten == ctx.rewrittenSharedOperators.end())
-        {
-            rewritten = ctx.rewrittenSharedOperators.emplace(op.getId(), predicatePushdownDispatch(ctx, op, {}, {})).first;
-        }
-        return addSelectionIfRequired(rewritten->second, std::move(predicateSet), fieldsWithNewOperator(rewritten->second, fields));
+        return ctx.rewriteShared(
+            op,
+            [&] { return predicatePushdownDispatch(ctx, op, {}, {}); },
+            [&](const LogicalOperator& rewritten)
+            { return addSelectionIfRequired(rewritten, std::move(predicateSet), fieldsWithNewOperator(rewritten, fields)); });
     }
     return predicatePushdownDispatch(ctx, std::move(op), std::move(predicateSet), std::move(fields));
 }
@@ -438,7 +429,7 @@ LogicalPlan PredicatePushdownRule::apply(const LogicalPlan& queryPlan) const
 {
     PRECONDITION(not queryPlan.getRootOperators().empty(), "Query must have a sink root operator");
 
-    PushdownContext ctx{.sharedOperatorIds = getSharedOperatorIds(queryPlan), .rewrittenSharedOperators = {}};
+    PushdownBarrier ctx{queryPlan};
     std::vector<LogicalOperator> newRoots;
     newRoots.reserve(queryPlan.getRootOperators().size());
     for (const auto& root : queryPlan.getRootOperators())

--- a/nes-query-optimizer/src/Rules/Static/PredicatePushdownRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/PredicatePushdownRule.cpp
@@ -28,6 +28,7 @@
 #include <Functions/BooleanFunctions/AndLogicalFunction.hpp>
 #include <Functions/FieldAccessLogicalFunction.hpp>
 #include <Functions/LogicalFunction.hpp>
+#include <Identifiers/Identifiers.hpp>
 #include <Iterators/BFSIterator.hpp>
 #include <Operators/EventTimeWatermarkAssignerLogicalOperator.hpp>
 #include <Operators/IngestionTimeWatermarkAssignerLogicalOperator.hpp>
@@ -53,8 +54,18 @@ namespace NES
 
 namespace
 {
-[[nodiscard]] LogicalOperator
-predicatePushdown(LogicalOperator op, std::vector<LogicalFunction> predicateSet, std::unordered_map<Field, Field> fields);
+/// Tracks operators reachable through more than one parent during pushdown. Predicates from one parent must not be
+/// pushed into a subtree another parent also reads, so shared operators act as pushdown barriers: pending predicates
+/// are materialized above them, while the shared subtree itself is rewritten exactly once (with an empty predicate
+/// set) and the rewritten instance is reused by every parent, preserving sharing.
+struct PushdownContext
+{
+    std::unordered_set<OperatorId> sharedOperatorIds;
+    std::unordered_map<OperatorId, LogicalOperator> rewrittenSharedOperators;
+};
+
+[[nodiscard]] LogicalOperator predicatePushdown(
+    PushdownContext& ctx, LogicalOperator op, std::vector<LogicalFunction> predicateSet, std::unordered_map<Field, Field> fields);
 
 std::vector<LogicalFunction> splitPredicate(LogicalFunction function)
 {
@@ -123,18 +134,27 @@ std::unordered_map<Field, Field> fieldsWithNewOperator(const LogicalOperator& ba
 }
 
 LogicalOperator applyToAllChildren(
-    const LogicalOperator& op, const std::vector<LogicalFunction>& predicateSet, const std::unordered_map<Field, Field>& fields)
+    PushdownContext& ctx,
+    const LogicalOperator& op,
+    const std::vector<LogicalFunction>& predicateSet,
+    const std::unordered_map<Field, Field>& fields)
 {
     std::vector<LogicalOperator> children;
     for (const auto& child : op.getChildren())
     {
-        auto newChild = predicatePushdown(child, predicateSet, fieldsWithNewOperator(child, fields));
+        auto newChild = predicatePushdown(ctx, child, predicateSet, fieldsWithNewOperator(child, fields));
         children.push_back(newChild);
     }
-    return op.withChildren(children).withInferredSchema();
+    /// withChildren re-infers only the local schema and does not recurse into the children. This relies on the
+    /// children's schemas already being inferred, which holds here: the input plan is type-inferred before this
+    /// rule runs, and every child was rebuilt through withChildren or a constructor that infers locally.
+    /// A recursive withInferredSchema would copy the already-rewritten (potentially shared) subtrees and break
+    /// operator sharing in multi-sink plans.
+    return op.withChildren(children);
 }
 
 LogicalOperator pushBeyondSelection(
+    PushdownContext& ctx,
     const TypedLogicalOperator<SelectionLogicalOperator>& op,
     std::vector<LogicalFunction> predicateSet,
     std::unordered_map<Field, Field> fields)
@@ -156,10 +176,11 @@ LogicalOperator pushBeyondSelection(
         predicateSet.emplace_back(newPredicate);
     }
 
-    return predicatePushdown(op->getChild(), std::move(predicateSet), std::move(fields));
+    return predicatePushdown(ctx, op->getChild(), std::move(predicateSet), std::move(fields));
 }
 
 LogicalOperator pushBeyondUnion(
+    PushdownContext& ctx,
     const TypedLogicalOperator<UnionLogicalOperator>& op,
     const std::vector<LogicalFunction>& predicateSet,
     const std::unordered_map<Field, Field>& fields)
@@ -170,13 +191,14 @@ LogicalOperator pushBeyondUnion(
     for (const auto& child : op.getChildren())
     {
         const auto childFields = fieldsWithNewOperator(child, fields);
-        newChildren.emplace_back(predicatePushdown(child, predicateSet, childFields));
+        newChildren.emplace_back(predicatePushdown(ctx, child, predicateSet, childFields));
     }
 
-    return op.withChildren(newChildren).withInferredSchema();
+    return op.withChildren(newChildren);
 }
 
 LogicalOperator pushBeyondProjection(
+    PushdownContext& ctx,
     const TypedLogicalOperator<ProjectionLogicalOperator>& op,
     const std::vector<LogicalFunction>& predicateSet,
     const std::unordered_map<Field, Field>& fields)
@@ -234,12 +256,13 @@ LogicalOperator pushBeyondProjection(
         }
     }
 
-    const auto newOp = applyToAllChildren(op, pushable, fields);
+    const auto newOp = applyToAllChildren(ctx, op, pushable, fields);
 
     return addSelectionIfRequired(newOp, std::move(nonPushable), fields);
 }
 
 LogicalOperator pushBeyondJoin(
+    PushdownContext& ctx,
     const TypedLogicalOperator<JoinLogicalOperator>& op,
     const std::vector<LogicalFunction>& predicateSet,
     const std::unordered_map<Field, Field>& fields)
@@ -281,25 +304,29 @@ LogicalOperator pushBeyondJoin(
         }
     }
 
-    const auto newLeft = predicatePushdown(left, std::move(leftPushable), leftFields);
-    const auto newRight = predicatePushdown(right, std::move(rightPushable), rightFields);
+    const auto newLeft = predicatePushdown(ctx, left, std::move(leftPushable), leftFields);
+    const auto newRight = predicatePushdown(ctx, right, std::move(rightPushable), rightFields);
 
-    const auto newOp = op->withChildren({newLeft, newRight}).withInferredSchema();
+    const auto newOp = op->withChildren({newLeft, newRight});
 
     return addSelectionIfRequired(newOp, std::move(nonPushable), fields);
 }
 
 LogicalOperator pushBeyondWatermarkAssigner(
-    const LogicalOperator& op, const std::vector<LogicalFunction>& predicateSet, const std::unordered_map<Field, Field>& fields)
+    PushdownContext& ctx,
+    const LogicalOperator& op,
+    const std::vector<LogicalFunction>& predicateSet,
+    const std::unordered_map<Field, Field>& fields)
 {
     /// pushes all predicates further because
     /// operator does not add/modify any fields
 
     const auto newFields = fieldsWithNewOperator(op->getChildren().at(0), fields);
-    return applyToAllChildren(op, predicateSet, newFields);
+    return applyToAllChildren(ctx, op, predicateSet, newFields);
 }
 
 LogicalOperator pushBeyondWindowedAggregation(
+    PushdownContext& ctx,
     const TypedLogicalOperator<WindowedAggregationLogicalOperator>& op,
     const std::vector<LogicalFunction>& predicateSet,
     std::unordered_map<Field, Field> fields)
@@ -344,12 +371,13 @@ LogicalOperator pushBeyondWindowedAggregation(
         }
     }
 
-    const auto newOp = applyToAllChildren(op, pushable, fields);
+    const auto newOp = applyToAllChildren(ctx, op, pushable, fields);
 
     return addSelectionIfRequired(newOp, std::move(nonPushable), fields);
 }
 
-LogicalOperator predicatePushdown(LogicalOperator op, std::vector<LogicalFunction> predicateSet, std::unordered_map<Field, Field> fields)
+LogicalOperator predicatePushdownDispatch(
+    PushdownContext& ctx, LogicalOperator op, std::vector<LogicalFunction> predicateSet, std::unordered_map<Field, Field> fields)
 {
     if (op.tryGetAs<SourceDescriptorLogicalOperator>())
     {
@@ -357,35 +385,50 @@ LogicalOperator predicatePushdown(LogicalOperator op, std::vector<LogicalFunctio
     }
     if (auto selectionOp = op.tryGetAs<SelectionLogicalOperator>())
     {
-        return pushBeyondSelection(selectionOp.value(), std::move(predicateSet), std::move(fields));
+        return pushBeyondSelection(ctx, selectionOp.value(), std::move(predicateSet), std::move(fields));
     }
     if (auto projectionOp = op.tryGetAs<ProjectionLogicalOperator>())
     {
-        return pushBeyondProjection(projectionOp.value(), predicateSet, fields);
+        return pushBeyondProjection(ctx, projectionOp.value(), predicateSet, fields);
     }
     if (auto joinOp = op.tryGetAs<JoinLogicalOperator>())
     {
-        return pushBeyondJoin(joinOp.value(), predicateSet, fields);
+        return pushBeyondJoin(ctx, joinOp.value(), predicateSet, fields);
     }
     if (auto unionOp = op.tryGetAs<UnionLogicalOperator>())
     {
-        return pushBeyondUnion(unionOp.value(), predicateSet, fields);
+        return pushBeyondUnion(ctx, unionOp.value(), predicateSet, fields);
     }
     if (auto eventTimeOp = op.tryGetAs<EventTimeWatermarkAssignerLogicalOperator>())
     {
-        return pushBeyondWatermarkAssigner(std::move(eventTimeOp.value()), predicateSet, fields);
+        return pushBeyondWatermarkAssigner(ctx, std::move(eventTimeOp.value()), predicateSet, fields);
     }
     if (auto ingestionTimeOp = op.tryGetAs<IngestionTimeWatermarkAssignerLogicalOperator>())
     {
-        return pushBeyondWatermarkAssigner(std::move(ingestionTimeOp.value()), predicateSet, fields);
+        return pushBeyondWatermarkAssigner(ctx, std::move(ingestionTimeOp.value()), predicateSet, fields);
     }
     if (auto windowedAggOp = op.tryGetAs<WindowedAggregationLogicalOperator>())
     {
-        return pushBeyondWindowedAggregation(windowedAggOp.value(), predicateSet, std::move(fields));
+        return pushBeyondWindowedAggregation(ctx, windowedAggOp.value(), predicateSet, std::move(fields));
     }
 
-    op = applyToAllChildren(op, {}, {});
+    op = applyToAllChildren(ctx, op, {}, {});
     return addSelectionIfRequired(std::move(op), std::move(predicateSet), fields);
+}
+
+LogicalOperator predicatePushdown(
+    PushdownContext& ctx, LogicalOperator op, std::vector<LogicalFunction> predicateSet, std::unordered_map<Field, Field> fields)
+{
+    if (ctx.sharedOperatorIds.contains(op.getId()))
+    {
+        auto rewritten = ctx.rewrittenSharedOperators.find(op.getId());
+        if (rewritten == ctx.rewrittenSharedOperators.end())
+        {
+            rewritten = ctx.rewrittenSharedOperators.emplace(op.getId(), predicatePushdownDispatch(ctx, op, {}, {})).first;
+        }
+        return addSelectionIfRequired(rewritten->second, std::move(predicateSet), fieldsWithNewOperator(rewritten->second, fields));
+    }
+    return predicatePushdownDispatch(ctx, std::move(op), std::move(predicateSet), std::move(fields));
 }
 
 }
@@ -393,12 +436,16 @@ LogicalOperator predicatePushdown(LogicalOperator op, std::vector<LogicalFunctio
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 LogicalPlan PredicatePushdownRule::apply(const LogicalPlan& queryPlan) const
 {
-    const auto originalRoots = queryPlan.getRootOperators();
-    PRECONDITION(originalRoots.size() == 1, "predicate pushdown not yet implemented for more than one root");
+    PRECONDITION(not queryPlan.getRootOperators().empty(), "Query must have a sink root operator");
 
-    auto newRoot = predicatePushdown(originalRoots.at(0), {}, {});
-
-    return queryPlan.withRootOperators({newRoot});
+    PushdownContext ctx{.sharedOperatorIds = getSharedOperatorIds(queryPlan), .rewrittenSharedOperators = {}};
+    std::vector<LogicalOperator> newRoots;
+    newRoots.reserve(queryPlan.getRootOperators().size());
+    for (const auto& root : queryPlan.getRootOperators())
+    {
+        newRoots.push_back(predicatePushdown(ctx, root, {}, {}));
+    }
+    return queryPlan.withRootOperators(newRoots);
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Static/ProjectionPushdownRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/ProjectionPushdownRule.cpp
@@ -30,6 +30,7 @@
 #include <Functions/FieldAccessLogicalFunction.hpp>
 #include <Functions/LogicalFunction.hpp>
 #include <Identifiers/Identifier.hpp>
+#include <Identifiers/Identifiers.hpp>
 #include <Iterators/BFSIterator.hpp>
 #include <Operators/EventTimeWatermarkAssignerLogicalOperator.hpp>
 #include <Operators/IngestionTimeWatermarkAssignerLogicalOperator.hpp>
@@ -51,6 +52,7 @@
 #include <WindowTypes/Measures/TimeCharacteristic.hpp>
 #include <fmt/format.h>
 #include <ErrorHandling.hpp>
+#include <PlanRewriteUtils.hpp>
 
 #include <PlanRuleRegistry.hpp>
 
@@ -59,7 +61,17 @@ namespace NES
 namespace
 {
 
-LogicalOperator projectionPushdown(const LogicalOperator& op, const std::unordered_set<Field>& required);
+/// Tracks operators reachable through more than one parent during pushdown. The required-field set of one parent must
+/// not narrow a subtree another parent also reads, so shared operators act as pushdown barriers: they are rewritten
+/// exactly once requiring their full output schema, and the rewritten instance is reused by every parent, preserving
+/// sharing.
+struct PushdownContext
+{
+    std::unordered_set<OperatorId> sharedOperatorIds;
+    std::unordered_map<OperatorId, LogicalOperator> rewrittenSharedOperators;
+};
+
+LogicalOperator projectionPushdown(PushdownContext& ctx, const LogicalOperator& op, const std::unordered_set<Field>& required);
 
 std::unordered_set<Field> getAccessedFields(const LogicalFunction& logicalFunction)
 {
@@ -85,7 +97,7 @@ std::vector<Field> sortFields(const std::unordered_set<Field>& fields)
     return sortedFields;
 }
 
-LogicalOperator pushBeyondSink(const TypedLogicalOperator<SinkLogicalOperator>& op)
+LogicalOperator pushBeyondSink(PushdownContext& ctx, const TypedLogicalOperator<SinkLogicalOperator>& op)
 {
     /// Use identifiers from output schema as starting point for required fields.
     std::unordered_set<Field> required{};
@@ -94,9 +106,14 @@ LogicalOperator pushBeyondSink(const TypedLogicalOperator<SinkLogicalOperator>& 
         required.insert(field);
     }
 
-    auto newChild = projectionPushdown(op->getChild(), required);
+    auto newChild = projectionPushdown(ctx, op->getChild(), required);
 
-    return op.withChildren({newChild}).withInferredSchema();
+    /// withChildren re-infers only the local schema and does not recurse into the children. This relies on the
+    /// children's schemas already being inferred, which holds here: the input plan is type-inferred before this
+    /// rule runs, and every child was rebuilt through withChildren or a constructor that infers locally.
+    /// A recursive withInferredSchema would copy the already-rewritten (potentially shared) subtrees and break
+    /// operator sharing in multi-sink plans.
+    return op.withChildren({newChild});
 }
 
 LogicalOperator pushBeyondSource(TypedLogicalOperator<SourceDescriptorLogicalOperator> op, std::unordered_set<Field> required)
@@ -128,7 +145,8 @@ LogicalOperator pushBeyondSource(TypedLogicalOperator<SourceDescriptorLogicalOpe
     return op;
 }
 
-LogicalOperator pushBeyondSelection(const TypedLogicalOperator<SelectionLogicalOperator>& op, const std::unordered_set<Field>& required)
+LogicalOperator pushBeyondSelection(
+    PushdownContext& ctx, const TypedLogicalOperator<SelectionLogicalOperator>& op, const std::unordered_set<Field>& required)
 {
     /// Add accessed identifiers in predicate if necessary
 
@@ -140,11 +158,12 @@ LogicalOperator pushBeyondSelection(const TypedLogicalOperator<SelectionLogicalO
         newRequired.insert(newField.value());
     }
 
-    auto child = projectionPushdown(op->getChild(), newRequired);
-    return op.withChildren({child}).withInferredSchema();
+    auto child = projectionPushdown(ctx, op->getChild(), newRequired);
+    return op.withChildren({child});
 }
 
-LogicalOperator pushBeyondProjection(const TypedLogicalOperator<ProjectionLogicalOperator>& op, const std::unordered_set<Field>& required)
+LogicalOperator pushBeyondProjection(
+    PushdownContext& ctx, const TypedLogicalOperator<ProjectionLogicalOperator>& op, const std::unordered_set<Field>& required)
 {
     /// remove unnecessary projections, replace required identifiers via accessed fields from remaining projections
 
@@ -181,11 +200,12 @@ LogicalOperator pushBeyondProjection(const TypedLogicalOperator<ProjectionLogica
         }
     }
 
-    auto newChild = projectionPushdown(op->getChild(), newRequired);
+    auto newChild = projectionPushdown(ctx, op->getChild(), newRequired);
     return TypedLogicalOperator<ProjectionLogicalOperator>{newChild, newProjections, ProjectionLogicalOperator::Asterisk{false}};
 }
 
-LogicalOperator pushBeyondJoin(const TypedLogicalOperator<JoinLogicalOperator>& op, const std::unordered_set<Field>& required)
+LogicalOperator
+pushBeyondJoin(PushdownContext& ctx, const TypedLogicalOperator<JoinLogicalOperator>& op, const std::unordered_set<Field>& required)
 {
     /// Add accessed identifiers in join predicate if necessary
     /// Apply recursion to both children, each with the relevant subset of required fields that come from the individual child
@@ -260,14 +280,15 @@ LogicalOperator pushBeyondJoin(const TypedLogicalOperator<JoinLogicalOperator>& 
     }
 
 
-    auto newLeft = projectionPushdown(left, requiredLeft);
-    auto newRight = projectionPushdown(right, requiredRight);
+    auto newLeft = projectionPushdown(ctx, left, requiredLeft);
+    auto newRight = projectionPushdown(ctx, right, requiredRight);
 
     return TypedLogicalOperator<JoinLogicalOperator>{
         std::array{newLeft, newRight}, predicate, op->getWindowType(), op->getJoinType(), op->getJoinTimeCharacteristics()};
 }
 
-LogicalOperator pushBeyondUnion(const TypedLogicalOperator<UnionLogicalOperator>& op, const std::unordered_set<Field>& required)
+LogicalOperator
+pushBeyondUnion(PushdownContext& ctx, const TypedLogicalOperator<UnionLogicalOperator>& op, const std::unordered_set<Field>& required)
 {
     /// no new required fields are added in union operator
 
@@ -281,14 +302,16 @@ LogicalOperator pushBeyondUnion(const TypedLogicalOperator<UnionLogicalOperator>
             INVARIANT(newField.has_value(), "the given field must be available in the plan");
             newRequired.insert(newField.value());
         }
-        newChildren.emplace_back(projectionPushdown(child, newRequired));
+        newChildren.emplace_back(projectionPushdown(ctx, child, newRequired));
     }
 
-    return op.withChildren(newChildren).withInferredSchema();
+    return op.withChildren(newChildren);
 }
 
 LogicalOperator pushBeyondEventTimeWatermarkAssigner(
-    const TypedLogicalOperator<EventTimeWatermarkAssignerLogicalOperator>& op, const std::unordered_set<Field>& required)
+    PushdownContext& ctx,
+    const TypedLogicalOperator<EventTimeWatermarkAssignerLogicalOperator>& op,
+    const std::unordered_set<Field>& required)
 {
     /// Add eventTime field if necessary
 
@@ -300,12 +323,14 @@ LogicalOperator pushBeyondEventTimeWatermarkAssigner(
         newRequired.insert(newField.value());
     }
 
-    auto newChild = projectionPushdown(op->getChild(), newRequired);
-    return op.withChildren({newChild}).withInferredSchema();
+    auto newChild = projectionPushdown(ctx, op->getChild(), newRequired);
+    return op.withChildren({newChild});
 }
 
 LogicalOperator pushBeyondIngestionTimeWatermarkAssigner(
-    const TypedLogicalOperator<IngestionTimeWatermarkAssignerLogicalOperator>& op, const std::unordered_set<Field>& required)
+    PushdownContext& ctx,
+    const TypedLogicalOperator<IngestionTimeWatermarkAssignerLogicalOperator>& op,
+    const std::unordered_set<Field>& required)
 {
     /// No new required fields are added in ingestion time watermark assigner operator.
 
@@ -317,12 +342,12 @@ LogicalOperator pushBeyondIngestionTimeWatermarkAssigner(
         newRequired.insert(newField.value());
     }
 
-    auto newChild = projectionPushdown(op->getChild(), newRequired);
-    return op.withChildren({newChild}).withInferredSchema();
+    auto newChild = projectionPushdown(ctx, op->getChild(), newRequired);
+    return op.withChildren({newChild});
 }
 
-LogicalOperator
-pushBeyondWindowedAggregation(const TypedLogicalOperator<WindowedAggregationLogicalOperator>& op, const std::unordered_set<Field>& required)
+LogicalOperator pushBeyondWindowedAggregation(
+    PushdownContext& ctx, const TypedLogicalOperator<WindowedAggregationLogicalOperator>& op, const std::unordered_set<Field>& required)
 {
     /// Add grouping keys if necessary and remove aggregations that are not accessed later
 
@@ -394,13 +419,13 @@ pushBeyondWindowedAggregation(const TypedLogicalOperator<WindowedAggregationLogi
         }
     }
 
-    auto newChild = projectionPushdown(op->getChild(), newRequired);
+    auto newChild = projectionPushdown(ctx, op->getChild(), newRequired);
 
     return TypedLogicalOperator<WindowedAggregationLogicalOperator>{
         newChild, op->getGroupingKeysWithName(), newAggregations, op->getWindowType(), op->getCharacteristic()};
 }
 
-LogicalOperator pushBeyondDefault(const LogicalOperator& op, const std::unordered_set<Field>& required)
+LogicalOperator pushBeyondDefault(PushdownContext& ctx, const LogicalOperator& op, const std::unordered_set<Field>& required)
 {
     /// Default behavior if concrete operator is not explicitly handled above.
     /// New projection with all required fields is added.
@@ -415,10 +440,10 @@ LogicalOperator pushBeyondDefault(const LogicalOperator& op, const std::unordere
         {
             newRequired.insert(field);
         }
-        newChildren.push_back(projectionPushdown(child, newRequired));
+        newChildren.push_back(projectionPushdown(ctx, child, newRequired));
     }
 
-    auto newOp = op.withChildren(newChildren).withInferredSchema();
+    auto newOp = op.withChildren(newChildren);
 
     std::vector<ProjectionLogicalOperator::UnboundProjection> newProjections;
     for (const auto& field : required)
@@ -430,11 +455,11 @@ LogicalOperator pushBeyondDefault(const LogicalOperator& op, const std::unordere
     return TypedLogicalOperator<ProjectionLogicalOperator>{newOp, newProjections, ProjectionLogicalOperator::Asterisk{false}};
 }
 
-LogicalOperator projectionPushdown(const LogicalOperator& op, const std::unordered_set<Field>& required)
+LogicalOperator projectionPushdownDispatch(PushdownContext& ctx, const LogicalOperator& op, const std::unordered_set<Field>& required)
 {
     if (auto sinkOp = op.tryGetAs<SinkLogicalOperator>())
     {
-        return pushBeyondSink(sinkOp.value());
+        return pushBeyondSink(ctx, sinkOp.value());
     }
     if (auto sourceOp = op.tryGetAs<SourceDescriptorLogicalOperator>())
     {
@@ -442,44 +467,65 @@ LogicalOperator projectionPushdown(const LogicalOperator& op, const std::unorder
     }
     if (auto selectionOp = op.tryGetAs<SelectionLogicalOperator>())
     {
-        return pushBeyondSelection(selectionOp.value(), required);
+        return pushBeyondSelection(ctx, selectionOp.value(), required);
     }
     if (auto projectionOp = op.tryGetAs<ProjectionLogicalOperator>())
     {
-        return pushBeyondProjection(projectionOp.value(), required);
+        return pushBeyondProjection(ctx, projectionOp.value(), required);
     }
     if (auto joinOp = op.tryGetAs<JoinLogicalOperator>())
     {
-        return pushBeyondJoin(joinOp.value(), required);
+        return pushBeyondJoin(ctx, joinOp.value(), required);
     }
     if (auto unionOp = op.tryGetAs<UnionLogicalOperator>())
     {
-        return pushBeyondUnion(unionOp.value(), required);
+        return pushBeyondUnion(ctx, unionOp.value(), required);
     }
     if (auto eventTimeOp = op.tryGetAs<EventTimeWatermarkAssignerLogicalOperator>())
     {
-        return pushBeyondEventTimeWatermarkAssigner(eventTimeOp.value(), required);
+        return pushBeyondEventTimeWatermarkAssigner(ctx, eventTimeOp.value(), required);
     }
     if (auto ingestionTimeOp = op.tryGetAs<IngestionTimeWatermarkAssignerLogicalOperator>())
     {
-        return pushBeyondIngestionTimeWatermarkAssigner(ingestionTimeOp.value(), required);
+        return pushBeyondIngestionTimeWatermarkAssigner(ctx, ingestionTimeOp.value(), required);
     }
     if (auto windowedAggOp = op.tryGetAs<WindowedAggregationLogicalOperator>())
     {
-        return pushBeyondWindowedAggregation(windowedAggOp.value(), required);
+        return pushBeyondWindowedAggregation(ctx, windowedAggOp.value(), required);
     }
-    return pushBeyondDefault(op, required);
+    return pushBeyondDefault(ctx, op, required);
+}
+
+LogicalOperator projectionPushdown(PushdownContext& ctx, const LogicalOperator& op, const std::unordered_set<Field>& required)
+{
+    if (ctx.sharedOperatorIds.contains(op.getId()))
+    {
+        auto rewritten = ctx.rewrittenSharedOperators.find(op.getId());
+        if (rewritten == ctx.rewrittenSharedOperators.end())
+        {
+            /// Require the full output schema so no parent-specific narrowing leaks into the shared subtree.
+            const auto allFields = op.getOutputSchema() | std::ranges::to<std::unordered_set<Field>>();
+            rewritten = ctx.rewrittenSharedOperators.emplace(op.getId(), projectionPushdownDispatch(ctx, op, allFields)).first;
+        }
+        return rewritten->second;
+    }
+    return projectionPushdownDispatch(ctx, op, required);
 }
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 LogicalPlan ProjectionPushdownRule::apply(LogicalPlan queryPlan) const
 {
-    const auto originalRoots = queryPlan.getRootOperators();
-    PRECONDITION(originalRoots.size() == 1, "projection pushdown not yet implemented for more than one root");
-    auto newRoot = projectionPushdown(originalRoots.at(0), {});
-    queryPlan = queryPlan.withRootOperators({newRoot});
-    return queryPlan;
+    PRECONDITION(not queryPlan.getRootOperators().empty(), "Query must have a sink root operator");
+
+    PushdownContext ctx{.sharedOperatorIds = getSharedOperatorIds(queryPlan), .rewrittenSharedOperators = {}};
+    std::vector<LogicalOperator> newRoots;
+    newRoots.reserve(queryPlan.getRootOperators().size());
+    for (const auto& root : queryPlan.getRootOperators())
+    {
+        newRoots.push_back(projectionPushdown(ctx, root, {}));
+    }
+    return queryPlan.withRootOperators(newRoots);
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Static/ProjectionPushdownRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/ProjectionPushdownRule.cpp
@@ -61,17 +61,7 @@ namespace NES
 namespace
 {
 
-/// Tracks operators reachable through more than one parent during pushdown. The required-field set of one parent must
-/// not narrow a subtree another parent also reads, so shared operators act as pushdown barriers: they are rewritten
-/// exactly once requiring their full output schema, and the rewritten instance is reused by every parent, preserving
-/// sharing.
-struct PushdownContext
-{
-    std::unordered_set<OperatorId> sharedOperatorIds;
-    std::unordered_map<OperatorId, LogicalOperator> rewrittenSharedOperators;
-};
-
-LogicalOperator projectionPushdown(PushdownContext& ctx, const LogicalOperator& op, const std::unordered_set<Field>& required);
+LogicalOperator projectionPushdown(PushdownBarrier& ctx, const LogicalOperator& op, const std::unordered_set<Field>& required);
 
 std::unordered_set<Field> getAccessedFields(const LogicalFunction& logicalFunction)
 {
@@ -97,7 +87,7 @@ std::vector<Field> sortFields(const std::unordered_set<Field>& fields)
     return sortedFields;
 }
 
-LogicalOperator pushBeyondSink(PushdownContext& ctx, const TypedLogicalOperator<SinkLogicalOperator>& op)
+LogicalOperator pushBeyondSink(PushdownBarrier& ctx, const TypedLogicalOperator<SinkLogicalOperator>& op)
 {
     /// Use identifiers from output schema as starting point for required fields.
     std::unordered_set<Field> required{};
@@ -146,7 +136,7 @@ LogicalOperator pushBeyondSource(TypedLogicalOperator<SourceDescriptorLogicalOpe
 }
 
 LogicalOperator pushBeyondSelection(
-    PushdownContext& ctx, const TypedLogicalOperator<SelectionLogicalOperator>& op, const std::unordered_set<Field>& required)
+    PushdownBarrier& ctx, const TypedLogicalOperator<SelectionLogicalOperator>& op, const std::unordered_set<Field>& required)
 {
     /// Add accessed identifiers in predicate if necessary
 
@@ -163,7 +153,7 @@ LogicalOperator pushBeyondSelection(
 }
 
 LogicalOperator pushBeyondProjection(
-    PushdownContext& ctx, const TypedLogicalOperator<ProjectionLogicalOperator>& op, const std::unordered_set<Field>& required)
+    PushdownBarrier& ctx, const TypedLogicalOperator<ProjectionLogicalOperator>& op, const std::unordered_set<Field>& required)
 {
     /// remove unnecessary projections, replace required identifiers via accessed fields from remaining projections
 
@@ -205,7 +195,7 @@ LogicalOperator pushBeyondProjection(
 }
 
 LogicalOperator
-pushBeyondJoin(PushdownContext& ctx, const TypedLogicalOperator<JoinLogicalOperator>& op, const std::unordered_set<Field>& required)
+pushBeyondJoin(PushdownBarrier& ctx, const TypedLogicalOperator<JoinLogicalOperator>& op, const std::unordered_set<Field>& required)
 {
     /// Add accessed identifiers in join predicate if necessary
     /// Apply recursion to both children, each with the relevant subset of required fields that come from the individual child
@@ -288,7 +278,7 @@ pushBeyondJoin(PushdownContext& ctx, const TypedLogicalOperator<JoinLogicalOpera
 }
 
 LogicalOperator
-pushBeyondUnion(PushdownContext& ctx, const TypedLogicalOperator<UnionLogicalOperator>& op, const std::unordered_set<Field>& required)
+pushBeyondUnion(PushdownBarrier& ctx, const TypedLogicalOperator<UnionLogicalOperator>& op, const std::unordered_set<Field>& required)
 {
     /// no new required fields are added in union operator
 
@@ -309,7 +299,7 @@ pushBeyondUnion(PushdownContext& ctx, const TypedLogicalOperator<UnionLogicalOpe
 }
 
 LogicalOperator pushBeyondEventTimeWatermarkAssigner(
-    PushdownContext& ctx,
+    PushdownBarrier& ctx,
     const TypedLogicalOperator<EventTimeWatermarkAssignerLogicalOperator>& op,
     const std::unordered_set<Field>& required)
 {
@@ -328,7 +318,7 @@ LogicalOperator pushBeyondEventTimeWatermarkAssigner(
 }
 
 LogicalOperator pushBeyondIngestionTimeWatermarkAssigner(
-    PushdownContext& ctx,
+    PushdownBarrier& ctx,
     const TypedLogicalOperator<IngestionTimeWatermarkAssignerLogicalOperator>& op,
     const std::unordered_set<Field>& required)
 {
@@ -347,7 +337,7 @@ LogicalOperator pushBeyondIngestionTimeWatermarkAssigner(
 }
 
 LogicalOperator pushBeyondWindowedAggregation(
-    PushdownContext& ctx, const TypedLogicalOperator<WindowedAggregationLogicalOperator>& op, const std::unordered_set<Field>& required)
+    PushdownBarrier& ctx, const TypedLogicalOperator<WindowedAggregationLogicalOperator>& op, const std::unordered_set<Field>& required)
 {
     /// Add grouping keys if necessary and remove aggregations that are not accessed later
 
@@ -425,7 +415,7 @@ LogicalOperator pushBeyondWindowedAggregation(
         newChild, op->getGroupingKeysWithName(), newAggregations, op->getWindowType(), op->getCharacteristic()};
 }
 
-LogicalOperator pushBeyondDefault(PushdownContext& ctx, const LogicalOperator& op, const std::unordered_set<Field>& required)
+LogicalOperator pushBeyondDefault(PushdownBarrier& ctx, const LogicalOperator& op, const std::unordered_set<Field>& required)
 {
     /// Default behavior if concrete operator is not explicitly handled above.
     /// New projection with all required fields is added.
@@ -455,7 +445,7 @@ LogicalOperator pushBeyondDefault(PushdownContext& ctx, const LogicalOperator& o
     return TypedLogicalOperator<ProjectionLogicalOperator>{newOp, newProjections, ProjectionLogicalOperator::Asterisk{false}};
 }
 
-LogicalOperator projectionPushdownDispatch(PushdownContext& ctx, const LogicalOperator& op, const std::unordered_set<Field>& required)
+LogicalOperator projectionPushdownDispatch(PushdownBarrier& ctx, const LogicalOperator& op, const std::unordered_set<Field>& required)
 {
     if (auto sinkOp = op.tryGetAs<SinkLogicalOperator>())
     {
@@ -496,18 +486,20 @@ LogicalOperator projectionPushdownDispatch(PushdownContext& ctx, const LogicalOp
     return pushBeyondDefault(ctx, op, required);
 }
 
-LogicalOperator projectionPushdown(PushdownContext& ctx, const LogicalOperator& op, const std::unordered_set<Field>& required)
+LogicalOperator projectionPushdown(PushdownBarrier& ctx, const LogicalOperator& op, const std::unordered_set<Field>& required)
 {
-    if (ctx.sharedOperatorIds.contains(op.getId()))
+    /// A shared operator is a pushdown barrier: it is rewritten once requiring its full output schema so that no
+    /// parent-specific field narrowing leaks into a subtree another parent also reads.
+    if (ctx.isShared(op))
     {
-        auto rewritten = ctx.rewrittenSharedOperators.find(op.getId());
-        if (rewritten == ctx.rewrittenSharedOperators.end())
-        {
-            /// Require the full output schema so no parent-specific narrowing leaks into the shared subtree.
-            const auto allFields = op.getOutputSchema() | std::ranges::to<std::unordered_set<Field>>();
-            rewritten = ctx.rewrittenSharedOperators.emplace(op.getId(), projectionPushdownDispatch(ctx, op, allFields)).first;
-        }
-        return rewritten->second;
+        return ctx.rewriteShared(
+            op,
+            [&]
+            {
+                const auto allFields = op.getOutputSchema() | std::ranges::to<std::unordered_set<Field>>();
+                return projectionPushdownDispatch(ctx, op, allFields);
+            },
+            [](const LogicalOperator& rewritten) { return rewritten; });
     }
     return projectionPushdownDispatch(ctx, op, required);
 }
@@ -518,7 +510,7 @@ LogicalPlan ProjectionPushdownRule::apply(LogicalPlan queryPlan) const
 {
     PRECONDITION(not queryPlan.getRootOperators().empty(), "Query must have a sink root operator");
 
-    PushdownContext ctx{.sharedOperatorIds = getSharedOperatorIds(queryPlan), .rewrittenSharedOperators = {}};
+    PushdownBarrier ctx{queryPlan};
     std::vector<LogicalOperator> newRoots;
     newRoots.reserve(queryPlan.getRootOperators().size());
     for (const auto& root : queryPlan.getRootOperators())

--- a/nes-query-optimizer/src/Rules/Static/RedundantProjectionRemovalRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/RedundantProjectionRemovalRule.cpp
@@ -14,7 +14,6 @@
 
 #include <Rules/Static/RedundantProjectionRemovalRule.hpp>
 
-#include <ranges>
 #include <set>
 #include <string_view>
 #include <typeindex>
@@ -33,6 +32,7 @@
 #include <Rules/Static/ProjectionPushdownRule.hpp>
 #include <Schema/Binder.hpp>
 #include <ErrorHandling.hpp>
+#include <PlanRewriteUtils.hpp>
 #include <PlanRuleRegistry.hpp>
 
 namespace NES
@@ -56,46 +56,42 @@ std::set<std::type_index> RedundantProjectionRemovalRule::needs() const
     return {typeid(SemanticAnalysisBarrier)};
 }
 
-namespace
-{
-LogicalOperator recur(const LogicalOperator& op)
-{
-    auto newChildren = op.getChildren() | std::views::transform(recur) | std::ranges::to<std::vector>();
-
-    if (const auto projection = op.tryGetAs<ProjectionLogicalOperator>())
-    {
-        const auto trivial = [&]
-        {
-            INVARIANT(op.getChildren().size() == 1, "Projection operator must have exactly one child");
-            for (const auto& [as, function] : projection.value()->getProjections())
-            {
-                const auto fieldAccessFunction = function.tryGetAs<FieldAccessLogicalFunction>();
-                if (!fieldAccessFunction.has_value())
-                {
-                    return false;
-                }
-                if (fieldAccessFunction.value()->getField().getLastName() != as.getLastName())
-                {
-                    return false;
-                }
-            }
-            return unbind(op.getChildren().front().getOutputSchema()) == unbind(op.getOutputSchema());
-        }();
-        if (trivial)
-        {
-            return newChildren.front();
-        }
-    }
-    return op.withChildren(std::move(newChildren));
-}
-}
-
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 LogicalPlan RedundantProjectionRemovalRule::apply(LogicalPlan queryPlan) const
 {
-    PRECONDITION(queryPlan.getRootOperators().size() == 1, "Query plan must have exactly one root operator");
-    queryPlan = queryPlan.withRootOperators({recur(queryPlan.getRootOperators().front().withInferredSchema())});
-    return queryPlan;
+    PRECONDITION(not queryPlan.getRootOperators().empty(), "Query must have a sink root operator");
+    /// No upfront deep schema inference: withChildren re-infers each operator's local schema bottom-up,
+    /// while a recursive withInferredSchema would copy shared subtrees per parent.
+    return rewritePlanBottomUp(
+        queryPlan,
+        [](const LogicalOperator& op, std::vector<LogicalOperator> newChildren) -> LogicalOperator
+        {
+            if (const auto projection = op.tryGetAs<ProjectionLogicalOperator>())
+            {
+                const auto trivial = [&]
+                {
+                    INVARIANT(op.getChildren().size() == 1, "Projection operator must have exactly one child");
+                    for (const auto& [as, function] : projection.value()->getProjections())
+                    {
+                        const auto fieldAccessFunction = function.tryGetAs<FieldAccessLogicalFunction>();
+                        if (!fieldAccessFunction.has_value())
+                        {
+                            return false;
+                        }
+                        if (fieldAccessFunction.value()->getField().getLastName() != as.getLastName())
+                        {
+                            return false;
+                        }
+                    }
+                    return unbind(op.getChildren().front().getOutputSchema()) == unbind(op.getOutputSchema());
+                }();
+                if (trivial)
+                {
+                    return newChildren.front();
+                }
+            }
+            return op.withChildren(std::move(newChildren));
+        });
 }
 
 /// NOLINTNEXTLINE(performance-unnecessary-value-param)

--- a/nes-query-optimizer/src/Rules/Static/WatermarkAssignerPushdownRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/WatermarkAssignerPushdownRule.cpp
@@ -18,12 +18,14 @@
 #include <string_view>
 #include <typeindex>
 #include <typeinfo>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
 
 #include <DataTypes/TimeUnit.hpp>
 #include <Functions/FieldAccessLogicalFunction.hpp>
+#include <Identifiers/Identifiers.hpp>
 #include <Operators/EventTimeWatermarkAssignerLogicalOperator.hpp>
 #include <Operators/IngestionTimeWatermarkAssignerLogicalOperator.hpp>
 #include <Operators/LogicalOperator.hpp>
@@ -39,14 +41,25 @@
 #include <Rules/Static/PredicatePushdownRule.hpp>
 #include <Schema/Field.hpp>
 #include <ErrorHandling.hpp>
+#include <PlanRewriteUtils.hpp>
 #include <PlanRuleRegistry.hpp>
 
 namespace NES
 {
 namespace
 {
-LogicalOperator
-watermarkAssignerPushdown(const LogicalOperator& op, bool ingestionTime, std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime);
+/// Tracks operators reachable through more than one parent during pushdown. Watermark assigners from one parent must
+/// not be pushed into a subtree another parent also reads, so shared operators act as pushdown barriers: pending
+/// assigners are materialized above them, while the shared subtree itself is rewritten exactly once (with no pending
+/// assigners) and the rewritten instance is reused by every parent, preserving sharing.
+struct PushdownContext
+{
+    std::unordered_set<OperatorId> sharedOperatorIds;
+    std::unordered_map<OperatorId, LogicalOperator> rewrittenSharedOperators;
+};
+
+LogicalOperator watermarkAssignerPushdown(
+    PushdownContext& ctx, const LogicalOperator& op, bool ingestionTime, std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime);
 
 LogicalOperator
 addWatermarkAssigners(LogicalOperator op, const bool ingestionTime, std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime)
@@ -80,28 +93,36 @@ fieldsWithNewBase(const LogicalOperator& base, std::vector<std::pair<Field, Wind
     return eventTime;
 }
 
-LogicalOperator
-applyToAllChildren(const LogicalOperator& op, const bool ingestionTime, const std::vector<std::pair<Field, Windowing::TimeUnit>>& eventTime)
+LogicalOperator applyToAllChildren(
+    PushdownContext& ctx,
+    const LogicalOperator& op,
+    const bool ingestionTime,
+    const std::vector<std::pair<Field, Windowing::TimeUnit>>& eventTime)
 {
     std::vector<LogicalOperator> children;
     for (const auto& child : op.getChildren())
     {
         const auto childEventTime = fieldsWithNewBase(child, eventTime);
-        auto newChild = watermarkAssignerPushdown(child, ingestionTime, childEventTime);
+        auto newChild = watermarkAssignerPushdown(ctx, child, ingestionTime, childEventTime);
         children.push_back(newChild);
     }
-    return op.withChildren(children).withInferredSchema();
+    /// withChildren re-infers only the local schema and does not recurse into the children. This relies on the
+    /// children's schemas already being inferred, which holds here: the input plan is type-inferred before this
+    /// rule runs, and every child was rebuilt through withChildren or a constructor that infers locally.
+    /// A recursive withInferredSchema would copy the already-rewritten (potentially shared) subtrees and break
+    /// operator sharing in multi-sink plans.
+    return op.withChildren(children);
 }
 
-LogicalOperator pushBeyondSink(const TypedLogicalOperator<SinkLogicalOperator>& op)
+LogicalOperator pushBeyondSink(PushdownContext& ctx, const TypedLogicalOperator<SinkLogicalOperator>& op)
 {
     /// Sinks are the starting point of the recursion.
     /// Because they don't have parents, no watermark assigner
     /// has to be pushed here.
     /// The recursion starts thus with an empty event time watermark assigner set,
     /// and no ingestion time watermark assigner.
-    auto newChild = watermarkAssignerPushdown(op->getChild(), {}, {});
-    return op->withChildren({newChild}).withInferredSchema();
+    auto newChild = watermarkAssignerPushdown(ctx, op->getChild(), {}, {});
+    return op->withChildren({newChild});
 }
 
 LogicalOperator pushBeyondSource(
@@ -113,14 +134,18 @@ LogicalOperator pushBeyondSource(
 }
 
 LogicalOperator pushBeyondTransparentOperator(
-    const LogicalOperator& op, bool ingestionTime, const std::vector<std::pair<Field, Windowing::TimeUnit>>& eventTime)
+    PushdownContext& ctx,
+    const LogicalOperator& op,
+    bool ingestionTime,
+    const std::vector<std::pair<Field, Windowing::TimeUnit>>& eventTime)
 {
     /// Pushes watermark assigners beyond operators that do not affect the
     /// watermark assigners.
-    return applyToAllChildren(op, std::move(ingestionTime), eventTime);
+    return applyToAllChildren(ctx, op, std::move(ingestionTime), eventTime);
 }
 
 LogicalOperator pushBeyondProjection(
+    PushdownContext& ctx,
     const TypedLogicalOperator<ProjectionLogicalOperator>& op,
     bool ingestionTime,
     const std::vector<std::pair<Field, Windowing::TimeUnit>>& eventTime)
@@ -170,7 +195,7 @@ LogicalOperator pushBeyondProjection(
         }
     }
 
-    auto newOp = applyToAllChildren(op, ingestionTime, pushFurther);
+    auto newOp = applyToAllChildren(ctx, op, ingestionTime, pushFurther);
 
     for (const auto& [onField, unit] : std::ranges::reverse_view(applyNow))
     {
@@ -182,6 +207,7 @@ LogicalOperator pushBeyondProjection(
 }
 
 LogicalOperator pushBeyondEventTimeWatermarkAssigner(
+    PushdownContext& ctx,
     const TypedLogicalOperator<EventTimeWatermarkAssignerLogicalOperator>& op,
     const bool ingestionTime,
     std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime)
@@ -196,10 +222,11 @@ LogicalOperator pushBeyondEventTimeWatermarkAssigner(
     const auto fieldAccess = op->getOnField().tryGetAs<FieldAccessLogicalFunction>();
     eventTime = fieldsWithNewBase(op->getChild(), eventTime);
     eventTime.emplace_back(fieldAccess.value()->getField(), op->getUnit());
-    return watermarkAssignerPushdown(op->getChild(), ingestionTime, eventTime);
+    return watermarkAssignerPushdown(ctx, op->getChild(), ingestionTime, eventTime);
 }
 
 LogicalOperator pushBeyondIngestionTimeWatermarkAssigner(
+    PushdownContext& ctx,
     const TypedLogicalOperator<IngestionTimeWatermarkAssignerLogicalOperator>& op,
     bool /* ingestionTime */,
     std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime)
@@ -207,24 +234,24 @@ LogicalOperator pushBeyondIngestionTimeWatermarkAssigner(
     /// Adds flag that a ingestion time watermark assigner is required
 
     eventTime = fieldsWithNewBase(op->getChild(), eventTime);
-    return watermarkAssignerPushdown(op->getChild(), true, eventTime);
+    return watermarkAssignerPushdown(ctx, op->getChild(), true, eventTime);
 }
 
-LogicalOperator
-pushBeyondDefault(const LogicalOperator& op, const bool ingestionTime, std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime)
+LogicalOperator pushBeyondDefault(
+    PushdownContext& ctx, const LogicalOperator& op, const bool ingestionTime, std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime)
 {
     /// Implements default behavior if operator is not explicitly handled.
     /// Applies all watermark assigners and restarts recursion for all children.
-    auto newOp = applyToAllChildren(op, false, {});
+    auto newOp = applyToAllChildren(ctx, op, false, {});
     return addWatermarkAssigners(std::move(newOp), ingestionTime, std::move(eventTime));
 }
 
-LogicalOperator
-watermarkAssignerPushdown(const LogicalOperator& op, bool ingestionTime, std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime)
+LogicalOperator watermarkAssignerPushdownDispatch(
+    PushdownContext& ctx, const LogicalOperator& op, bool ingestionTime, std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime)
 {
     if (const auto sink = op.tryGetAs<SinkLogicalOperator>())
     {
-        return pushBeyondSink(sink.value());
+        return pushBeyondSink(ctx, sink.value());
     }
     if (const auto source = op.tryGetAs<SourceDescriptorLogicalOperator>())
     {
@@ -232,23 +259,39 @@ watermarkAssignerPushdown(const LogicalOperator& op, bool ingestionTime, std::ve
     }
     if (const auto eventTimeWA = op.tryGetAs<EventTimeWatermarkAssignerLogicalOperator>())
     {
-        return pushBeyondEventTimeWatermarkAssigner(eventTimeWA.value(), std::move(ingestionTime), std::move(eventTime));
+        return pushBeyondEventTimeWatermarkAssigner(ctx, eventTimeWA.value(), std::move(ingestionTime), std::move(eventTime));
     }
     if (const auto ingestionTimeWatermarkAssigner = op.tryGetAs<IngestionTimeWatermarkAssignerLogicalOperator>())
     {
         return pushBeyondIngestionTimeWatermarkAssigner(
-            ingestionTimeWatermarkAssigner.value(), std::move(ingestionTime), std::move(eventTime));
+            ctx, ingestionTimeWatermarkAssigner.value(), std::move(ingestionTime), std::move(eventTime));
     }
     if (op.tryGetAs<SelectionLogicalOperator>().has_value() || op.tryGetAs<UnionLogicalOperator>().has_value())
     {
-        return pushBeyondTransparentOperator(op, std::move(ingestionTime), eventTime);
+        return pushBeyondTransparentOperator(ctx, op, std::move(ingestionTime), eventTime);
     }
     if (const auto projOp = op.tryGetAs<ProjectionLogicalOperator>())
     {
-        return pushBeyondProjection(projOp.value(), std::move(ingestionTime), eventTime);
+        return pushBeyondProjection(ctx, projOp.value(), std::move(ingestionTime), eventTime);
     }
 
-    return pushBeyondDefault(op, std::move(ingestionTime), std::move(eventTime));
+    return pushBeyondDefault(ctx, op, std::move(ingestionTime), std::move(eventTime));
+}
+
+LogicalOperator watermarkAssignerPushdown(
+    PushdownContext& ctx, const LogicalOperator& op, bool ingestionTime, std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime)
+{
+    if (ctx.sharedOperatorIds.contains(op.getId()))
+    {
+        auto rewritten = ctx.rewrittenSharedOperators.find(op.getId());
+        if (rewritten == ctx.rewrittenSharedOperators.end())
+        {
+            rewritten = ctx.rewrittenSharedOperators.emplace(op.getId(), watermarkAssignerPushdownDispatch(ctx, op, false, {})).first;
+        }
+        /// addWatermarkAssigners rebinds the event time fields to the rewritten operator by name
+        return addWatermarkAssigners(rewritten->second, ingestionTime, std::move(eventTime));
+    }
+    return watermarkAssignerPushdownDispatch(ctx, op, std::move(ingestionTime), std::move(eventTime));
 }
 
 }
@@ -256,11 +299,16 @@ watermarkAssignerPushdown(const LogicalOperator& op, bool ingestionTime, std::ve
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 LogicalPlan WatermarkAssignerPushdownRule::apply(LogicalPlan queryPlan) const
 {
-    auto originalRoots = queryPlan.getRootOperators();
-    PRECONDITION(originalRoots.size() == 1, "watermark pushdown not yet implemented for more than one root");
-    auto newRoot = watermarkAssignerPushdown(originalRoots.at(0), false, {});
-    queryPlan = queryPlan.withRootOperators({newRoot});
-    return queryPlan;
+    PRECONDITION(not queryPlan.getRootOperators().empty(), "Query must have a sink root operator");
+
+    PushdownContext ctx{.sharedOperatorIds = getSharedOperatorIds(queryPlan), .rewrittenSharedOperators = {}};
+    std::vector<LogicalOperator> newRoots;
+    newRoots.reserve(queryPlan.getRootOperators().size());
+    for (const auto& root : queryPlan.getRootOperators())
+    {
+        newRoots.push_back(watermarkAssignerPushdown(ctx, root, false, {}));
+    }
+    return queryPlan.withRootOperators(newRoots);
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Static/WatermarkAssignerPushdownRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/WatermarkAssignerPushdownRule.cpp
@@ -18,7 +18,6 @@
 #include <string_view>
 #include <typeindex>
 #include <typeinfo>
-#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -48,18 +47,8 @@ namespace NES
 {
 namespace
 {
-/// Tracks operators reachable through more than one parent during pushdown. Watermark assigners from one parent must
-/// not be pushed into a subtree another parent also reads, so shared operators act as pushdown barriers: pending
-/// assigners are materialized above them, while the shared subtree itself is rewritten exactly once (with no pending
-/// assigners) and the rewritten instance is reused by every parent, preserving sharing.
-struct PushdownContext
-{
-    std::unordered_set<OperatorId> sharedOperatorIds;
-    std::unordered_map<OperatorId, LogicalOperator> rewrittenSharedOperators;
-};
-
 LogicalOperator watermarkAssignerPushdown(
-    PushdownContext& ctx, const LogicalOperator& op, bool ingestionTime, std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime);
+    PushdownBarrier& ctx, const LogicalOperator& op, bool ingestionTime, std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime);
 
 LogicalOperator
 addWatermarkAssigners(LogicalOperator op, const bool ingestionTime, std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime)
@@ -94,7 +83,7 @@ fieldsWithNewBase(const LogicalOperator& base, std::vector<std::pair<Field, Wind
 }
 
 LogicalOperator applyToAllChildren(
-    PushdownContext& ctx,
+    PushdownBarrier& ctx,
     const LogicalOperator& op,
     const bool ingestionTime,
     const std::vector<std::pair<Field, Windowing::TimeUnit>>& eventTime)
@@ -114,7 +103,7 @@ LogicalOperator applyToAllChildren(
     return op.withChildren(children);
 }
 
-LogicalOperator pushBeyondSink(PushdownContext& ctx, const TypedLogicalOperator<SinkLogicalOperator>& op)
+LogicalOperator pushBeyondSink(PushdownBarrier& ctx, const TypedLogicalOperator<SinkLogicalOperator>& op)
 {
     /// Sinks are the starting point of the recursion.
     /// Because they don't have parents, no watermark assigner
@@ -134,7 +123,7 @@ LogicalOperator pushBeyondSource(
 }
 
 LogicalOperator pushBeyondTransparentOperator(
-    PushdownContext& ctx,
+    PushdownBarrier& ctx,
     const LogicalOperator& op,
     bool ingestionTime,
     const std::vector<std::pair<Field, Windowing::TimeUnit>>& eventTime)
@@ -145,7 +134,7 @@ LogicalOperator pushBeyondTransparentOperator(
 }
 
 LogicalOperator pushBeyondProjection(
-    PushdownContext& ctx,
+    PushdownBarrier& ctx,
     const TypedLogicalOperator<ProjectionLogicalOperator>& op,
     bool ingestionTime,
     const std::vector<std::pair<Field, Windowing::TimeUnit>>& eventTime)
@@ -207,7 +196,7 @@ LogicalOperator pushBeyondProjection(
 }
 
 LogicalOperator pushBeyondEventTimeWatermarkAssigner(
-    PushdownContext& ctx,
+    PushdownBarrier& ctx,
     const TypedLogicalOperator<EventTimeWatermarkAssignerLogicalOperator>& op,
     const bool ingestionTime,
     std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime)
@@ -226,7 +215,7 @@ LogicalOperator pushBeyondEventTimeWatermarkAssigner(
 }
 
 LogicalOperator pushBeyondIngestionTimeWatermarkAssigner(
-    PushdownContext& ctx,
+    PushdownBarrier& ctx,
     const TypedLogicalOperator<IngestionTimeWatermarkAssignerLogicalOperator>& op,
     bool /* ingestionTime */,
     std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime)
@@ -238,7 +227,7 @@ LogicalOperator pushBeyondIngestionTimeWatermarkAssigner(
 }
 
 LogicalOperator pushBeyondDefault(
-    PushdownContext& ctx, const LogicalOperator& op, const bool ingestionTime, std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime)
+    PushdownBarrier& ctx, const LogicalOperator& op, const bool ingestionTime, std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime)
 {
     /// Implements default behavior if operator is not explicitly handled.
     /// Applies all watermark assigners and restarts recursion for all children.
@@ -247,7 +236,7 @@ LogicalOperator pushBeyondDefault(
 }
 
 LogicalOperator watermarkAssignerPushdownDispatch(
-    PushdownContext& ctx, const LogicalOperator& op, bool ingestionTime, std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime)
+    PushdownBarrier& ctx, const LogicalOperator& op, bool ingestionTime, std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime)
 {
     if (const auto sink = op.tryGetAs<SinkLogicalOperator>())
     {
@@ -279,17 +268,17 @@ LogicalOperator watermarkAssignerPushdownDispatch(
 }
 
 LogicalOperator watermarkAssignerPushdown(
-    PushdownContext& ctx, const LogicalOperator& op, bool ingestionTime, std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime)
+    PushdownBarrier& ctx, const LogicalOperator& op, bool ingestionTime, std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime)
 {
-    if (ctx.sharedOperatorIds.contains(op.getId()))
+    /// A shared operator is a pushdown barrier: pending assigners must not enter a subtree another parent also reads, so
+    /// they are materialized above it while the shared subtree itself is rewritten once with no pending assigners.
+    if (ctx.isShared(op))
     {
-        auto rewritten = ctx.rewrittenSharedOperators.find(op.getId());
-        if (rewritten == ctx.rewrittenSharedOperators.end())
-        {
-            rewritten = ctx.rewrittenSharedOperators.emplace(op.getId(), watermarkAssignerPushdownDispatch(ctx, op, false, {})).first;
-        }
-        /// addWatermarkAssigners rebinds the event time fields to the rewritten operator by name
-        return addWatermarkAssigners(rewritten->second, ingestionTime, std::move(eventTime));
+        return ctx.rewriteShared(
+            op,
+            [&] { return watermarkAssignerPushdownDispatch(ctx, op, false, {}); },
+            /// addWatermarkAssigners rebinds the event time fields to the rewritten operator by name
+            [&](const LogicalOperator& rewritten) { return addWatermarkAssigners(rewritten, ingestionTime, std::move(eventTime)); });
     }
     return watermarkAssignerPushdownDispatch(ctx, op, std::move(ingestionTime), std::move(eventTime));
 }
@@ -301,7 +290,7 @@ LogicalPlan WatermarkAssignerPushdownRule::apply(LogicalPlan queryPlan) const
 {
     PRECONDITION(not queryPlan.getRootOperators().empty(), "Query must have a sink root operator");
 
-    PushdownContext ctx{.sharedOperatorIds = getSharedOperatorIds(queryPlan), .rewrittenSharedOperators = {}};
+    PushdownBarrier ctx{queryPlan};
     std::vector<LogicalOperator> newRoots;
     newRoots.reserve(queryPlan.getRootOperators().size());
     for (const auto& root : queryPlan.getRootOperators())

--- a/nes-query-optimizer/tests/PlanRewriteUtilsTest.cpp
+++ b/nes-query-optimizer/tests/PlanRewriteUtilsTest.cpp
@@ -94,20 +94,10 @@ TEST_F(PlanRewriteUtilsTest, testReplaceFieldAccesses)
     ASSERT_EQ(fieldAccess3->getField().getProducedBy(), op3);
 }
 
-namespace
-{
-LogicalFunction equalsZero(const LogicalOperator& producer, const std::string& fieldName)
-{
-    return EqualsLogicalFunction{
-        FieldAccessLogicalFunction{producer.getOutputSchema()[Identifier::parse(fieldName)].value()},
-        ConstantValueLogicalFunction{DataType{DataType::Type::UINT64, DataType::NULLABLE::NOT_NULLABLE}, "0"}};
-}
-}
-
 TEST_F(PlanRewriteUtilsTest, getSharedOperatorIdsOnSingleSinkPlan)
 {
     const auto source = utils.createSource("shared_ids_single", {"a", "b"});
-    const auto selection = SelectionLogicalOperator::create(source, equalsZero(source, "a"));
+    const auto selection = SelectionLogicalOperator::create(source, OptimizerTestUtils::equalsZero(source, "a"));
     const auto plan = utils.createPlan(utils.createSink(selection, "shared_ids_single_sink", {"a", "b"}));
 
     EXPECT_TRUE(getSharedOperatorIds(plan).empty());
@@ -116,7 +106,7 @@ TEST_F(PlanRewriteUtilsTest, getSharedOperatorIdsOnSingleSinkPlan)
 TEST_F(PlanRewriteUtilsTest, getSharedOperatorIdsOnMultiSinkPlan)
 {
     const auto source = utils.createSource("shared_ids_multi", {"a", "b"});
-    const auto selection = SelectionLogicalOperator::create(source, equalsZero(source, "a"));
+    const auto selection = SelectionLogicalOperator::create(source, OptimizerTestUtils::equalsZero(source, "a"));
     const auto sink1 = utils.createSink(selection, "shared_ids_multi_sink1", {"a", "b"});
     const auto sink2 = utils.createSink(selection, "shared_ids_multi_sink2", {"a", "b"});
     const auto plan = utils.createPlan({sink1, sink2});
@@ -137,7 +127,7 @@ TEST_F(PlanRewriteUtilsTest, getSharedOperatorIdsCountsDuplicateEdgesFromSamePar
 TEST_F(PlanRewriteUtilsTest, rewritePlanBottomUpVisitsSharedOperatorsOnce)
 {
     const auto source = utils.createSource("rewrite_once", {"a", "b"});
-    const auto selection = SelectionLogicalOperator::create(source, equalsZero(source, "a"));
+    const auto selection = SelectionLogicalOperator::create(source, OptimizerTestUtils::equalsZero(source, "a"));
     const auto sink1 = utils.createSink(selection, "rewrite_once_sink1", {"a", "b"});
     const auto sink2 = utils.createSink(selection, "rewrite_once_sink2", {"a", "b"});
     const auto plan = utils.createPlan({sink1, sink2});
@@ -159,7 +149,7 @@ TEST_F(PlanRewriteUtilsTest, rewritePlanBottomUpVisitsSharedOperatorsOnce)
 TEST_F(PlanRewriteUtilsTest, rewritePlanBottomUpPreservesSharing)
 {
     const auto source = utils.createSource("rewrite_sharing", {"a", "b"});
-    const auto selection = SelectionLogicalOperator::create(source, equalsZero(source, "a"));
+    const auto selection = SelectionLogicalOperator::create(source, OptimizerTestUtils::equalsZero(source, "a"));
     const auto sink1 = utils.createSink(selection, "rewrite_sharing_sink1", {"a", "b"});
     const auto sink2 = utils.createSink(selection, "rewrite_sharing_sink2", {"a", "b"});
     const auto plan = utils.createPlan({sink1, sink2});

--- a/nes-query-optimizer/tests/PlanRewriteUtilsTest.cpp
+++ b/nes-query-optimizer/tests/PlanRewriteUtilsTest.cpp
@@ -12,9 +12,14 @@
     limitations under the License.
 */
 
+#include <string>
 #include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 #include <gtest/gtest.h>
 
+#include <DataTypes/DataType.hpp>
 #include <Functions/BooleanFunctions/AndLogicalFunction.hpp>
 #include <Functions/BooleanFunctions/EqualsLogicalFunction.hpp>
 #include <Functions/ComparisonFunctions/GreaterLogicalFunction.hpp>
@@ -23,6 +28,11 @@
 #include <Functions/FieldAccessLogicalFunction.hpp>
 #include <Functions/LogicalFunction.hpp>
 #include <Identifiers/Identifier.hpp>
+#include <Operators/LogicalOperator.hpp>
+#include <Operators/LogicalOperatorFwd.hpp>
+#include <Operators/SelectionLogicalOperator.hpp>
+#include <Operators/UnionLogicalOperator.hpp>
+#include <Plans/LogicalPlan.hpp>
 #include <Schema/Field.hpp>
 #include <Util/Logger/LogLevel.hpp>
 #include <Util/Logger/impl/NesLogger.hpp>
@@ -82,6 +92,88 @@ TEST_F(PlanRewriteUtilsTest, testReplaceFieldAccesses)
     ASSERT_EQ(fieldAccess1->getField().getProducedBy(), op1New);
     ASSERT_EQ(fieldAccess2->getField().getProducedBy(), op2New);
     ASSERT_EQ(fieldAccess3->getField().getProducedBy(), op3);
+}
+
+namespace
+{
+LogicalFunction equalsZero(const LogicalOperator& producer, const std::string& fieldName)
+{
+    return EqualsLogicalFunction{
+        FieldAccessLogicalFunction{producer.getOutputSchema()[Identifier::parse(fieldName)].value()},
+        ConstantValueLogicalFunction{DataType{DataType::Type::UINT64, DataType::NULLABLE::NOT_NULLABLE}, "0"}};
+}
+}
+
+TEST_F(PlanRewriteUtilsTest, getSharedOperatorIdsOnSingleSinkPlan)
+{
+    const auto source = utils.createSource("shared_ids_single", {"a", "b"});
+    const auto selection = SelectionLogicalOperator::create(source, equalsZero(source, "a"));
+    const auto plan = utils.createPlan(utils.createSink(selection, "shared_ids_single_sink", {"a", "b"}));
+
+    EXPECT_TRUE(getSharedOperatorIds(plan).empty());
+}
+
+TEST_F(PlanRewriteUtilsTest, getSharedOperatorIdsOnMultiSinkPlan)
+{
+    const auto source = utils.createSource("shared_ids_multi", {"a", "b"});
+    const auto selection = SelectionLogicalOperator::create(source, equalsZero(source, "a"));
+    const auto sink1 = utils.createSink(selection, "shared_ids_multi_sink1", {"a", "b"});
+    const auto sink2 = utils.createSink(selection, "shared_ids_multi_sink2", {"a", "b"});
+    const auto plan = utils.createPlan({sink1, sink2});
+
+    /// Only the selection has two parents; the source is reachable through two paths but has a single parent edge.
+    EXPECT_EQ(getSharedOperatorIds(plan), (std::unordered_set{selection.getId()}));
+}
+
+TEST_F(PlanRewriteUtilsTest, getSharedOperatorIdsCountsDuplicateEdgesFromSameParent)
+{
+    const auto source = utils.createSource("shared_ids_duplicate", {"a", "b"});
+    const auto unionOp = UnionLogicalOperator::create(std::vector<LogicalOperator>{source, source});
+    const auto plan = utils.createPlan(utils.createSink(unionOp, "shared_ids_duplicate_sink", {"a", "b"}));
+
+    EXPECT_EQ(getSharedOperatorIds(plan), (std::unordered_set{source.getId()}));
+}
+
+TEST_F(PlanRewriteUtilsTest, rewritePlanBottomUpVisitsSharedOperatorsOnce)
+{
+    const auto source = utils.createSource("rewrite_once", {"a", "b"});
+    const auto selection = SelectionLogicalOperator::create(source, equalsZero(source, "a"));
+    const auto sink1 = utils.createSink(selection, "rewrite_once_sink1", {"a", "b"});
+    const auto sink2 = utils.createSink(selection, "rewrite_once_sink2", {"a", "b"});
+    const auto plan = utils.createPlan({sink1, sink2});
+
+    int invocations = 0;
+    const auto rewritten = rewritePlanBottomUp(
+        plan,
+        [&invocations](const LogicalOperator& original, std::vector<LogicalOperator> children)
+        {
+            ++invocations;
+            return original.withChildren(std::move(children));
+        });
+
+    /// source, selection, sink1, sink2 — the shared selection and source are rewritten once
+    EXPECT_EQ(invocations, 4);
+    EXPECT_EQ(OptimizerTestUtils::collectOperatorIds(rewritten).size(), 4);
+}
+
+TEST_F(PlanRewriteUtilsTest, rewritePlanBottomUpPreservesSharing)
+{
+    const auto source = utils.createSource("rewrite_sharing", {"a", "b"});
+    const auto selection = SelectionLogicalOperator::create(source, equalsZero(source, "a"));
+    const auto sink1 = utils.createSink(selection, "rewrite_sharing_sink1", {"a", "b"});
+    const auto sink2 = utils.createSink(selection, "rewrite_sharing_sink2", {"a", "b"});
+    const auto plan = utils.createPlan({sink1, sink2});
+
+    const auto rewritten = rewritePlanBottomUp(
+        plan,
+        [](const LogicalOperator& original, std::vector<LogicalOperator> children) { return original.withChildren(std::move(children)); });
+
+    const auto roots = rewritten.getRootOperators();
+    ASSERT_EQ(roots.size(), 2);
+    const auto sharedChild1 = roots.at(0).getChildren().at(0);
+    const auto sharedChild2 = roots.at(1).getChildren().at(0);
+    EXPECT_EQ(sharedChild1.getId(), sharedChild2.getId());
+    EXPECT_EQ(sharedChild1.getChildren().at(0).getId(), sharedChild2.getChildren().at(0).getId());
 }
 
 /// NOLINTEND(bugprone-unchecked-optional-access)

--- a/nes-query-optimizer/tests/Rules/CMakeLists.txt
+++ b/nes-query-optimizer/tests/Rules/CMakeLists.txt
@@ -13,3 +13,4 @@
 add_subdirectory(Static)
 
 add_nes_optimizer_test(RuleManagerTest RuleManagerTest.cpp)
+add_nes_optimizer_test(MultiSinkPlanTest MultiSinkPlanTest.cpp)

--- a/nes-query-optimizer/tests/Rules/MultiSinkPlanTest.cpp
+++ b/nes-query-optimizer/tests/Rules/MultiSinkPlanTest.cpp
@@ -1,0 +1,460 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/// Tests that all optimization rules handle multi-sink plans (#1753). Multi-sink plans share operator instances
+/// between sink roots, so every rule must rewrite each unique operator exactly once and reuse the rewritten instance
+/// for every parent. Sharing is observable through operator ids: the same id reachable through two roots.
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <unordered_set>
+#include <utility>
+#include <variant>
+#include <vector>
+#include <gtest/gtest.h>
+
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/Schema.hpp>
+#include <DataTypes/SchemaFwd.hpp>
+#include <DataTypes/TimeUnit.hpp>
+#include <DataTypes/UnboundField.hpp>
+#include <Functions/BooleanFunctions/EqualsLogicalFunction.hpp>
+#include <Functions/ConstantValueLogicalFunction.hpp>
+#include <Functions/FieldAccessLogicalFunction.hpp>
+#include <Functions/LogicalFunction.hpp>
+#include <Identifiers/Identifier.hpp>
+#include <Identifiers/Identifiers.hpp>
+#include <Operators/EventTimeWatermarkAssignerLogicalOperator.hpp>
+#include <Operators/LogicalOperator.hpp>
+#include <Operators/LogicalOperatorFwd.hpp>
+#include <Operators/ProjectionLogicalOperator.hpp>
+#include <Operators/SelectionLogicalOperator.hpp>
+#include <Operators/Sinks/SinkLogicalOperator.hpp>
+#include <Operators/Sources/SourceDescriptorLogicalOperator.hpp>
+#include <Operators/Sources/SourceNameLogicalOperator.hpp>
+#include <Operators/UnionLogicalOperator.hpp>
+#include <Phases/RuleBasedOptimizer.hpp>
+#include <Plans/LogicalPlan.hpp>
+#include <Rules/Semantic/AnonymousSourceBindingRule.hpp>
+#include <Rules/Semantic/CalcTargetOrderRule.hpp>
+#include <Rules/Semantic/InferModelResolutionRule.hpp>
+#include <Rules/Semantic/LogicalSourceExpansionRule.hpp>
+#include <Rules/Semantic/SinkBindingRule.hpp>
+#include <Rules/Semantic/TypeInferenceRule.hpp>
+#include <Rules/Static/DecideFieldMappings.hpp>
+#include <Rules/Static/DecideFieldOrder.hpp>
+#include <Rules/Static/DecideJoinTypesRule.hpp>
+#include <Rules/Static/DecideMemoryLayoutRule.hpp>
+#include <Rules/Static/OriginIdInferenceRule.hpp>
+#include <Rules/Static/PredicatePushdownRule.hpp>
+#include <Rules/Static/ProjectionPushdownRule.hpp>
+#include <Rules/Static/RedundantProjectionRemovalRule.hpp>
+#include <Rules/Static/WatermarkAssignerPushdownRule.hpp>
+#include <Sinks/SinkCatalog.hpp>
+#include <Sinks/SinkDescriptor.hpp>
+#include <Sources/SourceCatalog.hpp>
+#include <Sources/SourceDescriptor.hpp>
+#include <Traits/FieldMappingTrait.hpp>
+#include <Traits/FieldOrderingTrait.hpp>
+#include <Traits/JoinImplementationTypeTrait.hpp>
+#include <Traits/MemoryLayoutTypeTrait.hpp>
+#include <Traits/OutputOriginIdsTrait.hpp>
+#include <Traits/TraitSet.hpp>
+#include <Util/Logger/LogLevel.hpp>
+#include <Util/Logger/impl/NesLogger.hpp>
+#include <BaseUnitTest.hpp>
+#include <ErrorHandling.hpp>
+#include <ModelCatalog.hpp>
+#include <OptimizerTestUtils.hpp>
+#include <QueryOptimizerConfiguration.hpp>
+
+namespace NES
+{
+/// NOLINTBEGIN(bugprone-unchecked-optional-access)
+namespace
+{
+
+LogicalFunction equalsZero(const LogicalOperator& producer, const std::string& fieldName)
+{
+    return EqualsLogicalFunction{
+        FieldAccessLogicalFunction{producer.getOutputSchema()[Identifier::parse(fieldName)].value()},
+        ConstantValueLogicalFunction{DataType{DataType::Type::UINT64, DataType::NULLABLE::NOT_NULLABLE}, "0"}};
+}
+
+std::vector<LogicalOperator> collectUniqueOperators(const LogicalPlan& plan)
+{
+    std::vector<LogicalOperator> operators;
+    std::unordered_set<OperatorId> seen;
+    std::vector<LogicalOperator> pending{plan.getRootOperators()};
+    while (!pending.empty())
+    {
+        const auto current = pending.back();
+        pending.pop_back();
+        if (!seen.insert(current.getId()).second)
+        {
+            continue;
+        }
+        operators.push_back(current);
+        for (const auto& child : current.getChildren())
+        {
+            pending.push_back(child);
+        }
+    }
+    return operators;
+}
+
+void expectSharedRootChild(const LogicalPlan& plan)
+{
+    const auto roots = plan.getRootOperators();
+    ASSERT_EQ(roots.size(), 2);
+    EXPECT_EQ(roots.at(0).getChildren().at(0).getId(), roots.at(1).getChildren().at(0).getId());
+}
+}
+
+class MultiSinkPlanTest : public Testing::BaseUnitTest
+{
+public:
+    static void SetUpTestSuite() { Logger::setupLogging("MultiSinkPlanTest.log", LogLevel::LOG_DEBUG); }
+
+    OptimizerTestUtils utils;
+
+    /// source(a, b) <- selection(a == 0) <- {sink1, sink2}: the selection (and everything below) is shared.
+    LogicalPlan createSharedChainPlan(const std::string& prefix)
+    {
+        auto source = utils.createSource(prefix + "_src", {"a", "b"});
+        auto selection = SelectionLogicalOperator::create(source, equalsZero(source, "a"));
+        auto sink1 = utils.createSink(selection, prefix + "_sink1", {"a", "b"});
+        auto sink2 = utils.createSink(selection, prefix + "_sink2", {"a", "b"});
+        return utils.createPlan({sink1, sink2});
+    }
+};
+
+TEST_F(MultiSinkPlanTest, DecideMemoryLayoutPreservesSharing)
+{
+    const auto result = DecideMemoryLayoutRule{}.apply(createSharedChainPlan("memory_layout"));
+
+    expectSharedRootChild(result);
+    const auto operators = collectUniqueOperators(result);
+    EXPECT_EQ(operators.size(), 4);
+    for (const auto& op : operators)
+    {
+        EXPECT_TRUE(hasTrait<MemoryLayoutTypeTrait>(op.getTraitSet())) << "missing memory layout trait on " << op;
+    }
+}
+
+TEST_F(MultiSinkPlanTest, DecideJoinTypesPreservesSharing)
+{
+    const auto result = DecideJoinTypesRule{StreamJoinStrategy::OPTIMIZER_CHOOSES}.apply(createSharedChainPlan("join_types"));
+
+    expectSharedRootChild(result);
+    const auto operators = collectUniqueOperators(result);
+    EXPECT_EQ(operators.size(), 4);
+    for (const auto& op : operators)
+    {
+        EXPECT_TRUE(hasTrait<JoinImplementationTypeTrait>(op.getTraitSet())) << "missing join implementation trait on " << op;
+    }
+}
+
+TEST_F(MultiSinkPlanTest, DecideFieldMappingsPreservesSharing)
+{
+    const auto result = DecideFieldMappings{}.apply(createSharedChainPlan("field_mappings"));
+
+    expectSharedRootChild(result);
+    const auto operators = collectUniqueOperators(result);
+    EXPECT_EQ(operators.size(), 4);
+    for (const auto& op : operators)
+    {
+        EXPECT_TRUE(hasTrait<FieldMappingTrait>(op.getTraitSet())) << "missing field mapping trait on " << op;
+    }
+}
+
+TEST_F(MultiSinkPlanTest, OriginIdInferenceAssignsSharedOperatorsOneOriginId)
+{
+    const auto result = OriginIdInferenceRule{}.apply(createSharedChainPlan("origin_ids"));
+
+    expectSharedRootChild(result);
+    const auto roots = result.getRootOperators();
+
+    /// The shared source is the only origin id assigner; it must have been assigned exactly one origin id
+    /// that both sinks observe.
+    std::unordered_set<OriginId> allOriginIds;
+    for (const auto& op : collectUniqueOperators(result))
+    {
+        const auto traitOpt = getTrait<OutputOriginIdsTrait>(op.getTraitSet());
+        ASSERT_TRUE(traitOpt.has_value()) << "missing origin ids trait on " << op;
+        allOriginIds.insert(traitOpt.value().get().begin(), traitOpt.value().get().end());
+    }
+    EXPECT_EQ(allOriginIds.size(), 1);
+
+    const auto sink1Ids = getTrait<OutputOriginIdsTrait>(roots.at(0).getTraitSet()).value().get();
+    const auto sink2Ids = getTrait<OutputOriginIdsTrait>(roots.at(1).getTraitSet()).value().get();
+    EXPECT_TRUE(sink1Ids == sink2Ids);
+}
+
+TEST_F(MultiSinkPlanTest, RedundantProjectionRemovalRemovesSharedProjectionOnce)
+{
+    auto source = utils.createSource("redundant_proj_src", {"a", "b"});
+    auto projection = ProjectionLogicalOperator::create(
+        source,
+        std::vector<std::pair<Identifier, LogicalFunction>>{
+            {Identifier::parse("a"), FieldAccessLogicalFunction{source.getOutputSchema()[Identifier::parse("a")].value()}},
+            {Identifier::parse("b"), FieldAccessLogicalFunction{source.getOutputSchema()[Identifier::parse("b")].value()}}},
+        ProjectionLogicalOperator::Asterisk{false});
+    auto sink1 = utils.createSink(projection, "redundant_proj_sink1", {"a", "b"});
+    auto sink2 = utils.createSink(projection, "redundant_proj_sink2", {"a", "b"});
+
+    const auto result = RedundantProjectionRemovalRule{}.apply(utils.createPlan({sink1, sink2}));
+
+    expectSharedRootChild(result);
+    const auto roots = result.getRootOperators();
+    EXPECT_TRUE(roots.at(0).getChildren().at(0).tryGetAs<SourceDescriptorLogicalOperator>().has_value());
+    EXPECT_EQ(collectUniqueOperators(result).size(), 3);
+}
+
+TEST_F(MultiSinkPlanTest, DecideFieldOrderStampsAgreedTargetOrderOnSharedChild)
+{
+    const auto result = DecideFieldOrder{}.apply(createSharedChainPlan("field_order"));
+
+    expectSharedRootChild(result);
+    const auto operators = collectUniqueOperators(result);
+    EXPECT_EQ(operators.size(), 4);
+    for (const auto& op : operators)
+    {
+        EXPECT_TRUE(hasTrait<FieldOrderingTrait>(op.getTraitSet())) << "missing field ordering trait on " << op;
+    }
+
+    /// Both sinks demand the same target order, so the shared child carries exactly that order.
+    const auto sharedChild = result.getRootOperators().at(0).getChildren().at(0);
+    const auto orderedFields = sharedChild.getTraitSet().get<FieldOrderingTrait>()->getOrderedFields();
+    EXPECT_EQ(orderedFields, utils.createSchema({"a", "b"}));
+}
+
+TEST_F(MultiSinkPlanTest, DecideFieldOrderThrowsOnConflictingTargetOrders)
+{
+    auto source = utils.createSource("field_order_conflict_src", {"a", "b"});
+    auto selection = SelectionLogicalOperator::create(source, equalsZero(source, "a"));
+    auto sink1 = utils.createSink(selection, "field_order_conflict_sink1", {"a", "b"});
+    auto sink2 = utils.createSink(selection, "field_order_conflict_sink2", {"b", "a"});
+    const auto plan = utils.createPlan({sink1, sink2});
+
+    ASSERT_EXCEPTION_ERRORCODE(std::ignore = DecideFieldOrder{}.apply(plan), ErrorCode::UnsupportedQuery);
+}
+
+TEST_F(MultiSinkPlanTest, PredicatePushdownKeepsBranchPredicateAboveSharedOperator)
+{
+    /// BEFORE: source <- sharedSelection(b == 0) <- {branchSelection(a == 0) <- sink1, sink2}
+    /// AFTER:  the branch predicate must stay above the shared boundary; the shared subtree is rewritten once.
+    auto source = utils.createSource("pred_pushdown_src", {"a", "b"});
+    auto sharedSelection = SelectionLogicalOperator::create(source, equalsZero(source, "b"));
+    auto branchSelection = SelectionLogicalOperator::create(sharedSelection, equalsZero(sharedSelection, "a"));
+    auto sink1 = utils.createSink(branchSelection, "pred_pushdown_sink1", {"a", "b"});
+    auto sink2 = utils.createSink(sharedSelection, "pred_pushdown_sink2", {"a", "b"});
+
+    const auto result = PredicatePushdownRule{}.apply(utils.createPlan({sink1, sink2}));
+
+    const auto roots = result.getRootOperators();
+    ASSERT_EQ(roots.size(), 2);
+
+    /// Branch 1: sink <- selection(a == 0) <- selection(b == 0) <- source
+    const auto branch1Selection = roots.at(0).getChildren().at(0);
+    ASSERT_TRUE(branch1Selection.tryGetAs<SelectionLogicalOperator>().has_value());
+    const auto branch1Shared = branch1Selection.getChildren().at(0);
+    ASSERT_TRUE(branch1Shared.tryGetAs<SelectionLogicalOperator>().has_value());
+
+    /// Branch 2: sink <- selection(b == 0) <- source, without the branch predicate
+    const auto branch2Shared = roots.at(1).getChildren().at(0);
+    ASSERT_TRUE(branch2Shared.tryGetAs<SelectionLogicalOperator>().has_value());
+    EXPECT_EQ(branch1Shared.getId(), branch2Shared.getId());
+    EXPECT_TRUE(branch2Shared.getChildren().at(0).tryGetAs<SourceDescriptorLogicalOperator>().has_value());
+
+    /// sink1, sink2, branch selection, shared selection, source
+    EXPECT_EQ(collectUniqueOperators(result).size(), 5);
+}
+
+TEST_F(MultiSinkPlanTest, WatermarkAssignerPushdownStopsAtSharedOperator)
+{
+    /// BEFORE: source <- sharedSelection <- {eventTimeAssigner <- sink1, sink2}
+    /// AFTER:  the assigner must not descend into the shared subtree, where sink2 would observe it.
+    auto source = utils.createSource("watermark_src", {"a", "b"});
+    auto sharedSelection = SelectionLogicalOperator::create(source, equalsZero(source, "a"));
+    auto eventTime = EventTimeWatermarkAssignerLogicalOperator::create(
+        sharedSelection,
+        FieldAccessLogicalFunction{sharedSelection.getOutputSchema()[Identifier::parse("a")].value()},
+        Windowing::TimeUnit{0});
+    auto sink1 = utils.createSink(eventTime, "watermark_sink1", {"a", "b"});
+    auto sink2 = utils.createSink(sharedSelection, "watermark_sink2", {"a", "b"});
+
+    const auto result = WatermarkAssignerPushdownRule{}.apply(utils.createPlan({sink1, sink2}));
+
+    const auto roots = result.getRootOperators();
+    ASSERT_EQ(roots.size(), 2);
+
+    /// Branch 1: sink <- eventTimeAssigner <- selection <- source
+    const auto branch1Assigner = roots.at(0).getChildren().at(0);
+    ASSERT_TRUE(branch1Assigner.tryGetAs<EventTimeWatermarkAssignerLogicalOperator>().has_value());
+    const auto branch1Shared = branch1Assigner.getChildren().at(0);
+    ASSERT_TRUE(branch1Shared.tryGetAs<SelectionLogicalOperator>().has_value());
+
+    /// Branch 2: sink <- selection <- source, without any watermark assigner
+    const auto branch2Shared = roots.at(1).getChildren().at(0);
+    EXPECT_EQ(branch1Shared.getId(), branch2Shared.getId());
+    ASSERT_TRUE(branch2Shared.getChildren().at(0).tryGetAs<SourceDescriptorLogicalOperator>().has_value());
+
+    EXPECT_EQ(collectUniqueOperators(result).size(), 5);
+}
+
+TEST_F(MultiSinkPlanTest, ProjectionPushdownDoesNotNarrowSharedSubtree)
+{
+    /// BEFORE: source(a, b) <- sharedSelection <- {projection(a) <- sink1(a), sink2(a, b)}
+    /// AFTER:  sink1 only requires "a", but the shared subtree must keep the full schema for sink2.
+    auto source = utils.createSource("proj_pushdown_src", {"a", "b"});
+    auto sharedSelection = SelectionLogicalOperator::create(source, equalsZero(source, "a"));
+    auto projection = ProjectionLogicalOperator::create(
+        sharedSelection,
+        std::vector<std::pair<Identifier, LogicalFunction>>{
+            {Identifier::parse("a"), FieldAccessLogicalFunction{sharedSelection.getOutputSchema()[Identifier::parse("a")].value()}}},
+        ProjectionLogicalOperator::Asterisk{false});
+    auto sink1 = utils.createSink(projection, "proj_pushdown_sink1", {"a"});
+    auto sink2 = utils.createSink(sharedSelection, "proj_pushdown_sink2", {"a", "b"});
+
+    const auto result = ProjectionPushdownRule{}.apply(utils.createPlan({sink1, sink2}));
+
+    const auto roots = result.getRootOperators();
+    ASSERT_EQ(roots.size(), 2);
+
+    const auto branch1Projection = roots.at(0).getChildren().at(0);
+    ASSERT_TRUE(branch1Projection.tryGetAs<ProjectionLogicalOperator>().has_value());
+    const auto branch1Shared = branch1Projection.getChildren().at(0);
+    const auto branch2Shared = roots.at(1).getChildren().at(0);
+    EXPECT_EQ(branch1Shared.getId(), branch2Shared.getId());
+
+    /// The shared subtree still produces both fields and contains no narrowing projection.
+    EXPECT_TRUE(branch2Shared.getOutputSchema()[Identifier::parse("a")].has_value());
+    EXPECT_TRUE(branch2Shared.getOutputSchema()[Identifier::parse("b")].has_value());
+    for (const auto& op : collectUniqueOperators(utils.createPlan({roots.at(1)})))
+    {
+        EXPECT_FALSE(op.tryGetAs<ProjectionLogicalOperator>().has_value()) << "unexpected projection below shared boundary: " << op;
+    }
+}
+
+TEST_F(MultiSinkPlanTest, TypeInferencePreservesSharing)
+{
+    const auto result = TypeInferenceRule{}.apply(createSharedChainPlan("type_inference"));
+
+    expectSharedRootChild(result);
+    EXPECT_EQ(collectUniqueOperators(result).size(), 4);
+}
+
+TEST_F(MultiSinkPlanTest, SinkBindingHandlesMultipleRoots)
+{
+    /// The sinks already carry descriptors, so binding passes them through and must not touch the shared subtree.
+    const auto plan = createSharedChainPlan("sink_binding");
+    const auto sharedChildId = plan.getRootOperators().at(0).getChildren().at(0).getId();
+
+    const auto result = SinkBindingRule{std::make_shared<SinkCatalog>()}.apply(plan);
+
+    const auto roots = result.getRootOperators();
+    ASSERT_EQ(roots.size(), 2);
+    EXPECT_EQ(roots.at(0).getChildren().at(0).getId(), sharedChildId);
+    EXPECT_EQ(roots.at(1).getChildren().at(0).getId(), sharedChildId);
+}
+
+TEST_F(MultiSinkPlanTest, AnonymousSourceBindingPreservesSharing)
+{
+    const auto result = AnonymousSourceBindingRule{std::make_shared<SourceCatalog>()}.apply(createSharedChainPlan("anonymous_source"));
+
+    expectSharedRootChild(result);
+    EXPECT_EQ(collectUniqueOperators(result).size(), 4);
+}
+
+TEST_F(MultiSinkPlanTest, InferModelResolutionPreservesSharing)
+{
+    const auto result = InferModelResolutionRule{std::make_shared<ModelCatalog>()}.apply(createSharedChainPlan("infer_model"));
+
+    expectSharedRootChild(result);
+    EXPECT_EQ(collectUniqueOperators(result).size(), 4);
+}
+
+TEST_F(MultiSinkPlanTest, LogicalSourceExpansionExpandsSharedSourceNameOnce)
+{
+    auto sourceCatalog = std::make_shared<SourceCatalog>();
+    const auto schema = utils.createSchema({"a", "b"});
+    const auto logicalSource = sourceCatalog->addLogicalSource(Identifier::parse("expansion_src"), schema);
+    ASSERT_TRUE(logicalSource.has_value());
+    const std::unordered_map<Identifier, std::string> sourceConfig{{Identifier::parse("FILE_PATH"), "/dev/null"}};
+    const std::unordered_map<Identifier, std::string> parserConfig{{Identifier::parse("TYPE"), "CSV"}};
+    ASSERT_TRUE(
+        sourceCatalog->addPhysicalSource(logicalSource.value(), Identifier::parse("file"), Host{"localhost"}, sourceConfig, parserConfig)
+            .has_value());
+
+    const auto sourceName = SourceNameLogicalOperator::create(Identifier::parse("expansion_src"));
+    const auto sink1 = SinkLogicalOperator::create(utils.createSinkDescriptor(Identifier::parse("expansion_sink1"), schema))
+                           .withChildrenUnsafe({sourceName});
+    const auto sink2 = SinkLogicalOperator::create(utils.createSinkDescriptor(Identifier::parse("expansion_sink2"), schema))
+                           .withChildrenUnsafe({sourceName});
+
+    const auto result = LogicalSourceExpansionRule{sourceCatalog}.apply(utils.createPlan({sink1, sink2}));
+
+    expectSharedRootChild(result);
+    const auto expandedUnion = result.getRootOperators().at(0).getChildren().at(0);
+    ASSERT_TRUE(expandedUnion.tryGetAs<UnionLogicalOperator>().has_value());
+    ASSERT_EQ(expandedUnion.getChildren().size(), 1);
+    EXPECT_TRUE(expandedUnion.getChildren().at(0).tryGetAs<SourceDescriptorLogicalOperator>().has_value());
+    /// sink1, sink2, union, physical source
+    EXPECT_EQ(collectUniqueOperators(result).size(), 4);
+}
+
+TEST_F(MultiSinkPlanTest, CalcTargetOrderInfersOrderForAllSinks)
+{
+    SinkCatalog sinkCatalog;
+    const std::unordered_map<Identifier, std::string> sinkConfig{
+        {Identifier::parse("file_path"), "/dev/null"}, {Identifier::parse("output_format"), "CSV"}};
+    const auto descriptor1 = sinkCatalog.getAnonymousSink(std::nullopt, Identifier::parse("file"), Host{"localhost"}, sinkConfig, {});
+    const auto descriptor2 = sinkCatalog.getAnonymousSink(std::nullopt, Identifier::parse("file"), Host{"localhost"}, sinkConfig, {});
+    ASSERT_TRUE(descriptor1.has_value());
+    ASSERT_TRUE(descriptor2.has_value());
+
+    auto source = utils.createSource("calc_target_order_src", {"a", "b"});
+    auto selection = SelectionLogicalOperator::create(source, equalsZero(source, "a"));
+    const auto sink1 = SinkLogicalOperator::create(selection, descriptor1.value());
+    const auto sink2 = SinkLogicalOperator::create(selection, descriptor2.value());
+
+    const auto result = CalcTargetOrderRule{}.apply(utils.createPlan({sink1, sink2}));
+
+    expectSharedRootChild(result);
+    for (const auto& root : result.getRootOperators())
+    {
+        const auto schemaVariant = root.getAs<SinkLogicalOperator>()->getSinkDescriptor()->getSchema();
+        EXPECT_TRUE((std::holds_alternative<std::shared_ptr<const Schema<UnqualifiedUnboundField, Ordered>>>(schemaVariant)))
+            << "sink target schema order was not inferred";
+    }
+    /// The rule only rebinds sink descriptors; the shared subtree must be untouched.
+    EXPECT_EQ(result.getRootOperators().at(0).getChildren().at(0).getId(), LogicalOperator{selection}.getId());
+}
+
+TEST_F(MultiSinkPlanTest, RuleBasedOptimizerSequencePreservesSharing)
+{
+    const RuleBasedOptimizer optimizer{
+        QueryOptimizerConfiguration{}, utils.getSourceCatalog(), utils.getSinkCatalog(), std::make_shared<const ModelCatalog>()};
+
+    const auto result = optimizer.optimize(createSharedChainPlan("full_sequence"));
+
+    expectSharedRootChild(result);
+    /// sink1, sink2, the shared selection, and the source — no rule in the sequence may duplicate the shared subtree
+    EXPECT_EQ(collectUniqueOperators(result).size(), 4);
+}
+
+/// NOLINTEND(bugprone-unchecked-optional-access)
+}

--- a/nes-query-optimizer/tests/Rules/MultiSinkPlanTest.cpp
+++ b/nes-query-optimizer/tests/Rules/MultiSinkPlanTest.cpp
@@ -25,13 +25,10 @@
 #include <vector>
 #include <gtest/gtest.h>
 
-#include <DataTypes/DataType.hpp>
 #include <DataTypes/Schema.hpp>
 #include <DataTypes/SchemaFwd.hpp>
 #include <DataTypes/TimeUnit.hpp>
 #include <DataTypes/UnboundField.hpp>
-#include <Functions/BooleanFunctions/EqualsLogicalFunction.hpp>
-#include <Functions/ConstantValueLogicalFunction.hpp>
 #include <Functions/FieldAccessLogicalFunction.hpp>
 #include <Functions/LogicalFunction.hpp>
 #include <Identifiers/Identifier.hpp>
@@ -86,35 +83,6 @@ namespace NES
 namespace
 {
 
-LogicalFunction equalsZero(const LogicalOperator& producer, const std::string& fieldName)
-{
-    return EqualsLogicalFunction{
-        FieldAccessLogicalFunction{producer.getOutputSchema()[Identifier::parse(fieldName)].value()},
-        ConstantValueLogicalFunction{DataType{DataType::Type::UINT64, DataType::NULLABLE::NOT_NULLABLE}, "0"}};
-}
-
-std::vector<LogicalOperator> collectUniqueOperators(const LogicalPlan& plan)
-{
-    std::vector<LogicalOperator> operators;
-    std::unordered_set<OperatorId> seen;
-    std::vector<LogicalOperator> pending{plan.getRootOperators()};
-    while (!pending.empty())
-    {
-        const auto current = pending.back();
-        pending.pop_back();
-        if (!seen.insert(current.getId()).second)
-        {
-            continue;
-        }
-        operators.push_back(current);
-        for (const auto& child : current.getChildren())
-        {
-            pending.push_back(child);
-        }
-    }
-    return operators;
-}
-
 void expectSharedRootChild(const LogicalPlan& plan)
 {
     const auto roots = plan.getRootOperators();
@@ -134,7 +102,7 @@ public:
     LogicalPlan createSharedChainPlan(const std::string& prefix)
     {
         auto source = utils.createSource(prefix + "_src", {"a", "b"});
-        auto selection = SelectionLogicalOperator::create(source, equalsZero(source, "a"));
+        auto selection = SelectionLogicalOperator::create(source, OptimizerTestUtils::equalsZero(source, "a"));
         auto sink1 = utils.createSink(selection, prefix + "_sink1", {"a", "b"});
         auto sink2 = utils.createSink(selection, prefix + "_sink2", {"a", "b"});
         return utils.createPlan({sink1, sink2});
@@ -146,7 +114,7 @@ TEST_F(MultiSinkPlanTest, DecideMemoryLayoutPreservesSharing)
     const auto result = DecideMemoryLayoutRule{}.apply(createSharedChainPlan("memory_layout"));
 
     expectSharedRootChild(result);
-    const auto operators = collectUniqueOperators(result);
+    const auto operators = OptimizerTestUtils::collectOperators(result);
     EXPECT_EQ(operators.size(), 4);
     for (const auto& op : operators)
     {
@@ -159,7 +127,7 @@ TEST_F(MultiSinkPlanTest, DecideJoinTypesPreservesSharing)
     const auto result = DecideJoinTypesRule{StreamJoinStrategy::OPTIMIZER_CHOOSES}.apply(createSharedChainPlan("join_types"));
 
     expectSharedRootChild(result);
-    const auto operators = collectUniqueOperators(result);
+    const auto operators = OptimizerTestUtils::collectOperators(result);
     EXPECT_EQ(operators.size(), 4);
     for (const auto& op : operators)
     {
@@ -172,7 +140,7 @@ TEST_F(MultiSinkPlanTest, DecideFieldMappingsPreservesSharing)
     const auto result = DecideFieldMappings{}.apply(createSharedChainPlan("field_mappings"));
 
     expectSharedRootChild(result);
-    const auto operators = collectUniqueOperators(result);
+    const auto operators = OptimizerTestUtils::collectOperators(result);
     EXPECT_EQ(operators.size(), 4);
     for (const auto& op : operators)
     {
@@ -190,7 +158,7 @@ TEST_F(MultiSinkPlanTest, OriginIdInferenceAssignsSharedOperatorsOneOriginId)
     /// The shared source is the only origin id assigner; it must have been assigned exactly one origin id
     /// that both sinks observe.
     std::unordered_set<OriginId> allOriginIds;
-    for (const auto& op : collectUniqueOperators(result))
+    for (const auto& op : OptimizerTestUtils::collectOperators(result))
     {
         const auto traitOpt = getTrait<OutputOriginIdsTrait>(op.getTraitSet());
         ASSERT_TRUE(traitOpt.has_value()) << "missing origin ids trait on " << op;
@@ -220,7 +188,7 @@ TEST_F(MultiSinkPlanTest, RedundantProjectionRemovalRemovesSharedProjectionOnce)
     expectSharedRootChild(result);
     const auto roots = result.getRootOperators();
     EXPECT_TRUE(roots.at(0).getChildren().at(0).tryGetAs<SourceDescriptorLogicalOperator>().has_value());
-    EXPECT_EQ(collectUniqueOperators(result).size(), 3);
+    EXPECT_EQ(OptimizerTestUtils::collectOperators(result).size(), 3);
 }
 
 TEST_F(MultiSinkPlanTest, DecideFieldOrderStampsAgreedTargetOrderOnSharedChild)
@@ -228,7 +196,7 @@ TEST_F(MultiSinkPlanTest, DecideFieldOrderStampsAgreedTargetOrderOnSharedChild)
     const auto result = DecideFieldOrder{}.apply(createSharedChainPlan("field_order"));
 
     expectSharedRootChild(result);
-    const auto operators = collectUniqueOperators(result);
+    const auto operators = OptimizerTestUtils::collectOperators(result);
     EXPECT_EQ(operators.size(), 4);
     for (const auto& op : operators)
     {
@@ -244,7 +212,7 @@ TEST_F(MultiSinkPlanTest, DecideFieldOrderStampsAgreedTargetOrderOnSharedChild)
 TEST_F(MultiSinkPlanTest, DecideFieldOrderThrowsOnConflictingTargetOrders)
 {
     auto source = utils.createSource("field_order_conflict_src", {"a", "b"});
-    auto selection = SelectionLogicalOperator::create(source, equalsZero(source, "a"));
+    auto selection = SelectionLogicalOperator::create(source, OptimizerTestUtils::equalsZero(source, "a"));
     auto sink1 = utils.createSink(selection, "field_order_conflict_sink1", {"a", "b"});
     auto sink2 = utils.createSink(selection, "field_order_conflict_sink2", {"b", "a"});
     const auto plan = utils.createPlan({sink1, sink2});
@@ -252,13 +220,48 @@ TEST_F(MultiSinkPlanTest, DecideFieldOrderThrowsOnConflictingTargetOrders)
     ASSERT_EXCEPTION_ERRORCODE(std::ignore = DecideFieldOrder{}.apply(plan), ErrorCode::UnsupportedQuery);
 }
 
+TEST_F(MultiSinkPlanTest, DecideFieldOrderPropagatesSharedTargetOrderIntoOtherSinkBranch)
+{
+    /// A shared operator has a single physical output order, so an order one sink imposes on it legitimately propagates
+    /// into the heuristic order of operators in another sink's branch that also read it.
+    /// Topology: source(a,b) <- shared <- {sink1(order b,a); middle <- top <- sink2(order a,b)}.
+    /// `shared` is the direct child of sink1 (so sink1 pins it to [b,a]) and, via middle/top, also feeds sink2.
+    /// `middle` is not a direct sink child, so it receives a heuristic order derived from `shared`.
+    auto source = utils.createSource("shared_target_order_src", {"a", "b"});
+    auto shared = SelectionLogicalOperator::create(source, OptimizerTestUtils::equalsZero(source, "a"));
+    auto sink1 = utils.createSink(shared, "shared_target_order_sink1", {"b", "a"});
+    auto middle = SelectionLogicalOperator::create(shared, OptimizerTestUtils::equalsZero(shared, "b"));
+    auto top = SelectionLogicalOperator::create(middle, OptimizerTestUtils::equalsZero(middle, "a"));
+    auto sink2 = utils.createSink(top, "shared_target_order_sink2", {"a", "b"});
+
+    const auto result = DecideFieldOrder{}.apply(utils.createPlan({sink1, sink2}));
+
+    const auto roots = result.getRootOperators();
+    ASSERT_EQ(roots.size(), 2);
+
+    /// The shared operator stays a single instance reachable directly from sink1 and via top -> middle from sink2.
+    const auto sharedFromSink1 = roots.at(0).getChildren().at(0);
+    const auto middleRewritten = roots.at(1).getChildren().at(0).getChildren().at(0);
+    const auto sharedFromSink2 = middleRewritten.getChildren().at(0);
+    EXPECT_EQ(sharedFromSink1.getId(), sharedFromSink2.getId());
+
+    /// sink1 pins the shared operator to [b, a]; `middle` in sink2's branch inherits exactly that order rather than the
+    /// [a, b] it would carry in isolation.
+    const auto reversed = utils.createSchema({"b", "a"});
+    EXPECT_EQ(sharedFromSink1.getTraitSet().get<FieldOrderingTrait>()->getOrderedFields(), reversed);
+    EXPECT_EQ(middleRewritten.getTraitSet().get<FieldOrderingTrait>()->getOrderedFields(), reversed);
+
+    /// source, shared, sink1, middle, top, sink2 — no rule duplicated the shared subtree.
+    EXPECT_EQ(OptimizerTestUtils::collectOperators(result).size(), 6);
+}
+
 TEST_F(MultiSinkPlanTest, PredicatePushdownKeepsBranchPredicateAboveSharedOperator)
 {
     /// BEFORE: source <- sharedSelection(b == 0) <- {branchSelection(a == 0) <- sink1, sink2}
     /// AFTER:  the branch predicate must stay above the shared boundary; the shared subtree is rewritten once.
     auto source = utils.createSource("pred_pushdown_src", {"a", "b"});
-    auto sharedSelection = SelectionLogicalOperator::create(source, equalsZero(source, "b"));
-    auto branchSelection = SelectionLogicalOperator::create(sharedSelection, equalsZero(sharedSelection, "a"));
+    auto sharedSelection = SelectionLogicalOperator::create(source, OptimizerTestUtils::equalsZero(source, "b"));
+    auto branchSelection = SelectionLogicalOperator::create(sharedSelection, OptimizerTestUtils::equalsZero(sharedSelection, "a"));
     auto sink1 = utils.createSink(branchSelection, "pred_pushdown_sink1", {"a", "b"});
     auto sink2 = utils.createSink(sharedSelection, "pred_pushdown_sink2", {"a", "b"});
 
@@ -280,7 +283,7 @@ TEST_F(MultiSinkPlanTest, PredicatePushdownKeepsBranchPredicateAboveSharedOperat
     EXPECT_TRUE(branch2Shared.getChildren().at(0).tryGetAs<SourceDescriptorLogicalOperator>().has_value());
 
     /// sink1, sink2, branch selection, shared selection, source
-    EXPECT_EQ(collectUniqueOperators(result).size(), 5);
+    EXPECT_EQ(OptimizerTestUtils::collectOperators(result).size(), 5);
 }
 
 TEST_F(MultiSinkPlanTest, WatermarkAssignerPushdownStopsAtSharedOperator)
@@ -288,7 +291,7 @@ TEST_F(MultiSinkPlanTest, WatermarkAssignerPushdownStopsAtSharedOperator)
     /// BEFORE: source <- sharedSelection <- {eventTimeAssigner <- sink1, sink2}
     /// AFTER:  the assigner must not descend into the shared subtree, where sink2 would observe it.
     auto source = utils.createSource("watermark_src", {"a", "b"});
-    auto sharedSelection = SelectionLogicalOperator::create(source, equalsZero(source, "a"));
+    auto sharedSelection = SelectionLogicalOperator::create(source, OptimizerTestUtils::equalsZero(source, "a"));
     auto eventTime = EventTimeWatermarkAssignerLogicalOperator::create(
         sharedSelection,
         FieldAccessLogicalFunction{sharedSelection.getOutputSchema()[Identifier::parse("a")].value()},
@@ -312,7 +315,7 @@ TEST_F(MultiSinkPlanTest, WatermarkAssignerPushdownStopsAtSharedOperator)
     EXPECT_EQ(branch1Shared.getId(), branch2Shared.getId());
     ASSERT_TRUE(branch2Shared.getChildren().at(0).tryGetAs<SourceDescriptorLogicalOperator>().has_value());
 
-    EXPECT_EQ(collectUniqueOperators(result).size(), 5);
+    EXPECT_EQ(OptimizerTestUtils::collectOperators(result).size(), 5);
 }
 
 TEST_F(MultiSinkPlanTest, ProjectionPushdownDoesNotNarrowSharedSubtree)
@@ -320,7 +323,7 @@ TEST_F(MultiSinkPlanTest, ProjectionPushdownDoesNotNarrowSharedSubtree)
     /// BEFORE: source(a, b) <- sharedSelection <- {projection(a) <- sink1(a), sink2(a, b)}
     /// AFTER:  sink1 only requires "a", but the shared subtree must keep the full schema for sink2.
     auto source = utils.createSource("proj_pushdown_src", {"a", "b"});
-    auto sharedSelection = SelectionLogicalOperator::create(source, equalsZero(source, "a"));
+    auto sharedSelection = SelectionLogicalOperator::create(source, OptimizerTestUtils::equalsZero(source, "a"));
     auto projection = ProjectionLogicalOperator::create(
         sharedSelection,
         std::vector<std::pair<Identifier, LogicalFunction>>{
@@ -343,7 +346,7 @@ TEST_F(MultiSinkPlanTest, ProjectionPushdownDoesNotNarrowSharedSubtree)
     /// The shared subtree still produces both fields and contains no narrowing projection.
     EXPECT_TRUE(branch2Shared.getOutputSchema()[Identifier::parse("a")].has_value());
     EXPECT_TRUE(branch2Shared.getOutputSchema()[Identifier::parse("b")].has_value());
-    for (const auto& op : collectUniqueOperators(utils.createPlan({roots.at(1)})))
+    for (const auto& op : OptimizerTestUtils::collectOperators(utils.createPlan({roots.at(1)})))
     {
         EXPECT_FALSE(op.tryGetAs<ProjectionLogicalOperator>().has_value()) << "unexpected projection below shared boundary: " << op;
     }
@@ -354,7 +357,7 @@ TEST_F(MultiSinkPlanTest, TypeInferencePreservesSharing)
     const auto result = TypeInferenceRule{}.apply(createSharedChainPlan("type_inference"));
 
     expectSharedRootChild(result);
-    EXPECT_EQ(collectUniqueOperators(result).size(), 4);
+    EXPECT_EQ(OptimizerTestUtils::collectOperators(result).size(), 4);
 }
 
 TEST_F(MultiSinkPlanTest, SinkBindingHandlesMultipleRoots)
@@ -376,7 +379,7 @@ TEST_F(MultiSinkPlanTest, AnonymousSourceBindingPreservesSharing)
     const auto result = AnonymousSourceBindingRule{std::make_shared<SourceCatalog>()}.apply(createSharedChainPlan("anonymous_source"));
 
     expectSharedRootChild(result);
-    EXPECT_EQ(collectUniqueOperators(result).size(), 4);
+    EXPECT_EQ(OptimizerTestUtils::collectOperators(result).size(), 4);
 }
 
 TEST_F(MultiSinkPlanTest, InferModelResolutionPreservesSharing)
@@ -384,7 +387,7 @@ TEST_F(MultiSinkPlanTest, InferModelResolutionPreservesSharing)
     const auto result = InferModelResolutionRule{std::make_shared<ModelCatalog>()}.apply(createSharedChainPlan("infer_model"));
 
     expectSharedRootChild(result);
-    EXPECT_EQ(collectUniqueOperators(result).size(), 4);
+    EXPECT_EQ(OptimizerTestUtils::collectOperators(result).size(), 4);
 }
 
 TEST_F(MultiSinkPlanTest, LogicalSourceExpansionExpandsSharedSourceNameOnce)
@@ -413,7 +416,7 @@ TEST_F(MultiSinkPlanTest, LogicalSourceExpansionExpandsSharedSourceNameOnce)
     ASSERT_EQ(expandedUnion.getChildren().size(), 1);
     EXPECT_TRUE(expandedUnion.getChildren().at(0).tryGetAs<SourceDescriptorLogicalOperator>().has_value());
     /// sink1, sink2, union, physical source
-    EXPECT_EQ(collectUniqueOperators(result).size(), 4);
+    EXPECT_EQ(OptimizerTestUtils::collectOperators(result).size(), 4);
 }
 
 TEST_F(MultiSinkPlanTest, CalcTargetOrderInfersOrderForAllSinks)
@@ -427,7 +430,7 @@ TEST_F(MultiSinkPlanTest, CalcTargetOrderInfersOrderForAllSinks)
     ASSERT_TRUE(descriptor2.has_value());
 
     auto source = utils.createSource("calc_target_order_src", {"a", "b"});
-    auto selection = SelectionLogicalOperator::create(source, equalsZero(source, "a"));
+    auto selection = SelectionLogicalOperator::create(source, OptimizerTestUtils::equalsZero(source, "a"));
     const auto sink1 = SinkLogicalOperator::create(selection, descriptor1.value());
     const auto sink2 = SinkLogicalOperator::create(selection, descriptor2.value());
 
@@ -453,7 +456,7 @@ TEST_F(MultiSinkPlanTest, RuleBasedOptimizerSequencePreservesSharing)
 
     expectSharedRootChild(result);
     /// sink1, sink2, the shared selection, and the source — no rule in the sequence may duplicate the shared subtree
-    EXPECT_EQ(collectUniqueOperators(result).size(), 4);
+    EXPECT_EQ(OptimizerTestUtils::collectOperators(result).size(), 4);
 }
 
 /// NOLINTEND(bugprone-unchecked-optional-access)

--- a/nes-query-optimizer/tests/Util/OptimizerTestUtils.cpp
+++ b/nes-query-optimizer/tests/Util/OptimizerTestUtils.cpp
@@ -25,6 +25,10 @@
 #include <DataTypes/Schema.hpp>
 #include <DataTypes/SchemaFwd.hpp>
 #include <DataTypes/UnboundField.hpp>
+#include <Functions/BooleanFunctions/EqualsLogicalFunction.hpp>
+#include <Functions/ConstantValueLogicalFunction.hpp>
+#include <Functions/FieldAccessLogicalFunction.hpp>
+#include <Functions/LogicalFunction.hpp>
 #include <Identifiers/Identifier.hpp>
 #include <Operators/LogicalOperator.hpp>
 #include <Operators/LogicalOperatorFwd.hpp>
@@ -124,23 +128,43 @@ LogicalPlan OptimizerTestUtils::createPlan(std::vector<LogicalOperator> sinks)
         QueryId::create(LocalQueryId{LocalQueryId::INVALID}, DistributedQueryId{DistributedQueryId::INVALID}), std::move(sinks)};
 }
 
-std::unordered_set<OperatorId> OptimizerTestUtils::collectOperatorIds(const LogicalPlan& plan)
+std::vector<LogicalOperator> OptimizerTestUtils::collectOperators(const LogicalPlan& plan)
 {
-    std::unordered_set<OperatorId> operatorIds;
+    std::vector<LogicalOperator> operators;
+    std::unordered_set<OperatorId> seen;
     std::vector<LogicalOperator> pending{plan.getRootOperators()};
     while (!pending.empty())
     {
         const auto current = pending.back();
         pending.pop_back();
-        if (!operatorIds.insert(current.getId()).second)
+        if (!seen.insert(current.getId()).second)
         {
             continue;
         }
+        operators.push_back(current);
         for (const auto& child : current.getChildren())
         {
             pending.push_back(child);
         }
     }
+    return operators;
+}
+
+std::unordered_set<OperatorId> OptimizerTestUtils::collectOperatorIds(const LogicalPlan& plan)
+{
+    std::unordered_set<OperatorId> operatorIds;
+    for (const auto& op : collectOperators(plan))
+    {
+        operatorIds.insert(op.getId());
+    }
     return operatorIds;
+}
+
+/// NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+LogicalFunction OptimizerTestUtils::equalsZero(const LogicalOperator& producer, const std::string& fieldName)
+{
+    return EqualsLogicalFunction{
+        FieldAccessLogicalFunction{producer.getOutputSchema()[Identifier::parse(fieldName)].value()},
+        ConstantValueLogicalFunction{DataType{DataType::Type::UINT64, DataType::NULLABLE::NOT_NULLABLE}, "0"}};
 }
 }

--- a/nes-query-optimizer/tests/Util/OptimizerTestUtils.cpp
+++ b/nes-query-optimizer/tests/Util/OptimizerTestUtils.cpp
@@ -16,6 +16,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -66,7 +67,7 @@ OptimizerTestUtils::createSource(std::string name, const std::vector<std::string
 SourceDescriptor
 OptimizerTestUtils::createSourceDescriptor(const Identifier& identifier, const Schema<UnqualifiedUnboundField, Ordered>& schema)
 {
-    auto source = sourceCatalog.addLogicalSource(identifier, schema);
+    auto source = sourceCatalog->addLogicalSource(identifier, schema);
 
     if (!source.has_value())
     {
@@ -74,7 +75,8 @@ OptimizerTestUtils::createSourceDescriptor(const Identifier& identifier, const S
     }
     const std::unordered_map<Identifier, std::string> sourceConfig{{Identifier::parse("FILE_PATH"), "/dev/null"}};
     const std::unordered_map<Identifier, std::string> parserConfig{{Identifier::parse("TYPE"), "CSV"}};
-    auto result = sourceCatalog.addPhysicalSource(source.value(), Identifier::parse("file"), Host{"localhost"}, sourceConfig, parserConfig);
+    auto result
+        = sourceCatalog->addPhysicalSource(source.value(), Identifier::parse("file"), Host{"localhost"}, sourceConfig, parserConfig);
 
     if (!result.has_value())
     {
@@ -88,7 +90,7 @@ SinkDescriptor OptimizerTestUtils::createSinkDescriptor(const Identifier& sinkNa
     const std::unordered_map<Identifier, std::string> sinkConfig{
         {Identifier::parse("FILE_PATH"), "/dev/null"}, {Identifier::parse("OUTPUT_FORMAT"), "CSV"}};
 
-    auto sinkDescriptor = sinkCatalog.addSinkDescriptor(sinkName, schema, Identifier::parse("file"), Host{"localhost"}, sinkConfig, {});
+    auto sinkDescriptor = sinkCatalog->addSinkDescriptor(sinkName, schema, Identifier::parse("file"), Host{"localhost"}, sinkConfig, {});
     if (!sinkDescriptor.has_value())
     {
         throw TestException();
@@ -113,5 +115,32 @@ LogicalPlan OptimizerTestUtils::createPlan(LogicalOperator sink)
 {
     return LogicalPlan{
         QueryId::create(LocalQueryId{LocalQueryId::INVALID}, DistributedQueryId{DistributedQueryId::INVALID}), {std::move(sink)}};
+}
+
+/// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+LogicalPlan OptimizerTestUtils::createPlan(std::vector<LogicalOperator> sinks)
+{
+    return LogicalPlan{
+        QueryId::create(LocalQueryId{LocalQueryId::INVALID}, DistributedQueryId{DistributedQueryId::INVALID}), std::move(sinks)};
+}
+
+std::unordered_set<OperatorId> OptimizerTestUtils::collectOperatorIds(const LogicalPlan& plan)
+{
+    std::unordered_set<OperatorId> operatorIds;
+    std::vector<LogicalOperator> pending{plan.getRootOperators()};
+    while (!pending.empty())
+    {
+        const auto current = pending.back();
+        pending.pop_back();
+        if (!operatorIds.insert(current.getId()).second)
+        {
+            continue;
+        }
+        for (const auto& child : current.getChildren())
+        {
+            pending.push_back(child);
+        }
+    }
+    return operatorIds;
 }
 }

--- a/nes-query-optimizer/tests/Util/OptimizerTestUtils.hpp
+++ b/nes-query-optimizer/tests/Util/OptimizerTestUtils.hpp
@@ -13,12 +13,15 @@
 */
 #pragma once
 
+#include <memory>
 #include <string>
+#include <unordered_set>
 #include <vector>
 #include <DataTypes/Schema.hpp>
 #include <DataTypes/SchemaFwd.hpp>
 #include <DataTypes/UnboundField.hpp>
 #include <Identifiers/Identifier.hpp>
+#include <Identifiers/Identifiers.hpp>
 #include <Operators/LogicalOperator.hpp>
 #include <Operators/LogicalOperatorFwd.hpp>
 #include <Operators/Sinks/SinkLogicalOperator.hpp>
@@ -51,10 +54,20 @@ public:
     TypedLogicalOperator<SinkLogicalOperator>
     createSink(LogicalOperator child, std::string name, const std::vector<std::string>& fieldNames);
     LogicalPlan createPlan(LogicalOperator sink);
+    /// Creates a plan with multiple sink roots. Sinks sharing (parts of) their subtrees form a DAG-shaped plan.
+    LogicalPlan createPlan(std::vector<LogicalOperator> sinks);
     SinkDescriptor createSinkDescriptor(const Identifier& sinkName, const Schema<UnqualifiedUnboundField, Ordered>& schema);
 
+    /// Collects the ids of all unique operators reachable from the plan roots. Operators shared between multiple
+    /// parents are counted once, so the size of the result detects accidental duplication of shared subtrees.
+    static std::unordered_set<OperatorId> collectOperatorIds(const LogicalPlan& plan);
+
+    /// The catalogs the created sources and sinks live in, for tests that run rules which resolve names against them.
+    [[nodiscard]] std::shared_ptr<const SourceCatalog> getSourceCatalog() const { return sourceCatalog; }
+    [[nodiscard]] std::shared_ptr<const SinkCatalog> getSinkCatalog() const { return sinkCatalog; }
+
 private:
-    SourceCatalog sourceCatalog;
-    SinkCatalog sinkCatalog;
+    std::shared_ptr<SourceCatalog> sourceCatalog = std::make_shared<SourceCatalog>();
+    std::shared_ptr<SinkCatalog> sinkCatalog = std::make_shared<SinkCatalog>();
 };
 }

--- a/nes-query-optimizer/tests/Util/OptimizerTestUtils.hpp
+++ b/nes-query-optimizer/tests/Util/OptimizerTestUtils.hpp
@@ -20,6 +20,7 @@
 #include <DataTypes/Schema.hpp>
 #include <DataTypes/SchemaFwd.hpp>
 #include <DataTypes/UnboundField.hpp>
+#include <Functions/LogicalFunction.hpp>
 #include <Identifiers/Identifier.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Operators/LogicalOperator.hpp>
@@ -58,12 +59,19 @@ public:
     LogicalPlan createPlan(std::vector<LogicalOperator> sinks);
     SinkDescriptor createSinkDescriptor(const Identifier& sinkName, const Schema<UnqualifiedUnboundField, Ordered>& schema);
 
-    /// Collects the ids of all unique operators reachable from the plan roots. Operators shared between multiple
-    /// parents are counted once, so the size of the result detects accidental duplication of shared subtrees.
+    /// Collects all unique operators reachable from the plan roots. Operators shared between multiple parents (in a
+    /// DAG-shaped plan) are visited once, so the size of the result detects accidental duplication of shared subtrees.
+    static std::vector<LogicalOperator> collectOperators(const LogicalPlan& plan);
+
+    /// Collects the ids of the operators returned by collectOperators.
     static std::unordered_set<OperatorId> collectOperatorIds(const LogicalPlan& plan);
+
+    /// Builds a `producer.<fieldName> == 0` predicate over a UINT64 field; a common building block for rule tests.
+    static LogicalFunction equalsZero(const LogicalOperator& producer, const std::string& fieldName);
 
     /// The catalogs the created sources and sinks live in, for tests that run rules which resolve names against them.
     [[nodiscard]] std::shared_ptr<const SourceCatalog> getSourceCatalog() const { return sourceCatalog; }
+
     [[nodiscard]] std::shared_ptr<const SinkCatalog> getSinkCatalog() const { return sinkCatalog; }
 
 private:


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

Multi-sink plans share operator instances between sink roots (the same operator is reachable through more than one parent), so the logical plan is a DAG. Previously, every rule in nes-query-optimizer either asserted a single root or recursed from each root without visited-tracking, cloning the shared subtree once per parent — e.g. a source shared by two sinks came out as two unrelated copies with two different origin ids.

Visited-tracking is only needed by rules whose rewrite traverses the whole plan; rules that only touch the sink roots or only read the plan get by without it. Where tracking is needed, it uses an external mapping keyed on the *input* plan's `OperatorId`s — those are stable during a rule application, whereas every rewrite creates a new operator with a new id (and operator hashing/equality are structural, so operators themselves cannot serve as visited-set keys). The change list is as follows:

- `PlanRewriteUtils` gains the shared machinery (plain free functions; each rule opts in inside its own `apply()`, the `Rule` interface is unchanged):
  - `rewritePlanBottomUp(plan, rewrite)`: memoized bottom-up rewrite that invokes `rewrite` exactly once per unique operator with the original operator and its already-rewritten children; the result is reused by every additional parent, so shared operators stay shared in the output.
  - `getSharedOperatorIds(plan)`: ids of operators reachable through more than one parent edge (duplicate edges from the same parent count).
  - `PushdownBarrier`: visited-tracking restricted to shared operators, for rules that keep their own traversal; rewrites a shared operator at most once and re-introduces each parent's pending state above the cached rewrite.
- Eleven rules rewrite the whole plan bottom-up and now do so through `rewritePlanBottomUp`, with their existing per-operator logic as the callback: `DecideJoinTypes`, `DecideMemoryLayout`, `DecideFieldMappings`, `DecideFieldOrder`, `OriginIdInference`, `RedundantUnionRemoval`, `RedundantProjectionRemoval`, `TypeInference`, `InferModelResolution`, `AnonymousSourceBinding`, and `LogicalSourceExpansion`.
  - `DecideFieldOrder` additionally collects each sink's target order up front, keyed by the sink child's id: sinks sharing a child must agree on the order (a shared operator can only carry one `FieldOrderingTrait`), an agreed order is stamped once, and conflicting orders throw `UnsupportedQuery`.
- The three pushdown rules (`PredicatePushdown`, `WatermarkAssignerPushdown`, `ProjectionPushdown`) keep their own top-down recursion, because the state they thread downward (predicates, watermark assigners, required fields) doesn't fit a bottom-up callback. They use `PushdownBarrier` to track only the shared operators, which act as pushdown barriers: downward-flowing state must not enter a subtree another parent also reads, so pending state is materialized above the barrier per parent edge and the shared subtree is rewritten exactly once with empty pending state. `ProjectionPushdown` rewrites shared operators requiring their full output schema, so one sink's narrowing cannot affect another sink.
  - These rules also no longer call the recursive `withInferredSchema()` after `withChildren(...)`: `withChildren` already re-infers the local schema (children are guaranteed inferred at that point), while the recursive variant deep-copies the just-wired — potentially shared — subtrees and would break sharing again.
- The remaining rules need no visited-tracking at all: `CalcTargetOrder` now infers the target schema order per root instead of asserting a single root (its traversal is read-only, so sharing is not at risk), and the two sink binding rules already iterated all roots without touching the subtrees — they are unchanged, but now covered by tests.

Out of scope, tracked by the sibling issues of this series: lowering (#1754, PR #1797), pipelining (#1755), executable plans/backpressure (#1756), and plan serialization (#1804).

## Verifying this change

This change is tested by

- A new `MultiSinkPlanTest` suite (19 unit tests): one sharing-preservation test per rule, the DAG-specific edge cases (branch predicate/assigner kept above the shared boundary, no narrowing of a shared subtree, one origin id for a shared assigner, agreed vs. conflicting sink field orders, target order feeding another sink's branch), and the full `RuleBasedOptimizer` sequence over a shared-chain plan. Sharing is asserted through operator ids, since structural operator equality cannot detect duplication.
- New `PlanRewriteUtilsTest` cases for `getSharedOperatorIds` (tree, multi-sink, duplicate-edge) and `rewritePlanBottomUp` (once-per-unique-operator invocation, sharing preservation).
- All existing optimizer rule tests pass unchanged, covering the single-sink behavior of every touched rule.

## What components does this pull request potentially affect?

- Query Optimizer

## Documentation

- The new `PlanRewriteUtils` helpers and `PushdownBarrier` are documented in-code, including the invariants they rely on (id-based visited-tracking, bottom-up invocation order).
- The non-obvious decisions carry comments at the point of use: why the pushdown rules must not call the recursive `withInferredSchema()` on rewritten children, and how `DecideFieldOrder` resolves target orders for shared sink children.

## Issue Closed by this pull request:

This PR closes #1753