### PR TITLE
remove unnecessary usage of static_val to improve tracing performance

### DIFF
--- a/nes-input-formatters/src/FieldOffsetRawBufferIndex.cpp
+++ b/nes-input-formatters/src/FieldOffsetRawBufferIndex.cpp
@@ -70,7 +70,7 @@ Record FieldOffsetRawBufferIndex::readSpanningRecord(
 {
     Record record;
     const auto indexBufferPtr = nautilus::invoke(getIndexValuesProxy, rawBufferIndex);
-    const auto numberOfFields = nautilus::static_val{bufferRef.getAllDataTypes().size()};
+    const auto numberOfFields = bufferRef.getAllDataTypes().size();
     for (nautilus::static_val<uint64_t> i = 0; i < numberOfFields; ++i)
     {
         const auto fieldName = bufferRef.getAllFieldNames().at(i);
@@ -80,9 +80,9 @@ Record FieldOffsetRawBufferIndex::readSpanningRecord(
             continue;
         }
 
-        const auto numPriorFields = recordIndex * nautilus::static_val(numberOfFields + 1);
+        const auto numPriorFields = recordIndex * (numberOfFields + 1);
         const auto fieldOffsetAddress = indexBufferPtr + (numPriorFields + i);
-        const auto fieldOffsetEndAddress = indexBufferPtr + (numPriorFields + i + nautilus::static_val<uint64_t>(1));
+        const auto fieldOffsetEndAddress = indexBufferPtr + (numPriorFields + i + 1);
         const auto fieldOffsetStart = readValueFromMemRef<FieldIndex>(fieldOffsetAddress);
         const auto fieldOffsetEnd = readValueFromMemRef<FieldIndex>(fieldOffsetEndAddress);
 

--- a/nes-nautilus/src/Interface/HashMap/ChainedHashMap/ChainedEntryMemoryProvider.cpp
+++ b/nes-nautilus/src/Interface/HashMap/ChainedHashMap/ChainedEntryMemoryProvider.cpp
@@ -210,7 +210,7 @@ void ChainedEntryMemoryProvider::writeEntryRef(
 std::vector<Record::RecordFieldIdentifier> ChainedEntryMemoryProvider::getAllFieldIdentifiers() const
 {
     std::vector<Record::RecordFieldIdentifier> fieldIdentifiers;
-    for (const auto& [fieldIdentifier, type, fieldOffset] : nautilus::static_iterable(fields))
+    for (const auto& [fieldIdentifier, type, fieldOffset] : fields)
     {
         fieldIdentifiers.push_back(fieldIdentifier);
     }

--- a/nes-nautilus/src/Interface/HashMap/ChainedHashMap/ChainedHashMapRef.cpp
+++ b/nes-nautilus/src/Interface/HashMap/ChainedHashMap/ChainedHashMapRef.cpp
@@ -88,12 +88,12 @@ nautilus::val<int8_t*> ChainedHashMapRef::ChainedEntryRef::getValueMemArea() con
     /// We call this method solely, if we actually need the value memory area and not a VarVal.
     /// Therefore, we do not store the valueOffset in the ChainedEntryRef or the ChainedEntryMemoryProvider
     /// During tracing the offset is calculated and should be stored as a constant in the compiled code
-    nautilus::static_val<uint64_t> valueMemAreaOffset(0);
+    uint64_t valueMemAreaOffset = 0;
     if (memoryProviderValues.getAllFields().empty())
     {
         /// We take the max offset of the keys
         valueMemAreaOffset = std::numeric_limits<uint64_t>::min();
-        for (const auto& field : nautilus::static_iterable(memoryProviderKeys.getAllFields()))
+        for (const auto& field : memoryProviderKeys.getAllFields())
         {
             const auto offset = field.fieldOffset;
             const auto fieldSize = field.type.getSizeInBytesWithNull();
@@ -107,7 +107,7 @@ nautilus::val<int8_t*> ChainedHashMapRef::ChainedEntryRef::getValueMemArea() con
     {
         /// We take the min offset of the values
         valueMemAreaOffset = std::numeric_limits<uint64_t>::max();
-        for (const auto& field : nautilus::static_iterable(memoryProviderValues.getAllFields()))
+        for (const auto& field : memoryProviderValues.getAllFields())
         {
             const auto offset = field.fieldOffset;
             if (valueMemAreaOffset > offset)

--- a/nes-output-formatters/include/OutputFormatters/OutputFormatter.hpp
+++ b/nes-output-formatters/include/OutputFormatters/OutputFormatter.hpp
@@ -27,7 +27,6 @@
 #include <fmt/base.h>
 #include <fmt/ostream.h>
 #include <ErrorHandling.hpp>
-#include <static.hpp>
 #include <val_arith.hpp>
 #include <val_concepts.hpp>
 #include <val_ptr.hpp>
@@ -55,7 +54,7 @@ public:
     [[nodiscard]] virtual nautilus::val<uint64_t> writeFormattedValue(
         const VarVal& value,
         const DataType& fieldType,
-        const nautilus::static_val<uint64_t>& fieldIndex,
+        uint64_t fieldIndex,
         const nautilus::val<int8_t*>& fieldPointer,
         const nautilus::val<uint64_t>& remainingSize,
         const RecordBuffer& recordBuffer,

--- a/nes-output-formatters/private/CSVOutputFormatter.hpp
+++ b/nes-output-formatters/private/CSVOutputFormatter.hpp
@@ -31,7 +31,6 @@
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Util/Logger/Formatter.hpp>
 #include <fmt/core.h>
-#include <static.hpp>
 #include <val_arith.hpp>
 #include <val_concepts.hpp>
 #include <val_ptr.hpp>
@@ -46,7 +45,7 @@ public:
     [[nodiscard]] nautilus::val<uint64_t> writeFormattedValue(
         const VarVal& value,
         const DataType& fieldType,
-        const nautilus::static_val<uint64_t>& fieldIndex,
+        uint64_t fieldIndex,
         const nautilus::val<int8_t*>& fieldPointer,
         const nautilus::val<uint64_t>& remainingSize,
         const RecordBuffer& recordBuffer,

--- a/nes-output-formatters/src/CSVOutputFormatter.cpp
+++ b/nes-output-formatters/src/CSVOutputFormatter.cpp
@@ -42,7 +42,6 @@
 #include <OutputFormatterValidationRegistry.hpp>
 #include <function.hpp>
 #include <select.hpp>
-#include <static.hpp>
 #include <val_arith.hpp>
 #include <val_bool.hpp>
 #include <val_concepts.hpp>
@@ -149,7 +148,7 @@ CSVOutputFormatter::CSVOutputFormatter(
 nautilus::val<uint64_t> CSVOutputFormatter::writeFormattedValue(
     const VarVal& value,
     const DataType& fieldType,
-    const nautilus::static_val<uint64_t>& fieldIndex,
+    uint64_t fieldIndex,
     const nautilus::val<int8_t*>& fieldPointer,
     const nautilus::val<uint64_t>& remainingSize,
     const RecordBuffer& recordBuffer,
@@ -185,7 +184,7 @@ nautilus::val<uint64_t> CSVOutputFormatter::writeFormattedValue(
 
     /// Write either the field delimiter or the tuple delimiter, depending on the field index
     const auto delimiter = nautilus::select(
-        fieldIndex == nautilus::val<uint64_t>{fieldNames.size()} - 1,
+        nautilus::val<uint64_t>{fieldIndex} == nautilus::val<uint64_t>{fieldNames.size()} - 1,
         nautilus::val<const char*>{tupleDelimiter.c_str()},
         nautilus::val<const char*>{fieldDelimiter.c_str()});
 

--- a/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONInputFormatIndexer.hpp
+++ b/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONInputFormatIndexer.hpp
@@ -128,20 +128,11 @@ public:
 
     static DescriptorConfig::Config validateAndFormat(std::unordered_map<std::string, std::string> config);
 
-    [[nodiscard]] const Record::RecordFieldIdentifier& getFieldNameAt(const nautilus::static_val<uint64_t>& fieldIndex) const
-    {
-        return fieldNamesOutput[fieldIndex];
-    }
+    [[nodiscard]] const Record::RecordFieldIdentifier& getFieldNameAt(uint64_t fieldIndex) const { return fieldNamesOutput[fieldIndex]; }
 
-    [[nodiscard]] const Identifier& getFieldNameInJsonAt(const nautilus::static_val<uint64_t>& fieldIndex) const
-    {
-        return fieldNamesInJson[fieldIndex];
-    }
+    [[nodiscard]] const Identifier& getFieldNameInJsonAt(uint64_t fieldIndex) const { return fieldNamesInJson[fieldIndex]; }
 
-    [[nodiscard]] const DataType& getFieldDataTypeAt(const nautilus::static_val<uint64_t>& fieldIndex) const
-    {
-        return fieldDataTypes[fieldIndex];
-    }
+    [[nodiscard]] const DataType& getFieldDataTypeAt(uint64_t fieldIndex) const { return fieldDataTypes[fieldIndex]; }
 
     [[nodiscard]] uint64_t getNumberOfFields() const
     {

--- a/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONRawBufferIndex.cpp
+++ b/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONRawBufferIndex.cpp
@@ -143,7 +143,7 @@ Record SIMDJSONRawBufferIndex::readSpanningRecord(
     const TupleBufferRef& bufferRef) const
 {
     Record record;
-    const auto numberOfFields = nautilus::static_val{bufferRef.getAllDataTypes().size()};
+    const auto numberOfFields = bufferRef.getAllDataTypes().size();
     for (nautilus::static_val<uint64_t> i = 0; i < numberOfFields; ++i)
     {
         const auto fieldName = bufferRef.getAllFieldNames().at(i);

--- a/nes-plugins/OutputFormatters/JSONOutputFormatter/JSONOutputFormatter.cpp
+++ b/nes-plugins/OutputFormatters/JSONOutputFormatter/JSONOutputFormatter.cpp
@@ -43,7 +43,6 @@
 #include <OutputFormatterValidationRegistry.hpp>
 #include <function.hpp>
 #include <select.hpp>
-#include <static.hpp>
 #include <val_arith.hpp>
 #include <val_bool.hpp>
 #include <val_concepts.hpp>
@@ -177,7 +176,7 @@ JSONOutputFormatter::JSONOutputFormatter(const std::vector<Record::RecordFieldId
 nautilus::val<uint64_t> JSONOutputFormatter::writeFormattedValue(
     const VarVal& value,
     const DataType& fieldType,
-    const nautilus::static_val<uint64_t>& fieldIndex,
+    uint64_t fieldIndex,
     const nautilus::val<int8_t*>& fieldPointer,
     const nautilus::val<uint64_t>& remainingSize,
     const RecordBuffer& recordBuffer,
@@ -192,7 +191,7 @@ nautilus::val<uint64_t> JSONOutputFormatter::writeFormattedValue(
     /// Write the pre-value content
     const nautilus::val<uint64_t> amountWritten = nautilus::invoke(
         writePreValueContents,
-        fieldIndex == nautilus::val<uint64_t>(0),
+        nautilus::val<uint64_t>(fieldIndex) == nautilus::val<uint64_t>(0),
         fieldName,
         currentRemainingSize,
         recordBuffer.getReference(),
@@ -228,7 +227,9 @@ nautilus::val<uint64_t> JSONOutputFormatter::writeFormattedValue(
 
     /// Either write a , or a }\n depending on if this is the last value of the record
     const auto delimiter = nautilus::select(
-        fieldIndex == nautilus::val<uint64_t>(fieldNames.size()) - 1, nautilus::val<const char*>{"}\n"}, nautilus::val<const char*>{","});
+        nautilus::val<uint64_t>(fieldIndex) == nautilus::val<uint64_t>(fieldNames.size()) - 1,
+        nautilus::val<const char*>{"}\n"},
+        nautilus::val<const char*>{","});
 
     written += nautilus::invoke(
         writeValueToBuffer, delimiter, currentRemainingSize, recordBuffer.getReference(), bufferProvider, fieldPointer + written);

--- a/nes-plugins/OutputFormatters/JSONOutputFormatter/JSONOutputFormatter.hpp
+++ b/nes-plugins/OutputFormatters/JSONOutputFormatter/JSONOutputFormatter.hpp
@@ -28,7 +28,6 @@
 #include <OutputFormatters/OutputFormatter.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Util/Logger/Formatter.hpp>
-#include <static.hpp>
 #include <val_arith.hpp>
 #include <val_concepts.hpp>
 #include <val_ptr.hpp>
@@ -43,7 +42,7 @@ public:
     [[nodiscard]] nautilus::val<uint64_t> writeFormattedValue(
         const VarVal& value,
         const DataType& fieldType,
-        const nautilus::static_val<uint64_t>& fieldIndex,
+        uint64_t fieldIndex,
         const nautilus::val<int8_t*>& fieldPointer,
         const nautilus::val<uint64_t>& remainingSize,
         const RecordBuffer& recordBuffer,


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This change remove some unnecessary usages of static val in the operator implementations. 
The usage of static_val is explained here: https://github.com/nebulastream/nautilus/blob/main/docs/static-val.md

