### PR TITLE
dummy pr for ci-refactor (code change)

### DIFF
--- a/nes-common/src/Util/Common.cpp
+++ b/nes-common/src/Util/Common.cpp
@@ -13,6 +13,8 @@
 */
 #include <Util/Common.hpp>
 
+/// Trivial change to exercise the full CI pipeline on a non-docs PR (verifies that the
+/// docs-only skip in the classify gate does NOT skip real code changes).
 namespace NES
 {
 }


### PR DESCRIPTION
Code-only dummy PR to test the `ci-refactor` required checks (mirror of #1795).

Expected: **Code CI Done** runs the full pipeline and is green after build/tests; **Docs CI Done** passes trivially (`hasDocChanges=false`).

Bypass check: editing this PR's title mid/after run should publish a **Code CI Done (skipped)** context (not `Code CI Done`), so a title edit can't satisfy branch protection over failing code. Delete once confirmed.