### PR TITLE
feat(Version): expose the worker build info over gRPC and via SHOW VERSION

### DIFF
--- a/grpc/SingleNodeWorkerRPCService.proto
+++ b/grpc/SingleNodeWorkerRPCService.proto
@@ -23,6 +23,11 @@ service WorkerRPCService {
 
   rpc RequestQueryStatus (QueryStatusRequest) returns (QueryStatusReply) {}
   rpc RequestStatus (WorkerStatusRequest) returns (WorkerStatusResponse) {}
+  rpc RequestVersion (google.protobuf.Empty) returns (VersionResponse) {}
+}
+
+message VersionResponse {
+  string version = 1;
 }
 
 message StartQueryRequest {

--- a/nes-common/include/Version.hpp
+++ b/nes-common/include/Version.hpp
@@ -14,18 +14,20 @@
 
 #pragma once
 
-#include <string>
 #include <string_view>
+#include <Identifiers/NESStrongType.hpp>
 
 namespace NES
 {
 
+using VersionInfo = NESStrongStringType<struct VersionInfo_, "INVALID">;
+
 /// Builds the multi-line build-info report for the given binary name. The first line is
 /// `<binaryName> <version>`, followed by indented fields (commit, build, sanitizer, compiler,
 /// compiler flags, stdlib, log level, vcpkg baseline). The build metadata is embedded at CMake generation time (see BuildInfo.hpp).
-[[nodiscard]] std::string formatVersion(std::string_view binaryName);
+[[nodiscard]] VersionInfo versionInfo(std::string_view binaryName);
 
-/// Prints the build-info report produced by formatVersion to stdout.
+/// Prints the build-info report produced by versionInfo to stdout.
 void printVersion(std::string_view binaryName);
 
 /// Returns true if argv contains a `-v` or `--version` flag. Intended to be checked early in main()

--- a/nes-common/src/Version.cpp
+++ b/nes-common/src/Version.cpp
@@ -29,11 +29,11 @@
 namespace NES
 {
 
-std::string formatVersion(const std::string_view binaryName)
+VersionInfo versionInfo(const std::string_view binaryName)
 {
     /// Plugin listing is deferred to a follow-up (see issue #1640); listing the registered
     /// plugins requires restructuring the CMake plugin discovery / registry.
-    return fmt::format(
+    return VersionInfo{fmt::format(
         "{} {}\n"
         "  commit:         {}\n"
         "  built:          {}\n"
@@ -54,12 +54,12 @@ std::string formatVersion(const std::string_view binaryName)
         BuildInfo::compilerFlags,
         BuildInfo::stdlib,
         BuildInfo::logLevel,
-        BuildInfo::vcpkgBaseline);
+        BuildInfo::vcpkgBaseline)};
 }
 
 void printVersion(const std::string_view binaryName)
 {
-    std::cout << formatVersion(binaryName);
+    std::cout << versionInfo(binaryName);
 }
 
 bool hasVersionFlag(const int argc, const char* const* argv)

--- a/nes-common/tests/UnitTests/Util/VersionTest.cpp
+++ b/nes-common/tests/UnitTests/Util/VersionTest.cpp
@@ -21,15 +21,15 @@
 namespace NES
 {
 
-TEST(VersionTest, formatVersionContainsBinaryName)
+TEST(VersionTest, versionInfoContainsBinaryName)
 {
-    const auto output = formatVersion("my-binary");
+    const auto output = versionInfo("my-binary").getRawValue();
     EXPECT_THAT(output, testing::HasSubstr("my-binary"));
 }
 
-TEST(VersionTest, formatVersionContainsAllFields)
+TEST(VersionTest, versionInfoContainsAllFields)
 {
-    const auto output = formatVersion("nes-single-node-worker");
+    const auto output = versionInfo("nes-single-node-worker").getRawValue();
     /// The labels for every embedded build-info field must be present.
     EXPECT_THAT(output, testing::HasSubstr("commit:"));
     EXPECT_THAT(output, testing::HasSubstr("built:"));
@@ -42,9 +42,9 @@ TEST(VersionTest, formatVersionContainsAllFields)
     EXPECT_THAT(output, testing::HasSubstr("vcpkg baseline:"));
 }
 
-TEST(VersionTest, formatVersionFirstLineIsBinaryNameAndVersion)
+TEST(VersionTest, versionInfoFirstLineIsBinaryNameAndVersion)
 {
-    const auto output = formatVersion("checksum");
+    const auto output = versionInfo("checksum").getRawValue();
     const auto firstLineEnd = output.find('\n');
     ASSERT_NE(firstLineEnd, std::string::npos);
     const auto firstLine = output.substr(0, firstLineEnd);

--- a/nes-frontend/apps/repl/tests/distributed.bats
+++ b/nes-frontend/apps/repl/tests/distributed.bats
@@ -89,6 +89,29 @@ docker_nes_repl() {
   assert_json_equal '[]' "${lines[3]}"
 }
 
+@test "show version matches the worker's own --version output" {
+  setup_distributed tests/topologies/1-node.yaml
+
+  expected=$(docker compose exec -T worker-node nes-single-node-worker --version)
+
+  run docker_nes_repl tests/sql-file-tests/good/show_version_distributed.sql
+  [ "$status" -eq 0 ]
+
+  [ "$(echo "${lines[1]}" | jq -r '.[0].worker')" = "worker-node:8080" ]
+  [ "$(echo "${lines[1]}" | jq -r '.[0].version')" = "$expected" ]
+}
+
+@test "show version reports an unreachable worker as an error" {
+  setup_distributed tests/topologies/1-node.yaml
+  docker compose stop worker-node
+
+  run docker_nes_repl tests/sql-file-tests/good/show_version_distributed.sql
+  [ "$status" -eq 0 ]
+
+  [ "$(echo "${lines[1]}" | jq -r '.[0].worker')" = "worker-node:8080" ]
+  echo "${lines[1]}" | jq -r '.[0].version' | grep -q "error:"
+}
+
 @test "launch bad query should fail" {
   setup_distributed tests/topologies/1-node.yaml
   run docker_nes_repl tests/sql-file-tests/bad/invalid_projection_distributed.sql

--- a/nes-frontend/apps/repl/tests/distributed.bats
+++ b/nes-frontend/apps/repl/tests/distributed.bats
@@ -109,7 +109,8 @@ docker_nes_repl() {
   [ "$status" -eq 0 ]
 
   [ "$(echo "${lines[1]}" | jq -r '.[0].worker')" = "worker-node:8080" ]
-  echo "${lines[1]}" | jq -r '.[0].version' | grep -q "error:"
+  [ "$(echo "${lines[1]}" | jq -r '.[0].version')" = "null" ]
+  [ "$(echo "${lines[1]}" | jq -r '.[0].error')" != "null" ]
 }
 
 @test "launch bad query should fail" {

--- a/nes-frontend/apps/repl/tests/embedded.bats
+++ b/nes-frontend/apps/repl/tests/embedded.bats
@@ -45,6 +45,16 @@ setup()         { nes_offline_setup; }
   assert_json_contains "[]" "${lines[7]}"
 }
 
+@test "show version reports the embedded worker build info" {
+  run $NES_REPL -f JSON <tests/sql-file-tests/good/show_version.sql
+  [ "$status" -eq 0 ]
+
+  [ "$(echo "${lines[0]}" | jq -r '.[0].worker')" = "localhost:8080" ]
+  version=$(echo "${lines[0]}" | jq -r '.[0].version')
+  [[ "$(echo "$version" | sed -n '1p')" == "nes-single-node-worker "* ]]
+  echo "$version" | grep -q "commit:"
+}
+
 @test "launch multiple queries distributed" {
   run $NES_REPL -f JSON <tests/sql-file-tests/good/multiple_queries_distributed.sql
   [ "$status" -eq 0 ]

--- a/nes-frontend/apps/repl/tests/sql-file-tests/good/show_version.sql
+++ b/nes-frontend/apps/repl/tests/sql-file-tests/good/show_version.sql
@@ -1,0 +1,1 @@
+SHOW VERSION;

--- a/nes-frontend/apps/repl/tests/sql-file-tests/good/show_version_distributed.sql
+++ b/nes-frontend/apps/repl/tests/sql-file-tests/good/show_version_distributed.sql
@@ -1,0 +1,2 @@
+CREATE WORKER 'worker-node:8080' SET ('worker-node:9090' AS DATA);
+SHOW VERSION;

--- a/nes-frontend/include/QueryManager/EmbeddedWorkerQuerySubmissionBackend.hpp
+++ b/nes-frontend/include/QueryManager/EmbeddedWorkerQuerySubmissionBackend.hpp
@@ -17,13 +17,13 @@
 
 #include <chrono>
 #include <memory>
-#include <string>
 #include <Identifiers/Identifiers.hpp>
 #include <Listeners/QueryLog.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <ErrorHandling.hpp>
 #include <QueryStatus.hpp>
 #include <SingleNodeWorkerConfiguration.hpp>
+#include <Version.hpp>
 #include <WorkerStatus.hpp>
 
 namespace NES
@@ -46,7 +46,7 @@ public:
     std::expected<void, Exception> stop(QueryId) override;
     [[nodiscard]] std::expected<LocalQueryStatusSnapshot, Exception> status(QueryId) const override;
     [[nodiscard]] std::expected<WorkerStatus, Exception> workerStatus(std::chrono::system_clock::time_point after) const override;
-    [[nodiscard]] std::expected<std::string, Exception> version() const override;
+    [[nodiscard]] std::expected<VersionInfo, Exception> version() const override;
 
 private:
     std::unique_ptr<detail::Channel> channel;

--- a/nes-frontend/include/QueryManager/EmbeddedWorkerQuerySubmissionBackend.hpp
+++ b/nes-frontend/include/QueryManager/EmbeddedWorkerQuerySubmissionBackend.hpp
@@ -17,6 +17,7 @@
 
 #include <chrono>
 #include <memory>
+#include <string>
 #include <Identifiers/Identifiers.hpp>
 #include <Listeners/QueryLog.hpp>
 #include <Plans/LogicalPlan.hpp>
@@ -45,6 +46,7 @@ public:
     std::expected<void, Exception> stop(QueryId) override;
     [[nodiscard]] std::expected<LocalQueryStatusSnapshot, Exception> status(QueryId) const override;
     [[nodiscard]] std::expected<WorkerStatus, Exception> workerStatus(std::chrono::system_clock::time_point after) const override;
+    [[nodiscard]] std::expected<std::string, Exception> version() const override;
 
 private:
     std::unique_ptr<detail::Channel> channel;

--- a/nes-frontend/include/QueryManager/GRPCQuerySubmissionBackend.hpp
+++ b/nes-frontend/include/QueryManager/GRPCQuerySubmissionBackend.hpp
@@ -18,6 +18,7 @@
 
 #include <chrono>
 #include <memory>
+#include <string>
 #include <Identifiers/Identifiers.hpp>
 #include <Listeners/QueryLog.hpp>
 #include <Plans/LogicalPlan.hpp>
@@ -40,6 +41,7 @@ public:
     std::expected<void, Exception> stop(QueryId) override;
     [[nodiscard]] std::expected<LocalQueryStatusSnapshot, Exception> status(QueryId) const override;
     [[nodiscard]] std::expected<WorkerStatus, Exception> workerStatus(std::chrono::system_clock::time_point after) const override;
+    [[nodiscard]] std::expected<std::string, Exception> version() const override;
 };
 
 BackendProvider createGRPCBackend();

--- a/nes-frontend/include/QueryManager/GRPCQuerySubmissionBackend.hpp
+++ b/nes-frontend/include/QueryManager/GRPCQuerySubmissionBackend.hpp
@@ -18,7 +18,6 @@
 
 #include <chrono>
 #include <memory>
-#include <string>
 #include <Identifiers/Identifiers.hpp>
 #include <Listeners/QueryLog.hpp>
 #include <Plans/LogicalPlan.hpp>
@@ -26,6 +25,7 @@
 #include <QueryId.hpp>
 #include <QueryStatus.hpp>
 #include <SingleNodeWorkerRPCService.grpc.pb.h>
+#include <Version.hpp>
 #include <WorkerStatus.hpp>
 
 namespace NES
@@ -41,7 +41,7 @@ public:
     std::expected<void, Exception> stop(QueryId) override;
     [[nodiscard]] std::expected<LocalQueryStatusSnapshot, Exception> status(QueryId) const override;
     [[nodiscard]] std::expected<WorkerStatus, Exception> workerStatus(std::chrono::system_clock::time_point after) const override;
-    [[nodiscard]] std::expected<std::string, Exception> version() const override;
+    [[nodiscard]] std::expected<VersionInfo, Exception> version() const override;
 };
 
 BackendProvider createGRPCBackend();

--- a/nes-frontend/include/QueryManager/QueryManager.hpp
+++ b/nes-frontend/include/QueryManager/QueryManager.hpp
@@ -18,7 +18,6 @@
 #include <cstdint>
 #include <expected>
 #include <map>
-#include <string>
 #include <unordered_map>
 #include <vector>
 #include <Identifiers/Identifiers.hpp>
@@ -31,6 +30,7 @@
 #include <ErrorHandling.hpp>
 #include <QueryId.hpp>
 #include <QueryStatus.hpp>
+#include <Version.hpp>
 #include <WorkerCatalog.hpp>
 #include <WorkerConfig.hpp>
 #include <WorkerStatus.hpp>
@@ -46,7 +46,7 @@ public:
     virtual std::expected<void, Exception> stop(QueryId) = 0;
     [[nodiscard]] virtual std::expected<LocalQueryStatusSnapshot, Exception> status(QueryId) const = 0;
     [[nodiscard]] virtual std::expected<WorkerStatus, Exception> workerStatus(std::chrono::system_clock::time_point after) const = 0;
-    [[nodiscard]] virtual std::expected<std::string, Exception> version() const = 0;
+    [[nodiscard]] virtual std::expected<VersionInfo, Exception> version() const = 0;
 };
 
 /// std::move_only_function is the C++23 equivalent but is not yet available in libc++19.
@@ -117,7 +117,7 @@ public:
     [[nodiscard]] std::vector<DistributedQueryId> getRunningQueries() const;
     [[nodiscard]] std::vector<DistributedQueryId> queries() const;
     [[nodiscard]] std::expected<DistributedWorkerStatus, Exception> workerStatus(std::chrono::system_clock::time_point after) const;
-    [[nodiscard]] std::map<Host, std::expected<std::string, Exception>> workerVersions() const;
+    [[nodiscard]] std::map<Host, std::expected<VersionInfo, Exception>> workerVersions() const;
     [[nodiscard]] std::expected<DistributedQuery, Exception> getQuery(DistributedQueryId query) const;
 };
 

--- a/nes-frontend/include/QueryManager/QueryManager.hpp
+++ b/nes-frontend/include/QueryManager/QueryManager.hpp
@@ -17,6 +17,8 @@
 #include <chrono>
 #include <cstdint>
 #include <expected>
+#include <map>
+#include <string>
 #include <unordered_map>
 #include <vector>
 #include <Identifiers/Identifiers.hpp>
@@ -44,6 +46,7 @@ public:
     virtual std::expected<void, Exception> stop(QueryId) = 0;
     [[nodiscard]] virtual std::expected<LocalQueryStatusSnapshot, Exception> status(QueryId) const = 0;
     [[nodiscard]] virtual std::expected<WorkerStatus, Exception> workerStatus(std::chrono::system_clock::time_point after) const = 0;
+    [[nodiscard]] virtual std::expected<std::string, Exception> version() const = 0;
 };
 
 /// std::move_only_function is the C++23 equivalent but is not yet available in libc++19.
@@ -114,6 +117,7 @@ public:
     [[nodiscard]] std::vector<DistributedQueryId> getRunningQueries() const;
     [[nodiscard]] std::vector<DistributedQueryId> queries() const;
     [[nodiscard]] std::expected<DistributedWorkerStatus, Exception> workerStatus(std::chrono::system_clock::time_point after) const;
+    [[nodiscard]] std::map<Host, std::expected<std::string, Exception>> workerVersions() const;
     [[nodiscard]] std::expected<DistributedQuery, Exception> getQuery(DistributedQueryId query) const;
 };
 

--- a/nes-frontend/include/Statements/StatementHandler.hpp
+++ b/nes-frontend/include/Statements/StatementHandler.hpp
@@ -16,6 +16,7 @@
 
 #include <concepts>
 #include <expected>
+#include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -109,6 +110,11 @@ struct WorkerStatusStatementResult
     DistributedWorkerStatus status;
 };
 
+struct ShowVersionStatementResult
+{
+    std::map<Host, std::expected<std::string, Exception>> versions;
+};
+
 struct CreateWorkerStatementResult
 {
     Host host;
@@ -151,6 +157,7 @@ using StatementResult = std::variant<
     DropWorkerStatementResult,
     CreateWorkerStatementResult,
     WorkerStatusStatementResult,
+    ShowVersionStatementResult,
     CreateModelStatementResult,
     ShowLogicalSourcesStatementResult,
     ShowPhysicalSourcesStatementResult,
@@ -265,6 +272,7 @@ public:
     TopologyStatementHandler(SharedPtr<QueryManager> queryManager, SharedPtr<WorkerCatalog> workerCatalog);
 
     std::expected<WorkerStatusStatementResult, Exception> operator()(const WorkerStatusStatement& statement);
+    std::expected<ShowVersionStatementResult, Exception> operator()(const ShowVersionStatement& statement);
     std::expected<CreateWorkerStatementResult, Exception> operator()(const CreateWorkerStatement& statement);
     std::expected<DropWorkerStatementResult, Exception> operator()(const DropWorkerStatement& statement);
 };

--- a/nes-frontend/include/Statements/StatementHandler.hpp
+++ b/nes-frontend/include/Statements/StatementHandler.hpp
@@ -39,6 +39,7 @@
 #include <ErrorHandling.hpp>
 #include <ModelCatalog.hpp>
 #include <QueryOptimizer.hpp>
+#include <Version.hpp>
 #include <WorkerCatalog.hpp>
 
 namespace NES
@@ -112,7 +113,7 @@ struct WorkerStatusStatementResult
 
 struct ShowVersionStatementResult
 {
-    std::map<Host, std::expected<std::string, Exception>> versions;
+    std::map<Host, std::expected<VersionInfo, Exception>> versions;
 };
 
 struct CreateWorkerStatementResult

--- a/nes-frontend/include/Statements/StatementOutputAssembler.hpp
+++ b/nes-frontend/include/Statements/StatementOutputAssembler.hpp
@@ -40,6 +40,7 @@
 #include <DistributedQuery.hpp>
 #include <InputFormatterDescriptor.hpp>
 #include <QueryStatus.hpp>
+#include <Version.hpp>
 
 namespace NES
 {
@@ -439,8 +440,8 @@ struct StatementOutputAssembler<WorkerStatusStatementResult>
     }
 };
 
-using WorkerVersionOutputRowType = std::tuple<Host, std::string>;
-constexpr std::array<std::string_view, 2> workerVersionOutputColumns{"worker", "version"};
+using WorkerVersionOutputRowType = std::tuple<Host, std::optional<VersionInfo>, std::optional<std::string>>;
+constexpr std::array<std::string_view, 3> workerVersionOutputColumns{"worker", "version", "error"};
 
 template <>
 struct StatementOutputAssembler<ShowVersionStatementResult>
@@ -453,7 +454,14 @@ struct StatementOutputAssembler<ShowVersionStatementResult>
         output.reserve(result.versions.size());
         for (const auto& [host, version] : result.versions)
         {
-            output.emplace_back(host, version.has_value() ? *version : fmt::format("error: {}", version.error().what()));
+            if (version.has_value())
+            {
+                output.emplace_back(host, *version, std::nullopt);
+            }
+            else
+            {
+                output.emplace_back(host, std::nullopt, version.error().what());
+            }
         }
         return std::make_pair(workerVersionOutputColumns, output);
     }

--- a/nes-frontend/include/Statements/StatementOutputAssembler.hpp
+++ b/nes-frontend/include/Statements/StatementOutputAssembler.hpp
@@ -439,6 +439,26 @@ struct StatementOutputAssembler<WorkerStatusStatementResult>
     }
 };
 
+using WorkerVersionOutputRowType = std::tuple<Host, std::string>;
+constexpr std::array<std::string_view, 2> workerVersionOutputColumns{"worker", "version"};
+
+template <>
+struct StatementOutputAssembler<ShowVersionStatementResult>
+{
+    using OutputRowType = WorkerVersionOutputRowType;
+
+    auto convert(const ShowVersionStatementResult& result)
+    {
+        std::vector<OutputRowType> output;
+        output.reserve(result.versions.size());
+        for (const auto& [host, version] : result.versions)
+        {
+            output.emplace_back(host, version.has_value() ? *version : fmt::format("error: {}", version.error().what()));
+        }
+        return std::make_pair(workerVersionOutputColumns, output);
+    }
+};
+
 using ModelNameOutputRowType = std::tuple<std::string>;
 constexpr std::array<std::string_view, 1> modelNameOutputColumns{"model_name"};
 
@@ -501,6 +521,7 @@ static_assert(AssemblembleStatementResult<DropSinkStatementResult>);
 static_assert(AssemblembleStatementResult<QueryStatementResult>);
 static_assert(AssemblembleStatementResult<ShowQueriesStatementResult>);
 static_assert(AssemblembleStatementResult<WorkerStatusStatementResult>);
+static_assert(AssemblembleStatementResult<ShowVersionStatementResult>);
 static_assert(AssemblembleStatementResult<DropQueryStatementResult>);
 static_assert(AssemblembleStatementResult<CreateModelStatementResult>);
 static_assert(AssemblembleStatementResult<ShowModelsStatementResult>);

--- a/nes-frontend/src/QueryManager/EmbeddedWorkerQuerySubmissionBackend.cpp
+++ b/nes-frontend/src/QueryManager/EmbeddedWorkerQuerySubmissionBackend.cpp
@@ -222,9 +222,9 @@ std::expected<WorkerStatus, Exception> EmbeddedWorkerQuerySubmissionBackend::wor
     return channel->workerStatus(after);
 }
 
-std::expected<std::string, Exception> EmbeddedWorkerQuerySubmissionBackend::version() const
+std::expected<VersionInfo, Exception> EmbeddedWorkerQuerySubmissionBackend::version() const
 {
-    return formatVersion(SingleNodeWorkerBinaryName);
+    return versionInfo(SingleNodeWorkerBinaryName);
 }
 
 BackendProvider createEmbeddedBackend(const SingleNodeWorkerConfiguration& workerConfiguration)

--- a/nes-frontend/src/QueryManager/EmbeddedWorkerQuerySubmissionBackend.cpp
+++ b/nes-frontend/src/QueryManager/EmbeddedWorkerQuerySubmissionBackend.cpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <mutex>
 #include <stop_token>
+#include <string>
 #include <utility>
 #include <variant>
 #include <Listeners/QueryLog.hpp>
@@ -31,6 +32,7 @@
 #include <SingleNodeWorker.hpp>
 #include <SingleNodeWorkerConfiguration.hpp>
 #include <Thread.hpp>
+#include <Version.hpp>
 #include <WorkerConfig.hpp>
 #include <WorkerStatus.hpp>
 
@@ -218,6 +220,11 @@ std::expected<LocalQueryStatusSnapshot, Exception> EmbeddedWorkerQuerySubmission
 std::expected<WorkerStatus, Exception> EmbeddedWorkerQuerySubmissionBackend::workerStatus(std::chrono::system_clock::time_point after) const
 {
     return channel->workerStatus(after);
+}
+
+std::expected<std::string, Exception> EmbeddedWorkerQuerySubmissionBackend::version() const
+{
+    return formatVersion(SingleNodeWorkerBinaryName);
 }
 
 BackendProvider createEmbeddedBackend(const SingleNodeWorkerConfiguration& workerConfiguration)

--- a/nes-frontend/src/QueryManager/GRPCQuerySubmissionBackend.cpp
+++ b/nes-frontend/src/QueryManager/GRPCQuerySubmissionBackend.cpp
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <string>
 #include <utility>
 #include <Identifiers/Identifiers.hpp>
 #include <Listeners/QueryLog.hpp>
@@ -149,6 +150,24 @@ std::expected<WorkerStatus, Exception> GRPCQuerySubmissionBackend::workerStatus(
         return std::unexpected(UnknownException("GRPC Status: {}", responseCode.error_message()));
     }
     return deserializeWorkerStatus(&response);
+}
+
+std::expected<std::string, Exception> GRPCQuerySubmissionBackend::version() const
+{
+    grpc::ClientContext context;
+    const google::protobuf::Empty request;
+    VersionResponse response;
+    const auto responseCode = stub->RequestVersion(&context, request, &response);
+    if (responseCode.error_code() == grpc::StatusCode::UNIMPLEMENTED)
+    {
+        return std::unexpected(
+            NotImplemented("worker {} does not support the RequestVersion RPC; it was built before this client", workerConfig.host));
+    }
+    if (!responseCode.ok())
+    {
+        return std::unexpected(UnknownException("GRPC Status: {}", responseCode.error_message()));
+    }
+    return response.version();
 }
 
 std::expected<void, Exception> GRPCQuerySubmissionBackend::stop(QueryId queryId)

--- a/nes-frontend/src/QueryManager/GRPCQuerySubmissionBackend.cpp
+++ b/nes-frontend/src/QueryManager/GRPCQuerySubmissionBackend.cpp
@@ -152,7 +152,7 @@ std::expected<WorkerStatus, Exception> GRPCQuerySubmissionBackend::workerStatus(
     return deserializeWorkerStatus(&response);
 }
 
-std::expected<std::string, Exception> GRPCQuerySubmissionBackend::version() const
+std::expected<VersionInfo, Exception> GRPCQuerySubmissionBackend::version() const
 {
     grpc::ClientContext context;
     const google::protobuf::Empty request;
@@ -167,7 +167,7 @@ std::expected<std::string, Exception> GRPCQuerySubmissionBackend::version() cons
     {
         return std::unexpected(UnknownException("GRPC Status: {}", responseCode.error_message()));
     }
-    return response.version();
+    return VersionInfo{response.version()};
 }
 
 std::expected<void, Exception> GRPCQuerySubmissionBackend::stop(QueryId queryId)

--- a/nes-frontend/src/QueryManager/QueryManager.cpp
+++ b/nes-frontend/src/QueryManager/QueryManager.cpp
@@ -18,6 +18,7 @@
 #include <cmath>
 #include <cstddef>
 #include <exception>
+#include <map>
 #include <optional>
 #include <ranges>
 #include <string>
@@ -259,6 +260,16 @@ std::expected<DistributedWorkerStatus, Exception> QueryManager::workerStatus(std
         distributedStatus.workerStatus.try_emplace(wId, backend->workerStatus(after));
     }
     return distributedStatus;
+}
+
+std::map<Host, std::expected<std::string, Exception>> QueryManager::workerVersions() const
+{
+    std::map<Host, std::expected<std::string, Exception>> versions;
+    for (const auto& [wId, backend] : backends)
+    {
+        versions.try_emplace(wId, backend->version());
+    }
+    return versions;
 }
 
 std::vector<DistributedQueryId> QueryManager::getRunningQueries() const

--- a/nes-frontend/src/QueryManager/QueryManager.cpp
+++ b/nes-frontend/src/QueryManager/QueryManager.cpp
@@ -262,9 +262,9 @@ std::expected<DistributedWorkerStatus, Exception> QueryManager::workerStatus(std
     return distributedStatus;
 }
 
-std::map<Host, std::expected<std::string, Exception>> QueryManager::workerVersions() const
+std::map<Host, std::expected<VersionInfo, Exception>> QueryManager::workerVersions() const
 {
-    std::map<Host, std::expected<std::string, Exception>> versions;
+    std::map<Host, std::expected<VersionInfo, Exception>> versions;
     for (const auto& [wId, backend] : backends)
     {
         versions.try_emplace(wId, backend->version());

--- a/nes-frontend/src/Statements/StatementHandler.cpp
+++ b/nes-frontend/src/Statements/StatementHandler.cpp
@@ -448,6 +448,11 @@ std::expected<WorkerStatusStatementResult, Exception> TopologyStatementHandler::
     return WorkerStatusStatementResult{status};
 }
 
+std::expected<ShowVersionStatementResult, Exception> TopologyStatementHandler::operator()(const ShowVersionStatement&)
+{
+    return ShowVersionStatementResult{queryManager->workerVersions()};
+}
+
 std::expected<CreateWorkerStatementResult, Exception> TopologyStatementHandler::operator()(const CreateWorkerStatement& statement)
 {
     SingleNodeWorkerConfiguration config;

--- a/nes-frontend/tests/CMakeLists.txt
+++ b/nes-frontend/tests/CMakeLists.txt
@@ -15,3 +15,6 @@ target_link_libraries(distributed-planning-test nes-frontend-lib)
 target_include_directories(distributed-planning-test
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../private
 )
+
+add_nes_test(grpc-query-submission-backend-test GRPCQuerySubmissionBackendTest.cpp)
+target_link_libraries(grpc-query-submission-backend-test nes-frontend-lib)

--- a/nes-frontend/tests/GRPCQuerySubmissionBackendTest.cpp
+++ b/nes-frontend/tests/GRPCQuerySubmissionBackendTest.cpp
@@ -1,0 +1,84 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <string>
+#include <Identifiers/Identifiers.hpp>
+#include <QueryManager/GRPCQuerySubmissionBackend.hpp>
+#include <Util/Logger/LogLevel.hpp>
+#include <Util/Logger/impl/NesLogger.hpp>
+#include <fmt/format.h>
+#include <grpcpp/security/server_credentials.h>
+#include <grpcpp/server_builder.h>
+#include <gtest/gtest.h>
+#include <BaseUnitTest.hpp>
+#include <ErrorHandling.hpp>
+#include <SingleNodeWorkerRPCService.grpc.pb.h>
+#include <WorkerConfig.hpp>
+
+namespace NES::Test
+{
+namespace
+{
+/// A worker built before the RequestVersion RPC existed: the generated service base answers every RPC
+/// that is not overridden with UNIMPLEMENTED, which is exactly what such a worker puts on the wire.
+class OldWorkerService final : public WorkerRPCService::Service
+{
+};
+
+/// Only `host` matters here; everything else stays default so the ctor's isExplicitlySet() warning stays quiet.
+GRPCQuerySubmissionBackend backendFor(const std::string& host)
+{
+    return GRPCQuerySubmissionBackend{
+        WorkerConfig{.host = Host{host}, .dataAddress = {}, .maxOperators = {}, .downstream = {}, .config = {}}};
+}
+}
+
+class GRPCQuerySubmissionBackendTest : public Testing::BaseUnitTest
+{
+public:
+    static void SetUpTestSuite() { Logger::setupLogging("GRPCQuerySubmissionBackend.log", LogLevel::LOG_DEBUG); }
+};
+
+TEST_F(GRPCQuerySubmissionBackendTest, VersionOnOldWorkerReportsNotImplemented)
+{
+    OldWorkerService service;
+    int port = 0;
+    grpc::ServerBuilder builder;
+    /// port 0 lets the kernel pick a free port and write it back, so parallel test runs cannot collide
+    builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
+    builder.RegisterService(&service);
+    const auto server = builder.BuildAndStart();
+    ASSERT_NE(server, nullptr);
+
+    const auto backend = backendFor(fmt::format("127.0.0.1:{}", port));
+    const auto result = backend.version();
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code(), ErrorCode::NotImplemented);
+
+    server->Shutdown();
+    server->Wait();
+}
+
+/// Pins that only UNIMPLEMENTED maps to NotImplemented; any other gRPC failure must not claim the worker
+/// is too old.
+TEST_F(GRPCQuerySubmissionBackendTest, VersionOnUnreachableWorkerIsNotNotImplemented)
+{
+    const auto backend = backendFor("127.0.0.1:1");
+    const auto result = backend.version();
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_NE(result.error().code(), ErrorCode::NotImplemented);
+}
+}

--- a/nes-single-node-worker/include/GrpcService.hpp
+++ b/nes-single-node-worker/include/GrpcService.hpp
@@ -37,6 +37,8 @@ public:
 
     grpc::Status RequestStatus(grpc::ServerContext* context, const WorkerStatusRequest* request, WorkerStatusResponse* response) override;
 
+    grpc::Status RequestVersion(grpc::ServerContext* context, const google::protobuf::Empty* request, VersionResponse* response) override;
+
     explicit GRPCServer(SingleNodeWorker&& delegate) : delegate(std::move(delegate)) { }
 
 private:

--- a/nes-single-node-worker/include/SingleNodeWorker.hpp
+++ b/nes-single-node-worker/include/SingleNodeWorker.hpp
@@ -18,6 +18,7 @@
 #include <expected>
 #include <memory>
 #include <optional>
+#include <string_view>
 #include <Identifiers/Identifiers.hpp>
 #include <Listeners/QueryLog.hpp>
 #include <Plans/LogicalPlan.hpp>
@@ -34,6 +35,10 @@
 
 namespace NES
 {
+
+/// Binary name reported by `nes-single-node-worker --version` and by the RequestVersion RPC.
+/// Both have to agree, so the literal lives in exactly one place.
+inline constexpr std::string_view SingleNodeWorkerBinaryName{"nes-single-node-worker"};
 
 /// @brief The SingleNodeWorker is a compiling StreamProcessingEngine, working alone on local sources and sinks, without external
 /// coordination. The SingleNodeWorker compiles and immediately starts LogicalQueryPlans via the QueryCompiler and NodeEngine.

--- a/nes-single-node-worker/src/GrpcService.cpp
+++ b/nes-single-node-worker/src/GrpcService.cpp
@@ -30,6 +30,7 @@
 #include <grpcpp/support/status.h>
 #include <ErrorHandling.hpp>
 #include <SingleNodeWorkerRPCService.pb.h>
+#include <Version.hpp>
 #include <WorkerStatus.hpp>
 
 namespace NES
@@ -207,6 +208,17 @@ grpc::Status GRPCServer::RequestStatus(grpc::ServerContext* context, const Worke
 
             serializeWorkerStatus(status, response);
 
+            return grpc::Status::OK;
+        },
+        context);
+}
+
+grpc::Status GRPCServer::RequestVersion(grpc::ServerContext* context, const google::protobuf::Empty*, VersionResponse* response)
+{
+    return tryWithDefaultHandling(
+        [&]
+        {
+            response->set_version(formatVersion(SingleNodeWorkerBinaryName));
             return grpc::Status::OK;
         },
         context);

--- a/nes-single-node-worker/src/GrpcService.cpp
+++ b/nes-single-node-worker/src/GrpcService.cpp
@@ -218,7 +218,7 @@ grpc::Status GRPCServer::RequestVersion(grpc::ServerContext* context, const goog
     return tryWithDefaultHandling(
         [&]
         {
-            response->set_version(formatVersion(SingleNodeWorkerBinaryName));
+            response->set_version(versionInfo(SingleNodeWorkerBinaryName).getRawValue());
             return grpc::Status::OK;
         },
         context);

--- a/nes-single-node-worker/src/SingleNodeWorkerStarter.cpp
+++ b/nes-single-node-worker/src/SingleNodeWorkerStarter.cpp
@@ -61,7 +61,7 @@ int main(const int argc, const char* argv[])
 {
     if (NES::hasVersionFlag(argc, argv))
     {
-        NES::printVersion("nes-single-node-worker");
+        NES::printVersion(NES::SingleNodeWorkerBinaryName);
         return 0;
     }
     CPPTRACE_TRY

--- a/nes-single-node-worker/tests/offline.bats
+++ b/nes-single-node-worker/tests/offline.bats
@@ -75,6 +75,14 @@ teardown() {
   echo "$output" | grep -q "INTERPRETER"
 }
 
+@test "worker shows version" {
+  run $NES_WORKER --version
+  [ "$status" -eq 0 ]
+
+  [[ "${lines[0]}" == "nes-single-node-worker "* ]]
+  echo "$output" | grep -q "commit:"
+}
+
 @test "worker launches and stays alive" {
   run timeout 5 $NES_WORKER
   [ "$status" -eq 124 ] # killed by timeout

--- a/nes-sql-parser/AntlrSQL.g4
+++ b/nes-sql-parser/AntlrSQL.g4
@@ -110,7 +110,8 @@ showSubject: QUERIES #showQueriesSubject
     | LOGICAL SOURCES #showLogicalSourcesSubject
     | PHYSICAL SOURCES (FOR logicalSourceName=strictIdentifier)? #showPhysicalSourcesSubject
     | SINKS #showSinksSubject
-    | MODELS #showModelsSubject;
+    | MODELS #showModelsSubject
+    | VERSION #showVersionSubject;
 
 showFilter: attr=strictIdentifier EQ value=constant;
 
@@ -646,6 +647,7 @@ LOGICAL: 'LOGICAL' | 'logical';
 PHYSICAL: 'PHYSICAL';
 WORKER: 'WORKER';
 SINK : 'SINK';
+VERSION : 'VERSION' | 'version';
 
 //Make sure that you add lexer rules for keywords before the identifier rule,
 //otherwise it will take priority and your grammars will not work

--- a/nes-sql-parser/include/SQLQueryParser/StatementBinder.hpp
+++ b/nes-sql-parser/include/SQLQueryParser/StatementBinder.hpp
@@ -172,6 +172,11 @@ struct ShowModelsStatement
     std::optional<StatementOutputFormat> format;
 };
 
+struct ShowVersionStatement
+{
+    std::optional<StatementOutputFormat> format;
+};
+
 struct DropModelStatement
 {
     std::string name;
@@ -215,6 +220,7 @@ using Statement = std::variant<
     ShowQueriesStatement,
     ShowSinksStatement,
     ShowModelsStatement,
+    ShowVersionStatement,
     DropQueryStatement>;
 
 inline std::optional<StatementOutputFormat> getOutputFormat(const Statement& statement)

--- a/nes-sql-parser/src/StatementBinder.cpp
+++ b/nes-sql-parser/src/StatementBinder.cpp
@@ -446,6 +446,17 @@ public:
                 = showAST->showFormat() != nullptr ? std::make_optional(bindFormat(showAST->showFormat())) : std::nullopt;
             return ShowModelsStatement{.format = format};
         }
+        if (const auto* versionSubject = dynamic_cast<AntlrSQLParser::ShowVersionSubjectContext*>(showAST->showSubject());
+            versionSubject != nullptr)
+        {
+            if (showFilter != nullptr)
+            {
+                throw InvalidQuerySyntax("SHOW VERSION does not support a filter");
+            }
+            const std::optional<StatementOutputFormat> format
+                = showAST->showFormat() != nullptr ? std::make_optional(bindFormat(showAST->showFormat())) : std::nullopt;
+            return ShowVersionStatement{.format = format};
+        }
         throw InvalidStatement("Unrecognized SHOW statement");
     }
 

--- a/nes-sql-parser/tests/StatementBinderTest.cpp
+++ b/nes-sql-parser/tests/StatementBinderTest.cpp
@@ -927,6 +927,20 @@ TEST_F(StatementBinderTest, CreateLogicalQueryPlanRejectsNonQueryStatements)
     EXPECT_THROW(AntlrSQLQueryParser::createLogicalQueryPlanFromSQLString("CREATE WORKER 'localhost:8080';"), Exception);
 }
 
+TEST_F(StatementBinderTest, ShowVersionStatementTest)
+{
+    const auto statement = binder->parseAndBindSingle("SHOW VERSION");
+    ASSERT_TRUE(statement.has_value()) << "Statement could not be parsed" << statement.error();
+    ASSERT_TRUE(std::holds_alternative<ShowVersionStatement>(*statement));
+    ASSERT_FALSE(std::get<ShowVersionStatement>(*statement).format.has_value());
+
+    const auto withFormat = binder->parseAndBindSingle("SHOW VERSION FORMAT JSON");
+    ASSERT_TRUE(withFormat.has_value()) << "Statement could not be parsed" << withFormat.error();
+    ASSERT_EQ(std::get<ShowVersionStatement>(*withFormat).format, StatementOutputFormat::JSON);
+
+    ASSERT_FALSE(binder->parseAndBindSingle("SHOW VERSION WHERE NAME = 'worker'").has_value());
+}
+
 TEST_F(StatementBinderTest, LeftOuterJoinParsesToOuterLeftJoinType)
 {
     const std::string query = "SELECT * FROM (SELECT * FROM s1) LEFT OUTER JOIN (SELECT * FROM s2) "

--- a/nes-systests/systest/tests/SystestRunnerTest.cpp
+++ b/nes-systests/systest/tests/SystestRunnerTest.cpp
@@ -51,6 +51,7 @@
 #include <QueryStatus.hpp>
 #include <QuerySubmitter.hpp>
 #include <SystestProgressTracker.hpp>
+#include <Version.hpp>
 
 #include <DataTypes/Schema.hpp>
 #include <DataTypes/SchemaFwd.hpp>
@@ -142,7 +143,7 @@ public:
     MOCK_METHOD((std::expected<void, Exception>), stop, (QueryId), (override));
     MOCK_METHOD((std::expected<LocalQueryStatusSnapshot, Exception>), status, (QueryId), (const, override));
     MOCK_METHOD((std::expected<WorkerStatus, Exception>), workerStatus, (std::chrono::system_clock::time_point), (const, override));
-    MOCK_METHOD((std::expected<std::string, Exception>), version, (), (const, override));
+    MOCK_METHOD((std::expected<VersionInfo, Exception>), version, (), (const, override));
 };
 
 namespace

--- a/nes-systests/systest/tests/SystestRunnerTest.cpp
+++ b/nes-systests/systest/tests/SystestRunnerTest.cpp
@@ -142,6 +142,7 @@ public:
     MOCK_METHOD((std::expected<void, Exception>), stop, (QueryId), (override));
     MOCK_METHOD((std::expected<LocalQueryStatusSnapshot, Exception>), status, (QueryId), (const, override));
     MOCK_METHOD((std::expected<WorkerStatus, Exception>), workerStatus, (std::chrono::system_clock::time_point), (const, override));
+    MOCK_METHOD((std::expected<std::string, Exception>), version, (), (const, override));
 };
 
 namespace


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

`nes-single-node-worker --version` prints a build report (version, git commit, build timestamp, build
type, sanitizer, compiler + flags, stdlib, log level, vcpkg baseline), but that string was only
reachable by running the binary locally with a flag. There was no way to ask a *running* worker what
build it is — which matters as soon as workers run in containers and you want to confirm the worker
you talk to actually runs the code you think it does.

This PR exposes that exact string over gRPC and makes it readable from `nes-repl`. The change list is
as follows

Example (`nes-repl -f TEXT`):

```
version
=====================================================================
worker localhost:8080
nes-single-node-worker TBA
  commit:         c9be00290422095d2e7234902a179c8e52b96cf4+dirty
  built:          2026-07-28 15:03:50 +0000
  build:          Debug
  ...
  vcpkg baseline: 4334d8b4c8916018600212ab4dd4bbdc343065d1
```

## Verifying this change

This change is tested by
- *Added `repl/tests/distributed.bats` case that byte-compares the string returned over gRPC against
  `docker compose exec worker-node nes-single-node-worker --version`, so the RPC and the flag cannot
  diverge unnoticed.*
- *Added `repl/tests/distributed.bats` case that stops the worker and asserts the statement still
  succeeds while reporting `error:` for that worker.*
- *Added `repl/tests/embedded.bats` case covering the embedded backend path.*
- *Added `StatementBinderTest.ShowVersionStatementTest` for binding, `FORMAT JSON`, and rejection of
  `SHOW VERSION WHERE ...`.*
- *Added a `--version` smoke test to `nes-single-node-worker/tests/offline.bats`

## What components does this pull request potentially affect?
- gRPC interface (adds one RPC and one message; wire- and source-compatible in both directions)
- SingleNodeWorker
- Frontend (`QueryManager`, both query submission backends, statement layer)
- SQL parser — **note:** `VERSION` becomes a reserved keyword, so an unquoted identifier named
  `version` no longer parses (`"version"` still does). No fixture or systest uses that name.
