### PR TITLE
fix(ci): notify on failure of any nightly job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -152,7 +152,18 @@ jobs:
       dockerhub-tag: "latest"
 
   send-zulip-msg-on-failure:
-    needs: [ compile-time-regression, create-nightly-image, large-tests, full-clang-tidy ]
+    needs:
+      - nix-build
+      - full-clang-tidy
+      - compile-time-regression
+      - check-format
+      - stress-test
+      - build-and-test
+      - run_large_scale_tests_random_config
+      - large-tests
+      - build-and-benchmark
+      - benchmark-compile-time
+      - create-nightly-image
     runs-on: [ self-hosted ]
     if: ${{ failure() && !github.event.act }}
     steps:


### PR DESCRIPTION
## Summary

Only the failures of specific jobs created a message for the ci channel.
E.g. one recent [nighlty run](https://github.com/nebulastream/nebulastream/actions/runs/30420091276) failed silently

## Fix

Make the ci message trigger on any nighly job failure.