### PR TITLE
fix(LogicalOperators): Ptr equality in LogicalOperators

### DIFF
--- a/nes-logical-operators/include/Operators/LogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/LogicalOperator.hpp
@@ -278,24 +278,15 @@ struct TypedLogicalOperator
 
     [[nodiscard]] OperatorId getId() const { return self->getOperatorId(); }
 
+    /// Identity comparison: two wrappers are equal if they refer to the same underlying operator instance,
+    /// analogous to comparing pointers. Compare dereferenced operators (`*lhs == *rhs`) for structural equality.
     [[nodiscard]] bool operator==(const TypedLogicalOperator& other) const
     requires(!std::is_same_v<Checked, NES::detail::ErasedLogicalOperator>)
     {
-        if (self == other.self)
-        {
-            return true;
-        }
-        return self->equals(*other.self);
+        return self == other.self;
     }
 
-    [[nodiscard]] bool operator==(const LogicalOperator& other) const
-    {
-        if (self == other.self)
-        {
-            return true;
-        }
-        return self->equals(*other.self);
-    }
+    [[nodiscard]] bool operator==(const LogicalOperator& other) const { return self == other.self; }
 
     [[nodiscard]] std::string_view getName() const noexcept { return self->getName(); }
 
@@ -567,9 +558,23 @@ inline std::ostream& operator<<(std::ostream& os, const LogicalOperator& op)
     return os << op.explain(ExplainVerbosity::Short);
 }
 
+/// Hash/equality functors that defer to the dereferenced operator, like hashing/comparing through a pointer.
+/// Structural comparison is single-node: it considers the operator's own state, not its id or its children.
+/// Use these for containers that should deduplicate structurally-identical operators regardless of instance identity.
+struct StructuralOperatorHash
+{
+    std::size_t operator()(const LogicalOperator& op) const { return op->hash(); }
+};
+
+struct StructuralOperatorEqual
+{
+    bool operator()(const LogicalOperator& lhs, const LogicalOperator& rhs) const { return *lhs == *rhs; }
+};
+
 }
 
-/// Hash is based solely on unique identifier (needed for e.g. unordered_set)
+/// Hash is identity-based (the wrapped instance), consistent with the identity operator==.
+/// Use StructuralOperatorHash/StructuralOperatorEqual for structural container semantics.
 namespace std
 {
 /// NOLINTBEGIN(cert-dcl58-cpp)
@@ -577,7 +582,10 @@ template <typename T>
 requires(NES::LogicalOperatorConcept<T> && !std::is_same_v<T, NES::detail::ErasedLogicalOperator>)
 struct hash<NES::TypedLogicalOperator<T>>
 {
-    std::size_t operator()(const NES::TypedLogicalOperator<T>& op) const noexcept { return std::hash<T>{}(op.get()); }
+    std::size_t operator()(const NES::TypedLogicalOperator<T>& op) const noexcept
+    {
+        return std::hash<std::shared_ptr<const NES::detail::ErasedLogicalOperator>>{}(op.self);
+    }
 };
 
 /// NOLINTEND(cert-dcl58-cpp)
@@ -585,7 +593,10 @@ struct hash<NES::TypedLogicalOperator<T>>
 template <>
 struct hash<NES::LogicalOperator>
 {
-    std::size_t operator()(const NES::LogicalOperator& op) const noexcept { return op.self->hash(); }
+    std::size_t operator()(const NES::LogicalOperator& op) const noexcept
+    {
+        return std::hash<std::shared_ptr<const NES::detail::ErasedLogicalOperator>>{}(op.self);
+    }
 };
 }
 

--- a/nes-logical-operators/include/Plans/LogicalPlan.hpp
+++ b/nes-logical-operators/include/Plans/LogicalPlan.hpp
@@ -93,8 +93,8 @@ template <LogicalOperatorConcept T>
 /// @note: in certain stages the source operators might not be Leaf operators
 [[nodiscard]] std::vector<LogicalOperator> getLeafOperators(const LogicalPlan& plan);
 
-/// Returns a set of all operators
-[[nodiscard]] std::unordered_set<LogicalOperator> flatten(const LogicalPlan& plan);
+/// Returns a set of all operators, deduplicated structurally (see StructuralOperatorHash/StructuralOperatorEqual)
+[[nodiscard]] std::unordered_set<LogicalOperator, StructuralOperatorHash, StructuralOperatorEqual> flatten(const LogicalPlan& plan);
 
 }
 

--- a/nes-logical-operators/src/Plans/LogicalPlan.cpp
+++ b/nes-logical-operators/src/Plans/LogicalPlan.cpp
@@ -199,10 +199,10 @@ std::optional<LogicalOperator> getOperatorById(const LogicalPlan& plan, Operator
     return std::nullopt;
 }
 
-std::unordered_set<LogicalOperator> flatten(const LogicalPlan& plan)
+std::unordered_set<LogicalOperator, StructuralOperatorHash, StructuralOperatorEqual> flatten(const LogicalPlan& plan)
 {
     /// Maintain a list of visited nodes as there are multiple root nodes
-    std::unordered_set<LogicalOperator> visitedOperators;
+    std::unordered_set<LogicalOperator, StructuralOperatorHash, StructuralOperatorEqual> visitedOperators;
     for (const auto& rootOperator : plan.getRootOperators())
     {
         for (auto itr : BFSRange(rootOperator))


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Currently, Logical Operators only use ptr equality to short-circuit the comparison, but if it is false, still a structural comparison with the == of the concrete operator is done.
That also means, that if you want to have ptr equality, you'd have to use the operator ID, which is only supposed to be used for serialization.

This was never the intended behaviour, its part of the semantics of a `LogicalOperator` that it is heap-allocated, and PRs like #1813 should be able to just use LogicalOperators as keys.
We already do this in some rules, which also means that the current behaviour is a latent bug, because it would swallow structurally equivalent operators when building up a set or map, even if the intent was, to have them twice.

If you want to have structural comparison, I added `StructuralOperatorEqual` and `StructuralOperatorHash` which you can pass to std::unordered_set or std::unordered_map. Currently, the `flatten` method in `LogicalPlan.hpp` uses it.


## Verifying this change
All tests run.

## What components does this pull request potentially affect?
- LogicalOperators
- Optimizer


