### PR TITLE
Fix(CI) clang-tidy-diff: create the results dir before exporting fixes

### DIFF
--- a/.github/workflows/clang_tidy_diff.yml
+++ b/.github/workflows/clang_tidy_diff.yml
@@ -92,6 +92,9 @@ jobs:
         with:
           image_name: nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{matrix.sanitizer}}
           run: |
+            # clang-tidy-diff crashes with FileNotFoundError when the -export-fixes directory is missing,
+            # masking the actual findings behind the crash.
+            mkdir -p clang-tidy-result
             git diff -U0 ${{ inputs.base_sha }} -- ':!*.inc' ':!*nes-rust-bindings' ':!vcpkg/**' | clang-tidy-diff-19.py -clang-tidy-binary clang-tidy-19 -p1 -path build -export-fixes clang-tidy-result/fixes.yml -j $(nproc)
       # Findings are printed by clang-tidy-diff in the steps above and exported here for download.
       # A failing step means clang-tidy flagged something in .clang-tidy's WarningsAsErrors list.


### PR DESCRIPTION
The PR-CI split (6d666a0db7) dropped the "Create results directory" step from the clang-tidy-diff workflow. The full all-checks pass writes `-export-fixes clang-tidy-result/fixes.yml` inline, so clang-tidy-diff.py now dies with

```
FileNotFoundError: [Errno 2] No such file or directory: 'clang-tidy-result/fixes.yml'
```

after analysis, failing the check regardless of findings (and masking any real findings behind the crash). First observed on #1776, reproduced deterministically on rerun.

One-line fix: `mkdir -p clang-tidy-result` before the pass. (The pre-check step is unaffected — it goes through `scripts/tidy-diff.sh`, which already creates the directory for its export path.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)