### PR TITLE
fix(ci): bump memory limit for nightly random tests on randomized buffer size parameters

### DIFF
--- a/.github/workflows/large_test.yml
+++ b/.github/workflows/large_test.yml
@@ -27,6 +27,10 @@ on:
         type: string
         description: "Number of partitions large scale tests should be run with"
         default: 128
+      total_memory_in_bytes:
+        type: string
+        description: "Total memory budget in bytes for the global buffer pool (pooled + unpooled)"
+        default: "76911476736"
       enable_slice_cache:
         type: boolean
         description: "Enable slice cache for the large scale tests"
@@ -92,7 +96,7 @@ jobs:
               --worker.default_query_execution.operator_buffer_size=${{ inputs.buffer_size }} \
               --worker.default_query_execution.page_size=${{ inputs.page_size }} \
               --worker.default_query_execution.number_of_partitions=${{ inputs.number_of_partitions }} \
-              --worker.total_memory_in_bytes=76911476736 \
+              --worker.total_memory_in_bytes=${{ inputs.total_memory_in_bytes }} \
               --worker.unpooled_memory_fraction=0.8935 \
               --worker.default_query_execution.slice_cache.enable_slice_cache=${{ inputs.enable_slice_cache }}
 

--- a/.github/workflows/large_tests_random_worker_config.yml
+++ b/.github/workflows/large_tests_random_worker_config.yml
@@ -61,3 +61,4 @@ jobs:
       buffer_size: ${{ needs.create_random_worker_config.outputs.buffer_size }}
       page_size: ${{ needs.create_random_worker_config.outputs.page_size }}
       number_of_partitions: ${{ needs.create_random_worker_config.outputs.number_of_partitions }}
+      total_memory_in_bytes: "214748364800"


### PR DESCRIPTION
bump memory limit for random worker config to prevent buffer allocation exception for larger buffer sizes
