### PR TITLE
feat(optimizer) enable multi sink optimization

### DIFF
--- a/docs/guide/how_to_add_an_optimizer_rule.md
+++ b/docs/guide/how_to_add_an_optimizer_rule.md
@@ -175,42 +175,50 @@ To assert that we correctly declared the rule, we assert that it follows the Rul
 Next, we define the actual behavior of the rule in `RedundantUnionRemovalRule.cpp`. 
 To keep the example readable, we'll only focus on individual snippets. 
 
+Traversing and rebuilding a `LogicalPlan` by hand is easy to get wrong for plans with multiple root
+operators (e.g. several sinks sharing part of a subplan), since a shared operator must then be visited and
+rebuilt exactly once, not once per parent. Rather than writing that traversal ourselves, we use the generic
+`PlanVisitor` utility (`Rules/PlanVisitor.hpp`), which walks the plan bottom-up (and, if needed, top-down first)
+and calls back into our rule for each operator.
+
 First, we define the `apply` method. 
-We first ensure that the given plan only has one root operator.
-Then we start a (yet-to-be-defined) recursive function call at that root operator, 
-replace that root operator with the updated one,
-and return the changed plan.
+We construct a `PlanVisitor<>` — using the default `OperatorContext`, `DownContext`, and `UpContext` of
+`std::monostate`, since this rule does not need to thread any information between operators — and hand it our
+bottom-up callback `redundantUnionRemoval`. `PlanVisitor` takes care of visiting every operator exactly once and
+rebuilding the plan for us, so we no longer need to assert that the plan has a single root or manage the
+recursion ourselves.
 
 ```cpp 
 LogicalPlan RedundantUnionRemovalRule::apply(LogicalPlan queryPlan) const
 {
-    PRECONDITION(queryPlan.getRootOperators().size() == 1, "Query plan must have exactly one root operator");
-    queryPlan = queryPlan.withRootOperators({recur(queryPlan.getRootOperators().front().withInferredSchema())});
-    return queryPlan;
+    PlanVisitor<> visitor{redundantUnionRemoval};
+    return visitor.apply(std::move(queryPlan));
 }
 ```
 
-Next, we define what is happening in the recursion.
-The algorithm works bottom up. Thus, we first continue the recursion for all child operators of the current operator. 
-It will stop at Source operators because source operators are the only operators that do not have children. 
-Then, if the current operator is a UNION operator with only one child, we return that child operator, thereby removing the unnecessary UNION operator. 
+Next, we define what happens on the bottom-up pass.
+`PlanVisitor` calls `redundantUnionRemoval` once per operator, always after all of that operator's children have
+already been rebuilt, passing in the operator itself and its (already rebuilt) children.
+If the current operator is a UNION operator with only one child, we return that child operator, thereby removing
+the unnecessary UNION operator. 
 If the current operator is not a UNION operator or if it is but has more than one child, we leave it as is, 
-but update its children with the recursively updated child operators. 
-The whole function is defined within an anonymous namespace because there is no need to expose the function to other objects or classes 
-by defining it in the class definition.
+but rebuild it with the already-rebuilt children.
+Because this rule needs neither the top-down `OperatorContext` nor per-child `UpContext`, we use `PlanVisitor`'s
+reduced-arity `FunctionUpAlt3` signature — `(LogicalOperator op, std::vector<LogicalOperator> children) -> UpResult` —
+instead of the full `FunctionUp` signature; see `PlanVisitor.hpp` for the other available callback signatures.
+The whole function is defined within an anonymous namespace because there is no need to expose the function to
+other objects or classes by defining it in the class definition.
 
 ```cpp
 namespace
 {
-LogicalOperator recur(const LogicalOperator& op)
+PlanVisitor<>::UpResult redundantUnionRemoval(const LogicalOperator& op, std::vector<LogicalOperator> children)
 {
-    auto newChildren = op.getChildren() | std::views::transform(recur) | std::ranges::to<std::vector>();
-
-    if (op.tryGetAs<UnionLogicalOperator>().has_value() && newChildren.size() == 1)
+    if (op.tryGetAs<UnionLogicalOperator>().has_value() && children.size() == 1)
     {
-        return newChildren.front();
+        return children.front();
     }
-    return op.withChildren(std::move(newChildren));
+    return op.withChildren(std::move(children));
 }
 }
 ```

--- a/nes-plugins/Rules/RedundantUnionRemovalRule/RedundantUnionRemovalRule.cpp
+++ b/nes-plugins/Rules/RedundantUnionRemovalRule/RedundantUnionRemovalRule.cpp
@@ -20,6 +20,7 @@
 #include <typeindex>
 #include <typeinfo>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include <Operators/LogicalOperator.hpp>
@@ -28,7 +29,7 @@
 #include <Plans/LogicalPlan.hpp>
 #include <Rules/Barriers/FixedPlanStructureBarrier.hpp>
 #include <Rules/Barriers/SemanticAnalysisBarrier.hpp>
-
+#include <Rules/PlanVisitor.hpp>
 #include <ErrorHandling.hpp>
 #include <PlanRuleRegistry.hpp>
 
@@ -38,24 +39,23 @@ namespace NES
 
 namespace
 {
-LogicalOperator recur(const LogicalOperator& op)
-{
-    auto newChildren = op.getChildren() | std::views::transform(recur) | std::ranges::to<std::vector>();
 
-    if (op.tryGetAs<UnionLogicalOperator>().has_value() && newChildren.size() == 1)
+
+PlanVisitor<>::UpResult redundantUnionRemoval(const LogicalOperator& op, std::vector<LogicalOperator> children)
+{
+    if (op.tryGetAs<UnionLogicalOperator>().has_value() && children.size() == 1)
     {
-        return newChildren.front();
+        return children.front();
     }
-    return op.withChildren(std::move(newChildren));
+    return op.withChildren(std::move(children));
 }
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 LogicalPlan RedundantUnionRemovalRule::apply(LogicalPlan queryPlan) const
 {
-    PRECONDITION(queryPlan.getRootOperators().size() == 1, "Query plan must have exactly one root operator");
-    queryPlan = queryPlan.withRootOperators({recur(queryPlan.getRootOperators().front().withInferredSchema())});
-    return queryPlan;
+    PlanVisitor<> visitor{redundantUnionRemoval};
+    return visitor.apply(std::move(queryPlan));
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/include/Rules/PlanVisitor.hpp
+++ b/nes-query-optimizer/include/Rules/PlanVisitor.hpp
@@ -1,0 +1,341 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <ranges>
+#include <stack>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include <Operators/LogicalOperatorFwd.hpp>
+#include <Plans/LogicalPlan.hpp>
+#include <Util/Overloaded.hpp>
+#include <ErrorHandling.hpp>
+
+/**
+ * @file PlanVisitor.hpp
+ * @brief Generic two-pass traversal/rewrite utility for LogicalPlan DAGs.
+ *
+ * PlanVisitor<OperatorContext, DownContext, UpContext> walks a LogicalPlan first top-down
+ * (sinks to sources) and then bottom-up (sources to sinks), threading user-defined context
+ * through the traversal. It is used to implement rules that need to accumulate information
+ * while descending the plan and then rebuild operators using that information while ascending.
+ *
+ * A plan may have multiple root operators (e.g. several sinks sharing part of a subplan),
+ * so the traversal handles a DAG, not just a tree: each operator is visited exactly once
+ * per pass, even if it is shared by multiple parents. The top-down pass only visits a node
+ * once all its parents have propagated their DownContext to it, and the bottom-up pass only
+ * rebuilds a node once all its children have been rebuilt; the resulting operator is then
+ * reused, not duplicated, by every parent that shares it.
+ *
+ * ## Callbacks
+ * - `FunctionDown`: `(LogicalOperator op, std::vector<DownContext> downContexts) -> DownResult`
+ *   Computes op's own OperatorContext (later handed to FunctionUp) from the DownContexts
+ *   propagated by its parents (one entry per parent edge, empty for a root), and a per-child
+ *   DownContext map to propagate further down — letting different children of the same
+ *   operator receive different contexts.
+ * - `FunctionUp`: `(LogicalOperator op, std::vector<LogicalOperator> newChildren, OperatorContext context,
+ *   std::unordered_map<LogicalOperator, UpContext> upContexts) -> UpResult`
+ *   Rebuilds/rewrites op using its already-rebuilt children, the OperatorContext computed for
+ *   it during the top-down pass, and the UpContext each child produced (keyed by the rebuilt
+ *   child), then returns the new operator together with the UpContext to forward to its own
+ *   parent(s).
+ *
+ * ## Alternative callback signatures
+ * The constructors also accept reduced-arity variants for rules that do not need the full
+ * signature, so callers do not have to accept and ignore parameters they never use:
+ * - `FunctionDownAlt`: `(LogicalOperator op) -> DownResult`
+ *   Drops the DownContexts parameter, for rules that only depend on the operator itself.
+ * - `FunctionUpAlt1`: `(LogicalOperator op, std::vector<LogicalOperator> newChildren, OperatorContext context) -> UpResult`
+ *   Drops the UpContexts map, for rules that do not need per-child UpContext.
+ * - `FunctionUpAlt2`: `(LogicalOperator op, std::vector<LogicalOperator> newChildren,
+ *   std::unordered_map<LogicalOperator, UpContext> upContexts) -> UpResult`
+ *   Drops the OperatorContext, for rules that do not need information from the top-down pass.
+ * - `FunctionUpAlt3`: `(LogicalOperator op, std::vector<LogicalOperator> newChildren) -> UpResult`
+ *   Drops both OperatorContext and UpContexts, for rules that only rebuild op from its
+ *   already-rebuilt children.
+ *
+ * Each constructor takes a `std::variant` of the full callback and its alternatives, so any
+ * of these forms can be passed directly; PlanVisitor normalizes them internally to the full
+ * `FunctionDown`/`FunctionUp` signature.
+ */
+
+namespace NES
+{
+template <typename OperatorContext = std::monostate, typename DownContext = std::monostate, typename UpContext = std::monostate>
+class PlanVisitor
+{
+public:
+    struct DownResult
+    {
+        OperatorContext operatorContext;
+        std::unordered_map<LogicalOperator, DownContext> downContexts;
+    };
+
+    struct UpResult
+    {
+        /// NOLINTNEXTLINE(google-explicit-constructor)
+        UpResult(LogicalOperator op) : op(std::move(op)), upContext({}) { };
+        UpResult(LogicalOperator op, UpContext upContext) : op(std::move(op)), upContext(std::move(upContext)) { };
+        LogicalOperator op;
+        UpContext upContext;
+    };
+
+    /// Main callbacks
+    using FunctionDown = std::function<DownResult(LogicalOperator, std::vector<DownContext>)>;
+    using FunctionUp = std::function<UpResult(
+        LogicalOperator, std::vector<LogicalOperator>, OperatorContext, std::unordered_map<LogicalOperator, UpContext>)>;
+
+    /// Alternative callbacks
+    using FunctionDownAlt = std::function<DownResult(LogicalOperator)>;
+    using FunctionUpAlt1 = std::function<UpResult(LogicalOperator, std::vector<LogicalOperator>, OperatorContext)>;
+    using FunctionUpAlt2
+        = std::function<UpResult(LogicalOperator, std::vector<LogicalOperator>, std::unordered_map<LogicalOperator, UpContext>)>;
+    using FunctionUpAlt3 = std::function<UpResult(LogicalOperator, std::vector<LogicalOperator>)>;
+
+    explicit PlanVisitor(
+        std::variant<FunctionDown, FunctionDownAlt> fnDown, std::variant<FunctionUp, FunctionUpAlt1, FunctionUpAlt2, FunctionUpAlt3> fnUp)
+        : fnDown(normalizeFnDown(fnDown)), fnUp(normalizeFnUp(fnUp)) { };
+
+    explicit PlanVisitor(std::variant<FunctionDown, FunctionDownAlt> fnDown) : PlanVisitor(fnDown, noOpUp) { };
+    explicit PlanVisitor(std::variant<FunctionUp, FunctionUpAlt1, FunctionUpAlt2, FunctionUpAlt3> fnUp) : PlanVisitor(noOpDown, fnUp) { };
+
+    [[nodiscard]] LogicalPlan apply(LogicalPlan plan)
+    {
+        Instance instance{fnDown, fnUp};
+
+        instance.init(plan);
+        instance.traverseDown(plan);
+        instance.traverseUp();
+        const auto newRoots = instance.getNewRoots(plan);
+
+        return plan.withRootOperators(newRoots);
+    }
+
+private:
+    struct Instance
+    {
+        Instance(FunctionDown fnDown, FunctionUp fnUp) : fnDown(std::move(fnDown)), fnUp(std::move(fnUp)) { };
+
+        void init(const LogicalPlan& plan)
+        {
+            std::stack<LogicalOperator> toVisit;
+            std::unordered_set<LogicalOperator> visited;
+
+            for (const auto& op : plan.getRootOperators())
+            {
+                toVisit.push(op);
+            }
+
+            while (!toVisit.empty())
+            {
+                auto op = toVisit.top();
+                toVisit.pop();
+                if (visited.contains(op))
+                {
+                    continue;
+                }
+                visited.insert(op);
+
+                childCounter.emplace(op, op.getChildren().size());
+
+                for (const auto& child : op.getChildren())
+                {
+                    parentCounter[child]++;
+                    parentMap[child].emplace_back(op);
+                    toVisit.push(child);
+                }
+            }
+        }
+
+        void traverseDown(const LogicalPlan& plan)
+        {
+            std::stack<LogicalOperator> toVisit;
+
+            for (const auto& root : plan.getRootOperators() | std::views::reverse)
+            {
+                toVisit.push(root);
+            }
+
+            while (!toVisit.empty())
+            {
+                auto op = toVisit.top();
+                toVisit.pop();
+
+                auto [opCon, childCon] = fnDown(op, std::move(downContextMap[op]));
+
+                operatorContextMap.insert_or_assign(op, opCon);
+
+                for (auto child : op.getChildren())
+                {
+                    auto itr = childCon.find(child);
+                    downContextMap[child].emplace_back(itr == childCon.end() ? DownContext{} : itr->second);
+                }
+
+                if (op.getChildren().empty())
+                {
+                    leaves.emplace_back(op);
+                }
+
+                for (const auto& child : op.getChildren() | std::views::reverse)
+                {
+                    parentCounter[child]--;
+                    if (parentCounter[child] == 0)
+                    {
+                        toVisit.push(child);
+                    }
+                }
+            }
+        }
+
+        void traverseUp()
+        {
+            std::stack<LogicalOperator> toVisit;
+
+            for (const auto& leaf : leaves | std::views::reverse)
+            {
+                toVisit.push(leaf);
+            }
+
+            while (!toVisit.empty())
+            {
+                auto op = toVisit.top();
+                toVisit.pop();
+
+                auto context = operatorContextMap.at(op);
+                std::vector<LogicalOperator> newChildren;
+
+                std::unordered_map<LogicalOperator, UpContext> upContext;
+
+                for (const auto& child : op.getChildren())
+                {
+                    auto newChild = newOperatorMap.at(child);
+                    newChildren.emplace_back(newChild);
+                    upContext.emplace(newChild, upContextMap.at(child));
+                }
+
+                auto [newOp, newUpContext] = fnUp(op, newChildren, context, upContext);
+
+                INVARIANT(
+                    !newOperatorMap.contains(op),
+                    "each operator can only be inserted once into newOperatorMap since it is only visited once");
+                newOperatorMap.insert_or_assign(op, std::move(newOp));
+                INVARIANT(
+                    !upContextMap.contains(op), "each operator can only be inserted once into upContextMap since it is only visited once");
+                upContextMap.insert_or_assign(op, std::move(newUpContext));
+
+                if (auto it = parentMap.find(op); it != parentMap.end())
+                {
+                    for (const auto& parent : it->second)
+                    {
+                        childCounter[parent]--;
+                        if (childCounter[parent] == 0)
+                        {
+                            toVisit.push(parent);
+                        }
+                    }
+                }
+            }
+        }
+
+        std::vector<LogicalOperator> getNewRoots(const LogicalPlan& plan)
+        {
+            std::vector<LogicalOperator> newRoots;
+            for (const auto& root : plan.getRootOperators())
+            {
+                newRoots.emplace_back(newOperatorMap.at(root));
+            }
+
+            return newRoots;
+        }
+
+        FunctionDown fnDown;
+        FunctionUp fnUp;
+        std::unordered_map<LogicalOperator, uint64_t> parentCounter;
+        std::unordered_map<LogicalOperator, std::vector<LogicalOperator>> parentMap;
+        std::unordered_map<LogicalOperator, uint64_t> childCounter;
+
+        std::vector<LogicalOperator> leaves;
+        std::unordered_map<LogicalOperator, std::vector<DownContext>> downContextMap{};
+        std::unordered_map<LogicalOperator, UpContext> upContextMap{};
+        std::unordered_map<LogicalOperator, OperatorContext> operatorContextMap{};
+
+        std::unordered_map<LogicalOperator, LogicalOperator> newOperatorMap;
+    };
+
+    FunctionDown fnDown;
+    FunctionUp fnUp;
+
+    FunctionDown normalizeFnDown(std::variant<FunctionDown, FunctionDownAlt> function)
+    {
+        return std::visit(
+            Overloaded{
+                [](FunctionDown fnDown) -> FunctionDown { return fnDown; },
+                [](FunctionDownAlt fnDown) -> FunctionDown
+                { return [fnDown](LogicalOperator op, std::vector<DownContext>) -> DownResult { return fnDown(op); }; }},
+            function);
+    }
+
+    FunctionUp normalizeFnUp(std::variant<FunctionUp, FunctionUpAlt1, FunctionUpAlt2, FunctionUpAlt3> function)
+    {
+        return std::visit(
+            Overloaded{
+                [](FunctionUp fnUp) -> FunctionUp { return fnUp; },
+                [](FunctionUpAlt1 fnUp) -> FunctionUp
+                {
+                    return [fnUp](
+                               LogicalOperator op,
+                               std::vector<LogicalOperator> children,
+                               OperatorContext operatorContext,
+                               std::unordered_map<LogicalOperator, UpContext>) { return fnUp(op, std::move(children), operatorContext); };
+                },
+                [](FunctionUpAlt2 fnUp) -> FunctionUp
+                {
+                    return [fnUp](
+                               LogicalOperator op,
+                               std::vector<LogicalOperator> children,
+                               OperatorContext,
+                               std::unordered_map<LogicalOperator, UpContext> upContexts)
+                    { return fnUp(op, std::move(children), upContexts); };
+                },
+                [](FunctionUpAlt3 fnUp) -> FunctionUp
+                {
+                    return [fnUp](
+                               LogicalOperator op,
+                               std::vector<LogicalOperator> children,
+                               OperatorContext,
+                               std::unordered_map<LogicalOperator, UpContext>) { return fnUp(op, std::move(children)); };
+                },
+            },
+            function);
+    }
+
+    static DownResult noOpDown(const LogicalOperator&, const std::vector<DownContext>&) { return {}; }
+
+    static UpResult noOpUp(
+        const LogicalOperator& op,
+        std::vector<LogicalOperator> children,
+        const OperatorContext&,
+        const std::unordered_map<LogicalOperator, UpContext>&)
+    {
+        return op.withChildren(std::move(children));
+    }
+};
+}

--- a/nes-query-optimizer/include/Rules/Semantic/AnonymousSourceBindingRule.hpp
+++ b/nes-query-optimizer/include/Rules/Semantic/AnonymousSourceBindingRule.hpp
@@ -19,8 +19,10 @@
 #include <typeindex>
 #include <typeinfo>
 #include <utility>
+#include <vector>
 
 #include <Operators/LogicalOperator.hpp>
+#include <Operators/LogicalOperatorFwd.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <Rules/Rule.hpp>
 #include <Sources/SourceCatalog.hpp>
@@ -41,7 +43,7 @@ public:
     [[nodiscard]] std::set<std::type_index> neededBy() const;
 
 private:
-    [[nodiscard]] LogicalOperator bindAnonymousSourceLogicalOperators(const LogicalOperator& current) const;
+    [[nodiscard]] LogicalOperator bindAnonymousSources(const LogicalOperator& op, const std::vector<LogicalOperator>& children) const;
     std::shared_ptr<const SourceCatalog> sourceCatalog;
 };
 

--- a/nes-query-optimizer/include/Rules/Semantic/CalcTargetOrderRule.hpp
+++ b/nes-query-optimizer/include/Rules/Semantic/CalcTargetOrderRule.hpp
@@ -17,8 +17,17 @@
 #include <string_view>
 #include <typeindex>
 #include <typeinfo>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+#include <DataTypes/Schema.hpp>
+#include <DataTypes/SchemaFwd.hpp>
+#include <Operators/LogicalOperatorFwd.hpp>
 #include <Plans/LogicalPlan.hpp>
+#include <Rules/PlanVisitor.hpp>
 #include <Rules/Rule.hpp>
+#include <Schema/Field.hpp>
 
 namespace NES
 {
@@ -37,6 +46,12 @@ public:
     [[nodiscard]] LogicalPlan apply(LogicalPlan plan) const;
     [[nodiscard]] std::set<std::type_index> needs() const;
     [[nodiscard]] std::set<std::type_index> neededBy() const;
+
+private:
+    using Visitor = PlanVisitor<std::monostate, std::monostate, Schema<Field, Ordered>>;
+
+    [[nodiscard]] static Visitor::UpResult calcTargetOrder(
+        LogicalOperator op, std::vector<LogicalOperator> children, std::unordered_map<LogicalOperator, Schema<Field, Ordered>> upContexts);
 };
 
 static_assert(RuleConcept<CalcTargetOrderRule, LogicalPlan>);

--- a/nes-query-optimizer/include/Rules/Semantic/LogicalSourceExpansionRule.hpp
+++ b/nes-query-optimizer/include/Rules/Semantic/LogicalSourceExpansionRule.hpp
@@ -21,7 +21,9 @@
 #include <typeinfo>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 #include <Identifiers/Identifiers.hpp>
+#include <Operators/LogicalOperatorFwd.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <Rules/Rule.hpp>
 #include <Sources/SourceCatalog.hpp>
@@ -93,6 +95,8 @@ public:
 
 private:
     std::shared_ptr<const SourceCatalog> sourceCatalog;
+
+    [[nodiscard]] LogicalOperator expandLogicalSource(const LogicalOperator& visiting, std::vector<LogicalOperator> children) const;
 };
 
 static_assert(RuleConcept<LogicalSourceExpansionRule, LogicalPlan>);

--- a/nes-query-optimizer/include/Rules/Static/DecideFieldMappings.hpp
+++ b/nes-query-optimizer/include/Rules/Static/DecideFieldMappings.hpp
@@ -43,8 +43,5 @@ public:
 
     [[nodiscard]] LogicalPlan apply(const LogicalPlan& queryPlan) const;
     [[nodiscard]] std::set<std::type_index> needs() const;
-
-private:
-    [[nodiscard]] LogicalOperator apply(const LogicalOperator& logicalOperator) const;
 };
 }

--- a/nes-query-optimizer/include/Rules/Static/DecideFieldOrder.hpp
+++ b/nes-query-optimizer/include/Rules/Static/DecideFieldOrder.hpp
@@ -30,5 +30,6 @@ public:
 
     [[nodiscard]] LogicalPlan apply(const LogicalPlan& queryPlan) const;
     [[nodiscard]] std::set<std::type_index> needs() const;
+    [[nodiscard]] std::set<std::type_index> wantedBy() const;
 };
 }

--- a/nes-query-optimizer/include/Rules/Static/DecideMemoryLayoutRule.hpp
+++ b/nes-query-optimizer/include/Rules/Static/DecideMemoryLayoutRule.hpp
@@ -32,9 +32,6 @@ public:
 
     [[nodiscard]] LogicalPlan apply(const LogicalPlan& queryPlan) const;
     [[nodiscard]] std::set<std::type_index> needs() const;
-
-private:
-    [[nodiscard]] LogicalOperator apply(const LogicalOperator& logicalOperator) const;
 };
 
 static_assert(RuleConcept<DecideMemoryLayoutRule, LogicalPlan>);

--- a/nes-query-optimizer/src/Rules/Semantic/AnonymousSourceBindingRule.cpp
+++ b/nes-query-optimizer/src/Rules/Semantic/AnonymousSourceBindingRule.cpp
@@ -18,6 +18,9 @@
 #include <string_view>
 #include <typeindex>
 #include <typeinfo>
+#include <unordered_map>
+#include <utility>
+#include <variant>
 #include <vector>
 
 #include <Identifiers/Identifier.hpp>
@@ -26,25 +29,22 @@
 #include <Operators/LogicalOperatorFwd.hpp>
 #include <Operators/Sources/AnonymousSourceLogicalOperator.hpp>
 #include <Operators/Sources/SourceDescriptorLogicalOperator.hpp>
+#include <Operators/Sources/SourceNameLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <Rules/Barriers/SemanticAnalysisBarrier.hpp>
+#include <Rules/PlanVisitor.hpp>
 #include <ErrorHandling.hpp>
 #include <PlanRuleRegistry.hpp>
 
 namespace NES
 {
 
-LogicalOperator AnonymousSourceBindingRule::bindAnonymousSourceLogicalOperators(const LogicalOperator& current) const
+LogicalOperator
+AnonymousSourceBindingRule::bindAnonymousSources(const LogicalOperator& op, const std::vector<LogicalOperator>& children) const
 {
-    std::vector<LogicalOperator> newChildren;
-    for (const auto& child : current.getChildren())
+    if (const auto anonymousSource = op.tryGetAs<AnonymousSourceLogicalOperator>())
     {
-        newChildren.emplace_back(bindAnonymousSourceLogicalOperators(child));
-    }
-
-    if (const auto anonymousSource = current.tryGetAs<AnonymousSourceLogicalOperator>())
-    {
-        PRECONDITION(std::ranges::empty(anonymousSource->getChildren()), "Anonymous source operator must have no children");
+        PRECONDITION(children.empty(), "Anonymous source operator must have no children");
         const auto type = anonymousSource.value()->getSourceType();
         const auto schema = anonymousSource.value()->getSourceSchema();
         const auto parserConfig = anonymousSource.value()->getParserConfig();
@@ -66,21 +66,23 @@ LogicalOperator AnonymousSourceBindingRule::bindAnonymousSourceLogicalOperators(
         {
             throw InvalidConfigParameter("Could not create an anonymous source descriptor because of invalid config parameters");
         }
-        const auto& descriptor = descriptorOpt.value();
-        return SourceDescriptorLogicalOperator::create(descriptor);
+        return LogicalOperator{SourceDescriptorLogicalOperator::create(std::move(descriptorOpt).value())};
     }
 
-    return current.withChildrenUnsafe(newChildren);
+    if (op.tryGetAs<SourceNameLogicalOperator>())
+    {
+        return op;
+    }
+
+    return op.withChildrenUnsafe(children);
 }
 
 LogicalPlan AnonymousSourceBindingRule::apply(const LogicalPlan& queryPlan) const
 {
-    std::vector<LogicalOperator> newRoots;
-    for (const auto& root : queryPlan.getRootOperators())
-    {
-        newRoots.emplace_back(bindAnonymousSourceLogicalOperators(root));
-    }
-    return queryPlan.withRootOperators(newRoots);
+    PlanVisitor<> visitor{[this](const LogicalOperator& op, const std::vector<LogicalOperator>& children)
+                          { return this->bindAnonymousSources(op, children); }};
+
+    return visitor.apply(queryPlan);
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Semantic/CalcTargetOrderRule.cpp
+++ b/nes-query-optimizer/src/Rules/Semantic/CalcTargetOrderRule.cpp
@@ -33,6 +33,7 @@
 #include <Operators/Sinks/SinkLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <Rules/Barriers/SemanticAnalysisBarrier.hpp>
+#include <Rules/PlanVisitor.hpp>
 #include <Rules/Semantic/AnonymousSinkBindingRule.hpp>
 #include <Rules/Semantic/LogicalSourceExpansionRule.hpp>
 #include <Rules/Semantic/SinkBindingRule.hpp>
@@ -50,26 +51,67 @@ namespace NES
 
 namespace
 {
-Schema<Field, Ordered> applyRecursive(const LogicalOperator& visiting)
+bool hasOrder(const LogicalOperator& rootNode)
 {
-    const auto childrenWithOutputOrder = visiting.getChildren()
-        | std::views::transform([](const auto& child) { return std::pair{child, applyRecursive(child)}; })
-        | std::ranges::to<std::unordered_map>();
+    const auto sink = rootNode.getAs<SinkLogicalOperator>();
+    PRECONDITION(sink->getSinkDescriptor().has_value(), "Expected all sink descriptors to be set");
+    /// NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+    const auto schemaVariant = sink->getSinkDescriptor()->getSchema();
+    return std::visit(
+        Overloaded{
+            [](const std::monostate&) -> bool
+            {
+                PRECONDITION(false, "Expected schema to be set in sink descriptor, was schema inference run?");
+                std::unreachable();
+            },
+            [](const std::shared_ptr<const Schema<UnqualifiedUnboundField, Unordered>>&) { return false; },
+            [](const std::shared_ptr<const Schema<UnqualifiedUnboundField, Ordered>>&) { return true; }},
+        schemaVariant);
+}
+}
 
+CalcTargetOrderRule::Visitor::UpResult CalcTargetOrderRule::calcTargetOrder(
+    LogicalOperator op, std::vector<LogicalOperator> children, std::unordered_map<LogicalOperator, Schema<Field, Ordered>> upContexts)
+{
+    op = op.withChildren(children);
 
-    if (const auto reorderer = visiting.tryGetAs<Reorderer>())
+    if (auto sinkOp = op.tryGetAs<SinkLogicalOperator>())
     {
-        return reorderer.value()->get().getOrderedOutputSchema([&childrenWithOutputOrder](const LogicalOperator& child)
-                                                               { return childrenWithOutputOrder.at(child); });
+        const auto& sink = sinkOp.value();
+
+        /// avoid overwrite sink orders if they are predefined
+        if (hasOrder(op))
+        {
+            return {op, {}};
+        }
+
+        PRECONDITION(children.size() == 1, "Sinks can only have one child");
+
+        const auto newTargetSchema
+            = upContexts.at(children.at(0)) | RangeUnbinder{} | std::ranges::to<Schema<UnqualifiedUnboundField, Ordered>>();
+        auto sinkDescriptorOpt = sink->getSinkDescriptor();
+        PRECONDITION(sinkDescriptorOpt.has_value(), "Sink operator must have a descriptor to infer target schema order");
+        const auto oldDescriptor = NES::get<AnonymousSinkDescriptor>(sinkDescriptorOpt->getUnderlying());
+        auto newAnonymousSinkDescriptor = SinkDescriptor{oldDescriptor.withSchemaOrder(newTargetSchema)};
+        auto newSinkRoot = sink->withSinkDescriptor(newAnonymousSinkDescriptor);
+
+        return {newSinkRoot, {}};
     }
+
+    if (auto reorderer = op.tryGetAs<Reorderer>())
+    {
+        auto schema
+            = reorderer.value()->get().getOrderedOutputSchema([&upContexts](const LogicalOperator& child) { return upContexts.at(child); });
+        return {op, schema};
+    }
+
     /// the unordered map above does not maintain the order of the children, so we have to go through them again
-    const auto orderedBoundInputSchema = visiting->getChildren()
-        | std::views::transform([&](const auto& child) { return childrenWithOutputOrder.at(child); }) | std::views::join
-        | std::ranges::to<Schema<Field, Ordered>>();
+    const auto orderedBoundInputSchema = children | std::views::transform([&](const auto& child) { return upContexts.at(child); })
+        | std::views::join | std::ranges::to<Schema<Field, Ordered>>();
 
     std::vector<Field> outputOrder;
     std::vector<Field> rest;
-    const auto outputSchema = visiting.getOutputSchema();
+    const auto outputSchema = op.getOutputSchema();
     for (const auto& inputField : orderedBoundInputSchema)
     {
         if (const auto& outputFieldOpt = outputSchema[inputField.getFullyQualifiedName()])
@@ -95,47 +137,26 @@ Schema<Field, Ordered> applyRecursive(const LogicalOperator& visiting)
     {
         outputOrder.push_back(field);
     }
-    return outputOrder | std::ranges::to<Schema<Field, Ordered>>();
-}
 
+    auto schema = std::move(outputOrder) | std::ranges::to<Schema<Field, Ordered>>();
+
+    return {op, schema};
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 LogicalPlan CalcTargetOrderRule::apply(NES::LogicalPlan plan) const
 {
-    auto hasOrder = [](const LogicalOperator& rootNode)
-    {
-        const auto sink = rootNode.getAs<SinkLogicalOperator>();
-        PRECONDITION(sink->getSinkDescriptor().has_value(), "Expected all sink descriptors to be set");
-        const auto schemaVariant = sink->getSinkDescriptor()->getSchema();
-        return std::visit(
-            Overloaded{
-                [](const std::monostate&) -> bool
-                {
-                    PRECONDITION(false, "Expected schema to be set in sink descriptor, was schema inference run?");
-                    std::unreachable();
-                },
-                [](const std::shared_ptr<const Schema<UnqualifiedUnboundField, Unordered>>&) { return false; },
-                [](const std::shared_ptr<const Schema<UnqualifiedUnboundField, Ordered>>&) { return true; }},
-            schemaVariant);
-    };
-
     if (std::ranges::all_of(plan.getRootOperators(), hasOrder))
     {
         return plan;
     }
 
-    PRECONDITION(std::ranges::size(plan.getRootOperators()) == 1, "Can only infer target schema order for plans with exactly one root");
-    const auto root = plan.getRootOperators()[0].getAs<SinkLogicalOperator>();
-    auto outputOrder = applyRecursive(root->getChild());
-    const auto newTargetSchema
-        = outputOrder | std::views::transform(Unbinder<Field>{}) | std::ranges::to<Schema<UnqualifiedUnboundField, Ordered>>();
-    auto sinkDescriptorOpt = root->getSinkDescriptor();
-    PRECONDITION(sinkDescriptorOpt.has_value(), "Sink operator must have a descriptor to infer target schema order");
-    const auto oldDescriptor = NES::get<AnonymousSinkDescriptor>(sinkDescriptorOpt->getUnderlying());
-    auto newAnonymousSinkDescriptor = SinkDescriptor{oldDescriptor.withSchemaOrder(newTargetSchema)};
-    auto newSinkRoot = root->withSinkDescriptor(newAnonymousSinkDescriptor);
-    return plan.withRootOperators({newSinkRoot});
+    Visitor visitor{[](const LogicalOperator& op,
+                       std::vector<LogicalOperator> children,
+                       std::unordered_map<LogicalOperator, Schema<Field, Ordered>> upContexts)
+                    { return calcTargetOrder(op, std::move(children), std::move(upContexts)); }};
+
+    return visitor.apply(plan);
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Semantic/InferModelResolutionRule.cpp
+++ b/nes-query-optimizer/src/Rules/Semantic/InferModelResolutionRule.cpp
@@ -28,6 +28,7 @@
 #include <Operators/LogicalOperatorFwd.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <Rules/Barriers/SemanticAnalysisBarrier.hpp>
+#include <Rules/PlanVisitor.hpp>
 #include <Rules/Semantic/AnonymousSinkBindingRule.hpp>
 #include <Rules/Semantic/LogicalSourceExpansionRule.hpp>
 #include <Rules/Semantic/SinkBindingRule.hpp>
@@ -39,34 +40,30 @@
 namespace NES
 {
 
-namespace
-{
-LogicalOperator recur(const LogicalOperator& op, const ModelCatalog& modelCatalog)
-{
-    auto newChildren = op.getChildren() | std::views::transform([&](const auto& child) { return recur(child, modelCatalog); })
-        | std::ranges::to<std::vector>();
-
-    if (const auto inferModelName = op.tryGetAs<InferModelNameLogicalOperator>())
-    {
-        const auto& modelName = inferModelName->get().getModelName();
-        if (!modelCatalog.hasModel(modelName))
-        {
-            throw UnknownModelName("Model '{}' is not registered", modelName);
-        }
-        PRECONDITION(
-            std::ranges::size(newChildren) == 1,
-            "Expected InferModelName Logical Operator to have one child, but has {}",
-            std::ranges::size(newChildren));
-        return TypedLogicalOperator<InferModelLogicalOperator>{modelCatalog.load(modelName), std::move(newChildren.at(0))};
-    }
-    return op.withChildren(std::move(newChildren));
-}
-}
 
 LogicalPlan InferModelResolutionRule::apply(const LogicalPlan& queryPlan) const
 {
-    PRECONDITION(queryPlan.getRootOperators().size() == 1, "Query plan must have exactly one root operator");
-    return queryPlan.withRootOperators({recur(queryPlan.getRootOperators().front(), *modelCatalog)});
+    PlanVisitor<> visitor{
+        [this](const LogicalOperator& op, std::vector<LogicalOperator> children) -> PlanVisitor<>::UpResult
+        {
+            if (const auto inferModelName = op.tryGetAs<InferModelNameLogicalOperator>())
+            {
+                const auto& modelName = inferModelName->get().getModelName();
+                if (!modelCatalog->hasModel(modelName))
+                {
+                    throw UnknownModelName("Model '{}' is not registered", modelName);
+                }
+                PRECONDITION(
+                    std::ranges::size(children) == 1,
+                    "Expected InferModelName Logical Operator to have one child, but has {}",
+                    std::ranges::size(children));
+                return LogicalOperator{
+                    TypedLogicalOperator<InferModelLogicalOperator>{modelCatalog->load(modelName), std::move(children.at(0))}};
+            }
+            return op.withChildren(std::move(children));
+        }};
+
+    return visitor.apply(queryPlan);
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Semantic/LogicalSourceExpansionRule.cpp
+++ b/nes-query-optimizer/src/Rules/Semantic/LogicalSourceExpansionRule.cpp
@@ -29,6 +29,7 @@
 #include <Operators/UnionLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <Rules/Barriers/SemanticAnalysisBarrier.hpp>
+#include <Rules/PlanVisitor.hpp>
 #include <Sources/SourceCatalog.hpp>
 #include <Util/PlanRenderer.hpp>
 #include <ErrorHandling.hpp>
@@ -37,22 +38,18 @@
 namespace NES
 {
 
-namespace
+LogicalOperator
+LogicalSourceExpansionRule::expandLogicalSource(const LogicalOperator& visiting, std::vector<LogicalOperator> children) const
 {
-LogicalOperator applyRecursive(const LogicalOperator& visiting, const SourceCatalog& sourceCatalog)
-{
-    auto children = visiting.getChildren()
-        | std::views::transform([&sourceCatalog](const auto& child) { return applyRecursive(child, sourceCatalog); })
-        | std::ranges::to<std::vector>();
     if (const auto sourceNameOperator = visiting.tryGetAs<SourceNameLogicalOperator>())
     {
-        const auto logicalSourceOpt = sourceCatalog.getLogicalSource(sourceNameOperator.value()->getLogicalSourceName());
+        const auto logicalSourceOpt = sourceCatalog->getLogicalSource(sourceNameOperator.value()->getLogicalSourceName());
         if (not logicalSourceOpt.has_value())
         {
             throw UnknownSourceName("{}", sourceNameOperator.value()->getLogicalSourceName());
         }
         const auto& logicalSource = logicalSourceOpt.value();
-        const auto entriesOpt = sourceCatalog.getPhysicalSources(logicalSource);
+        const auto entriesOpt = sourceCatalog->getPhysicalSources(logicalSource);
 
         if (not entriesOpt.has_value())
         {
@@ -78,12 +75,14 @@ LogicalOperator applyRecursive(const LogicalOperator& visiting, const SourceCata
     }
     return visiting->withChildrenUnsafe(std::move(children));
 }
-}
 
 LogicalPlan LogicalSourceExpansionRule::apply(const LogicalPlan& queryPlan) const
 {
-    PRECONDITION(queryPlan.getRootOperators().size() == 1, "Query plan must have exactly one root operator");
-    return queryPlan.withRootOperators({applyRecursive(queryPlan.getRootOperators().at(0), *sourceCatalog)});
+    PlanVisitor<> visitor{
+        [this](const LogicalOperator& op, std::vector<LogicalOperator> children) -> PlanVisitor<>::UpResult
+        { return this->expandLogicalSource(op, std::move(children)); }};
+
+    return visitor.apply(queryPlan);
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Semantic/TypeInferenceRule.cpp
+++ b/nes-query-optimizer/src/Rules/Semantic/TypeInferenceRule.cpp
@@ -18,15 +18,17 @@
 #include <string_view>
 #include <typeindex>
 #include <typeinfo>
+#include <utility>
 #include <vector>
 
 #include <Operators/LogicalOperator.hpp>
+#include <Operators/LogicalOperatorFwd.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <Rules/Barriers/SemanticAnalysisBarrier.hpp>
+#include <Rules/PlanVisitor.hpp>
 #include <Rules/Semantic/AnonymousSinkBindingRule.hpp>
 #include <Rules/Semantic/LogicalSourceExpansionRule.hpp>
 #include <Rules/Semantic/SinkBindingRule.hpp>
-
 #include <PlanRuleRegistry.hpp>
 
 namespace NES
@@ -36,13 +38,10 @@ namespace NES
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 LogicalPlan TypeInferenceRule::apply(const LogicalPlan& queryPlan) const
 {
-    std::vector<LogicalOperator> newRoots;
-    for (const auto& sink : queryPlan.getRootOperators())
-    {
-        const LogicalOperator inferredRoot = sink->withInferredSchema();
-        newRoots.push_back(inferredRoot);
-    }
-    return queryPlan.withRootOperators(newRoots);
+    PlanVisitor<> visitor{
+        [](const LogicalOperator& op, std::vector<LogicalOperator> children) -> PlanVisitor<>::UpResult
+        { return op.withChildren(std::move(children)); }};
+    return visitor.apply(queryPlan);
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Static/DecideFieldMappings.cpp
+++ b/nes-query-optimizer/src/Rules/Static/DecideFieldMappings.cpp
@@ -25,6 +25,7 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+
 #include <DataTypes/Schema.hpp>
 #include <DataTypes/SchemaFwd.hpp>
 #include <DataTypes/UnboundField.hpp>
@@ -36,6 +37,7 @@
 #include <Operators/Sources/SourceDescriptorLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <Rules/Barriers/FixedPlanStructureBarrier.hpp>
+#include <Rules/PlanVisitor.hpp>
 #include <Schema/Field.hpp>
 #include <Traits/FieldMappingTrait.hpp>
 #include <Traits/TraitSet.hpp>
@@ -176,13 +178,9 @@ defaultMapping(const LogicalOperator& logicalOperator, const std::vector<Logical
     }
     return mapping;
 }
-}
 
-LogicalOperator DecideFieldMappings::apply(const LogicalOperator& logicalOperator) const
+PlanVisitor<>::UpResult decideFieldMappings(const LogicalOperator& logicalOperator, const std::vector<LogicalOperator>& children)
 {
-    const auto children = logicalOperator->getChildren() | std::views::transform([this](const auto& child) { return apply(child); })
-        | std::ranges::to<std::vector>();
-
     const auto mapping = [&]
     {
         if (const auto& reprojecter = logicalOperator.tryGetAs<Reprojecter>())
@@ -209,12 +207,14 @@ LogicalOperator DecideFieldMappings::apply(const LogicalOperator& logicalOperato
     PRECONDITION(success, "Field mapping trait already set");
     return logicalOperator.withTraitSet(std::move(traitSet)).withChildren(children);
 }
+}
 
+/// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 LogicalPlan DecideFieldMappings::apply(const LogicalPlan& queryPlan) const
 {
-    PRECONDITION(std::ranges::size(queryPlan.getRootOperators()) == 1, "Currently only one root operator is supported");
-    auto newRootOperator = apply(queryPlan.getRootOperators().at(0));
-    return queryPlan.withRootOperators({newRootOperator});
+    PlanVisitor<> visitor{decideFieldMappings};
+
+    return visitor.apply(queryPlan);
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Static/DecideFieldOrder.cpp
+++ b/nes-query-optimizer/src/Rules/Static/DecideFieldOrder.cpp
@@ -30,10 +30,16 @@
 #include <DataTypes/UnboundField.hpp>
 #include <Operators/LogicalOperator.hpp>
 #include <Operators/LogicalOperatorFwd.hpp>
+#include <Operators/ProjectionLogicalOperator.hpp>
 #include <Operators/Reorderer.hpp>
 #include <Operators/Sinks/SinkLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <Rules/Barriers/FixedPlanStructureBarrier.hpp>
+#include <Rules/PlanVisitor.hpp>
+#include <Rules/Static/DecideFieldMappings.hpp>
+#include <Rules/Static/DecideJoinTypesRule.hpp>
+#include <Rules/Static/DecideMemoryLayoutRule.hpp>
+#include <Rules/Static/OriginIdInferenceRule.hpp>
 #include <Schema/Binder.hpp>
 #include <Schema/Field.hpp>
 #include <Traits/FieldOrderingTrait.hpp>
@@ -54,76 +60,144 @@ namespace NES
 ///     If the current operator outputs a fields that has the same name, append it to the list of fields
 /// 2. Any field that does not appear in the input to the operator, is appended to the ordered output fields in lexicographic order.
 ///
-/// Concrete operators can overwrite this behavior by overwriting Reorderer
+/// Concrete operators can overwrite this behavior by overwriting Reorderer.
+///
+/// Implemented as a two-pass PlanVisitor over the (possibly DAG-shaped) plan: down-pass propagates the sink's required
+/// order to its child, up-pass rebuilds bottom-up assigning each op a FieldOrderingTrait (propagated, or computed via
+/// calculateOutputOrder). Shared subplans (multi-sink) get a synthetic Projection per sink to hold sink-specific ordering,
+/// see setSinkFieldOrder.
 namespace
 {
-LogicalOperator applyRecur(const LogicalOperator& visiting)
+
+struct OperatorContext
+{
+    Schema<UnqualifiedUnboundField, Ordered> requiredFieldOrdering;
+
+    /// True if this op has >1 parent in the plan DAG (shared subplan). A shared op can only hold one FieldOrderingTrait,
+    /// so setSinkFieldOrder must not impose its sink's order directly on it; instead it wraps it in a per-sink projection.
+    bool hasMultipleParents = false;
+};
+
+using Visitor = PlanVisitor<OperatorContext, Schema<UnqualifiedUnboundField, Ordered>, bool>;
+
+Visitor::UpResult setSinkFieldOrder(
+    const LogicalOperator& op, std::vector<LogicalOperator> children, const OperatorContext& operatorContext, bool childHasMultipleParents)
+{
+    PRECONDITION(op.tryGetAs<SinkLogicalOperator>(), "function can only be executed on SinkLogicalOperator");
+
+    auto sink = op.getAs<SinkLogicalOperator>();
+
+    PRECONDITION(children.size() == 1, "Sinks can only have exactly one child");
+    auto child = children.at(0);
+
+    auto sinkDescriptorOpt = sink->getSinkDescriptor();
+    PRECONDITION(sinkDescriptorOpt.has_value(), "Root sink must have a sink descriptor");
+    auto targetSchema = *NES::get<std::shared_ptr<const Schema<UnqualifiedUnboundField, Ordered>>>(sinkDescriptorOpt->getSchema());
+    for (const auto& targetField : targetSchema)
+    {
+        PRECONDITION(
+            children.at(0).getOutputSchema().contains(targetField.getFullyQualifiedName()),
+            "Field {} not present in root child output schema",
+            targetField.getFullyQualifiedName());
+    }
+
+    if (childHasMultipleParents)
+    {
+        auto newChild = ProjectionLogicalOperator::create(child, {}, ProjectionLogicalOperator::Asterisk{true});
+        auto traitSet = newChild.getTraitSet();
+        traitSet.insert(FieldOrderingTrait{operatorContext.requiredFieldOrdering});
+        child = newChild.withChildren({child}).withTraitSet(traitSet);
+    }
+
+    auto rootTraitSet = sink->getTraitSet();
+    rootTraitSet.insert(FieldOrderingTrait{Schema<UnqualifiedUnboundField, Ordered>{}});
+
+    return {op.withChildren({child}).withTraitSet(rootTraitSet), false};
+}
+
+Schema<Field, Ordered> calculateOutputOrder(const LogicalOperator& op, std::vector<LogicalOperator> children)
+{
+    const std::unordered_map<TypedLogicalOperator<>, Schema<Field, Ordered>> childrenWithOutputOrder
+        = children
+        | std::views::transform(
+              [](const auto& child) -> std::pair<TypedLogicalOperator<>, Schema<Field, Ordered>>
+              {
+                  return std::pair{
+                      child,
+                      child->getTraitSet().template get<FieldOrderingTrait>()->getOrderedFields() | RangeBinder{child}
+                          | std::ranges::to<Schema<Field, Ordered>>()};
+              })
+        | std::ranges::to<std::unordered_map>();
+
+    if (const auto reorderer = op.tryGetAs<Reorderer>())
+    {
+        return reorderer.value()->get().getOrderedOutputSchema([&childrenWithOutputOrder](const LogicalOperator& child)
+                                                               { return childrenWithOutputOrder.at(child); });
+    }
+
+    std::vector<Field> newOutputOrder;
+    std::vector<Field> rest;
+    const auto outputSchema = op.getOutputSchema();
+    const auto orderedBoundInputSchema = children
+        | std::views::transform([&](const auto& child) { return childrenWithOutputOrder.at(child); }) | std::views::join
+        | std::ranges::to<Schema<Field, Ordered>>();
+    for (const auto& inputField : orderedBoundInputSchema)
+    {
+        if (const auto& outputFieldOpt = outputSchema[inputField.getFullyQualifiedName()])
+        {
+            newOutputOrder.push_back(outputFieldOpt.value());
+        }
+    }
+
+    for (const auto& outputField : outputSchema)
+    {
+        if (!orderedBoundInputSchema.contains(outputField.getFullyQualifiedName()))
+        {
+            rest.push_back(outputField);
+        }
+    }
+
+    std::ranges::sort(
+        rest,
+        [](const auto& lhs, const auto& rhs)
+        { return fmt::format("{}", lhs.getFullyQualifiedName()) < fmt::format("{}", rhs.getFullyQualifiedName()); });
+
+    for (const auto& field : rest)
+    {
+        newOutputOrder.push_back(field);
+    }
+    return newOutputOrder | std::ranges::to<Schema<Field, Ordered>>();
+}
+
+Visitor::UpResult decideFieldOrder(
+    LogicalOperator op,
+    const std::vector<LogicalOperator>& children,
+    const OperatorContext& operatorContext,
+    const std::unordered_map<LogicalOperator, bool>& childHasMultipleParents)
 {
     /// For now we reuse the semantic field order of the operators as a heuristic for deciding the FieldOrdering trait
     /// Other strategies may be explored for better physical optimization
-    const auto oldWithNewChildren = visiting.getChildren()
-        | std::views::transform([&](const auto& child) { return std::pair{child, applyRecur(child)}; }) | std::ranges::to<std::vector>();
-    const auto newChildren
-        = oldWithNewChildren | std::views::transform(&std::pair<LogicalOperator, LogicalOperator>::second) | std::ranges::to<std::vector>();
 
-
-    const Schema<Field, Ordered> outputOrder = [&]
+    if (auto sinkOp = op.tryGetAs<SinkLogicalOperator>())
     {
-        const auto childrenMap = oldWithNewChildren | std::ranges::to<std::unordered_map>();
-        const std::unordered_map<TypedLogicalOperator<>, Schema<Field, Ordered>> childrenWithOutputOrder
-            = newChildren
-            | std::views::transform(
-                  [](const auto& child) -> std::pair<TypedLogicalOperator<>, Schema<Field, Ordered>>
-                  {
-                      return std::pair{
-                          child,
-                          child->getTraitSet().template get<FieldOrderingTrait>()->getOrderedFields() | RangeBinder{child}
-                              | std::ranges::to<Schema<Field, Ordered>>()};
-                  })
-            | std::ranges::to<std::unordered_map>();
+        PRECONDITION(children.size() == 1, "A sink can only have one child");
+        return setSinkFieldOrder(op, children, operatorContext, childHasMultipleParents.at(children.at(0)));
+    }
+    op = op.withChildren(children);
 
-        if (const auto reorderer = visiting.tryGetAs<Reorderer>())
-        {
-            return reorderer.value()->get().getOrderedOutputSchema([&childrenWithOutputOrder, &childrenMap](const LogicalOperator& child)
-                                                                   { return childrenWithOutputOrder.at(childrenMap.at(child)); });
-        }
-        std::vector<Field> outputOrder;
-        std::vector<Field> rest;
-        const auto outputSchema = visiting.getOutputSchema();
-        const auto orderedBoundInputSchema = newChildren
-            | std::views::transform([&](const auto& child) { return childrenWithOutputOrder.at(child); }) | std::views::join
-            | std::ranges::to<Schema<Field, Ordered>>();
-        for (const auto& inputField : orderedBoundInputSchema)
-        {
-            if (const auto& outputFieldOpt = outputSchema[inputField.getFullyQualifiedName()])
-            {
-                outputOrder.push_back(outputFieldOpt.value());
-            }
-        }
+    auto traitSet = op.getTraitSet();
 
-        for (const auto& outputField : outputSchema)
-        {
-            if (!orderedBoundInputSchema.contains(outputField.getFullyQualifiedName()))
-            {
-                rest.push_back(outputField);
-            }
-        }
+    if (operatorContext.requiredFieldOrdering.size() > 0)
+    {
+        traitSet.insert(FieldOrderingTrait{unbind(operatorContext.requiredFieldOrdering)});
+    }
+    else
+    {
+        const auto outputOrder = calculateOutputOrder(op, children);
+        traitSet.insert(FieldOrderingTrait{unbind(outputOrder)});
+    }
 
-        std::ranges::sort(
-            rest,
-            [](const auto& lhs, const auto& rhs)
-            { return fmt::format("{}", lhs.getFullyQualifiedName()) < fmt::format("{}", rhs.getFullyQualifiedName()); });
-
-        for (const auto& field : rest)
-        {
-            outputOrder.push_back(field);
-        }
-        return outputOrder | std::ranges::to<Schema<Field, Ordered>>();
-    }();
-
-    auto traitSet = visiting.getTraitSet();
-    traitSet.insert(FieldOrderingTrait{unbind(outputOrder)});
-    return visiting.withTraitSet(std::move(traitSet)).withChildren(newChildren);
+    return {op.withTraitSet(std::move(traitSet)), operatorContext.hasMultipleParents};
 }
 
 }
@@ -135,46 +209,40 @@ std::set<std::type_index> DecideFieldOrder::needs() const
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+std::set<std::type_index> DecideFieldOrder::wantedBy() const
+{
+    return {typeid(DecideFieldMappings), typeid(DecideJoinTypesRule), typeid(DecideMemoryLayoutRule), typeid(OriginIdInferenceRule)};
+}
+
+/// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 LogicalPlan DecideFieldOrder::apply(const LogicalPlan& queryPlan) const
 {
-    PRECONDITION(
-        std::ranges::size(queryPlan.getRootOperators()) == 1,
-        "query plan must have exactly one root operator but has {}",
-        std::ranges::size(queryPlan.getRootOperators()));
-
-    auto rootSink = queryPlan.getRootOperators()[0].getAs<SinkLogicalOperator>();
-    auto oldRootChild = rootSink->getChild();
-
-    const auto newRootChild = [&]
-    {
-        if (std::ranges::size(oldRootChild->getChildren()) > 0)
+    Visitor visitor{
+        [](const LogicalOperator& op, const std::vector<Schema<UnqualifiedUnboundField, Ordered>>& downContext) -> Visitor::DownResult
         {
-            auto newGrandchildren = oldRootChild->getChildren()
-                | std::views::transform([](const auto& grandchild) { return applyRecur(grandchild); }) | std::ranges::to<std::vector>();
-            return oldRootChild.withChildren(std::move(newGrandchildren));
-        }
-        return oldRootChild;
-    }();
+            if (auto sinkOp = op.tryGetAs<SinkLogicalOperator>())
+            {
+                const auto& sink = sinkOp.value();
 
-    auto sinkDescriptorOpt = rootSink->getSinkDescriptor();
-    PRECONDITION(sinkDescriptorOpt.has_value(), "Root sink must have a sink descriptor");
-    auto targetSchema = *NES::get<std::shared_ptr<const Schema<UnqualifiedUnboundField, Ordered>>>(sinkDescriptorOpt->getSchema());
-    for (const auto& targetField : targetSchema)
-    {
-        PRECONDITION(
-            newRootChild.getOutputSchema().contains(targetField.getFullyQualifiedName()),
-            "Field {} not present in root child output schema",
-            targetField.getFullyQualifiedName());
-    }
-    TraitSet rootChildTraitSet = newRootChild.getTraitSet();
-    rootChildTraitSet.insert(FieldOrderingTrait{targetSchema});
-    const auto rootChildWithTargetOrder = newRootChild.withTraitSet(TraitSet{rootChildTraitSet});
+                auto sinkDescriptorOpt = sink->getSinkDescriptor();
+                PRECONDITION(sinkDescriptorOpt.has_value(), "Root sink must have a sink descriptor");
+                auto targetSchema
+                    = *NES::get<std::shared_ptr<const Schema<UnqualifiedUnboundField, Ordered>>>(sinkDescriptorOpt->getSchema());
 
-    auto rootTraitSet = rootSink->getTraitSet();
-    rootTraitSet.insert(FieldOrderingTrait{Schema<UnqualifiedUnboundField, Ordered>{}});
+                const OperatorContext context = {.requiredFieldOrdering = targetSchema, .hasMultipleParents = downContext.size() > 1};
+                return {.operatorContext = context, .downContexts = {{sink->getChild(), targetSchema}}};
+            }
+            if (downContext.size() == 1)
+            {
+                return {
+                    .operatorContext = {.requiredFieldOrdering = downContext.at(0), .hasMultipleParents = downContext.size() > 1},
+                    .downContexts = {}};
+            }
+            return {.operatorContext = {.requiredFieldOrdering = {}, .hasMultipleParents = downContext.size() > 1}, .downContexts = {}};
+        },
+        decideFieldOrder};
 
-    auto newRoot = rootSink.withChildren({rootChildWithTargetOrder}).withTraitSet(rootTraitSet);
-    return queryPlan.withRootOperators({std::move(newRoot)});
+    return visitor.apply(queryPlan);
 }
 
 /// NOLINTNEXTLINE(performance-unnecessary-value-param)

--- a/nes-query-optimizer/src/Rules/Static/DecideJoinTypesRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/DecideJoinTypesRule.cpp
@@ -29,9 +29,11 @@
 #include <Functions/LogicalFunction.hpp>
 #include <Iterators/BFSIterator.hpp>
 #include <Operators/LogicalOperator.hpp>
+#include <Operators/LogicalOperatorFwd.hpp>
 #include <Operators/Windows/JoinLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <Rules/Barriers/FixedPlanStructureBarrier.hpp>
+#include <Rules/PlanVisitor.hpp>
 #include <Traits/JoinImplementationTypeTrait.hpp>
 #include <Traits/Trait.hpp>
 #include <Traits/TraitSet.hpp>
@@ -83,34 +85,14 @@ bool shallUseHashJoin(const LogicalFunction& joinFunction)
 
     return true;
 }
-}
 
-/// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-std::set<std::type_index> DecideJoinTypesRule::needs() const
+LogicalOperator
+decideJoinTypes(const LogicalOperator& logicalOperator, const std::vector<LogicalOperator>& children, const StreamJoinStrategy joinStrategy)
 {
-    return {typeid(FixedPlanStructureBarrier)};
-}
-
-LogicalPlan DecideJoinTypesRule::apply(const LogicalPlan& queryPlan) const
-{
-    PRECONDITION(queryPlan.getRootOperators().size() == 1, "Only single root operators are supported for now");
-    PRECONDITION(not queryPlan.getRootOperators().empty(), "Query must have a sink root operator");
-    return LogicalPlan{queryPlan.getQueryId(), {apply(queryPlan.getRootOperators()[0])}};
-}
-
-bool DecideJoinTypesRule::operator==(const DecideJoinTypesRule& other) const
-{
-    return this->joinStrategy == other.joinStrategy;
-}
-
-LogicalOperator DecideJoinTypesRule::apply(const LogicalOperator& logicalOperator) const
-{
-    const auto children = logicalOperator.getChildren()
-        | std::views::transform([this](const LogicalOperator& child) { return apply(child); }) | std::ranges::to<std::vector>();
     auto traitSet = logicalOperator.getTraitSet();
     if (const auto joinOperator = logicalOperator.tryGetAs<JoinLogicalOperator>())
     {
-        if (this->joinStrategy == StreamJoinStrategy::NESTED_LOOP_JOIN)
+        if (joinStrategy == StreamJoinStrategy::NESTED_LOOP_JOIN)
         {
             tryInsert(traitSet, JoinImplementationTypeTrait{JoinImplementation::NESTED_LOOP_JOIN});
         }
@@ -121,7 +103,7 @@ LogicalOperator DecideJoinTypesRule::apply(const LogicalOperator& logicalOperato
         else
         {
             tryInsert(traitSet, JoinImplementationTypeTrait{JoinImplementation::NESTED_LOOP_JOIN});
-            if (this->joinStrategy == StreamJoinStrategy::HASH_JOIN)
+            if (joinStrategy == StreamJoinStrategy::HASH_JOIN)
             {
                 NES_WARNING(
                     "Operator {} has not the HashJoinTrait, as the hash join is not supported for the join condition. Therefore, we "
@@ -135,6 +117,27 @@ LogicalOperator DecideJoinTypesRule::apply(const LogicalOperator& logicalOperato
         tryInsert(traitSet, JoinImplementationTypeTrait{JoinImplementation::CHOICELESS});
     }
     return logicalOperator.withChildren(children).withTraitSet(traitSet);
+}
+}
+
+/// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+std::set<std::type_index> DecideJoinTypesRule::needs() const
+{
+    return {typeid(FixedPlanStructureBarrier)};
+}
+
+LogicalPlan DecideJoinTypesRule::apply(const LogicalPlan& queryPlan) const
+{
+    PlanVisitor<> visitor{
+        [this](const LogicalOperator& op, const std::vector<LogicalOperator>& children) -> PlanVisitor<>::UpResult
+        { return decideJoinTypes(op, children, this->joinStrategy); }};
+
+    return visitor.apply(queryPlan);
+}
+
+bool DecideJoinTypesRule::operator==(const DecideJoinTypesRule& other) const
+{
+    return this->joinStrategy == other.joinStrategy;
 }
 
 /// NOLINTNEXTLINE(performance-unnecessary-value-param)

--- a/nes-query-optimizer/src/Rules/Static/DecideMemoryLayoutRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/DecideMemoryLayoutRule.cpp
@@ -18,11 +18,15 @@
 #include <string_view>
 #include <typeindex>
 #include <typeinfo>
+#include <utility>
+#include <vector>
 
 #include <Interface/BufferRef/LowerSchemaProvider.hpp>
 #include <Operators/LogicalOperator.hpp>
+#include <Operators/LogicalOperatorFwd.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <Rules/Barriers/FixedPlanStructureBarrier.hpp>
+#include <Rules/PlanVisitor.hpp>
 #include <Traits/MemoryLayoutTypeTrait.hpp>
 #include <Traits/TraitSet.hpp>
 #include <ErrorHandling.hpp>
@@ -31,27 +35,27 @@
 namespace NES
 {
 
+namespace
+{
+PlanVisitor<>::UpResult decideMemoryLayout(const LogicalOperator& op, const std::vector<LogicalOperator>& children)
+{
+    auto traitSet = op.getTraitSet();
+    tryInsert(traitSet, MemoryLayoutTypeTrait{MemoryLayoutType::ROW_LAYOUT});
+    return op.withChildren(children).withTraitSet(std::move(traitSet));
+}
+}
+
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 std::set<std::type_index> DecideMemoryLayoutRule::needs() const
 {
     return {typeid(FixedPlanStructureBarrier)};
 }
 
+/// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 LogicalPlan DecideMemoryLayoutRule::apply(const LogicalPlan& queryPlan) const
 {
-    PRECONDITION(queryPlan.getRootOperators().size() == 1, "Only single root operators are supported for now");
-    PRECONDITION(not queryPlan.getRootOperators().empty(), "Query must have a sink root operator");
-    return LogicalPlan{queryPlan.getQueryId(), {apply(queryPlan.getRootOperators()[0])}};
-}
-
-LogicalOperator DecideMemoryLayoutRule::apply(const LogicalOperator& logicalOperator) const
-{
-    /// Iterating over all operators and setting the memory layout trait to row
-    const auto children = logicalOperator.getChildren()
-        | std::views::transform([this](const LogicalOperator& child) { return apply(child); }) | std::ranges::to<std::vector>();
-    auto traitSet = logicalOperator.getTraitSet();
-    tryInsert(traitSet, MemoryLayoutTypeTrait{MemoryLayoutType::ROW_LAYOUT});
-    return logicalOperator.withChildren(children).withTraitSet(traitSet);
+    PlanVisitor<> visitor{decideMemoryLayout};
+    return visitor.apply(queryPlan);
 }
 
 /// NOLINTNEXTLINE(performance-unnecessary-value-param)

--- a/nes-query-optimizer/src/Rules/Static/OriginIdInferenceRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/OriginIdInferenceRule.cpp
@@ -27,10 +27,12 @@
 
 #include <Identifiers/Identifiers.hpp>
 #include <Operators/LogicalOperator.hpp>
+#include <Operators/LogicalOperatorFwd.hpp>
 #include <Operators/OriginIdAssigner.hpp>
 #include <Operators/Sources/SourceDescriptorLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <Rules/Barriers/FixedPlanStructureBarrier.hpp>
+#include <Rules/PlanVisitor.hpp>
 #include <Rules/Semantic/LogicalSourceExpansionRule.hpp>
 #include <Traits/OutputOriginIdsTrait.hpp>
 #include <Traits/Trait.hpp>
@@ -43,22 +45,19 @@ namespace NES
 
 namespace
 {
-LogicalOperator propagateOriginIds(const LogicalOperator& visitingOperator, OriginId& lastOriginId)
+LogicalOperator propagateOriginIds(const LogicalOperator& op, const std::vector<LogicalOperator>& children, OriginId& lastOriginId)
 {
-    std::vector<LogicalOperator> newChildren;
     std::vector<OutputOriginIdsTrait> childOriginIds;
-    for (const auto& child : visitingOperator.getChildren())
+    for (const auto& child : children)
     {
-        auto newChild = propagateOriginIds(child, lastOriginId);
-        newChildren.push_back(newChild);
-        const auto childOriginIdsOpt = getTrait<OutputOriginIdsTrait>(newChild.getTraitSet());
+        const auto childOriginIdsOpt = getTrait<OutputOriginIdsTrait>(child.getTraitSet());
         INVARIANT(childOriginIdsOpt.has_value(), "Child operator must have origin ids trait");
         childOriginIds.push_back(childOriginIdsOpt.value().get());
     }
 
-    auto traitSet = visitingOperator.getTraitSet();
+    auto traitSet = op.getTraitSet();
 
-    if (visitingOperator.tryGetAs<OriginIdAssigner>().has_value())
+    if (op.tryGetAs<OriginIdAssigner>().has_value())
     {
         lastOriginId = OriginId{lastOriginId.getRawValue() + 1};
         const auto success = tryInsert(traitSet, OutputOriginIdsTrait{{lastOriginId}});
@@ -73,7 +72,7 @@ LogicalOperator propagateOriginIds(const LogicalOperator& visitingOperator, Orig
         INVARIANT(success, "Failed to insert origin id trait, did another phase already assign them?");
     }
 
-    return visitingOperator.withTraitSet(traitSet).withChildren(newChildren);
+    return op.withTraitSet(traitSet).withChildren(children);
 }
 }
 
@@ -86,16 +85,13 @@ std::set<std::type_index> OriginIdInferenceRule::needs() const
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 LogicalPlan OriginIdInferenceRule::apply(const LogicalPlan& queryPlan) const
 {
-    /// origin ids, always start from 1 to n, whereby n is the number of operators that assign new orin ids
     auto originIdCounter = OriginId{INITIAL_ORIGIN_ID.getRawValue()};
-    /// propagate origin ids through the complete query plan
-    std::vector<LogicalOperator> newSinks;
-    newSinks.reserve(queryPlan.getRootOperators().size());
-    for (auto& sinkOperator : queryPlan.getRootOperators())
-    {
-        newSinks.push_back(propagateOriginIds(sinkOperator, originIdCounter));
-    }
-    return queryPlan.withRootOperators(newSinks);
+
+    PlanVisitor<> visitor{
+        [&originIdCounter](const LogicalOperator& op, const std::vector<LogicalOperator>& children) -> PlanVisitor<>::UpResult
+        { return propagateOriginIds(op, children, originIdCounter); }};
+
+    return visitor.apply(queryPlan);
 }
 
 /// NOLINTNEXTLINE(performance-unnecessary-value-param)

--- a/nes-query-optimizer/src/Rules/Static/PredicatePushdownRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/PredicatePushdownRule.cpp
@@ -15,6 +15,7 @@
 #include <Rules/Static/PredicatePushdownRule.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <ranges>
 #include <set>
 #include <string_view>
@@ -42,7 +43,7 @@
 #include <Plans/LogicalPlan.hpp>
 #include <Rules/Barriers/FixedPlanStructureBarrier.hpp>
 #include <Rules/Barriers/SemanticAnalysisBarrier.hpp>
-#include <Rules/Static/RedundantProjectionRemovalRule.hpp>
+#include <Rules/PlanVisitor.hpp>
 #include <Schema/Field.hpp>
 #include <ErrorHandling.hpp>
 #include <PlanRewriteUtils.hpp>
@@ -53,8 +54,32 @@ namespace NES
 
 namespace
 {
-[[nodiscard]] LogicalOperator
-predicatePushdown(LogicalOperator op, std::vector<LogicalFunction> predicateSet, std::unordered_map<Field, Field> fields);
+
+struct Projections
+{
+    std::vector<LogicalFunction> predicateSet;
+    std::unordered_map<Field, Field> fields;
+};
+
+struct OperatorContext
+{
+    Projections toApply;
+    std::unordered_map<LogicalOperator, Projections> pushed;
+    bool hasMultipleParents = false;
+};
+
+Projections merge(const std::vector<Projections>& contexts)
+{
+    if (contexts.empty() || contexts.size() > 1)
+    {
+        return {};
+    }
+    return contexts.at(0);
+}
+
+using Visitor = PlanVisitor<OperatorContext, Projections, bool>;
+
+[[nodiscard]] Visitor::DownResult predicatePushdown(const LogicalOperator& op, const std::vector<Projections>& downContexts);
 
 std::vector<LogicalFunction> splitPredicate(LogicalFunction function)
 {
@@ -122,19 +147,7 @@ std::unordered_map<Field, Field> fieldsWithNewOperator(const LogicalOperator& ba
     return newFields;
 }
 
-LogicalOperator applyToAllChildren(
-    const LogicalOperator& op, const std::vector<LogicalFunction>& predicateSet, const std::unordered_map<Field, Field>& fields)
-{
-    std::vector<LogicalOperator> children;
-    for (const auto& child : op.getChildren())
-    {
-        auto newChild = predicatePushdown(child, predicateSet, fieldsWithNewOperator(child, fields));
-        children.push_back(newChild);
-    }
-    return op.withChildren(children).withInferredSchema();
-}
-
-LogicalOperator pushBeyondSelection(
+Visitor::DownResult pushBeyondSelection(
     const TypedLogicalOperator<SelectionLogicalOperator>& op,
     std::vector<LogicalFunction> predicateSet,
     std::unordered_map<Field, Field> fields)
@@ -156,10 +169,13 @@ LogicalOperator pushBeyondSelection(
         predicateSet.emplace_back(newPredicate);
     }
 
-    return predicatePushdown(op->getChild(), std::move(predicateSet), std::move(fields));
+    std::unordered_map<LogicalOperator, Projections> toPush{{op->getChild(), {.predicateSet = predicateSet, .fields = fields}}};
+    const OperatorContext operatorContext{.toApply = {}, .pushed = toPush};
+
+    return {.operatorContext = operatorContext, .downContexts = std::move(toPush)};
 }
 
-LogicalOperator pushBeyondUnion(
+Visitor::DownResult pushBeyondUnion(
     const TypedLogicalOperator<UnionLogicalOperator>& op,
     const std::vector<LogicalFunction>& predicateSet,
     const std::unordered_map<Field, Field>& fields)
@@ -167,16 +183,21 @@ LogicalOperator pushBeyondUnion(
     /// predicates are pushed to all children
 
     std::vector<LogicalOperator> newChildren;
+
+    std::unordered_map<LogicalOperator, Projections> downContext;
+
     for (const auto& child : op.getChildren())
     {
         const auto childFields = fieldsWithNewOperator(child, fields);
-        newChildren.emplace_back(predicatePushdown(child, predicateSet, childFields));
+        downContext[child] = {.predicateSet = predicateSet, .fields = childFields};
     }
 
-    return op.withChildren(newChildren).withInferredSchema();
+    OperatorContext operatorContext{.toApply = {}, .pushed = downContext};
+
+    return {.operatorContext = std::move(operatorContext), .downContexts = downContext};
 }
 
-LogicalOperator pushBeyondProjection(
+Visitor::DownResult pushBeyondProjection(
     const TypedLogicalOperator<ProjectionLogicalOperator>& op,
     const std::vector<LogicalFunction>& predicateSet,
     const std::unordered_map<Field, Field>& fields)
@@ -234,12 +255,21 @@ LogicalOperator pushBeyondProjection(
         }
     }
 
-    const auto newOp = applyToAllChildren(op, pushable, fields);
 
-    return addSelectionIfRequired(newOp, std::move(nonPushable), fields);
+    std::unordered_map<LogicalOperator, Projections> downContext;
+    for (const auto& child : op.getChildren())
+    {
+        downContext[child] = {.predicateSet = pushable, .fields = fieldsWithNewOperator(child, fields)};
+    }
+
+    Projections toApply{.predicateSet = nonPushable, .fields = fields};
+
+    OperatorContext operatorContext{.toApply = std::move(toApply), .pushed = downContext};
+
+    return {.operatorContext = std::move(operatorContext), .downContexts = downContext};
 }
 
-LogicalOperator pushBeyondJoin(
+Visitor::DownResult pushBeyondJoin(
     const TypedLogicalOperator<JoinLogicalOperator>& op,
     const std::vector<LogicalFunction>& predicateSet,
     const std::unordered_map<Field, Field>& fields)
@@ -281,25 +311,34 @@ LogicalOperator pushBeyondJoin(
         }
     }
 
-    const auto newLeft = predicatePushdown(left, std::move(leftPushable), leftFields);
-    const auto newRight = predicatePushdown(right, std::move(rightPushable), rightFields);
 
-    const auto newOp = op->withChildren({newLeft, newRight}).withInferredSchema();
+    std::unordered_map<LogicalOperator, Projections> downContexts;
 
-    return addSelectionIfRequired(newOp, std::move(nonPushable), fields);
+    downContexts[left] = {.predicateSet = leftPushable, .fields = leftFields};
+    downContexts[right] = {.predicateSet = rightPushable, .fields = rightFields};
+
+    Projections toApply = {.predicateSet = nonPushable, .fields = fields};
+
+    OperatorContext operatorContext{.toApply = std::move(toApply), .pushed = downContexts};
+
+    return {.operatorContext = std::move(operatorContext), .downContexts = downContexts};
 }
 
-LogicalOperator pushBeyondWatermarkAssigner(
+Visitor::DownResult pushBeyondWatermarkAssigner(
     const LogicalOperator& op, const std::vector<LogicalFunction>& predicateSet, const std::unordered_map<Field, Field>& fields)
 {
     /// pushes all predicates further because
     /// operator does not add/modify any fields
 
-    const auto newFields = fieldsWithNewOperator(op->getChildren().at(0), fields);
-    return applyToAllChildren(op, predicateSet, newFields);
+    PRECONDITION(op.getChildren().size() == 1, "WatermarkAssigners must have exactly one child");
+
+    auto child = op.getChildren().at(0);
+    auto childFields = fieldsWithNewOperator(op->getChildren().at(0), fields);
+
+    return {.operatorContext = {}, .downContexts = {{std::move(child), {.predicateSet = predicateSet, .fields = std::move(childFields)}}}};
 }
 
-LogicalOperator pushBeyondWindowedAggregation(
+Visitor::DownResult pushBeyondWindowedAggregation(
     const TypedLogicalOperator<WindowedAggregationLogicalOperator>& op,
     const std::vector<LogicalFunction>& predicateSet,
     std::unordered_map<Field, Field> fields)
@@ -344,48 +383,98 @@ LogicalOperator pushBeyondWindowedAggregation(
         }
     }
 
-    const auto newOp = applyToAllChildren(op, pushable, fields);
+    std::unordered_map<LogicalOperator, Projections> downContexts;
 
-    return addSelectionIfRequired(newOp, std::move(nonPushable), fields);
+    downContexts[op->getChild()] = {.predicateSet = pushable, .fields = fieldsWithNewOperator(op->getChild(), fields)};
+
+    Projections toApply = {.predicateSet = nonPushable, .fields = fields};
+    OperatorContext operatorContext{.toApply = std::move(toApply), .pushed = downContexts};
+
+    return {.operatorContext = std::move(operatorContext), .downContexts = downContexts};
 }
 
-LogicalOperator predicatePushdown(LogicalOperator op, std::vector<LogicalFunction> predicateSet, std::unordered_map<Field, Field> fields)
+Visitor::DownResult predicatePushdown(const LogicalOperator& op, const std::vector<Projections>& downContexts)
 {
+    const bool hasMultipleParents = downContexts.size() > 1;
+
+    auto [predicateSet, fields] = merge(downContexts);
+
+    Visitor::DownResult downResult;
+
     if (op.tryGetAs<SourceDescriptorLogicalOperator>())
     {
-        return addSelectionIfRequired(std::move(op), std::move(predicateSet), fields);
+        OperatorContext operatorContext = {.toApply = {.predicateSet = predicateSet, .fields = fields}, .pushed = {}};
+        downResult = {.operatorContext = std::move(operatorContext), .downContexts = {}};
     }
-    if (auto selectionOp = op.tryGetAs<SelectionLogicalOperator>())
+    else if (auto selectionOp = op.tryGetAs<SelectionLogicalOperator>())
     {
-        return pushBeyondSelection(selectionOp.value(), std::move(predicateSet), std::move(fields));
+        downResult = pushBeyondSelection(selectionOp.value(), predicateSet, fields);
     }
-    if (auto projectionOp = op.tryGetAs<ProjectionLogicalOperator>())
+    else if (auto projectionOp = op.tryGetAs<ProjectionLogicalOperator>())
     {
-        return pushBeyondProjection(projectionOp.value(), predicateSet, fields);
+        downResult = pushBeyondProjection(projectionOp.value(), predicateSet, fields);
     }
-    if (auto joinOp = op.tryGetAs<JoinLogicalOperator>())
+    else if (auto joinOp = op.tryGetAs<JoinLogicalOperator>())
     {
-        return pushBeyondJoin(joinOp.value(), predicateSet, fields);
+        downResult = pushBeyondJoin(joinOp.value(), predicateSet, fields);
     }
-    if (auto unionOp = op.tryGetAs<UnionLogicalOperator>())
+    else if (auto unionOp = op.tryGetAs<UnionLogicalOperator>())
     {
-        return pushBeyondUnion(unionOp.value(), predicateSet, fields);
+        downResult = pushBeyondUnion(unionOp.value(), predicateSet, fields);
     }
-    if (auto eventTimeOp = op.tryGetAs<EventTimeWatermarkAssignerLogicalOperator>())
+    else if (auto eventTimeOp = op.tryGetAs<EventTimeWatermarkAssignerLogicalOperator>())
     {
-        return pushBeyondWatermarkAssigner(std::move(eventTimeOp.value()), predicateSet, fields);
+        downResult = pushBeyondWatermarkAssigner(std::move(eventTimeOp.value()), predicateSet, fields);
     }
-    if (auto ingestionTimeOp = op.tryGetAs<IngestionTimeWatermarkAssignerLogicalOperator>())
+    else if (auto ingestionTimeOp = op.tryGetAs<IngestionTimeWatermarkAssignerLogicalOperator>())
     {
-        return pushBeyondWatermarkAssigner(std::move(ingestionTimeOp.value()), predicateSet, fields);
+        downResult = pushBeyondWatermarkAssigner(std::move(ingestionTimeOp.value()), predicateSet, fields);
     }
-    if (auto windowedAggOp = op.tryGetAs<WindowedAggregationLogicalOperator>())
+    else if (auto windowedAggOp = op.tryGetAs<WindowedAggregationLogicalOperator>())
     {
-        return pushBeyondWindowedAggregation(windowedAggOp.value(), predicateSet, std::move(fields));
+        downResult = pushBeyondWindowedAggregation(windowedAggOp.value(), predicateSet, fields);
+    }
+    else
+    {
+        downResult
+            = {.operatorContext
+               = {.toApply = {.predicateSet = std::move(predicateSet), .fields = fields},
+                  .pushed = {},
+                  .hasMultipleParents = hasMultipleParents},
+               .downContexts = {}};
     }
 
-    op = applyToAllChildren(op, {}, {});
-    return addSelectionIfRequired(std::move(op), std::move(predicateSet), fields);
+    downResult.operatorContext.hasMultipleParents = hasMultipleParents;
+
+
+    return downResult;
+}
+
+Visitor::UpResult rebuildPlan(
+    LogicalOperator op,
+    std::vector<LogicalOperator> children,
+    const OperatorContext& opContext,
+    const std::unordered_map<LogicalOperator, bool>& childWithMultipleParents)
+{
+    /// Add selections infront of children if they couldn't apply predicates because they have mutliple children
+    const auto originalChildren = op.getChildren();
+    for (size_t i = 0; i < children.size(); ++i)
+    {
+        if (childWithMultipleParents.at(children[i]) && opContext.pushed.contains(originalChildren.at(i)))
+        {
+            auto [predicates, fields] = opContext.pushed.at(originalChildren.at(i));
+            children[i] = addSelectionIfRequired(children[i], predicates, fields);
+        }
+    }
+
+    if (op.tryGetAs<SelectionLogicalOperator>())
+    {
+        INVARIANT(children.size() == 1, "selection operators can only have one child");
+        return {children.at(0), opContext.hasMultipleParents};
+    }
+
+    op = op.withChildren(children);
+    return {addSelectionIfRequired(op, opContext.toApply.predicateSet, opContext.toApply.fields), opContext.hasMultipleParents};
 }
 
 }
@@ -393,12 +482,8 @@ LogicalOperator predicatePushdown(LogicalOperator op, std::vector<LogicalFunctio
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 LogicalPlan PredicatePushdownRule::apply(const LogicalPlan& queryPlan) const
 {
-    const auto originalRoots = queryPlan.getRootOperators();
-    PRECONDITION(originalRoots.size() == 1, "predicate pushdown not yet implemented for more than one root");
-
-    auto newRoot = predicatePushdown(originalRoots.at(0), {}, {});
-
-    return queryPlan.withRootOperators({newRoot});
+    Visitor visitor{predicatePushdown, rebuildPlan};
+    return visitor.apply(queryPlan);
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Static/ProjectionPushdownRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/ProjectionPushdownRule.cpp
@@ -45,13 +45,13 @@
 #include <Plans/LogicalPlan.hpp>
 #include <Rules/Barriers/FixedPlanStructureBarrier.hpp>
 #include <Rules/Barriers/SemanticAnalysisBarrier.hpp>
+#include <Rules/PlanVisitor.hpp>
 #include <Rules/Static/PredicatePushdownRule.hpp>
 #include <Rules/Static/WatermarkAssignerPushdownRule.hpp>
 #include <Schema/Field.hpp>
 #include <WindowTypes/Measures/TimeCharacteristic.hpp>
 #include <fmt/format.h>
 #include <ErrorHandling.hpp>
-
 #include <PlanRuleRegistry.hpp>
 
 namespace NES
@@ -59,7 +59,24 @@ namespace NES
 namespace
 {
 
-LogicalOperator projectionPushdown(const LogicalOperator& op, const std::unordered_set<Field>& required);
+
+struct OperatorContext
+{
+    std::variant<
+        std::monostate,
+        std::vector<ProjectionLogicalOperator::UnboundProjection>,
+        std::vector<WindowedAggregationLogicalOperator::ProjectedAggregation>>
+        context = std::monostate{};
+};
+
+using Visitor = PlanVisitor<OperatorContext, std::unordered_set<Field>>;
+
+Visitor::DownResult projectionPushdown(const LogicalOperator& op, const std::vector<std::unordered_set<Field>>& downContexts);
+
+std::unordered_set<Field> merge(const std::vector<std::unordered_set<Field>>& downContexts)
+{
+    return downContexts | std::views::join | std::ranges::to<std::unordered_set<Field>>();
+}
 
 std::unordered_set<Field> getAccessedFields(const LogicalFunction& logicalFunction)
 {
@@ -85,7 +102,7 @@ std::vector<Field> sortFields(const std::unordered_set<Field>& fields)
     return sortedFields;
 }
 
-LogicalOperator pushBeyondSink(const TypedLogicalOperator<SinkLogicalOperator>& op)
+Visitor::DownResult pushBeyondSink(const TypedLogicalOperator<SinkLogicalOperator>& op)
 {
     /// Use identifiers from output schema as starting point for required fields.
     std::unordered_set<Field> required{};
@@ -94,19 +111,18 @@ LogicalOperator pushBeyondSink(const TypedLogicalOperator<SinkLogicalOperator>& 
         required.insert(field);
     }
 
-    auto newChild = projectionPushdown(op->getChild(), required);
-
-    return op.withChildren({newChild}).withInferredSchema();
+    return {.operatorContext = {}, .downContexts = {{op->getChild(), required}}};
 }
 
-LogicalOperator pushBeyondSource(TypedLogicalOperator<SourceDescriptorLogicalOperator> op, std::unordered_set<Field> required)
+Visitor::DownResult
+pushBeyondSource(const TypedLogicalOperator<SourceDescriptorLogicalOperator>& op, const std::unordered_set<Field>& required)
 {
     /// Recursion stop. Add projection if required is a strict subset of output schema.
 
     /// Preserve the input schema for constant-only projections.
     if (required.empty())
     {
-        return op;
+        return {};
     }
 
     const auto allFieldsAreRequired
@@ -122,13 +138,13 @@ LogicalOperator pushBeyondSource(TypedLogicalOperator<SourceDescriptorLogicalOpe
         {
             projections.emplace_back(field.getLastName(), UnboundFieldAccessLogicalFunction{field.getLastName()});
         }
-
-        return TypedLogicalOperator<ProjectionLogicalOperator>{op, projections, ProjectionLogicalOperator::Asterisk{false}};
+        return {.operatorContext{std::move(projections)}, .downContexts = {}};
     }
-    return op;
+
+    return {};
 }
 
-LogicalOperator pushBeyondSelection(const TypedLogicalOperator<SelectionLogicalOperator>& op, const std::unordered_set<Field>& required)
+Visitor::DownResult pushBeyondSelection(const TypedLogicalOperator<SelectionLogicalOperator>& op, const std::unordered_set<Field>& required)
 {
     /// Add accessed identifiers in predicate if necessary
 
@@ -140,11 +156,11 @@ LogicalOperator pushBeyondSelection(const TypedLogicalOperator<SelectionLogicalO
         newRequired.insert(newField.value());
     }
 
-    auto child = projectionPushdown(op->getChild(), newRequired);
-    return op.withChildren({child}).withInferredSchema();
+    return {.operatorContext = {}, .downContexts = {{op->getChild(), newRequired}}};
 }
 
-LogicalOperator pushBeyondProjection(const TypedLogicalOperator<ProjectionLogicalOperator>& op, const std::unordered_set<Field>& required)
+Visitor::DownResult
+pushBeyondProjection(const TypedLogicalOperator<ProjectionLogicalOperator>& op, const std::unordered_set<Field>& required)
 {
     /// remove unnecessary projections, replace required identifiers via accessed fields from remaining projections
 
@@ -181,11 +197,10 @@ LogicalOperator pushBeyondProjection(const TypedLogicalOperator<ProjectionLogica
         }
     }
 
-    auto newChild = projectionPushdown(op->getChild(), newRequired);
-    return TypedLogicalOperator<ProjectionLogicalOperator>{newChild, newProjections, ProjectionLogicalOperator::Asterisk{false}};
+    return {.operatorContext = {std::move(newProjections)}, .downContexts = {{op->getChild(), newRequired}}};
 }
 
-LogicalOperator pushBeyondJoin(const TypedLogicalOperator<JoinLogicalOperator>& op, const std::unordered_set<Field>& required)
+Visitor::DownResult pushBeyondJoin(const TypedLogicalOperator<JoinLogicalOperator>& op, const std::unordered_set<Field>& required)
 {
     /// Add accessed identifiers in join predicate if necessary
     /// Apply recursion to both children, each with the relevant subset of required fields that come from the individual child
@@ -259,19 +274,19 @@ LogicalOperator pushBeyondJoin(const TypedLogicalOperator<JoinLogicalOperator>& 
         }
     }
 
+    std::unordered_map<LogicalOperator, std::unordered_set<Field>> downContexts;
 
-    auto newLeft = projectionPushdown(left, requiredLeft);
-    auto newRight = projectionPushdown(right, requiredRight);
+    downContexts[left] = std::move(requiredLeft);
+    downContexts[right] = std::move(requiredRight);
 
-    return TypedLogicalOperator<JoinLogicalOperator>{
-        std::array{newLeft, newRight}, predicate, op->getWindowType(), op->getJoinType(), op->getJoinTimeCharacteristics()};
+    return {.operatorContext = {}, .downContexts = std::move(downContexts)};
 }
 
-LogicalOperator pushBeyondUnion(const TypedLogicalOperator<UnionLogicalOperator>& op, const std::unordered_set<Field>& required)
+Visitor::DownResult pushBeyondUnion(const TypedLogicalOperator<UnionLogicalOperator>& op, const std::unordered_set<Field>& required)
 {
     /// no new required fields are added in union operator
 
-    std::vector<LogicalOperator> newChildren;
+    std::unordered_map<LogicalOperator, std::unordered_set<Field>> downContexts;
     for (const auto& child : op->getChildren())
     {
         std::unordered_set<Field> newRequired;
@@ -281,13 +296,13 @@ LogicalOperator pushBeyondUnion(const TypedLogicalOperator<UnionLogicalOperator>
             INVARIANT(newField.has_value(), "the given field must be available in the plan");
             newRequired.insert(newField.value());
         }
-        newChildren.emplace_back(projectionPushdown(child, newRequired));
+        downContexts[child] = newRequired;
     }
 
-    return op.withChildren(newChildren).withInferredSchema();
+    return {.operatorContext = {}, .downContexts = downContexts};
 }
 
-LogicalOperator pushBeyondEventTimeWatermarkAssigner(
+Visitor::DownResult pushBeyondEventTimeWatermarkAssigner(
     const TypedLogicalOperator<EventTimeWatermarkAssignerLogicalOperator>& op, const std::unordered_set<Field>& required)
 {
     /// Add eventTime field if necessary
@@ -300,11 +315,10 @@ LogicalOperator pushBeyondEventTimeWatermarkAssigner(
         newRequired.insert(newField.value());
     }
 
-    auto newChild = projectionPushdown(op->getChild(), newRequired);
-    return op.withChildren({newChild}).withInferredSchema();
+    return {.operatorContext = {}, .downContexts = {{op->getChild(), newRequired}}};
 }
 
-LogicalOperator pushBeyondIngestionTimeWatermarkAssigner(
+Visitor::DownResult pushBeyondIngestionTimeWatermarkAssigner(
     const TypedLogicalOperator<IngestionTimeWatermarkAssignerLogicalOperator>& op, const std::unordered_set<Field>& required)
 {
     /// No new required fields are added in ingestion time watermark assigner operator.
@@ -317,11 +331,10 @@ LogicalOperator pushBeyondIngestionTimeWatermarkAssigner(
         newRequired.insert(newField.value());
     }
 
-    auto newChild = projectionPushdown(op->getChild(), newRequired);
-    return op.withChildren({newChild}).withInferredSchema();
+    return {.operatorContext = {}, .downContexts = {{op->getChild(), newRequired}}};
 }
 
-LogicalOperator
+Visitor::DownResult
 pushBeyondWindowedAggregation(const TypedLogicalOperator<WindowedAggregationLogicalOperator>& op, const std::unordered_set<Field>& required)
 {
     /// Add grouping keys if necessary and remove aggregations that are not accessed later
@@ -394,19 +407,17 @@ pushBeyondWindowedAggregation(const TypedLogicalOperator<WindowedAggregationLogi
         }
     }
 
-    auto newChild = projectionPushdown(op->getChild(), newRequired);
 
-    return TypedLogicalOperator<WindowedAggregationLogicalOperator>{
-        newChild, op->getGroupingKeysWithName(), newAggregations, op->getWindowType(), op->getCharacteristic()};
+    return {.operatorContext = {newAggregations}, .downContexts = {{op->getChild(), newRequired}}};
 }
 
-LogicalOperator pushBeyondDefault(const LogicalOperator& op, const std::unordered_set<Field>& required)
+Visitor::DownResult pushBeyondDefault(const LogicalOperator& op, const std::unordered_set<Field>& required)
 {
     /// Default behavior if concrete operator is not explicitly handled above.
     /// New projection with all required fields is added.
     /// Recursion is restarted for all children with full set of their output schemas.
 
-    std::vector<LogicalOperator> newChildren;
+    std::unordered_map<LogicalOperator, std::unordered_set<Field>> downContext;
 
     for (const auto& child : op.getChildren())
     {
@@ -415,23 +426,24 @@ LogicalOperator pushBeyondDefault(const LogicalOperator& op, const std::unordere
         {
             newRequired.insert(field);
         }
-        newChildren.push_back(projectionPushdown(child, newRequired));
+        downContext[child] = newRequired;
     }
 
-    auto newOp = op.withChildren(newChildren).withInferredSchema();
 
     std::vector<ProjectionLogicalOperator::UnboundProjection> newProjections;
     for (const auto& field : required)
     {
-        auto function = FieldAccessLogicalFunction{Field(newOp, field.getLastName(), field.getDataType())};
+        auto function = UnboundFieldAccessLogicalFunction{field.getLastName()};
         newProjections.emplace_back(field.getLastName(), function);
     }
 
-    return TypedLogicalOperator<ProjectionLogicalOperator>{newOp, newProjections, ProjectionLogicalOperator::Asterisk{false}};
+    return {.operatorContext = {std::move(newProjections)}, .downContexts = std::move(downContext)};
 }
 
-LogicalOperator projectionPushdown(const LogicalOperator& op, const std::unordered_set<Field>& required)
+Visitor::DownResult projectionPushdown(const LogicalOperator& op, const std::vector<std::unordered_set<Field>>& downContexts)
 {
+    auto required = merge(downContexts);
+
     if (auto sinkOp = op.tryGetAs<SinkLogicalOperator>())
     {
         return pushBeyondSink(sinkOp.value());
@@ -470,16 +482,58 @@ LogicalOperator projectionPushdown(const LogicalOperator& op, const std::unorder
     }
     return pushBeyondDefault(op, required);
 }
+
+Visitor::UpResult rebuildPlan(LogicalOperator op, std::vector<LogicalOperator> children, const OperatorContext& context)
+{
+    if (op.tryGetAs<ProjectionLogicalOperator>())
+    {
+        PRECONDITION(
+            std::holds_alternative<std::vector<ProjectionLogicalOperator::UnboundProjection>>(context.context),
+            "OperatorContext must contain UnboundProjections");
+        auto projections = std::get<std::vector<ProjectionLogicalOperator::UnboundProjection>>(context.context);
+
+        LogicalOperator newProjection
+            = TypedLogicalOperator<ProjectionLogicalOperator>{children.at(0), projections, ProjectionLogicalOperator::Asterisk{false}};
+        return newProjection;
+    }
+    if (const auto windowedAggregationOp = op.tryGetAs<WindowedAggregationLogicalOperator>())
+    {
+        PRECONDITION(
+            std::holds_alternative<std::vector<WindowedAggregationLogicalOperator::ProjectedAggregation>>(context.context),
+            "OperatorContext must contain ProjectedAggregations");
+        auto aggregations = std::get<std::vector<WindowedAggregationLogicalOperator::ProjectedAggregation>>(context.context);
+        const auto& windowedAggregation = windowedAggregationOp.value();
+        LogicalOperator newOp = TypedLogicalOperator<WindowedAggregationLogicalOperator>{
+            children.at(0),
+            windowedAggregation->getGroupingKeysWithName(),
+            aggregations,
+            windowedAggregation->getWindowType(),
+            windowedAggregation->getCharacteristic()};
+
+        return newOp;
+    }
+    if (op.tryGetAs<SourceDescriptorLogicalOperator>())
+    {
+        if (!std::holds_alternative<std::vector<ProjectionLogicalOperator::UnboundProjection>>(context.context))
+        {
+            return op;
+        }
+        auto projections = std::get<std::vector<ProjectionLogicalOperator::UnboundProjection>>(context.context);
+        LogicalOperator newSource
+            = TypedLogicalOperator<ProjectionLogicalOperator>{op, projections, ProjectionLogicalOperator::Asterisk{false}};
+        return newSource;
+    }
+    return op.withChildren(children);
+}
+
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 LogicalPlan ProjectionPushdownRule::apply(LogicalPlan queryPlan) const
 {
-    const auto originalRoots = queryPlan.getRootOperators();
-    PRECONDITION(originalRoots.size() == 1, "projection pushdown not yet implemented for more than one root");
-    auto newRoot = projectionPushdown(originalRoots.at(0), {});
-    queryPlan = queryPlan.withRootOperators({newRoot});
-    return queryPlan;
+    Visitor visitor{projectionPushdown, rebuildPlan};
+
+    return visitor.apply(std::move(queryPlan));
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/src/Rules/Static/RedundantProjectionRemovalRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/RedundantProjectionRemovalRule.cpp
@@ -30,6 +30,7 @@
 #include <Plans/LogicalPlan.hpp>
 #include <Rules/Barriers/FixedPlanStructureBarrier.hpp>
 #include <Rules/Barriers/SemanticAnalysisBarrier.hpp>
+#include <Rules/PlanVisitor.hpp>
 #include <Rules/Static/ProjectionPushdownRule.hpp>
 #include <Schema/Binder.hpp>
 #include <ErrorHandling.hpp>
@@ -58,10 +59,8 @@ std::set<std::type_index> RedundantProjectionRemovalRule::needs() const
 
 namespace
 {
-LogicalOperator recur(const LogicalOperator& op)
+PlanVisitor<>::UpResult removeRedundantProjections(const LogicalOperator& op, const std::vector<LogicalOperator>& children)
 {
-    auto newChildren = op.getChildren() | std::views::transform(recur) | std::ranges::to<std::vector>();
-
     if (const auto projection = op.tryGetAs<ProjectionLogicalOperator>())
     {
         const auto trivial = [&]
@@ -83,19 +82,18 @@ LogicalOperator recur(const LogicalOperator& op)
         }();
         if (trivial)
         {
-            return newChildren.front();
+            return children.at(0);
         }
     }
-    return op.withChildren(std::move(newChildren));
+    return op.withChildren(children);
 }
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 LogicalPlan RedundantProjectionRemovalRule::apply(LogicalPlan queryPlan) const
 {
-    PRECONDITION(queryPlan.getRootOperators().size() == 1, "Query plan must have exactly one root operator");
-    queryPlan = queryPlan.withRootOperators({recur(queryPlan.getRootOperators().front().withInferredSchema())});
-    return queryPlan;
+    PlanVisitor<> visitor{removeRedundantProjections};
+    return visitor.apply(std::move(queryPlan));
 }
 
 /// NOLINTNEXTLINE(performance-unnecessary-value-param)

--- a/nes-query-optimizer/src/Rules/Static/WatermarkAssignerPushdownRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/WatermarkAssignerPushdownRule.cpp
@@ -13,11 +13,13 @@
 */
 #include <Rules/Static/WatermarkAssignerPushdownRule.hpp>
 
+#include <cstddef>
 #include <ranges>
 #include <set>
 #include <string_view>
 #include <typeindex>
 #include <typeinfo>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -36,6 +38,7 @@
 #include <Plans/LogicalPlan.hpp>
 #include <Rules/Barriers/FixedPlanStructureBarrier.hpp>
 #include <Rules/Barriers/SemanticAnalysisBarrier.hpp>
+#include <Rules/PlanVisitor.hpp>
 #include <Rules/Static/PredicatePushdownRule.hpp>
 #include <Schema/Field.hpp>
 #include <ErrorHandling.hpp>
@@ -45,8 +48,32 @@ namespace NES
 {
 namespace
 {
-LogicalOperator
-watermarkAssignerPushdown(const LogicalOperator& op, bool ingestionTime, std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime);
+
+struct RequiredWatermarkAssigners
+{
+    bool ingestionTime = false;
+    std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime;
+};
+
+struct OperatorContext
+{
+    RequiredWatermarkAssigners toApply;
+    std::unordered_map<LogicalOperator, RequiredWatermarkAssigners> pushed;
+    bool hasMultipleParents = false;
+};
+
+using Visitor = PlanVisitor<OperatorContext, RequiredWatermarkAssigners, bool>;
+
+Visitor::DownResult watermarkAssignerPushdown(const LogicalOperator& op, const std::vector<RequiredWatermarkAssigners>& contexts);
+
+RequiredWatermarkAssigners mergeContexts(const std::vector<RequiredWatermarkAssigners>& contexts)
+{
+    if (contexts.empty() || contexts.size() > 1)
+    {
+        return {};
+    }
+    return contexts.at(0);
+}
 
 LogicalOperator
 addWatermarkAssigners(LogicalOperator op, const bool ingestionTime, std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime)
@@ -80,50 +107,45 @@ fieldsWithNewBase(const LogicalOperator& base, std::vector<std::pair<Field, Wind
     return eventTime;
 }
 
-LogicalOperator
-applyToAllChildren(const LogicalOperator& op, const bool ingestionTime, const std::vector<std::pair<Field, Windowing::TimeUnit>>& eventTime)
+std::unordered_map<LogicalOperator, RequiredWatermarkAssigners>
+getChildContexts(const LogicalOperator& op, const RequiredWatermarkAssigners& context)
 {
-    std::vector<LogicalOperator> children;
+    std::unordered_map<LogicalOperator, RequiredWatermarkAssigners> childContexts;
+
     for (const auto& child : op.getChildren())
     {
-        const auto childEventTime = fieldsWithNewBase(child, eventTime);
-        auto newChild = watermarkAssignerPushdown(child, ingestionTime, childEventTime);
-        children.push_back(newChild);
+        const RequiredWatermarkAssigners childContext{
+            .ingestionTime = context.ingestionTime, .eventTime = fieldsWithNewBase(child, context.eventTime)};
+        childContexts.emplace(child, childContext);
     }
-    return op.withChildren(children).withInferredSchema();
+    return childContexts;
 }
 
-LogicalOperator pushBeyondSink(const TypedLogicalOperator<SinkLogicalOperator>& op)
+Visitor::DownResult pushBeyondSink(const TypedLogicalOperator<SinkLogicalOperator>& op)
 {
-    /// Sinks are the starting point of the recursion.
-    /// Because they don't have parents, no watermark assigner
-    /// has to be pushed here.
-    /// The recursion starts thus with an empty event time watermark assigner set,
-    /// and no ingestion time watermark assigner.
-    auto newChild = watermarkAssignerPushdown(op->getChild(), {}, {});
-    return op->withChildren({newChild}).withInferredSchema();
+    std::unordered_map<LogicalOperator, RequiredWatermarkAssigners> pushed = {{op->getChild(), {.ingestionTime = false, .eventTime = {}}}};
+    OperatorContext operatorContext{.toApply = {}, .pushed = pushed};
+    return {.operatorContext = std::move(operatorContext), .downContexts = std::move(pushed)};
 }
 
-LogicalOperator pushBeyondSource(
-    const TypedLogicalOperator<SourceDescriptorLogicalOperator>& op,
-    bool ingestionTime,
-    std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime)
+Visitor::DownResult pushBeyondSource(RequiredWatermarkAssigners context)
 {
-    return addWatermarkAssigners(op, std::move(ingestionTime), std::move(eventTime));
+    OperatorContext operatorContext{.toApply = std::move(context), .pushed = {}};
+    return {.operatorContext = std::move(operatorContext), .downContexts = {}};
 }
 
-LogicalOperator pushBeyondTransparentOperator(
-    const LogicalOperator& op, bool ingestionTime, const std::vector<std::pair<Field, Windowing::TimeUnit>>& eventTime)
+Visitor::DownResult pushBeyondTransparentOperator(const LogicalOperator& op, const RequiredWatermarkAssigners& context)
 {
     /// Pushes watermark assigners beyond operators that do not affect the
     /// watermark assigners.
-    return applyToAllChildren(op, std::move(ingestionTime), eventTime);
+
+    auto pushed = getChildContexts(op, context);
+    OperatorContext operatorContext{.toApply = {}, .pushed = pushed};
+    return {.operatorContext = std::move(operatorContext), .downContexts = std::move(pushed)};
 }
 
-LogicalOperator pushBeyondProjection(
-    const TypedLogicalOperator<ProjectionLogicalOperator>& op,
-    bool ingestionTime,
-    const std::vector<std::pair<Field, Windowing::TimeUnit>>& eventTime)
+Visitor::DownResult
+pushBeyondProjection(const TypedLogicalOperator<ProjectionLogicalOperator>& op, const RequiredWatermarkAssigners& context)
 {
     /// test if event time fields are generated by projection.
     /// If not, they are pushed further.
@@ -157,7 +179,7 @@ LogicalOperator pushBeyondProjection(
     std::vector<std::pair<Field, Windowing::TimeUnit>> pushFurther{};
     std::vector<std::pair<Field, Windowing::TimeUnit>> applyNow{};
 
-    for (const auto& [onField, unit] : eventTime)
+    for (const auto& [onField, unit] : context.eventTime)
     {
         auto pushable = pushableFields.contains(onField);
         if (pushable)
@@ -170,21 +192,13 @@ LogicalOperator pushBeyondProjection(
         }
     }
 
-    auto newOp = applyToAllChildren(op, ingestionTime, pushFurther);
-
-    for (const auto& [onField, unit] : std::ranges::reverse_view(applyNow))
-    {
-        auto field = newOp.getOutputSchema()[onField.getLastName()];
-        PRECONDITION(field.has_value(), "the operator must have the event time field");
-        newOp = TypedLogicalOperator<EventTimeWatermarkAssignerLogicalOperator>(newOp, FieldAccessLogicalFunction{field.value()}, unit);
-    }
-    return newOp;
+    auto pushed = getChildContexts(op, {.ingestionTime = context.ingestionTime, .eventTime = pushFurther});
+    OperatorContext operatorContext{.toApply = {.ingestionTime = false, .eventTime = applyNow}, .pushed = pushed};
+    return {.operatorContext = std::move(operatorContext), .downContexts = std::move(pushed)};
 }
 
-LogicalOperator pushBeyondEventTimeWatermarkAssigner(
-    const TypedLogicalOperator<EventTimeWatermarkAssignerLogicalOperator>& op,
-    const bool ingestionTime,
-    std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime)
+Visitor::DownResult pushBeyondEventTimeWatermarkAssigner(
+    const TypedLogicalOperator<EventTimeWatermarkAssignerLogicalOperator>& op, RequiredWatermarkAssigners context)
 {
     /// Adds relevant metadata to eventTime variable to push the assigner further down if possible
     /// Does not push event time water mark assigners that don't use a FieldAccessLogicalFunction.
@@ -194,61 +208,109 @@ LogicalOperator pushBeyondEventTimeWatermarkAssigner(
         "EventTime watermark assigner onField must be a FieldAccessLogicalFunction");
 
     const auto fieldAccess = op->getOnField().tryGetAs<FieldAccessLogicalFunction>();
-    eventTime = fieldsWithNewBase(op->getChild(), eventTime);
-    eventTime.emplace_back(fieldAccess.value()->getField(), op->getUnit());
-    return watermarkAssignerPushdown(op->getChild(), ingestionTime, eventTime);
+    context.eventTime = fieldsWithNewBase(op->getChild(), context.eventTime);
+
+    /// NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+    context.eventTime.emplace_back(fieldAccess.value()->getField(), op->getUnit());
+
+    std::unordered_map<LogicalOperator, RequiredWatermarkAssigners> pushed{{op->getChild(), context}};
+    OperatorContext operatorContext{.toApply = {}, .pushed = pushed};
+
+    return {.operatorContext = std::move(operatorContext), .downContexts = std::move(pushed)};
 }
 
-LogicalOperator pushBeyondIngestionTimeWatermarkAssigner(
-    const TypedLogicalOperator<IngestionTimeWatermarkAssignerLogicalOperator>& op,
-    bool /* ingestionTime */,
-    std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime)
+Visitor::DownResult pushBeyondIngestionTimeWatermarkAssigner(
+    const TypedLogicalOperator<IngestionTimeWatermarkAssignerLogicalOperator>& op, RequiredWatermarkAssigners context)
 {
     /// Adds flag that a ingestion time watermark assigner is required
 
-    eventTime = fieldsWithNewBase(op->getChild(), eventTime);
-    return watermarkAssignerPushdown(op->getChild(), true, eventTime);
+    context.eventTime = fieldsWithNewBase(op->getChild(), context.eventTime);
+
+    std::unordered_map<LogicalOperator, RequiredWatermarkAssigners> pushed{
+        {op->getChild(), {.ingestionTime = true, .eventTime = context.eventTime}}};
+    OperatorContext operatorContext{.toApply = {}, .pushed = pushed};
+
+    return {.operatorContext = std::move(operatorContext), .downContexts = std::move(pushed)};
 }
 
-LogicalOperator
-pushBeyondDefault(const LogicalOperator& op, const bool ingestionTime, std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime)
+Visitor::DownResult pushBeyondDefault(const LogicalOperator& op, RequiredWatermarkAssigners context)
 {
     /// Implements default behavior if operator is not explicitly handled.
     /// Applies all watermark assigners and restarts recursion for all children.
-    auto newOp = applyToAllChildren(op, false, {});
-    return addWatermarkAssigners(std::move(newOp), ingestionTime, std::move(eventTime));
+
+    std::unordered_map<LogicalOperator, RequiredWatermarkAssigners> pushed = getChildContexts(op, {});
+    OperatorContext operatorContext{.toApply = std::move(context), .pushed = pushed};
+
+    return {.operatorContext = std::move(operatorContext), .downContexts = std::move(pushed)};
 }
 
-LogicalOperator
-watermarkAssignerPushdown(const LogicalOperator& op, bool ingestionTime, std::vector<std::pair<Field, Windowing::TimeUnit>> eventTime)
+Visitor::DownResult watermarkAssignerPushdown(const LogicalOperator& op, const std::vector<RequiredWatermarkAssigners>& downContexts)
 {
+    const bool hasMultipleParents = downContexts.size() > 1;
+
+    Visitor::DownResult downResult;
+
+    auto context = mergeContexts(downContexts);
+
     if (const auto sink = op.tryGetAs<SinkLogicalOperator>())
     {
-        return pushBeyondSink(sink.value());
+        downResult = pushBeyondSink(sink.value());
     }
-    if (const auto source = op.tryGetAs<SourceDescriptorLogicalOperator>())
+    else if (const auto source = op.tryGetAs<SourceDescriptorLogicalOperator>())
     {
-        return pushBeyondSource(source.value(), std::move(ingestionTime), std::move(eventTime));
+        downResult = pushBeyondSource(context);
     }
-    if (const auto eventTimeWA = op.tryGetAs<EventTimeWatermarkAssignerLogicalOperator>())
+    else if (const auto eventTimeWA = op.tryGetAs<EventTimeWatermarkAssignerLogicalOperator>())
     {
-        return pushBeyondEventTimeWatermarkAssigner(eventTimeWA.value(), std::move(ingestionTime), std::move(eventTime));
+        downResult = pushBeyondEventTimeWatermarkAssigner(eventTimeWA.value(), std::move(context));
     }
-    if (const auto ingestionTimeWatermarkAssigner = op.tryGetAs<IngestionTimeWatermarkAssignerLogicalOperator>())
+    else if (const auto ingestionTimeWatermarkAssigner = op.tryGetAs<IngestionTimeWatermarkAssignerLogicalOperator>())
     {
-        return pushBeyondIngestionTimeWatermarkAssigner(
-            ingestionTimeWatermarkAssigner.value(), std::move(ingestionTime), std::move(eventTime));
+        downResult = pushBeyondIngestionTimeWatermarkAssigner(ingestionTimeWatermarkAssigner.value(), std::move(context));
     }
-    if (op.tryGetAs<SelectionLogicalOperator>().has_value() || op.tryGetAs<UnionLogicalOperator>().has_value())
+    else if (op.tryGetAs<SelectionLogicalOperator>().has_value() || op.tryGetAs<UnionLogicalOperator>().has_value())
     {
-        return pushBeyondTransparentOperator(op, std::move(ingestionTime), eventTime);
+        downResult = pushBeyondTransparentOperator(op, context);
     }
-    if (const auto projOp = op.tryGetAs<ProjectionLogicalOperator>())
+    else if (const auto projOp = op.tryGetAs<ProjectionLogicalOperator>())
     {
-        return pushBeyondProjection(projOp.value(), std::move(ingestionTime), eventTime);
+        downResult = pushBeyondProjection(projOp.value(), context);
+    }
+    else
+    {
+        downResult = pushBeyondDefault(op, std::move(context));
     }
 
-    return pushBeyondDefault(op, std::move(ingestionTime), std::move(eventTime));
+    downResult.operatorContext.hasMultipleParents = hasMultipleParents;
+
+    return downResult;
+}
+
+Visitor::UpResult rebuildPlan(
+    LogicalOperator op,
+    std::vector<LogicalOperator> children,
+    OperatorContext context,
+    const std::unordered_map<LogicalOperator, bool>& childWithMultipleParents)
+{
+    const auto originalChildren = op.getChildren();
+    for (size_t i = 0; i < children.size(); ++i)
+    {
+        if (childWithMultipleParents.at(children[i]) && context.pushed.contains(originalChildren[i]))
+        {
+            auto [ingestionTime, eventTime] = context.pushed.at(originalChildren.at(i));
+            children[i] = addWatermarkAssigners(children[i], ingestionTime, std::move(eventTime));
+        }
+    }
+
+    if (op.tryGetAs<IngestionTimeWatermarkAssignerLogicalOperator>().has_value()
+        || op.tryGetAs<EventTimeWatermarkAssignerLogicalOperator>().has_value())
+    {
+        PRECONDITION(children.size() == 1, "WatermarkAssigners can only have one child");
+        return {children[0], {}};
+    }
+
+    op = op.withChildren(children);
+    return {addWatermarkAssigners(op, context.toApply.ingestionTime, std::move(context.toApply.eventTime)), context.hasMultipleParents};
 }
 
 }
@@ -256,11 +318,8 @@ watermarkAssignerPushdown(const LogicalOperator& op, bool ingestionTime, std::ve
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 LogicalPlan WatermarkAssignerPushdownRule::apply(LogicalPlan queryPlan) const
 {
-    auto originalRoots = queryPlan.getRootOperators();
-    PRECONDITION(originalRoots.size() == 1, "watermark pushdown not yet implemented for more than one root");
-    auto newRoot = watermarkAssignerPushdown(originalRoots.at(0), false, {});
-    queryPlan = queryPlan.withRootOperators({newRoot});
-    return queryPlan;
+    Visitor visitor{watermarkAssignerPushdown, rebuildPlan};
+    return visitor.apply(std::move(queryPlan));
 }
 
 /// NOLINTNEXTLINE(readability-convert-member-functions-to-static)

--- a/nes-query-optimizer/tests/Rules/CMakeLists.txt
+++ b/nes-query-optimizer/tests/Rules/CMakeLists.txt
@@ -13,3 +13,4 @@
 add_subdirectory(Static)
 
 add_nes_optimizer_test(RuleManagerTest RuleManagerTest.cpp)
+add_nes_optimizer_test(PlanVisitorTest PlanVisitorTest.cpp)

--- a/nes-query-optimizer/tests/Rules/PlanVisitorTest.cpp
+++ b/nes-query-optimizer/tests/Rules/PlanVisitorTest.cpp
@@ -1,0 +1,222 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Rules/PlanVisitor.hpp>
+
+#include <algorithm>
+#include <ranges>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <DataTypes/DataType.hpp>
+#include <Functions/BooleanFunctions/EqualsLogicalFunction.hpp>
+#include <Functions/ConstantValueLogicalFunction.hpp>
+#include <Functions/FieldAccessLogicalFunction.hpp>
+#include <Identifiers/Identifier.hpp>
+#include <Identifiers/Identifiers.hpp>
+#include <Operators/LogicalOperator.hpp>
+#include <Operators/LogicalOperatorFwd.hpp>
+#include <Operators/SelectionLogicalOperator.hpp>
+#include <Operators/Sinks/SinkLogicalOperator.hpp>
+#include <Operators/Sources/SourceDescriptorLogicalOperator.hpp>
+#include <Operators/UnionLogicalOperator.hpp>
+#include <Plans/LogicalPlan.hpp>
+#include <Util/Logger/LogLevel.hpp>
+#include <Util/Logger/impl/NesLogger.hpp>
+#include <gtest/gtest.h>
+#include <BaseUnitTest.hpp>
+#include <ErrorHandling.hpp>
+#include <OptimizerTestUtils.hpp>
+
+namespace NES
+{
+/// NOLINTBEGIN(bugprone-unchecked-optional-access)
+class PlanVisitorTest : public Testing::BaseUnitTest
+{
+public:
+    static void SetUpTestSuite() { Logger::setupLogging("PlanVisitorTest.log", LogLevel::LOG_DEBUG); }
+
+    OptimizerTestUtils utils;
+};
+
+namespace
+{
+
+using TestVisitor = PlanVisitor<int, int, int>;
+
+TypedLogicalOperator<SelectionLogicalOperator> createSelection(const LogicalOperator& child, const std::string& value)
+{
+    return SelectionLogicalOperator::create(
+        child,
+        EqualsLogicalFunction{
+            FieldAccessLogicalFunction{child.getOutputSchema()[Identifier::parse("a")].value()},
+            ConstantValueLogicalFunction{DataType{DataType::Type::UINT64, DataType::NULLABLE::NOT_NULLABLE}, value}});
+}
+}
+
+TEST_F(PlanVisitorTest, IdentityKeepsLinearPlanStructureAndComputesDepthTopDown)
+{
+    /// source(depth 2) < selection(depth 1) < sink(depth 0)
+    auto source = utils.createSource("linear", {"a"});
+    auto selection = createSelection(source, "0");
+    auto sink = utils.createSink(selection, "linear", {"a"});
+    auto plan = utils.createPlan(sink);
+
+    std::unordered_map<OperatorId, int> depthByOriginalId;
+
+    TestVisitor visitor{
+        [](const LogicalOperator& op, const std::vector<int>& parentDepths) -> TestVisitor::DownResult
+        {
+            int depth = 0;
+            for (auto parentDepth : parentDepths)
+            {
+                depth = std::max(depth, parentDepth);
+            }
+            std::unordered_map<LogicalOperator, int> childDepths;
+            for (const auto& child : op.getChildren())
+            {
+                childDepths.emplace(child, depth + 1);
+            }
+            return {.operatorContext = depth, .downContexts = childDepths};
+        },
+        [&depthByOriginalId](
+            const LogicalOperator& op, std::vector<LogicalOperator> newChildren, int depth, const std::unordered_map<LogicalOperator, int>&)
+            -> TestVisitor::UpResult
+        {
+            depthByOriginalId.emplace(op.getId(), depth);
+            return {op.withChildren(std::move(newChildren)), {}};
+        }};
+
+    auto result = visitor.apply(plan);
+
+    auto newSink = result.getRootOperators().at(0);
+    ASSERT_TRUE(newSink.tryGetAs<SinkLogicalOperator>());
+    auto newSelection = newSink.getChildren().at(0);
+    ASSERT_TRUE(newSelection.tryGetAs<SelectionLogicalOperator>());
+    auto newSource = newSelection.getChildren().at(0);
+    ASSERT_TRUE(newSource.tryGetAs<SourceDescriptorLogicalOperator>());
+
+    EXPECT_EQ(depthByOriginalId.at(sink.getId()), 0);
+    EXPECT_EQ(depthByOriginalId.at(selection.getId()), 1);
+    EXPECT_EQ(depthByOriginalId.at(source.getId()), 2);
+}
+
+TEST_F(PlanVisitorTest, IdentityKeepsLinearPlanStructureAndComputesDepthBottomUp)
+{
+    /// source(depth 2) < selection(depth 1) < sink(depth 0)
+    auto source = utils.createSource("linearBottomUp", {"a"});
+    auto selection = createSelection(source, "0");
+    auto sink = utils.createSink(selection, "linearBottomUp", {"a"});
+    auto plan = utils.createPlan(sink);
+
+    std::unordered_map<OperatorId, int> depthByOriginalId;
+
+    TestVisitor visitor{
+        [&depthByOriginalId](
+            const LogicalOperator& op,
+            std::vector<LogicalOperator> newChildren,
+            int,
+            std::unordered_map<LogicalOperator, int> childContexts) -> TestVisitor::UpResult
+        {
+            int depth = 0;
+
+            for (const auto& child : newChildren)
+            {
+                if (!childContexts.contains(child))
+                {
+                    throw TestException("all children must be in childContext");
+                }
+            }
+
+            for (const auto& value : childContexts | std::views::values)
+            {
+                depth = std::max(value + 1, depth);
+            }
+            depthByOriginalId.emplace(op.getId(), depth);
+            return {op.withChildren(std::move(newChildren)), depth};
+        }};
+
+    auto result = visitor.apply(plan);
+
+    auto newSink = result.getRootOperators().at(0);
+    ASSERT_TRUE(newSink.tryGetAs<SinkLogicalOperator>());
+    auto newSelection = newSink.getChildren().at(0);
+    ASSERT_TRUE(newSelection.tryGetAs<SelectionLogicalOperator>());
+    auto newSource = newSelection.getChildren().at(0);
+    ASSERT_TRUE(newSource.tryGetAs<SourceDescriptorLogicalOperator>());
+
+    EXPECT_EQ(depthByOriginalId.at(sink.getId()), 2);
+    EXPECT_EQ(depthByOriginalId.at(selection.getId()), 1);
+    EXPECT_EQ(depthByOriginalId.at(source.getId()), 0);
+}
+
+TEST_F(PlanVisitorTest, SharedSubplanIsVisitedOnceAndSharingIsPreserved)
+{
+    /// sink < union < (selection1, selection2) < shared source
+    /// The source has two parents (selection1 and selection2), so this is a genuine DAG, not a tree.
+    auto source = utils.createSource("shared", {"a"});
+    auto selection1 = createSelection(source, "0");
+    auto selection2 = createSelection(source, "1");
+    auto unionOp = UnionLogicalOperator::create(std::vector<LogicalOperator>{selection1, selection2});
+    auto sink = utils.createSink(unionOp, "shared", {"a"});
+    auto plan = utils.createPlan(sink);
+
+    int sourceVisitCount = 0;
+    int sourceParentContextCount = 0;
+
+    TestVisitor visitor{
+        [&](const LogicalOperator& op, const std::vector<int>& parentContexts) -> TestVisitor::DownResult
+        {
+            if (op.tryGetAs<SourceDescriptorLogicalOperator>())
+            {
+                ++sourceVisitCount;
+                sourceParentContextCount = static_cast<int>(parentContexts.size());
+            }
+            std::unordered_map<LogicalOperator, int> childContexts;
+            for (const auto& child : op.getChildren())
+            {
+                childContexts.emplace(child, 0);
+            }
+            return {.operatorContext = 0, .downContexts = childContexts};
+        },
+        [](const LogicalOperator& op, std::vector<LogicalOperator> newChildren, int, const std::unordered_map<LogicalOperator, int>&)
+            -> TestVisitor::UpResult { return {op.withChildren(std::move(newChildren)), {}}; }};
+
+    auto result = visitor.apply(plan);
+
+    /// fnDown must only run once for the shared source, but must see contributions from both parents.
+    EXPECT_EQ(sourceVisitCount, 1);
+    EXPECT_EQ(sourceParentContextCount, 2);
+
+    auto newSink = result.getRootOperators().at(0);
+    auto newUnion = newSink.getChildren().at(0);
+    ASSERT_TRUE(newUnion.tryGetAs<UnionLogicalOperator>());
+    auto newSelection1 = newUnion.getChildren().at(0);
+    auto newSelection2 = newUnion.getChildren().at(1);
+    ASSERT_TRUE(newSelection1.tryGetAs<SelectionLogicalOperator>());
+    ASSERT_TRUE(newSelection2.tryGetAs<SelectionLogicalOperator>());
+
+    auto newSource1 = newSelection1.getChildren().at(0);
+    auto newSource2 = newSelection2.getChildren().at(0);
+    ASSERT_TRUE(newSource1.tryGetAs<SourceDescriptorLogicalOperator>());
+    ASSERT_TRUE(newSource2.tryGetAs<SourceDescriptorLogicalOperator>());
+
+    /// The rebuilt source must be the very same instance under both parents: fnUp is expected
+    /// to run once per shared node and the result is reused, not duplicated.
+    EXPECT_EQ(newSource1, newSource2);
+}
+
+/// NOLINTEND(bugprone-unchecked-optional-access)
+}

--- a/nes-query-optimizer/tests/Rules/Static/CMakeLists.txt
+++ b/nes-query-optimizer/tests/Rules/Static/CMakeLists.txt
@@ -12,8 +12,16 @@
 
 add_nes_optimizer_test(DecideJoinTypesTest DecideJoinTypesTest.cpp)
 add_nes_optimizer_test(DecideMemoryLayoutTest DecideMemoryLayoutTest.cpp)
+add_nes_optimizer_test(DecideFieldOrderTest DecideFieldOrderTest.cpp)
 add_nes_optimizer_test(CalcTargetOrderTest CalcTargetOrderTest.cpp)
 add_nes_optimizer_test(DecideFieldMappingsTest DecideFieldMappingsTest.cpp)
+add_nes_optimizer_test(OriginIdInferenceRuleTest OriginIdInferenceRuleTest.cpp)
 add_nes_optimizer_test(PredicatePushdownTest PredicatePushdownTest.cpp)
 add_nes_optimizer_test(ProjectionPushdownRuleTest ProjectionPushdownRuleTest.cpp)
+if (ENABLE_IREE_TESTS)
+    ### InferModel is the only operator that reaches projectionPushdown's default branch
+    target_link_libraries(ProjectionPushdownRuleTest nes-inference nes-grpc)
+    target_compile_definitions(ProjectionPushdownRuleTest PRIVATE INFERENCE_TEST_DATA="${CMAKE_SOURCE_DIR}/nes-inference/tests/testdata")
+endif ()
+add_nes_optimizer_test(RedundantProjectionRemovalRuleTest RedundantProjectionRemovalRuleTest.cpp)
 add_nes_optimizer_test(WatermarkAssignerPushdownRuleTest WatermarkAssignerPushdownRuleTest.cpp)

--- a/nes-query-optimizer/tests/Rules/Static/DecideFieldOrderTest.cpp
+++ b/nes-query-optimizer/tests/Rules/Static/DecideFieldOrderTest.cpp
@@ -1,0 +1,124 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Rules/Static/DecideFieldOrder.hpp>
+
+#include <DataTypes/DataType.hpp>
+#include <Functions/BooleanFunctions/EqualsLogicalFunction.hpp>
+#include <Functions/ConstantValueLogicalFunction.hpp>
+#include <Functions/FieldAccessLogicalFunction.hpp>
+#include <Identifiers/Identifier.hpp>
+#include <Iterators/BFSIterator.hpp>
+#include <Operators/LogicalOperator.hpp>
+#include <Operators/LogicalOperatorFwd.hpp>
+#include <Operators/ProjectionLogicalOperator.hpp>
+#include <Operators/SelectionLogicalOperator.hpp>
+#include <Operators/Sinks/SinkLogicalOperator.hpp>
+#include <Operators/Sources/SourceDescriptorLogicalOperator.hpp>
+#include <Traits/FieldOrderingTrait.hpp>
+#include <Traits/TraitSet.hpp>
+#include <gtest/gtest.h>
+#include <OptimizerTestUtils.hpp>
+
+namespace NES
+{
+/// NOLINTBEGIN(bugprone-unchecked-optional-access)
+namespace
+{
+
+void assertOrderedFieldsIncludeAllOutputFields(const LogicalOperator& op)
+{
+    const auto outputSchema = op.getOutputSchema();
+    ASSERT_TRUE(op.getTraitSet().contains<FieldOrderingTrait>());
+    const auto orderedFields = op.getTraitSet().get<FieldOrderingTrait>()->getOrderedFields();
+    ASSERT_EQ(orderedFields.size(), outputSchema.size());
+    for (const auto& field : orderedFields)
+    {
+        EXPECT_TRUE(outputSchema.contains(field.getFullyQualifiedName()));
+    }
+}
+}
+
+class DecideFieldOrderTest : public ::testing::Test
+{
+public:
+    OptimizerTestUtils utils;
+};
+
+TEST_F(DecideFieldOrderTest, SingleSink)
+{
+    /// BEFORE & AFTER: Sink > Select > Source
+
+    auto source = utils.createSource("singleSink", {"a", "b"});
+    auto select = SelectionLogicalOperator::create(
+        source,
+        EqualsLogicalFunction{
+            FieldAccessLogicalFunction{source.getOutputSchema()[Identifier::parse("a")].value()},
+            ConstantValueLogicalFunction{DataType{DataType::Type::UINT64, DataType::NULLABLE::NOT_NULLABLE}, "0"}});
+    auto sink = utils.createSink(select, "singleSink", {"a", "b"});
+    auto plan = utils.createPlan(sink);
+
+    const auto result = DecideFieldOrder{}.apply(plan);
+
+    for (const auto& op : BFSRange(result.getRootOperators().at(0)))
+    {
+        if (op.tryGetAs<SinkLogicalOperator>())
+        {
+            continue;
+        }
+        assertOrderedFieldsIncludeAllOutputFields(op);
+    }
+}
+
+TEST_F(DecideFieldOrderTest, MultiSink)
+{
+    /// BEFORE (Sink1, Sink2) < Select < Source
+    /// AFTER: (Sink1 < Projection1, Sink2 < Projection2) < Select Source
+
+    auto source = utils.createSource("multiSink", {"a", "b"});
+    auto select = SelectionLogicalOperator::create(
+        source,
+        EqualsLogicalFunction{
+            FieldAccessLogicalFunction{source.getOutputSchema()[Identifier::parse("a")].value()},
+            ConstantValueLogicalFunction{DataType{DataType::Type::UINT64, DataType::NULLABLE::NOT_NULLABLE}, "0"}});
+    auto sink1 = utils.createSink(select, "multiSink1", {"a", "b"});
+    auto sink2 = utils.createSink(select, "multiSink2", {"b", "a"});
+    auto plan = utils.createPlan({sink1, sink2});
+
+    const auto result = DecideFieldOrder{}.apply(plan);
+
+
+    auto op00 = result.getRootOperators().at(0);
+    ASSERT_TRUE(op00.tryGetAs<SinkLogicalOperator>());
+    auto op01 = op00.getChildren().at(0);
+    ASSERT_TRUE(op01.tryGetAs<ProjectionLogicalOperator>());
+    auto op02 = op01.getChildren().at(0);
+    ASSERT_TRUE(op02.tryGetAs<SelectionLogicalOperator>());
+
+    auto op10 = result.getRootOperators().at(1);
+    ASSERT_TRUE(op10.tryGetAs<SinkLogicalOperator>());
+    auto op11 = op10.getChildren().at(0);
+    ASSERT_TRUE(op11.tryGetAs<ProjectionLogicalOperator>());
+    auto op12 = op11.getChildren().at(0);
+    ASSERT_TRUE(op12.tryGetAs<SelectionLogicalOperator>());
+
+    ASSERT_FALSE(op11 == op01);
+    ASSERT_TRUE(op12 == op02);
+
+    auto op3 = op12.getChildren().at(0);
+    ASSERT_TRUE(op3.tryGetAs<SourceDescriptorLogicalOperator>());
+}
+}
+
+/// NOLINTEND(bugprone-unchecked-optional-access)

--- a/nes-query-optimizer/tests/Rules/Static/OriginIdInferenceRuleTest.cpp
+++ b/nes-query-optimizer/tests/Rules/Static/OriginIdInferenceRuleTest.cpp
@@ -1,0 +1,248 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Rules/Static/OriginIdInferenceRule.hpp>
+
+#include <utility>
+#include <vector>
+
+#include <DataTypes/DataType.hpp>
+#include <Functions/BooleanFunctions/EqualsLogicalFunction.hpp>
+#include <Functions/ComparisonFunctions/GreaterLogicalFunction.hpp>
+#include <Functions/ConstantValueLogicalFunction.hpp>
+#include <Identifiers/Identifier.hpp>
+#include <Operators/IngestionTimeWatermarkAssignerLogicalOperator.hpp>
+#include <Operators/LogicalOperator.hpp>
+#include <Operators/ProjectionLogicalOperator.hpp>
+#include <Operators/SelectionLogicalOperator.hpp>
+#include <Operators/Sinks/SinkLogicalOperator.hpp>
+#include <Operators/Sources/SourceDescriptorLogicalOperator.hpp>
+#include <Operators/Windows/JoinLogicalOperator.hpp>
+#include <Plans/LogicalPlan.hpp>
+#include <Traits/OutputOriginIdsTrait.hpp>
+#include <Util/Logger/LogLevel.hpp>
+#include <Util/Logger/impl/NesLogger.hpp>
+#include <gtest/gtest.h>
+#include <BaseUnitTest.hpp>
+#include <OptimizerTestUtils.hpp>
+
+namespace NES
+{
+/// NOLINTBEGIN(bugprone-unchecked-optional-access)
+class OriginIdInferenceRuleTest : public Testing::BaseUnitTest
+{
+public:
+    static void SetUpTestSuite() { Logger::setupLogging("OriginIdInferenceRuleTest.log", LogLevel::LOG_DEBUG); }
+
+    OptimizerTestUtils utils;
+};
+
+TEST_F(OriginIdInferenceRuleTest, singleSinkTest)
+{
+    const auto source1 = utils.createSource("singleSink1", {"a", "b"});
+    const auto source2 = utils.createSource("singleSink2", {"c", "d"});
+    const auto watermark1 = IngestionTimeWatermarkAssignerLogicalOperator::create(source1);
+    const auto watermark2 = IngestionTimeWatermarkAssignerLogicalOperator::create(source2);
+    const auto join = JoinLogicalOperator::create(
+        {watermark1, watermark2},
+        EqualsLogicalFunction{
+            FieldAccessLogicalFunction{watermark1.getOutputSchema().getFieldByName(Identifier::parse("a")).value()},
+            FieldAccessLogicalFunction{watermark2.getOutputSchema().getFieldByName(Identifier::parse("c")).value()}},
+        Windowing::TimeBasedWindowType{Windowing::TumblingWindow{Windowing::TimeMeasure{0}}},
+        JoinLogicalOperator::JoinType::INNER_JOIN,
+        JoinTimeCharacteristic{});
+
+    const auto sink = utils.createSink(join, "singleSink", {"a", "b", "c", "d", "start", "end"});
+
+    const auto plan = utils.createPlan(sink);
+
+    auto optimized = OriginIdInferenceRule{}.apply(plan);
+
+    auto op1 = optimized.getRootOperators().at(0);
+    ASSERT_TRUE(op1.tryGetAs<SinkLogicalOperator>());
+    ASSERT_TRUE(op1.getTraitSet().contains<OutputOriginIdsTrait>());
+    ASSERT_EQ(op1.getTraitSet().get<OutputOriginIdsTrait>()->size(), 1);
+    ASSERT_EQ((*op1.getTraitSet().get<OutputOriginIdsTrait>())[0], OriginId{4});
+
+
+    auto op2 = op1.getChildren().at(0);
+    ASSERT_TRUE(op2.tryGetAs<JoinLogicalOperator>());
+    ASSERT_TRUE(op2.getTraitSet().contains<OutputOriginIdsTrait>());
+    ASSERT_EQ(op2.getTraitSet().get<OutputOriginIdsTrait>()->size(), 1);
+    ASSERT_EQ((*op2.getTraitSet().get<OutputOriginIdsTrait>())[0], OriginId{4});
+
+    auto leftOp3 = op2.getChildren().at(0);
+    ASSERT_TRUE(leftOp3.tryGetAs<IngestionTimeWatermarkAssignerLogicalOperator>());
+    ASSERT_TRUE(leftOp3.getTraitSet().contains<OutputOriginIdsTrait>());
+    ASSERT_EQ(leftOp3.getTraitSet().get<OutputOriginIdsTrait>()->size(), 1);
+    ASSERT_EQ((*leftOp3.getTraitSet().get<OutputOriginIdsTrait>())[0], OriginId{2});
+
+    auto leftOp4 = leftOp3.getChildren().at(0);
+    ASSERT_TRUE(leftOp4.tryGetAs<SourceDescriptorLogicalOperator>());
+    ASSERT_TRUE(leftOp4.getTraitSet().contains<OutputOriginIdsTrait>());
+    ASSERT_EQ(leftOp4.getTraitSet().get<OutputOriginIdsTrait>()->size(), 1);
+    ASSERT_EQ((*leftOp4.getTraitSet().get<OutputOriginIdsTrait>())[0], OriginId{2});
+
+    auto rightOp3 = op2.getChildren().at(1);
+    ASSERT_TRUE(rightOp3.tryGetAs<IngestionTimeWatermarkAssignerLogicalOperator>());
+    ASSERT_TRUE(rightOp3.getTraitSet().contains<OutputOriginIdsTrait>());
+    ASSERT_EQ(rightOp3.getTraitSet().get<OutputOriginIdsTrait>()->size(), 1);
+    ASSERT_EQ((*rightOp3.getTraitSet().get<OutputOriginIdsTrait>())[0], OriginId{3});
+
+    auto rightOp4 = rightOp3.getChildren().at(0);
+    ASSERT_TRUE(rightOp4.tryGetAs<SourceDescriptorLogicalOperator>());
+    ASSERT_TRUE(rightOp4.getTraitSet().contains<OutputOriginIdsTrait>());
+    ASSERT_EQ(rightOp4.getTraitSet().get<OutputOriginIdsTrait>()->size(), 1);
+    ASSERT_EQ((*rightOp4.getTraitSet().get<OutputOriginIdsTrait>())[0], OriginId{3});
+}
+
+TEST_F(OriginIdInferenceRuleTest, MultiSink)
+{
+    /// PLAN. The brackets indicate the expected OriginId
+    ///
+    ///                  sink1 [4] > select1 [4]             > watermark1 [2] > source1 [2]
+    ///                                         \           /
+    ///                                          > join1 [4]
+    ///                                         /           \
+    ///                         > projection [4]             > watermark2 [3] > source2 [3]
+    ///                        /
+    ///   sink2 [6] > join2 [6]
+    ///                        \
+    ///                         >  watermark3 [5] > source3 [5]
+
+
+    const auto source1 = utils.createSource("multiSink1", {"a", "b"});
+    const auto source2 = utils.createSource("multiSink2", {"c", "d"});
+    const auto watermark1 = IngestionTimeWatermarkAssignerLogicalOperator::create(source1);
+    const auto watermark2 = IngestionTimeWatermarkAssignerLogicalOperator::create(source2);
+    const auto join1 = JoinLogicalOperator::create(
+        {watermark1, watermark2},
+        EqualsLogicalFunction{
+            FieldAccessLogicalFunction{watermark1.getOutputSchema().getFieldByName(Identifier::parse("a")).value()},
+            FieldAccessLogicalFunction{watermark2.getOutputSchema().getFieldByName(Identifier::parse("c")).value()}},
+        Windowing::TimeBasedWindowType{Windowing::TumblingWindow{Windowing::TimeMeasure{0}}},
+        JoinLogicalOperator::JoinType::INNER_JOIN,
+        JoinTimeCharacteristic{});
+
+    const auto select1 = SelectionLogicalOperator::create(
+        join1,
+        GreaterLogicalFunction{
+            FieldAccessLogicalFunction{join1.getOutputSchema().getFieldByName(Identifier::parse("a")).value()},
+            ConstantValueLogicalFunction{DataType{DataType::Type::UINT64, DataType::NULLABLE::IS_NULLABLE}, "0"}});
+
+    const auto sink1 = utils.createSink(select1, "multiSink1", {"a", "b", "c", "d", "start", "end"});
+    const std::vector<std::pair<Identifier, LogicalFunction>> projections{
+        {Identifier::parse("a"), FieldAccessLogicalFunction{join1.getOutputSchema()[Identifier::parse("a")].value()}},
+        {Identifier::parse("b"), FieldAccessLogicalFunction{join1.getOutputSchema()[Identifier::parse("b")].value()}}};
+
+    auto projection = ProjectionLogicalOperator::create(join1, projections, ProjectionLogicalOperator::Asterisk{false});
+
+    const auto source3 = utils.createSource("multiSink3", {"e", "f"});
+    const auto watermark3 = IngestionTimeWatermarkAssignerLogicalOperator::create(source3);
+
+
+    const auto join2 = JoinLogicalOperator::create(
+        {projection, watermark3},
+        EqualsLogicalFunction{
+            FieldAccessLogicalFunction{projection.getOutputSchema().getFieldByName(Identifier::parse("a")).value()},
+            FieldAccessLogicalFunction{watermark3.getOutputSchema().getFieldByName(Identifier::parse("e")).value()}},
+        Windowing::TimeBasedWindowType{Windowing::TumblingWindow{Windowing::TimeMeasure{0}}},
+        JoinLogicalOperator::JoinType::INNER_JOIN,
+        JoinTimeCharacteristic{});
+
+    const auto sink2 = utils.createSink(join2, "multiSink2", {"a", "b", "e", "f", "start", "end"});
+
+
+    const auto plan = utils.createPlan({sink1, sink2});
+
+    auto optimized = OriginIdInferenceRule{}.apply(plan);
+
+    auto optSink1 = optimized.getRootOperators().at(0);
+    ASSERT_TRUE(optSink1.tryGetAs<SinkLogicalOperator>());
+    ASSERT_TRUE(optSink1.getTraitSet().contains<OutputOriginIdsTrait>());
+    ASSERT_EQ(optSink1.getTraitSet().get<OutputOriginIdsTrait>()->size(), 1);
+    ASSERT_EQ((*optSink1.getTraitSet().get<OutputOriginIdsTrait>())[0], OriginId{4});
+
+    auto optSelect1 = optSink1.getChildren().at(0);
+    ASSERT_TRUE(optSelect1.tryGetAs<SelectionLogicalOperator>());
+    ASSERT_TRUE(optSelect1.getTraitSet().contains<OutputOriginIdsTrait>());
+    ASSERT_EQ(optSelect1.getTraitSet().get<OutputOriginIdsTrait>()->size(), 1);
+    ASSERT_EQ((*optSelect1.getTraitSet().get<OutputOriginIdsTrait>())[0], OriginId{4});
+
+    auto optJoin1 = optSelect1.getChildren().at(0);
+    ASSERT_TRUE(optJoin1.tryGetAs<JoinLogicalOperator>());
+    ASSERT_TRUE(optJoin1.getTraitSet().contains<OutputOriginIdsTrait>());
+    ASSERT_EQ(optJoin1.getTraitSet().get<OutputOriginIdsTrait>()->size(), 1);
+    ASSERT_EQ((*optJoin1.getTraitSet().get<OutputOriginIdsTrait>())[0], OriginId{4});
+
+    auto optWatermark1 = optJoin1.getChildren().at(0);
+    ASSERT_TRUE(optWatermark1.tryGetAs<IngestionTimeWatermarkAssignerLogicalOperator>());
+    ASSERT_TRUE(optWatermark1.getTraitSet().contains<OutputOriginIdsTrait>());
+    ASSERT_EQ(optWatermark1.getTraitSet().get<OutputOriginIdsTrait>()->size(), 1);
+    ASSERT_EQ((*optWatermark1.getTraitSet().get<OutputOriginIdsTrait>())[0], OriginId{2});
+
+    auto optSource1 = optWatermark1.getChildren().at(0);
+    ASSERT_TRUE(optSource1.tryGetAs<SourceDescriptorLogicalOperator>());
+    ASSERT_TRUE(optSource1.getTraitSet().contains<OutputOriginIdsTrait>());
+    ASSERT_EQ(optSource1.getTraitSet().get<OutputOriginIdsTrait>()->size(), 1);
+    ASSERT_EQ((*optSource1.getTraitSet().get<OutputOriginIdsTrait>())[0], OriginId{2});
+
+    auto optWatermark2 = optJoin1.getChildren().at(1);
+    ASSERT_TRUE(optWatermark2.tryGetAs<IngestionTimeWatermarkAssignerLogicalOperator>());
+    ASSERT_TRUE(optWatermark2.getTraitSet().contains<OutputOriginIdsTrait>());
+    ASSERT_EQ(optWatermark2.getTraitSet().get<OutputOriginIdsTrait>()->size(), 1);
+    ASSERT_EQ((*optWatermark2.getTraitSet().get<OutputOriginIdsTrait>())[0], OriginId{3});
+
+    auto optSource2 = optWatermark2.getChildren().at(0);
+    ASSERT_TRUE(optSource2.tryGetAs<SourceDescriptorLogicalOperator>());
+    ASSERT_TRUE(optSource2.getTraitSet().contains<OutputOriginIdsTrait>());
+    ASSERT_EQ(optSource2.getTraitSet().get<OutputOriginIdsTrait>()->size(), 1);
+    ASSERT_EQ((*optSource2.getTraitSet().get<OutputOriginIdsTrait>())[0], OriginId{3});
+
+    auto optSink2 = optimized.getRootOperators().at(1);
+    ASSERT_TRUE(optSink2.tryGetAs<SinkLogicalOperator>());
+    ASSERT_TRUE(optSink2.getTraitSet().contains<OutputOriginIdsTrait>());
+    ASSERT_EQ(optSink2.getTraitSet().get<OutputOriginIdsTrait>()->size(), 1);
+    ASSERT_EQ((*optSink2.getTraitSet().get<OutputOriginIdsTrait>())[0], OriginId{6});
+
+    auto optJoin2 = optSink2.getChildren().at(0);
+    ASSERT_TRUE(optJoin2.tryGetAs<JoinLogicalOperator>());
+    ASSERT_TRUE(optJoin2.getTraitSet().contains<OutputOriginIdsTrait>());
+    ASSERT_EQ(optJoin2.getTraitSet().get<OutputOriginIdsTrait>()->size(), 1);
+    ASSERT_EQ((*optJoin2.getTraitSet().get<OutputOriginIdsTrait>())[0], OriginId{6});
+
+    auto optProjection = optJoin2.getChildren().at(0);
+    ASSERT_TRUE(optProjection.tryGetAs<ProjectionLogicalOperator>());
+    ASSERT_TRUE(optProjection.getTraitSet().contains<OutputOriginIdsTrait>());
+    ASSERT_EQ(optProjection.getTraitSet().get<OutputOriginIdsTrait>()->size(), 1);
+    ASSERT_EQ((*optProjection.getTraitSet().get<OutputOriginIdsTrait>())[0], OriginId{4});
+
+    auto optJoin1Alt = optProjection.getChildren().at(0);
+    ASSERT_EQ(optJoin1Alt, optJoin1);
+
+    auto optWatermark3 = optJoin2.getChildren().at(1);
+    ASSERT_TRUE(optWatermark3.tryGetAs<IngestionTimeWatermarkAssignerLogicalOperator>());
+    ASSERT_TRUE(optWatermark3.getTraitSet().contains<OutputOriginIdsTrait>());
+    ASSERT_EQ(optWatermark3.getTraitSet().get<OutputOriginIdsTrait>()->size(), 1);
+    ASSERT_EQ((*optWatermark3.getTraitSet().get<OutputOriginIdsTrait>())[0], OriginId{5});
+
+    auto optSource3 = optWatermark3.getChildren().at(0);
+    ASSERT_TRUE(optSource3.tryGetAs<SourceDescriptorLogicalOperator>());
+    ASSERT_TRUE(optSource3.getTraitSet().contains<OutputOriginIdsTrait>());
+    ASSERT_EQ(optSource3.getTraitSet().get<OutputOriginIdsTrait>()->size(), 1);
+    ASSERT_EQ((*optSource3.getTraitSet().get<OutputOriginIdsTrait>())[0], OriginId{5});
+}
+
+/// NOLINTEND(bugprone-unchecked-optional-access)
+}

--- a/nes-query-optimizer/tests/Rules/Static/PredicatePushdownTest.cpp
+++ b/nes-query-optimizer/tests/Rules/Static/PredicatePushdownTest.cpp
@@ -393,5 +393,116 @@ TEST_F(PredicatePushdownTest, PushBeyondhasAsterisk)
     ASSERT_TRUE(op3.tryGetAs<SourceDescriptorLogicalOperator>());
 }
 
+TEST_F(PredicatePushdownTest, ValidateMultiSinkPlan)
+{
+    /// BEFORE: (sink1 > select (a>0) > projection, sink2 > select (b>0)) > source
+    /// AFTER: (sink1 > projection > select (a>0), sink2 > select (b>0)) > source
+
+
+    auto source = utils.createSource("multiSink", {"a", "b"});
+    auto select2 = SelectionLogicalOperator::create(
+        source,
+        GreaterEqualsLogicalFunction{
+            FieldAccessLogicalFunction{source.getOutputSchema()[Identifier::parse("b")].value()},
+            ConstantValueLogicalFunction{DataType{DataType::Type::UINT64, DataType::NULLABLE::IS_NULLABLE}, "0"}});
+    auto sink2 = utils.createSink(select2, "multiSink2", {"a", "b"});
+
+    auto projection = ProjectionLogicalOperator::create(source, {}, ProjectionLogicalOperator::Asterisk{true});
+    auto select1 = SelectionLogicalOperator::create(
+        projection,
+        GreaterEqualsLogicalFunction{
+            FieldAccessLogicalFunction{projection.getOutputSchema()[Identifier::parse("b")].value()},
+            ConstantValueLogicalFunction{DataType{DataType::Type::UINT64, DataType::NULLABLE::IS_NULLABLE}, "0"}});
+    auto sink1 = utils.createSink(select1, "multiSink1", {"a", "b"});
+
+    auto plan = utils.createPlan({sink1, sink2});
+
+    auto pushed = PredicatePushdownRule{}.apply(plan);
+
+    auto optSink1 = pushed.getRootOperators().at(0);
+    ASSERT_TRUE(optSink1.tryGetAs<SinkLogicalOperator>());
+    auto optProjection = optSink1.getChildren().at(0);
+    ASSERT_TRUE(optProjection.tryGetAs<ProjectionLogicalOperator>());
+    auto optSelect1 = optProjection.getChildren().at(0);
+    ASSERT_TRUE(optSelect1.tryGetAs<SelectionLogicalOperator>());
+    auto optSource = optSelect1.getChildren().at(0);
+    ASSERT_TRUE(optSource.tryGetAs<SourceDescriptorLogicalOperator>());
+
+    auto optSink2 = pushed.getRootOperators().at(1);
+    ASSERT_TRUE(optSink2.tryGetAs<SinkLogicalOperator>());
+    auto optSelect2 = optSink2.getChildren().at(0);
+    ASSERT_FALSE(optSelect1 == optSelect2);
+    ASSERT_TRUE(optSelect2.tryGetAs<SelectionLogicalOperator>());
+    auto optSourceAlt = optSelect2.getChildren().at(0);
+    ASSERT_EQ(optSource, optSourceAlt);
+}
+
+TEST_F(PredicatePushdownTest, SharedSourceUnderPlainSinkKeepsThatBranchUnfiltered)
+{
+    /// BEFORE: (sink1 > select (a>=0), sink2) > source
+    /// AFTER:  (sink1 > select (a>=0), sink2) > source
+    /// The source is shared, so the predicate must stay in sink1's branch and must not be folded into the source itself.
+
+    auto source = utils.createSource("sharedSinkOnly", {"a", "b"});
+    auto select = SelectionLogicalOperator::create(
+        source,
+        GreaterEqualsLogicalFunction{
+            FieldAccessLogicalFunction{source.getOutputSchema()[Identifier::parse("a")].value()},
+            ConstantValueLogicalFunction{DataType{DataType::Type::UINT64, DataType::NULLABLE::IS_NULLABLE}, "0"}});
+    auto sink1 = utils.createSink(select, "sharedSinkOnly1", {"a", "b"});
+    auto sink2 = utils.createSink(source, "sharedSinkOnly2", {"a", "b"});
+
+    auto plan = utils.createPlan({sink1, sink2});
+
+    auto pushed = PredicatePushdownRule{}.apply(plan);
+
+    auto optSink1 = pushed.getRootOperators().at(0);
+    ASSERT_TRUE(optSink1.tryGetAs<SinkLogicalOperator>());
+    auto optSelect = optSink1.getChildren().at(0);
+    ASSERT_TRUE(optSelect.tryGetAs<SelectionLogicalOperator>());
+    ASSERT_TRUE(optSelect.getChildren().at(0).tryGetAs<SourceDescriptorLogicalOperator>());
+
+    /// sink2 has no predicate of its own, so its branch must read the unfiltered source
+    auto optSink2 = pushed.getRootOperators().at(1);
+    ASSERT_TRUE(optSink2.tryGetAs<SinkLogicalOperator>());
+    ASSERT_TRUE(optSink2.getChildren().at(0).tryGetAs<SourceDescriptorLogicalOperator>());
+}
+
+TEST_F(PredicatePushdownTest, SharedSourceUnderWatermarkAssignerKeepsThatBranchUnfiltered)
+{
+    /// BEFORE: (sink1 > select (a>=0), sink2 > eventTimeWatermark) > source
+    /// AFTER:  (sink1 > select (a>=0), sink2 > eventTimeWatermark) > source
+
+    auto source = utils.createSource("sharedWatermark", {"a", "ts"});
+    auto select = SelectionLogicalOperator::create(
+        source,
+        GreaterEqualsLogicalFunction{
+            FieldAccessLogicalFunction{source.getOutputSchema()[Identifier::parse("a")].value()},
+            ConstantValueLogicalFunction{DataType{DataType::Type::UINT64, DataType::NULLABLE::IS_NULLABLE}, "0"}});
+    auto sink1 = utils.createSink(select, "sharedWatermark1", {"a", "ts"});
+
+    auto watermark = EventTimeWatermarkAssignerLogicalOperator::create(
+        source, FieldAccessLogicalFunction{source.getOutputSchema()[Identifier::parse("ts")].value()}, Windowing::TimeUnit{0});
+    auto sink2 = utils.createSink(watermark, "sharedWatermark2", {"a", "ts"});
+
+    auto plan = utils.createPlan({sink1, sink2});
+
+    std::optional<LogicalPlan> pushed;
+    ASSERT_NO_THROW(pushed.emplace(PredicatePushdownRule{}.apply(plan)));
+
+    auto optSink1 = pushed->getRootOperators().at(0);
+    ASSERT_TRUE(optSink1.tryGetAs<SinkLogicalOperator>());
+    auto optSelect = optSink1.getChildren().at(0);
+    ASSERT_TRUE(optSelect.tryGetAs<SelectionLogicalOperator>());
+    ASSERT_TRUE(optSelect.getChildren().at(0).tryGetAs<SourceDescriptorLogicalOperator>());
+
+    /// sink2's branch has no predicate of its own, so the watermark assigner must sit directly on the unfiltered source
+    auto optSink2 = pushed->getRootOperators().at(1);
+    ASSERT_TRUE(optSink2.tryGetAs<SinkLogicalOperator>());
+    auto optWatermark = optSink2.getChildren().at(0);
+    ASSERT_TRUE(optWatermark.tryGetAs<EventTimeWatermarkAssignerLogicalOperator>());
+    ASSERT_TRUE(optWatermark.getChildren().at(0).tryGetAs<SourceDescriptorLogicalOperator>());
+}
+
 /// NOLINTEND(bugprone-unchecked-optional-access)
 }

--- a/nes-query-optimizer/tests/Rules/Static/ProjectionPushdownRuleTest.cpp
+++ b/nes-query-optimizer/tests/Rules/Static/ProjectionPushdownRuleTest.cpp
@@ -13,17 +13,22 @@
 */
 
 #include <array>
+#include <filesystem>
 #include <optional>
 #include <utility>
 #include <vector>
 
 #include <DataTypes/DataType.hpp>
+#include <DataTypes/Schema.hpp>
+#include <DataTypes/SchemaFwd.hpp>
+#include <DataTypes/UnboundField.hpp>
 #include <Functions/BooleanFunctions/EqualsLogicalFunction.hpp>
 #include <Functions/ComparisonFunctions/GreaterLogicalFunction.hpp>
 #include <Functions/ConstantValueLogicalFunction.hpp>
 #include <Functions/LogicalFunction.hpp>
 #include <Identifiers/Identifier.hpp>
 #include <Operators/EventTimeWatermarkAssignerLogicalOperator.hpp>
+#include <Operators/InferModelLogicalOperator.hpp>
 #include <Operators/IngestionTimeWatermarkAssignerLogicalOperator.hpp>
 #include <Operators/LogicalOperator.hpp>
 #include <Operators/ProjectionLogicalOperator.hpp>
@@ -41,6 +46,7 @@
 #include <WindowTypes/Measures/TimeCharacteristic.hpp>
 #include <gtest/gtest.h>
 #include <BaseUnitTest.hpp>
+#include <ModelCatalog.hpp>
 #include <OptimizerTestUtils.hpp>
 
 namespace NES
@@ -495,6 +501,59 @@ TEST_F(ProjectionPushdownRuleTest, ValidateNoProjectionAddedIfFullSourceSchemaIs
     auto op2 = op1.getChildren().at(0);
     ASSERT_TRUE(op2.tryGetAs<SourceDescriptorLogicalOperator>());
 }
+
+#ifdef INFERENCE_TEST_DATA
+TEST_F(ProjectionPushdownRuleTest, UnhandledOperatorIsNarrowedToRequiredFields)
+{
+    /// PLAN BEFORE: Sink(prediction) < Project(prediction) < InferModel < Source(in_0, sibling)
+    /// PLAN AFTER:  Sink(prediction) < Project(prediction) < InferModel < Source(in_0, sibling)
+    /// InferModel is not in projectionPushdown's dispatch list, so it takes the default branch.
+    /// pushBeyondDefault computes the narrowing projection for it, so rebuildPlan has to materialize it.
+
+    ModelCatalog catalog;
+    catalog.registerModel(
+        "tiny",
+        std::filesystem::path{INFERENCE_TEST_DATA} / "tiny_1_to_1.onnx",
+        ModelSchema{
+            .inputs = ModelFieldList{UnqualifiedUnboundField{Identifier::parse("in_0"), DataType::Type::FLOAT32}},
+            .outputs = ModelFieldList{UnqualifiedUnboundField{Identifier::parse("prediction"), DataType::Type::FLOAT32}}});
+
+    auto source = utils.createSource(
+        "inferModel",
+        Schema<UnqualifiedUnboundField, Ordered>{
+            UnqualifiedUnboundField{Identifier::parse("a"), DataType::Type::FLOAT32},
+            UnqualifiedUnboundField{Identifier::parse("in_0"), DataType::Type::FLOAT32},
+            UnqualifiedUnboundField{Identifier::parse("sibling"), DataType::Type::UINT64}});
+
+    auto inferModel = TypedLogicalOperator<InferModelLogicalOperator>{catalog.load("tiny"), LogicalOperator{source}};
+
+    auto projection = ProjectionLogicalOperator::create(
+        inferModel,
+        std::vector<std::pair<Identifier, LogicalFunction>>{
+            {Identifier::parse("prediction"),
+             FieldAccessLogicalFunction{inferModel.getOutputSchema()[Identifier::parse("prediction")].value()}}},
+        ProjectionLogicalOperator::Asterisk{false});
+
+    auto sink = utils.createSink(
+        projection,
+        "inferModel",
+        Schema<UnqualifiedUnboundField, Ordered>{UnqualifiedUnboundField{Identifier::parse("prediction"), DataType::Type::FLOAT32}});
+    auto plan = utils.createPlan(sink);
+
+    auto pushed = ProjectionPushdownRule{}.apply(plan);
+
+    auto op0 = pushed.getRootOperators().at(0);
+    ASSERT_TRUE(op0.tryGetAs<SinkLogicalOperator>());
+    auto op1 = op0.getChildren().at(0);
+    ASSERT_TRUE(op1.tryGetAs<ProjectionLogicalOperator>());
+    ASSERT_EQ(op1.getOutputSchema().size(), 1);
+    ASSERT_TRUE(op1.getOutputSchema()[Identifier::parse("prediction")].has_value());
+    auto op2 = op1.getChildren().at(0);
+    ASSERT_TRUE(op2.tryGetAs<InferModelLogicalOperator>());
+    auto op3 = op2.getChildren().at(0);
+    ASSERT_TRUE(op3.tryGetAs<SourceDescriptorLogicalOperator>());
+}
+#endif
 
 /// NOLINTEND(bugprone-unchecked-optional-access)
 

--- a/nes-query-optimizer/tests/Rules/Static/RedundantProjectionRemovalRuleTest.cpp
+++ b/nes-query-optimizer/tests/Rules/Static/RedundantProjectionRemovalRuleTest.cpp
@@ -1,0 +1,73 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Rules/Static/RedundantProjectionRemovalRule.hpp>
+
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include <Functions/FieldAccessLogicalFunction.hpp>
+#include <Functions/LogicalFunction.hpp>
+#include <Identifiers/Identifier.hpp>
+#include <Operators/LogicalOperator.hpp>
+#include <Operators/ProjectionLogicalOperator.hpp>
+#include <Operators/Sinks/SinkLogicalOperator.hpp>
+#include <Operators/Sources/SourceDescriptorLogicalOperator.hpp>
+#include <Plans/LogicalPlan.hpp>
+#include <Util/Logger/LogLevel.hpp>
+#include <Util/Logger/impl/NesLogger.hpp>
+#include <gtest/gtest.h>
+#include <BaseUnitTest.hpp>
+#include <OptimizerTestUtils.hpp>
+
+namespace NES
+{
+/// NOLINTBEGIN(bugprone-unchecked-optional-access)
+class RedundantProjectionRemovalRuleTest : public Testing::BaseUnitTest
+{
+public:
+    static void SetUpTestSuite() { Logger::setupLogging("RedundantProjectionRemovalRuleTest.log", LogLevel::LOG_DEBUG); }
+
+    OptimizerTestUtils utils;
+};
+
+TEST_F(RedundantProjectionRemovalRuleTest, RemoveRedundant)
+{
+    auto source = utils.createSource("removeRedundant", {"a", "b"});
+
+    const std::vector<std::pair<Identifier, LogicalFunction>> projections1{
+        {Identifier::parse("a"), FieldAccessLogicalFunction{source.getOutputSchema()[Identifier::parse("a")].value()}}};
+    auto projection1 = ProjectionLogicalOperator::create(source, projections1, ProjectionLogicalOperator::Asterisk{false});
+
+    const std::vector<std::pair<Identifier, LogicalFunction>> projections2{
+        {Identifier::parse("a"), FieldAccessLogicalFunction{projection1.getOutputSchema()[Identifier::parse("a")].value()}}};
+    auto projection2 = ProjectionLogicalOperator::create(projection1, projections2, ProjectionLogicalOperator::Asterisk{false});
+
+    auto sink = utils.createSink(projection2, "removeRedundant", {"a"});
+
+    auto plan = utils.createPlan(sink);
+
+    auto optimized = RedundantProjectionRemovalRule{}.apply(plan);
+
+    auto optSink = optimized.getRootOperators().at(0);
+    ASSERT_TRUE(optSink.tryGetAs<SinkLogicalOperator>());
+    auto optProj = optSink.getChildren().at(0);
+    ASSERT_TRUE(optProj.tryGetAs<ProjectionLogicalOperator>());
+    auto optSource = optProj.getChildren().at(0);
+    ASSERT_TRUE(optSource.tryGetAs<SourceDescriptorLogicalOperator>());
+}
+
+/// NOLINTEND(bugprone-unchecked-optional-access)
+}

--- a/nes-query-optimizer/tests/Rules/Static/WatermarkAssignerPushdownRuleTest.cpp
+++ b/nes-query-optimizer/tests/Rules/Static/WatermarkAssignerPushdownRuleTest.cpp
@@ -301,7 +301,7 @@ TEST_F(WatermarkAssignerPushdownRuleTest, ProjectionPartialBreakers)
 
 TEST_F(WatermarkAssignerPushdownRuleTest, Breakers)
 {
-    /// BEFORE AND AFTER: Sink < IngestionTime < Join < Source
+    /// BEFORE AND AFTER: Sink < IngestionTime < Join <(source1, source2)
 
     auto sourceLeft = utils.createSource("breakers1", {"a", "b"});
     auto sourceRight = utils.createSource("breakers2", {"c", "d"});
@@ -419,6 +419,91 @@ TEST_F(WatermarkAssignerPushdownRuleTest, ProjectionAsteriskWithComputedFieldBre
     ASSERT_TRUE(op2.tryGetAs<ProjectionLogicalOperator>());
     auto op3 = op2.getChildren().at(0);
     ASSERT_TRUE(op3.tryGetAs<SourceDescriptorLogicalOperator>());
+}
+
+TEST_F(WatermarkAssignerPushdownRuleTest, MultiSinkDivergingTimeSemanticsStayInTheirBranch)
+{
+    /// BEFORE: (sink1 < IT, sink2 < ET(ts)) < selection < source
+    /// AFTER:  (sink1 < IT, sink2 < ET(ts)) < selection < source
+    /// The selection is shared, so the two branches' requirements must not be unioned onto it: a union of
+    /// requirements is not the requirement of the union. sink2's windows must not see ingestion-time
+    /// watermarks, and sink1 must not gain an event-time assigner it never asked for.
+
+    auto source = utils.createSource("divergingSemantics", {"a", "ts"});
+    auto select = SelectionLogicalOperator::create(
+        source,
+        EqualsLogicalFunction{
+            FieldAccessLogicalFunction{source.getOutputSchema()[Identifier::parse("a")].value()},
+            ConstantValueLogicalFunction{DataType{DataType::Type::UINT64, DataType::NULLABLE::NOT_NULLABLE}, "0"}});
+
+    auto ingestionTime = IngestionTimeWatermarkAssignerLogicalOperator::create(select);
+    auto sink1 = utils.createSink(ingestionTime, "divergingSemantics1", {"a", "ts"});
+
+    auto eventTime = EventTimeWatermarkAssignerLogicalOperator::create(
+        select, FieldAccessLogicalFunction{select.getOutputSchema()[Identifier::parse("ts")].value()}, Windowing::TimeUnit{0});
+    auto sink2 = utils.createSink(eventTime, "divergingSemantics2", {"a", "ts"});
+
+    auto plan = utils.createPlan({sink1, sink2});
+
+    auto pushed = WatermarkAssignerPushdownRule{}.apply(plan);
+
+    /// sink1 keeps ingestion time only
+    auto optSink1 = pushed.getRootOperators().at(0);
+    ASSERT_TRUE(optSink1.tryGetAs<SinkLogicalOperator>());
+    auto optIngestionTime = optSink1.getChildren().at(0);
+    ASSERT_TRUE(optIngestionTime.tryGetAs<IngestionTimeWatermarkAssignerLogicalOperator>());
+    auto optSelect1 = optIngestionTime.getChildren().at(0);
+    ASSERT_TRUE(optSelect1.tryGetAs<SelectionLogicalOperator>());
+
+    /// sink2 keeps event time only
+    auto optSink2 = pushed.getRootOperators().at(1);
+    ASSERT_TRUE(optSink2.tryGetAs<SinkLogicalOperator>());
+    auto optEventTime = optSink2.getChildren().at(0);
+    ASSERT_TRUE(optEventTime.tryGetAs<EventTimeWatermarkAssignerLogicalOperator>());
+    auto optSelect2 = optEventTime.getChildren().at(0);
+    ASSERT_TRUE(optSelect2.tryGetAs<SelectionLogicalOperator>());
+
+    /// the shared subplan is still shared and carries no assigner of either branch
+    ASSERT_EQ(optSelect1, optSelect2);
+    ASSERT_TRUE(optSelect1.getChildren().at(0).tryGetAs<SourceDescriptorLogicalOperator>());
+}
+
+TEST_F(WatermarkAssignerPushdownRuleTest, MultiSinkSameEventTimeFieldIsNotDuplicated)
+{
+    /// BEFORE: (sink1 < ET(ts), sink2 < ET(ts)) < selection < source
+    /// AFTER:  (sink1 < ET(ts), sink2 < ET(ts)) < selection < source
+    /// Both branches want the same assigner, so concatenating the two contexts must not produce two
+    /// stacked, identical event-time assigners on the shared subplan.
+
+    auto source = utils.createSource("duplicateEventTime", {"a", "ts"});
+    auto select = SelectionLogicalOperator::create(
+        source,
+        EqualsLogicalFunction{
+            FieldAccessLogicalFunction{source.getOutputSchema()[Identifier::parse("a")].value()},
+            ConstantValueLogicalFunction{DataType{DataType::Type::UINT64, DataType::NULLABLE::NOT_NULLABLE}, "0"}});
+
+    auto eventTime1 = EventTimeWatermarkAssignerLogicalOperator::create(
+        select, FieldAccessLogicalFunction{select.getOutputSchema()[Identifier::parse("ts")].value()}, Windowing::TimeUnit{0});
+    auto sink1 = utils.createSink(eventTime1, "duplicateEventTime1", {"a", "ts"});
+
+    auto eventTime2 = EventTimeWatermarkAssignerLogicalOperator::create(
+        select, FieldAccessLogicalFunction{select.getOutputSchema()[Identifier::parse("ts")].value()}, Windowing::TimeUnit{0});
+    auto sink2 = utils.createSink(eventTime2, "duplicateEventTime2", {"a", "ts"});
+
+    auto plan = utils.createPlan({sink1, sink2});
+
+    auto pushed = WatermarkAssignerPushdownRule{}.apply(plan);
+
+    for (const auto& root : pushed.getRootOperators())
+    {
+        ASSERT_TRUE(root.tryGetAs<SinkLogicalOperator>());
+        auto optEventTime = root.getChildren().at(0);
+        ASSERT_TRUE(optEventTime.tryGetAs<EventTimeWatermarkAssignerLogicalOperator>());
+        /// exactly one assigner per branch, not two identical ones stacked
+        auto optSelect = optEventTime.getChildren().at(0);
+        ASSERT_TRUE(optSelect.tryGetAs<SelectionLogicalOperator>());
+        ASSERT_TRUE(optSelect.getChildren().at(0).tryGetAs<SourceDescriptorLogicalOperator>());
+    }
 }
 
 /// NOLINTEND(bugprone-unchecked-optional-access)

--- a/nes-query-optimizer/tests/Util/OptimizerTestUtils.cpp
+++ b/nes-query-optimizer/tests/Util/OptimizerTestUtils.cpp
@@ -114,4 +114,11 @@ LogicalPlan OptimizerTestUtils::createPlan(LogicalOperator sink)
     return LogicalPlan{
         QueryId::create(LocalQueryId{LocalQueryId::INVALID}, DistributedQueryId{DistributedQueryId::INVALID}), {std::move(sink)}};
 }
+
+/// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+LogicalPlan OptimizerTestUtils::createPlan(std::vector<LogicalOperator> sinks)
+{
+    return LogicalPlan{
+        QueryId::create(LocalQueryId{LocalQueryId::INVALID}, DistributedQueryId{DistributedQueryId::INVALID}), std::move(sinks)};
+}
 }

--- a/nes-query-optimizer/tests/Util/OptimizerTestUtils.hpp
+++ b/nes-query-optimizer/tests/Util/OptimizerTestUtils.hpp
@@ -51,6 +51,7 @@ public:
     TypedLogicalOperator<SinkLogicalOperator>
     createSink(LogicalOperator child, std::string name, const std::vector<std::string>& fieldNames);
     LogicalPlan createPlan(LogicalOperator sink);
+    LogicalPlan createPlan(std::vector<LogicalOperator> sink);
     SinkDescriptor createSinkDescriptor(const Identifier& sinkName, const Schema<UnqualifiedUnboundField, Ordered>& schema);
 
 private:


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Enabled optimization of multi-sink plans.

* Adds `PlanVisitor<>`, a generic top-down/bottom-up traversal helper for `LogicalPlan` that treats the plan as a DAG: a node reachable through multiple parents is visited exactly once, with contexts from all parents aggregated before descending further, and its rebuilt result shared rather than duplicated. 
* Existing rules are updated to use PlanVisitor

## Verifying this change
* All existing tests continue to pass
* Created new unit tests where necessary for the existing rules. 

## What components does this pull request potentially affect?
- nes-query-optimizer

## Documentation
* PlanVisitor has in-code documentation explaining how it works and how to use it
* Updated `how_to_add_an_optimizer_rule.md` to reflect changes. 
