### PR TITLE
fix(ci): reuse runtime base for test volumes

### DIFF
--- a/nes-systests/systest/remote-test/distributed.bats
+++ b/nes-systests/systest/remote-test/distributed.bats
@@ -47,7 +47,7 @@ setup_file() {
   #                      This reconstructs the expected path $NES_DIR/nes-systests/* inside containers
   #   TESTDATA_VOLUME:   contains test input data, mounted at /data in containers
 
-  volume_host_container=$(docker run -d --rm -v $TESTCONFIG_VOLUME:/config -v $TESTDATA_VOLUME:/data alpine sleep infinite)
+  volume_host_container=$(docker run -d --rm -v $TESTCONFIG_VOLUME:/config -v $TESTDATA_VOLUME:/data "$NES_RUNTIME_BASE_IMAGE" sleep infinite)
   docker exec $volume_host_container sh -c "mkdir -p /config/nes-systests"
   # Dereference symlinks via tar and pipe directly into the volume container
   tar -chf - -C "${DATADIR}" . \
@@ -83,7 +83,7 @@ setup() {
   echo "# Using TEST_DIR: $TMP_DIR" >&3
 
   volume=$(docker volume create)
-  volume_host_container=$(docker run -d --rm -v $volume:/data alpine sleep infinite)
+  volume_host_container=$(docker run -d --rm -v $volume:/data "$NES_RUNTIME_BASE_IMAGE" sleep infinite)
   docker stop -t0 $volume_host_container
   export TEST_VOLUME=$volume
   echo "Using test volume: $TEST_VOLUME" >&3
@@ -129,7 +129,7 @@ function setup_distributed() {
 
   # Copy config files into the test volume
   if [ -n "$(ls -A "$config_dir")" ]; then
-    local volume_host=$(docker run -d --rm -v $TEST_VOLUME:/vol alpine sleep infinite)
+    local volume_host=$(docker run -d --rm -v $TEST_VOLUME:/vol "$NES_RUNTIME_BASE_IMAGE" sleep infinite)
     docker exec $volume_host mkdir -p /vol/configs
     tar -cf - -C "$config_dir" . | docker exec -i $volume_host tar -xf - -C /vol/configs
     docker stop -t0 $volume_host

--- a/scripts/testing/distributed_bats_lib.bash
+++ b/scripts/testing/distributed_bats_lib.bash
@@ -304,7 +304,7 @@ nes_distributed_setup() {
   local volume
   volume=$(docker volume create)
   local volume_host_container
-  volume_host_container=$(docker run -d --rm -v $volume:/data alpine sleep infinite)
+  volume_host_container=$(docker run -d --rm -v $volume:/data "$NES_RUNTIME_BASE_IMAGE" sleep infinite)
   docker cp . $volume_host_container:/data
   docker stop -t0 $volume_host_container
   export TEST_VOLUME=$volume
@@ -313,7 +313,7 @@ nes_distributed_setup() {
 
 sync_workdir() {
   local volume_host_container
-  volume_host_container=$(docker run -d --rm -v $TEST_VOLUME:/data alpine sleep infinite)
+  volume_host_container=$(docker run -d --rm -v $TEST_VOLUME:/data "$NES_RUNTIME_BASE_IMAGE" sleep infinite)
   docker cp $volume_host_container:/data/. .
   docker stop -t0 $volume_host_container
 }


### PR DESCRIPTION
## What changed

- replace Alpine helper containers in the distributed Bats utilities with `NES_RUNTIME_BASE_IMAGE`
- apply the same change to the remote system-test volume setup

## Why

The Docker test helpers only need a temporary running container for copying files into and out of named volumes. The runtime-base image is already required and explicitly preloaded by these test jobs, while the unqualified `alpine` image was an implicit Docker Hub dependency.

After a runner cache prune, that implicit dependency can trigger pulls from inside Bats. Registry connectivity failures are then surfaced as opaque CTest timeouts instead of failing during the image-preparation step.

Reusing the runtime-base image removes that additional registry dependency. It provides the `sleep`, shell, directory, and tar utilities used by the helpers.

## Validation

- `bash -n scripts/testing/distributed_bats_lib.bash nes-systests/systest/remote-test/distributed.bats`
- `git diff --check`
- confirmed no `docker run ... alpine` calls remain in the changed test helpers