### PR TITLE
ci: integrate clean build into test matrix

### DIFF
--- a/.github/ci/nightly_matrix.yaml
+++ b/.github/ci/nightly_matrix.yaml
@@ -112,6 +112,18 @@ jobs:
       NES_DEBUG_TUPLE_BUFFER_LEAKS: "ON"
     tests: [systest, docker]
 
+  # Validates a full build without compiler-cache assistance. Keep this on the
+  # self-hosted runner because every translation unit must be compiled locally.
+  - name: "{arch} {stdlib} {build_type} clean build (unit+systest+docker)"
+    arch: x64
+    stdlib: libcxx
+    build_type: Debug
+    sanitizer: none
+    runner: self-hosted-{arch}
+    cmake_flags:
+      USE_BUILD_CACHE: "OFF"
+    tests: [unit, systest, docker]
+
   # === Build-only (no tests, validates compilation) ===
 
   - name: "{arch} {stdlib} {build_type} (build only)"

--- a/.github/ci/pr_matrix.yaml
+++ b/.github/ci/pr_matrix.yaml
@@ -120,6 +120,18 @@ jobs:
       NES_DEBUG_TUPLE_BUFFER_LEAKS: "ON"
     tests: [systest, docker]
 
+  # Validates a full build without compiler-cache assistance. Keep this on the
+  # self-hosted runner because every translation unit must be compiled locally.
+  - name: "{arch} {stdlib} {build_type} clean build (unit+systest+docker)"
+    arch: x64
+    stdlib: libcxx
+    build_type: Debug
+    sanitizer: none
+    runner: self-hosted-{arch}
+    cmake_flags:
+      USE_BUILD_CACHE: "OFF"
+    tests: [unit, systest, docker]
+
   # === Build-only (no tests, validates compilation) ===
 
   - name: "{arch} {stdlib} {build_type} (build only)"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -176,91 +176,11 @@ jobs:
             sccache --show-stats
             sccache --stop-server
 
-  clean-build-and-test-linux:
-    # Ensures the build works from a clean build directory and that the dev image
-    # still supports network-isolated builds.
-    name: "Clean build and tests"
-    timeout-minutes: 80
-    runs-on: [ self-hosted, linux, Build, "${{matrix.arch}}" ]
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [ x64 ]
-        stdlib: [ 'libcxx' ]
-        build_type: [ 'Debug' ]
-        sanitizer: [ 'none' ]
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.head_sha }}
-      - uses: ./.github/steps/setup-sccache
-        with:
-          bucket: ${{ secrets.SCCACHE_CACHE_BUCKET }}
-          endpoint: ${{ secrets.SCCACHE_CACHE_ENDPOINT }}
-          access_key: ${{ secrets.SCCACHE_CACHE_ACCESS_KEY }}
-          secret_key: ${{ secrets.SCCACHE_CACHE_SECRET_KEY }}
-      - uses: ./.github/steps/prepare-github
-        name: Preparing Github Runners
-        with:
-          images: |
-            nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{ matrix.sanitizer }}
-            nebulastream/nes-runtime-base:${{ inputs.dev_image_tag }}
-            eclipse-mosquitto:2
-          docker_username: ${{ secrets.DOCKER_USER_NAME }}
-          docker_password: ${{ secrets.DOCKER_SECRET }}
-      - uses: ./.github/steps/run-in-container
-        name: Configure, build and test (online)
-        with:
-          image_name: nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{ matrix.sanitizer }}
-          docker_username: ${{ secrets.DOCKER_USER_NAME }}
-          docker_password: ${{ secrets.DOCKER_SECRET }}
-          run: |
-            source .github/.env/test-${{ matrix.sanitizer }}.env
-            rm -rf build
-            cmake -GNinja -B build -DUSE_SANITIZER=${{ matrix.sanitizer }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DNES_LOG_LEVEL=DEBUG
-            MOLD_JOBS=1 cmake --build build -j -- -k 0
-            ctest --test-dir build -j --output-on-failure --output-junit build/junit.xml --timeout 1200
-      - name: Offline clean build and tests (--network=none)
-        # Validates that the dev image still supports network-isolated builds: the offline-rust
-        # pre-fetch and the Corrosion ls-remote fallback in EnableRust.cmake should let a vanilla
-        # `cmake` + `cmake --build` + `ctest` cycle succeed without network. Runs on the host so
-        # `$(pwd)` resolves to the real workspace path and bind-mounts cleanly into the offline
-        # container — same pattern as run-in-container, just without sccache plumbing.
-        shell: bash
-        run: |
-          set -euo pipefail
-          IMAGE="nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{ matrix.sanitizer }}"
-          docker run --rm --network=none \
-            -v "$(pwd)":"$(pwd)" -w "$(pwd)" \
-            -u "$(id -u):$(id -g)" -e HOME="$(pwd)" \
-            "$IMAGE" \
-            bash -c '
-              set -euo pipefail
-              rm -rf build-offline
-              cmake -GNinja -B build-offline
-              cmake --build build-offline -j
-              # Exclude DockerCompose-labeled tests: they need /var/run/docker.sock to spin
-              # up sibling containers, which `--network=none` (and the missing socket bind)
-              # makes impossible. They are not testing offline-build behavior.
-              ctest --test-dir build-offline -j --output-on-failure --timeout 1200 -LE DockerCompose
-            '
-      - uses: actions/upload-artifact@v5
-        # Upload all log and stat files if any of the tests has failed.
-        name: Upload Test Logs on Failure
-        if: ${{ failure() && !github.event.act }}
-        with:
-          name: logs-${{ matrix.arch }}-${{ matrix.stdlib }}-${{ matrix.build_type }}
-          path: |
-            build/**/*.log
-            build/**/*.stats
-            build-offline/**/*.log
-            build-offline/**/*.stats
-
   # Aggregate gate for branch protection. Only this job needs to be required —
   # if any matrix entry or the log-level job fails/cancels/skips, this fails too.
   done:
     name: Done
-    needs: [build-and-test, build-and-test-log-level, clean-build-and-test-linux]
+    needs: [build-and-test, build-and-test-log-level]
     if: always()
     runs-on: ubuntu-24.04
     steps:
@@ -272,9 +192,5 @@ jobs:
           fi
           if [[ "${{ needs.build-and-test-log-level.result }}" != "success" ]]; then
             echo "build-and-test-log-level result: ${{ needs.build-and-test-log-level.result }}"
-            exit 1
-          fi
-          if [[ "${{ needs.clean-build-and-test-linux.result }}" != "success" ]]; then
-            echo "clean-build-and-test-linux result: ${{ needs.clean-build-and-test-linux.result }}"
             exit 1
           fi


### PR DESCRIPTION
## Summary

- move the cacheless clean build into the generated PR and nightly test matrices
- run that shard on the self-hosted x64 runner with `USE_BUILD_CACHE=OFF`
- remove the standalone clean-build job and use the matrix's separated unit, systest, and serial DockerCompose test steps

## Why

The standalone job still initialized sccache and ran every test class concurrently. In particular, `systest-remote-test` ran alongside the rest of the suite with a shorter timeout, unlike the regular matrix's serial DockerCompose step. Integrating the cacheless build into the matrix makes its test execution consistent while the CMake option guarantees compiler-cache bypass.

This also removes the standalone offline `--network=none` validation that was coupled to the old job.

## Validation

- `git diff --check`
- generated and inspected both `pr_matrix.yaml` and `nightly_matrix.yaml`
- confirmed each contains one self-hosted x64/libcxx/Debug entry with `-DUSE_BUILD_CACHE=OFF` and unit, systest, and DockerCompose tests enabled
