### PR TITLE
feat(systest): Let -t/--testLocations take multiple locations

### DIFF
--- a/docs/development/systests.md
+++ b/docs/development/systests.md
@@ -237,7 +237,15 @@ Alternatively, you can click the double triangle in the first line to run all te
 You can also run the systest via the CMake `systest` executable either in the terminal or via your IDE such as CLion.
 The executable can run individual tests, all tests in a given file, or all test files that belong to a defined group.
 You can select the test cases and define the behaviour via command line arguments. 
-The executable can run individual tests (`-t /path/to/test.test:1`), all tests in a given file (`-t /path/to/test.test`), or all test files that belong to a defined group (`-g group1 group2`, `-e excludedGroup`).
+The `-t`/`--testLocations` flag accepts one or more values, each of which can be:
+- A specific test with query number: `-t /path/to/test.test:1`
+- All tests in a file: `-t /path/to/test.test`
+- All `.test` files in a directory (searched recursively): `-t /path/to/directory`
+- Multiple locations at once: `-t dir1 dir2 /path/to/test.test`
+
+By default, the systest runner discovers tests in `nes-systests/` (recursively). Passing directories via `-t` replaces that default, so `-t dirA dirB` discovers in `dirA` and `dirB` only.
+
+Tests can also be filtered by group (`-g group1 group2`, `-e excludedGroup`).
 Tests can be run with specific configuration settings (`-- --worker.total_memory_in_bytes=81920000`).
 Permanent exclusions can be configured via `--disableConfigFile` (defaulting to `${TEST_CONFIGURATION_DIR}/systest-disable.yaml`) and can be ignored per run with `--ignoreDisableConfigFile`. The disable config file understands `exclude_groups` and `disabled_test_files`.
 To measure the execution time of tests use the benchmark mode (`-b`).

--- a/nes-systests/systest/include/SystestConfiguration.hpp
+++ b/nes-systests/systest/include/SystestConfiguration.hpp
@@ -39,11 +39,15 @@ struct SystestClusterConfiguration
 class SystestConfiguration final : public BaseConfiguration
 {
 public:
-    SystestConfiguration() = default;
+    SystestConfiguration()
+    {
+        /// Default discover directory; replaced when directories are passed via -t/--testLocations.
+        testDiscoverDirs.add(TEST_DISCOVER_DIR);
+    }
 
     /// Note: for now we ignore/override the here specified default values with ones provided by argparse in `SystestExecutor::parseConfiguration()`
-    StringOption testsDiscoverDir
-        = {"tests_discover_dir", TEST_DISCOVER_DIR, "Directory to lookup test files in. Default: " TEST_DISCOVER_DIR};
+    SequenceOption<StringOption> testDiscoverDirs
+        = {"test_discover_dirs", "Directories to discover test files in. Default: " TEST_DISCOVER_DIR};
     StringOption testDataDir
         = {"test_data_dir", SYSTEST_EXTERNAL_DATA_DIR, "Directory to lookup test data files in. Default: " SYSTEST_EXTERNAL_DATA_DIR};
     StringOption configDir

--- a/nes-systests/systest/src/SystestConfiguration.cpp
+++ b/nes-systests/systest/src/SystestConfiguration.cpp
@@ -22,7 +22,7 @@ namespace NES
 std::vector<BaseOption*> SystestConfiguration::getOptions()
 {
     return {
-        &testsDiscoverDir,
+        &testDiscoverDirs,
         &directlySpecifiedTestFiles,
         &testFileExtension,
         &workingDir,

--- a/nes-systests/systest/src/SystestStarter.cpp
+++ b/nes-systests/systest/src/SystestStarter.cpp
@@ -72,9 +72,11 @@ void configureArgumentParser(ArgumentParser& program)
 {
     const auto defaultDisableConfigPath = std::string{TEST_CONFIGURATION_DIR} + "/systest-disable.yaml";
 
-    program.add_argument("-t", "--testLocation")
-        .help("directly specified test file, e.g., filter.test, or a directory to discover test files in. Use "
-              "'path/to/testfile:testnumber' to run a specific test by testnumber within a file. Default: " TEST_DISCOVER_DIR);
+    program.add_argument("-t", "--testLocations")
+        .help("directly specified test files, directories, or multiple locations to discover test files in. "
+              "If a directory is given, all .test files are discovered recursively. "
+              "Use 'path/to/testfile:testnumber' to run a specific test by testnumber within a file. Default: " TEST_DISCOVER_DIR)
+        .nargs(argparse::nargs_pattern::any);
     program.add_argument("-g", "--groups").help("run specific test groups").nargs(argparse::nargs_pattern::at_least_one);
     program.add_argument("-e", "--exclude-groups")
         .help("ignore groups, takes precedence over -g")
@@ -246,60 +248,70 @@ std::vector<std::filesystem::path> findAllInTree(const std::filesystem::path& wa
     return hits;
 }
 
-std::vector<std::filesystem::path> resolveTestArg(const std::filesystem::path& arg, const std::filesystem::path& discoverRoot)
+void applyDiscoveredTestLocation(const std::filesystem::path& testFilePath, NES::SystestConfiguration& config)
 {
-    if (std::filesystem::exists(arg))
+    /// Search all discover directories for a matching file name
+    std::vector<std::filesystem::path> allMatches;
+    for (const auto& dir : config.testDiscoverDirs.getValues())
     {
-        return {std::filesystem::canonical(arg)};
+        auto matches = findAllInTree(testFilePath.filename(), dir.getValue());
+        allMatches.insert(allMatches.end(), matches.begin(), matches.end());
     }
-    return findAllInTree(arg.filename(), discoverRoot);
-}
 
-void applyDiscoveredTestLocation(
-    const std::filesystem::path& testFilePath, const std::filesystem::path& discoverRoot, NES::SystestConfiguration& config)
-{
-    const auto matches = resolveTestArg(testFilePath, discoverRoot);
-    if (matches.empty())
+    if (allMatches.empty())
     {
-        std::cerr << '\'' << testFilePath << "' could not be located under '" << discoverRoot << "'.\n";
+        std::cerr << '\'' << testFilePath << "' could not be located in any test discover directory.\n";
         std::exit(EXIT_FAILURE); ///NOLINT(concurrency-mt-unsafe)
     }
 
-    if (matches.size() == 1)
+    if (allMatches.size() == 1)
     {
-        config.directlySpecifiedTestFiles = matches.front();
+        config.directlySpecifiedTestFiles = allMatches.front();
         return;
     }
 
     std::cerr << "Ambiguous test name '" << testFilePath << "':\n";
-    for (const auto& path : matches)
+    for (const auto& path : allMatches)
     {
         std::cerr << "  • " << path << '\n';
     }
     std::exit(EXIT_FAILURE); ///NOLINT(concurrency-mt-unsafe)
 }
 
-void applyTestLocation(const ArgumentParser& program, NES::SystestConfiguration& config)
+void applyTestLocations(const ArgumentParser& program, NES::SystestConfiguration& config)
 {
-    if (not program.is_used("--testLocation"))
+    if (not program.is_used("--testLocations"))
     {
         return;
     }
 
-    const auto testFilePath = parseTestLocationPath(program.get<std::string>("--testLocation"), config);
-    if (std::filesystem::is_directory(testFilePath))
-    {
-        config.testsDiscoverDir = testFilePath;
-        return;
-    }
+    /// Directories given on the command line replace the default discover directory rather than extending it,
+    /// so `-t dirA dirB` discovers in dirA and dirB only. The default is dropped on the first directory seen.
+    bool defaultDiscoverDirReplaced = false;
 
-    if (std::filesystem::is_regular_file(testFilePath))
+    const auto testLocations = program.get<std::vector<std::string>>("--testLocations");
+    for (const auto& location : testLocations)
     {
-        config.directlySpecifiedTestFiles = testFilePath;
-        return;
-    }
+        const auto testFilePath = parseTestLocationPath(location, config);
+        if (std::filesystem::is_directory(testFilePath))
+        {
+            if (not defaultDiscoverDirReplaced)
+            {
+                config.testDiscoverDirs.clear();
+                defaultDiscoverDirReplaced = true;
+            }
+            config.testDiscoverDirs.add(testFilePath.string());
+            continue;
+        }
 
-    applyDiscoveredTestLocation(testFilePath, config.testsDiscoverDir.getValue(), config);
+        if (std::filesystem::is_regular_file(testFilePath))
+        {
+            config.directlySpecifiedTestFiles = testFilePath;
+            continue;
+        }
+
+        applyDiscoveredTestLocation(testFilePath, config);
+    }
 }
 
 void addSequenceOptionValues(
@@ -487,7 +499,7 @@ NES::SystestConfiguration parseConfiguration(int argc, const char** argv)
     applyBenchmarkMode(program, config);
     applyDebugMode(program);
     applyInputLocations(program, config);
-    applyTestLocation(program, config);
+    applyTestLocations(program, config);
     applyGroupSelection(program, config);
     applyExecutionOptions(program, config);
     applyConfigurationFiles(program, config);

--- a/nes-systests/systest/src/SystestState.cpp
+++ b/nes-systests/systest/src/SystestState.cpp
@@ -369,7 +369,7 @@ TestFileMap loadTestFileMap(const SystestConfiguration& config)
             if (matchesDisabledTestFile(testfile, filters.disabledTestFiles))
             {
                 std::cout << fmt::format(
-                    "Including file://{} because it was explicitly selected via --testLocation, overriding disabled_test_files\n",
+                    "Including file://{} because it was explicitly selected via --testLocations, overriding disabled_test_files\n",
                     testfile.getLogFilePath());
             }
             return TestFileMap{{testfile.file, testfile}};
@@ -383,13 +383,19 @@ TestFileMap loadTestFileMap(const SystestConfiguration& config)
         if (matchesDisabledTestFile(testfile, filters.disabledTestFiles))
         {
             std::cout << fmt::format(
-                "Including file://{} because it was explicitly selected via --testLocation, overriding disabled_test_files\n",
+                "Including file://{} because it was explicitly selected via --testLocations, overriding disabled_test_files\n",
                 testfile.getLogFilePath());
         }
         return TestFileMap{{testfile.file, testfile}};
     }
 
-    auto testMap = discoverTestsRecursively(config.testsDiscoverDir.getValue(), config.testFileExtension.getValue());
+    TestFileMap testMap;
+    for (const auto& discoverDir : config.testDiscoverDirs.getValues())
+    {
+        auto tests = discoverTestsRecursively(discoverDir.getValue(), config.testFileExtension.getValue());
+        testMap.merge(tests);
+    }
+
     std::erase_if(
         testMap,
         [&](const auto& nameAndFile)

--- a/nes-systests/systest/tests/SystestE2ETests.cpp
+++ b/nes-systests/systest/tests/SystestE2ETests.cpp
@@ -68,7 +68,7 @@ public:
 TEST_F(SystestE2ETest, CheckThatOnlyWrongQueriesFailInFileWithManyQueries)
 {
     SystestConfiguration config{};
-    config.testsDiscoverDir.setValue(SYSTEST_DATA_DIR);
+    config.testDiscoverDirs.add(SYSTEST_DATA_DIR);
     const auto testFileName = fmt::format("MultipleCorrectAndIncorrect{}", EXTENSION);
     config.directlySpecifiedTestFiles.setValue(fmt::format("{}/errors/{}", SYSTEST_DATA_DIR, testFileName));
     config.workingDir.setValue(fmt::format("{}/nes-systests/systest/MultipleCorrectAndIncorrect", PATH_TO_BINARY_DIR));
@@ -103,7 +103,7 @@ TEST_P(SystestE2ETest, correctAndIncorrectSchemaTestFile)
     const auto& [directory, testFile] = GetParam();
     const auto testFileName = testFile + std::string(".dummy");
     SystestConfiguration config{};
-    config.testsDiscoverDir.setValue(SYSTEST_DATA_DIR);
+    config.testDiscoverDirs.add(SYSTEST_DATA_DIR);
     config.directlySpecifiedTestFiles.setValue(fmt::format("{}/errors/{}/{}", SYSTEST_DATA_DIR, directory, testFileName));
     config.testFileExtension.setValue(std::string(EXTENSION));
     config.workingDir.setValue(fmt::format("{}/nes-systests/systest/{}", PATH_TO_BINARY_DIR, testFile));

--- a/nes-systests/systest/tests/SystestParserValidTestFilesTests.cpp
+++ b/nes-systests/systest/tests/SystestParserValidTestFilesTests.cpp
@@ -546,7 +546,7 @@ TEST_F(SystestParserValidTestFileTest, CreateStatementFormat)
 TEST_F(SystestParserValidTestFileTest, TextAfterClosingBracketOfGroups)
 {
     SystestConfiguration config{};
-    config.testsDiscoverDir.setValue(SYSTEST_DATA_DIR);
+    config.testDiscoverDirs.add(SYSTEST_DATA_DIR);
     const auto testFileName = fmt::format("comment_text_bracket{}", ".dummy");
     config.directlySpecifiedTestFiles.setValue(fmt::format("{}/{}", SYSTEST_DATA_DIR, testFileName));
     const auto testMap = Systest::loadTestFileMap(config);

--- a/nes-systests/systest/tests/SystestStateTests.cpp
+++ b/nes-systests/systest/tests/SystestStateTests.cpp
@@ -93,7 +93,9 @@ TEST_F(SystestStateTest, ExplicitlyIncludedGroupOverridesMatchingDisableConfigEx
     writeTextFile(otherFile, "# groups:[other]\n");
 
     SystestConfiguration config;
-    config.testsDiscoverDir = tempDir.get().string();
+    /// Drop the default TEST_DISCOVER_DIR so discovery is limited to the temporary directory of this test.
+    config.testDiscoverDirs.clear();
+    config.testDiscoverDirs.add(tempDir.get().string());
     config.testFileExtension = ".test";
     config.globalExcludedGroups = {"large"};
     config.testGroups.add("large");
@@ -111,7 +113,9 @@ TEST_F(SystestStateTest, ExplicitCommandLineExclusionOverridesExplicitInclusion)
     writeTextFile(joinFile, "# groups:[Join]\n");
 
     SystestConfiguration config;
-    config.testsDiscoverDir = tempDir.get().string();
+    /// Drop the default TEST_DISCOVER_DIR so discovery is limited to the temporary directory of this test.
+    config.testDiscoverDirs.clear();
+    config.testDiscoverDirs.add(tempDir.get().string());
     config.testFileExtension = ".test";
     config.testGroups.add("Join");
     config.excludeGroups.add("Join");
@@ -148,7 +152,9 @@ TEST_F(SystestStateTest, OnlyDuplicateDiscoveredTestNamesIncludeRelativeDirector
     writeTextFile(uniqueFile, "# groups:[Join]\n");
 
     SystestConfiguration config;
-    config.testsDiscoverDir = tempDir.get().string();
+    /// Drop the default TEST_DISCOVER_DIR so discovery is limited to the temporary directory of this test.
+    config.testDiscoverDirs.clear();
+    config.testDiscoverDirs.add(tempDir.get().string());
     config.testFileExtension = ".test";
 
     const auto testMap = loadTestFileMap(config);
@@ -168,7 +174,9 @@ TEST_F(SystestStateTest, FilteredDuplicateTestNameUsesStem)
     writeTextFile(filteredFile, "# groups:[Filtered]\n");
 
     SystestConfiguration config;
-    config.testsDiscoverDir = tempDir.get().string();
+    /// Drop the default TEST_DISCOVER_DIR so discovery is limited to the temporary directory of this test.
+    config.testDiscoverDirs.clear();
+    config.testDiscoverDirs.add(tempDir.get().string());
     config.testFileExtension = ".test";
     config.testGroups.add("Included");
 
@@ -185,7 +193,9 @@ TEST_F(SystestStateTest, DirectlySpecifiedTestNamesUseStem)
     writeTextFile(testFile, "# groups:[Join]\n");
 
     SystestConfiguration config;
-    config.testsDiscoverDir = tempDir.get().string();
+    /// Drop the default TEST_DISCOVER_DIR so discovery is limited to the temporary directory of this test.
+    config.testDiscoverDirs.clear();
+    config.testDiscoverDirs.add(tempDir.get().string());
     config.directlySpecifiedTestFiles = testFile.string();
 
     const auto directlySpecifiedTestMap = loadTestFileMap(config);


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Lets `-t`/`--testLocations` take several locations in one invocation, e.g. `-t dirA dirB some.test`, by giving the argument `nargs_pattern::any` and turning `tests_discover_dir` into the `test_discover_dirs` sequence. Directories keep the semantics they had, they replace the default discover directory rather than extending it.

## Verifying this change
This change is tested by existing tests in `SystestStateTests`, `SystestE2ETests` and `SystestParserValidTestFilesTests`.

## What components does this pull request potentially affect?
- Systest runner (`-t`/`--testLocations` CLI, test discovery)
