### PR TITLE
Add TupleBuffer child-buffer clearing

### DIFF
--- a/nes-memory/TupleBuffer.cpp
+++ b/nes-memory/TupleBuffer.cpp
@@ -191,6 +191,11 @@ TupleBuffer TupleBuffer::loadChildBuffer(ChildBufferIndex bufferIndex) const noe
     return childBuffer;
 }
 
+void TupleBuffer::clearChildBuffers() noexcept
+{
+    controlBlock->clearChildBuffers();
+}
+
 bool recycleTupleBuffer(void* bufferPointer)
 {
     PRECONDITION(bufferPointer, "invalid bufferPointer");

--- a/nes-memory/TupleBufferImpl.cpp
+++ b/nes-memory/TupleBufferImpl.cpp
@@ -191,11 +191,7 @@ bool BufferControlBlock::release()
     const uint32_t prevRefCnt = referenceCounter.fetch_sub(1);
     if (prevRefCnt == 1)
     {
-        for (auto&& child : children)
-        {
-            child->controlBlock->release();
-        }
-        children.clear();
+        clearChildBuffers();
 #ifdef NES_DEBUG_TUPLE_BUFFER_LEAKS
         {
             std::unique_lock lock(owningThreadsMutex);
@@ -319,5 +315,14 @@ bool BufferControlBlock::loadChildBuffer(const ChildBufferIndex index, BufferCon
     size = child->size;
 
     return true;
+}
+
+void BufferControlBlock::clearChildBuffers()
+{
+    for (auto&& child : children)
+    {
+        child->controlBlock->release();
+    }
+    children.clear();
 }
 }

--- a/nes-memory/TupleBufferImpl.hpp
+++ b/nes-memory/TupleBufferImpl.hpp
@@ -100,6 +100,7 @@ public:
     [[nodiscard]] Timestamp getCreationTimestamp() const noexcept;
     [[nodiscard]] ChildBufferIndex storeChildBuffer(BufferControlBlock* control);
     [[nodiscard]] bool loadChildBuffer(ChildBufferIndex index, BufferControlBlock*& control, uint8_t*& ptr, uint32_t& size) const;
+    void clearChildBuffers();
 
     [[nodiscard]] uint32_t getNumberOfChildBuffers() const noexcept { return children.size(); }
 #ifdef NES_DEBUG_TUPLE_BUFFER_LEAKS

--- a/nes-memory/include/Runtime/TupleBuffer.hpp
+++ b/nes-memory/include/Runtime/TupleBuffer.hpp
@@ -186,6 +186,9 @@ public:
 
     [[nodiscard]] uint32_t getNumberOfChildBuffers() const noexcept;
 
+    /// @brief Releases and removes all child buffers attached to this TupleBuffer.
+    void clearChildBuffers() noexcept;
+
 private:
     /**
      * @brief returns the control block of the buffer USE THIS WITH CAUTION!

--- a/nes-memory/tests/ChildBufferTests.cpp
+++ b/nes-memory/tests/ChildBufferTests.cpp
@@ -129,3 +129,27 @@ TEST(ChildBufferTests, StoreAndLoadChildBufferRandomSizes)
         EXPECT_EQ(loadedBuffer.getBufferSize(), bufferSizeBeforeStore);
     }
 }
+
+TEST(ChildBufferTests, ClearChildBuffers)
+{
+    auto bufferManager = NES::BufferManager::create(
+        TOTAL_MEMORY_IN_BYTES,
+        UNPOOLED_MEMORY_FRACTION,
+        BUFFER_ALIGNMENT,
+        POOLED_BUFFER_SIZE,
+        std::make_shared<NES::NesDefaultMemoryAllocator>());
+    auto baseBuffer = bufferManager->getBufferBlocking();
+
+    for (uint32_t childIndex = 0; childIndex < 3; ++childIndex)
+    {
+        auto child = bufferManager->getBufferBlocking();
+        EXPECT_EQ(baseBuffer.storeChildBuffer(child).getRawValue(), childIndex);
+    }
+    ASSERT_EQ(baseBuffer.getNumberOfChildBuffers(), 3);
+
+    baseBuffer.clearChildBuffers();
+
+    EXPECT_EQ(baseBuffer.getNumberOfChildBuffers(), 0);
+    auto replacement = bufferManager->getBufferBlocking();
+    EXPECT_EQ(baseBuffer.storeChildBuffer(replacement).getRawValue(), 0);
+}


### PR DESCRIPTION
## Summary

Adds `TupleBuffer::clearChildBuffers()` for explicitly releasing and removing every child buffer attached to a tuple buffer.

The implementation centralizes child release in `BufferControlBlock::clearChildBuffers()` and reuses it from normal buffer destruction, keeping the reference-counting behavior in one place.

## Motivation

PagedVector variable-sized record compaction needs to replace a page's child-buffer directory after sorting without replacing the fixed-size page itself. Exposing this operation on `TupleBuffer` keeps that lifecycle operation in the memory layer.

## Verification

- `MOLD_JOBS=1 cmake --build cmake-build-relwithdebinfo --target nes-unit-tests -j`
- `ctest --test-dir cmake-build-relwithdebinfo -R '^ChildBufferTests\\.' --output-on-failure`
- All four child-buffer tests pass, including the new `ChildBufferTests.ClearChildBuffers` case.