### PR TITLE
refactor(#1831): rename buffer abstractions (MemoryLayout, TaskBufferRef, Buffer)

### DIFF
--- a/nes-executable/include/ExecutablePipelineStage.hpp
+++ b/nes-executable/include/ExecutablePipelineStage.hpp
@@ -16,7 +16,7 @@
 #include <cstdint>
 #include <memory>
 #include <ostream>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <PipelineExecutionContext.hpp>
 
 namespace NES
@@ -33,7 +33,7 @@ public:
 
     /// Executes the ExecutablePipelineStage with a readonly input tuple buffer.
     /// `execute` should never be called on a pipeline that has not previously been `started`.
-    virtual void execute(const TupleBuffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext) = 0;
+    virtual void execute(const Buffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext) = 0;
 
     /// Stops the ExecutablePipelineStage allowing it to flush left over state.
     /// `stop` should never be called on a pipeline that has not previously been `started`.

--- a/nes-executable/include/PipelineExecutionContext.hpp
+++ b/nes-executable/include/PipelineExecutionContext.hpp
@@ -20,15 +20,15 @@
 #include <vector>
 #include <Identifiers/Identifiers.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
-#include <Runtime/TupleBuffer.hpp>
 
 namespace NES
 {
 class PipelineExecutionContext
 {
 public:
-    /// Policy whether an emitted TupleBuffer is able to process immediately or
+    /// Policy whether an emitted Buffer is able to process immediately or
     /// needs to be dispatched as a new Task.
     enum class ContinuationPolicy : uint8_t
     {
@@ -39,21 +39,21 @@ public:
     virtual ~PipelineExecutionContext() = default;
 
     /// Returns success, if the buffer was emitted successfully.
-    bool emitBuffer(const TupleBuffer& buffer) { return emitBuffer(buffer, ContinuationPolicy::POSSIBLE); };
+    bool emitBuffer(const Buffer& buffer) { return emitBuffer(buffer, ContinuationPolicy::POSSIBLE); };
 
     /// Please be aware of how you are setting the continuation policy, as this will/can lead to deadlocks and no progress in our system.
     /// We advise to use ContinuationPolicy::POSSIBLE, as this will ensure no deadlock arising.
     /// Returns success, if the buffer was emitted successfully.
 
-    virtual bool emitBuffer(const TupleBuffer&, ContinuationPolicy) = 0;
+    virtual bool emitBuffer(const Buffer&, ContinuationPolicy) = 0;
 
     /// This method can only be called once per pipeline execution! The Pipeline should immediately finish its execution as the exact same task could be executed
     /// immediately.
-    virtual void repeatTask(const TupleBuffer&, std::chrono::milliseconds) = 0;
+    virtual void repeatTask(const Buffer&, std::chrono::milliseconds) = 0;
 
-    virtual TupleBuffer allocateTupleBuffer() = 0;
+    virtual Buffer allocateTupleBuffer() = 0;
     /// Pins a buffer, meaning the returned reference should be valid throughout the lifetime of the pipeline execution context
-    virtual TupleBuffer& pinBuffer(TupleBuffer&& tupleBuffer) = 0;
+    virtual Buffer& pinBuffer(Buffer&& tupleBuffer) = 0;
     [[nodiscard]] virtual WorkerThreadId getWorkerThreadId() const = 0;
     [[nodiscard]] virtual uint64_t getNumberOfWorkerThreads() const = 0;
     [[nodiscard]] virtual std::shared_ptr<AbstractBufferProvider> getBufferManager() const = 0;

--- a/nes-executable/tests/TestUtils/TestTaskQueue.cpp
+++ b/nes-executable/tests/TestUtils/TestTaskQueue.cpp
@@ -24,7 +24,7 @@
 
 #include <Identifiers/Identifiers.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <magic_enum/magic_enum.hpp>
 #include <ErrorHandling.hpp>
@@ -32,7 +32,7 @@
 
 namespace NES
 {
-bool TestPipelineExecutionContext::emitBuffer(const TupleBuffer& resultBuffer, const ContinuationPolicy continuationPolicy)
+bool TestPipelineExecutionContext::emitBuffer(const Buffer& resultBuffer, const ContinuationPolicy continuationPolicy)
 {
     if (resultBuffer.getNumberOfTuples() == 0)
     {
@@ -50,13 +50,13 @@ bool TestPipelineExecutionContext::emitBuffer(const TupleBuffer& resultBuffer, c
     return true;
 }
 
-TupleBuffer& TestPipelineExecutionContext::pinBuffer(TupleBuffer&& tupleBuffer)
+Buffer& TestPipelineExecutionContext::pinBuffer(Buffer&& tupleBuffer)
 {
-    pinnedBuffers.emplace_back(std::make_unique<TupleBuffer>(tupleBuffer));
+    pinnedBuffers.emplace_back(std::make_unique<Buffer>(tupleBuffer));
     return *pinnedBuffers.back();
 }
 
-TupleBuffer TestPipelineExecutionContext::allocateTupleBuffer()
+Buffer TestPipelineExecutionContext::allocateTupleBuffer()
 {
     if (auto buffer = bufferManager->getBufferNoBlocking())
     {
@@ -65,13 +65,13 @@ TupleBuffer TestPipelineExecutionContext::allocateTupleBuffer()
     throw BufferAllocationFailure("Required more buffers in TestTaskQueue than provided.");
 }
 
-void TestPipelineExecutionContext::repeatTask(const TupleBuffer&, std::chrono::milliseconds)
+void TestPipelineExecutionContext::repeatTask(const Buffer&, std::chrono::milliseconds)
 {
     PRECONDITION(repeatTaskCallback != nullptr, "Cannot repeat a task without a valid repeatTaskCallback function");
     repeatTaskCallback();
 }
 
-void TestPipelineStage::execute(const TupleBuffer& tupleBuffer, PipelineExecutionContext& pec)
+void TestPipelineStage::execute(const Buffer& tupleBuffer, PipelineExecutionContext& pec)
 {
     for (const auto& [_, taskFunction] : taskSteps)
     {
@@ -95,7 +95,7 @@ std::ostream& TestPipelineStage::toString(std::ostream& os) const
 }
 
 SingleThreadedTestTaskQueue::SingleThreadedTestTaskQueue(
-    std::shared_ptr<BufferManager> bufferProvider, std::shared_ptr<std::vector<std::vector<TupleBuffer>>> resultBuffers)
+    std::shared_ptr<BufferManager> bufferProvider, std::shared_ptr<std::vector<std::vector<Buffer>>> resultBuffers)
     : bufferProvider(std::move(bufferProvider)), resultBuffers(std::move(resultBuffers))
 {
 }
@@ -149,7 +149,7 @@ MultiThreadedTestTaskQueue::MultiThreadedTestTaskQueue(
     const size_t numberOfThreads,
     const std::vector<TestPipelineTask>& testTasks,
     std::shared_ptr<AbstractBufferProvider> bufferProvider,
-    std::shared_ptr<std::vector<std::vector<TupleBuffer>>> resultBuffers)
+    std::shared_ptr<std::vector<std::vector<Buffer>>> resultBuffers)
     : threadTasks(testTasks.size())
     , numberOfWorkerThreads(numberOfThreads)
     , completionLatch(numberOfThreads)

--- a/nes-executable/tests/TestUtils/TestTaskQueue.hpp
+++ b/nes-executable/tests/TestUtils/TestTaskQueue.hpp
@@ -30,9 +30,9 @@
 #include <Identifiers/Identifiers.hpp>
 #include <Identifiers/NESStrongType.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/BufferManager.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Util/Timer.hpp>
 #include <folly/MPMCQueue.h>
 #include <ErrorHandling.hpp>
@@ -56,7 +56,7 @@ public:
         std::shared_ptr<AbstractBufferProvider> bufferManager,
         const WorkerThreadId workerThreadId,
         const PipelineId pipelineId,
-        std::shared_ptr<std::vector<std::vector<TupleBuffer>>> resultBuffers)
+        std::shared_ptr<std::vector<std::vector<Buffer>>> resultBuffers)
         : workerThreadId(workerThreadId)
         , pipelineId(pipelineId)
         , bufferManager(std::move(bufferManager))
@@ -72,7 +72,7 @@ public:
 
     /// Setting invalid values for ids, since we set the values later.
     explicit TestPipelineExecutionContext(
-        std::shared_ptr<AbstractBufferProvider> bufferManager, std::shared_ptr<std::vector<std::vector<TupleBuffer>>> resultBufferPtr)
+        std::shared_ptr<AbstractBufferProvider> bufferManager, std::shared_ptr<std::vector<std::vector<Buffer>>> resultBufferPtr)
         : workerThreadId(WorkerThreadId(0))
         , pipelineId(PipelineId(0))
         , bufferManager(std::move(bufferManager))
@@ -87,11 +87,11 @@ public:
     }
 
     /// if buffer contains data, writes it into the result buffer vector, otherwise, calls the 'repeatTaskCallback'
-    bool emitBuffer(const TupleBuffer& resultBuffer, ContinuationPolicy continuationPolicy) override;
+    bool emitBuffer(const Buffer& resultBuffer, ContinuationPolicy continuationPolicy) override;
 
-    TupleBuffer allocateTupleBuffer() override;
+    Buffer allocateTupleBuffer() override;
 
-    TupleBuffer& pinBuffer(TupleBuffer&& tupleBuffer) override;
+    Buffer& pinBuffer(Buffer&& tupleBuffer) override;
 
     void setRepeatTaskCallback(std::function<void()> repeatTaskCallback) { this->repeatTaskCallback = std::move(repeatTaskCallback); }
 
@@ -110,22 +110,22 @@ public:
         this->operatorHandlers = operatorHandlers;
     }
 
-    void repeatTask(const TupleBuffer&, std::chrono::milliseconds) override;
+    void repeatTask(const Buffer&, std::chrono::milliseconds) override;
 
     WorkerThreadId workerThreadId;
     PipelineId pipelineId;
 
 private:
-    /// We want to ensure that the address of the TupleBuffer is always the same. If we would simply store the object directly in the vector,
+    /// We want to ensure that the address of the Buffer is always the same. If we would simply store the object directly in the vector,
     /// the address might change as the vector might be resized and thus, the object have a different address.
-    std::vector<std::unique_ptr<TupleBuffer>> pinnedBuffers;
+    std::vector<std::unique_ptr<Buffer>> pinnedBuffers;
     std::function<void()> repeatTaskCallback;
     std::shared_ptr<AbstractBufferProvider> bufferManager;
     std::unordered_map<OperatorHandlerId, std::shared_ptr<OperatorHandler>> operatorHandlers;
     /// Different threads have different TestPipelineExecutionContexts. All threads share the same pointer to the result buffers.
     /// Each thread writes its own results in a dedicated slot. This keeps results in a single place and does not require awkward logic
     /// to get the result buffers out of the TestPipelineExecutionContexts.
-    std::shared_ptr<std::vector<std::vector<TupleBuffer>>> resultBuffers;
+    std::shared_ptr<std::vector<std::vector<Buffer>>> resultBuffers;
 };
 
 /// Represents a single ExecutablePipelineStage with multiple functions ('taskSteps').
@@ -133,7 +133,7 @@ private:
 class TestPipelineStage final : public ExecutablePipelineStage
 {
 public:
-    using ExecuteFunction = std::function<void(const TupleBuffer&, PipelineExecutionContext&)>;
+    using ExecuteFunction = std::function<void(const Buffer&, PipelineExecutionContext&)>;
     TestPipelineStage() = default;
 
     TestPipelineStage(const std::string& stepName, ExecuteFunction testTask) { addStep(stepName, std::move(testTask)); }
@@ -141,7 +141,7 @@ public:
     void addStep(const std::string& stepName, ExecuteFunction testTask) { taskSteps.emplace_back(stepName, std::move(testTask)); }
 
     /// executes all task steps (ExecuteFunctions)
-    void execute(const TupleBuffer& tupleBuffer, PipelineExecutionContext& pec) override;
+    void execute(const Buffer& tupleBuffer, PipelineExecutionContext& pec) override;
 
 private:
     std::vector<std::pair<std::string, ExecuteFunction>> taskSteps;
@@ -158,12 +158,12 @@ struct TestPipelineTask
 {
     TestPipelineTask() : workerThreadId(INVALID<WorkerThreadId>) { };
 
-    TestPipelineTask(const WorkerThreadId workerThreadId, TupleBuffer tupleBuffer, std::shared_ptr<ExecutablePipelineStage> eps)
+    TestPipelineTask(const WorkerThreadId workerThreadId, Buffer tupleBuffer, std::shared_ptr<ExecutablePipelineStage> eps)
         : workerThreadId(workerThreadId), tupleBuffer(std::move(tupleBuffer)), eps(std::move(eps))
     {
     }
 
-    TestPipelineTask(TupleBuffer tupleBuffer, std::shared_ptr<ExecutablePipelineStage> eps)
+    TestPipelineTask(Buffer tupleBuffer, std::shared_ptr<ExecutablePipelineStage> eps)
         : workerThreadId(INVALID<WorkerThreadId>), tupleBuffer(std::move(tupleBuffer)), eps(std::move(eps))
     {
     }
@@ -172,7 +172,7 @@ struct TestPipelineTask
     void execute(TestPipelineExecutionContext& pec) const { eps->execute(tupleBuffer, pec); }
 
     WorkerThreadId workerThreadId;
-    TupleBuffer tupleBuffer;
+    Buffer tupleBuffer;
     std::shared_ptr<ExecutablePipelineStage> eps;
 };
 
@@ -189,7 +189,7 @@ class SingleThreadedTestTaskQueue
 {
 public:
     SingleThreadedTestTaskQueue(
-        std::shared_ptr<BufferManager> bufferProvider, std::shared_ptr<std::vector<std::vector<TupleBuffer>>> resultBuffers);
+        std::shared_ptr<BufferManager> bufferProvider, std::shared_ptr<std::vector<std::vector<Buffer>>> resultBuffers);
 
     ~SingleThreadedTestTaskQueue() = default;
 
@@ -199,7 +199,7 @@ public:
 private:
     std::queue<TestTaskQueueEntry> tasks;
     std::shared_ptr<AbstractBufferProvider> bufferProvider;
-    std::shared_ptr<std::vector<std::vector<TupleBuffer>>> resultBuffers;
+    std::shared_ptr<std::vector<std::vector<Buffer>>> resultBuffers;
 
     std::shared_ptr<ExecutablePipelineStage> eps;
 
@@ -218,7 +218,7 @@ public:
         size_t numberOfThreads,
         const std::vector<TestPipelineTask>& testTasks,
         std::shared_ptr<AbstractBufferProvider> bufferProvider,
-        std::shared_ptr<std::vector<std::vector<TupleBuffer>>> resultBuffers);
+        std::shared_ptr<std::vector<std::vector<Buffer>>> resultBuffers);
 
     /// Activates threads which start to concurrently process the WorkTasks in the MPMC queue.
     void startProcessing();
@@ -231,7 +231,7 @@ private:
     uint64_t numberOfWorkerThreads;
     std::latch completionLatch;
     std::shared_ptr<AbstractBufferProvider> bufferProvider;
-    std::shared_ptr<std::vector<std::vector<TupleBuffer>>> resultBuffers;
+    std::shared_ptr<std::vector<std::vector<Buffer>>> resultBuffers;
     std::shared_ptr<ExecutablePipelineStage> eps;
     std::vector<std::jthread> threads;
     Timer<std::chrono::microseconds> timer;

--- a/nes-input-formatters/CMakeLists.txt
+++ b/nes-input-formatters/CMakeLists.txt
@@ -29,7 +29,7 @@ target_include_directories(nes-input-formatters PUBLIC
         $<INSTALL_INTERFACE:include/nebulastream/>
         PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/private>)
 
-# 'Public' provider library, only exposing the provider and the TupleBufferRef
+# 'Public' provider library, only exposing the provider and the MemoryLayout
 add_library(nes-input-formatter-provider src/InputFormatterProvider.cpp)
 target_link_libraries(nes-input-formatter-provider PUBLIC nes-memory nes-executable PRIVATE nes-input-formatters-registry nes-input-formatters)
 target_include_directories(nes-input-formatter-provider PUBLIC

--- a/nes-input-formatters/CMakeLists.txt
+++ b/nes-input-formatters/CMakeLists.txt
@@ -19,7 +19,7 @@ add_subdirectory(src)
 get_source(nes-input-formatters NES_SOURCE_PARSERS_SOURCE_FILES)
 add_library(nes-input-formatters ${NES_SOURCE_PARSERS_SOURCE_FILES})
 
-# Exposing TupleBuffer (nes-memory) and PipelineExecutionContext (nes-executable) from public APIs
+# Exposing Buffer (nes-memory) and PipelineExecutionContext (nes-executable) from public APIs
 target_link_libraries(nes-input-formatters PUBLIC nes-memory nes-executable PRIVATE nes-common nes-configurations nes-runtime nes-executable nes-physical-operators)
 
 

--- a/nes-input-formatters/include/InputFormatterProvider/InputFormatterProvider.hpp
+++ b/nes-input-formatters/include/InputFormatterProvider/InputFormatterProvider.hpp
@@ -17,15 +17,15 @@
 #include <memory>
 
 #include <Identifiers/Identifiers.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <InputFormatterDescriptor.hpp>
 
 namespace NES
 {
 
-std::shared_ptr<TupleBufferRef>
-provideInputFormatter(const InputFormatterDescriptor& formatScanConfig, std::shared_ptr<TupleBufferRef> memoryProvider);
+std::shared_ptr<MemoryLayout>
+provideInputFormatter(const InputFormatterDescriptor& formatScanConfig, std::shared_ptr<MemoryLayout> memoryProvider);
 
 bool contains(const std::string& parserType);
 }

--- a/nes-input-formatters/include/InputFormatters/InputFormatter.hpp
+++ b/nes-input-formatters/include/InputFormatters/InputFormatter.hpp
@@ -24,7 +24,7 @@
 
 #include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Runtime/TupleBuffer.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Arena.hpp>
@@ -76,23 +76,23 @@ public:
     InputFormatter(InputFormatter&&) = default;
     InputFormatter& operator=(InputFormatter&&) = delete;
 
-    Record readRecord(const std::vector<Record::RecordFieldIdentifier>&, const RecordBuffer&, nautilus::val<uint64_t>&) const override;
+    Record readRecord(const std::vector<Record::RecordFieldIdentifier>&, const TaskBufferRef&, nautilus::val<uint64_t>&) const override;
 
     WriteRecordResult
-    writeRecord(nautilus::val<uint64_t>&, const RecordBuffer&, const Record&, const nautilus::val<AbstractBufferProvider*>&) const override;
+    writeRecord(nautilus::val<uint64_t>&, const TaskBufferRef&, const Record&, const nautilus::val<AbstractBufferProvider*>&) const override;
 
     [[nodiscard]] std::vector<Record::RecordFieldIdentifier> getAllFieldNames() const override;
 
     /// Executes the first phase, which indexes a (raw) buffer enabling the second phase, which calls 'readBuffer()' to index specific
     /// records/fields within the (raw) buffer. Relies on static thread_local member variables to 'bridge' the result of the indexing phase
     /// to the second phase, which uses the index to access specific records/fields
-    [[nodiscard]] nautilus::val<bool> indexBuffer(const RecordBuffer& recordBuffer, const ArenaRef& arenaRef) const;
+    [[nodiscard]] nautilus::val<bool> indexBuffer(const TaskBufferRef& recordBuffer, const ArenaRef& arenaRef) const;
 
     /// Executes the second phase, which iterates over a (raw) buffer, reading specific records and fields from a (raw) buffer
     /// Relies on the index created in the first phase (indexBuffer), which it accesses through the static_thread local member
     void readBuffer(
         ExecutionContext& executionCtx,
-        const RecordBuffer& recordBuffer,
+        const TaskBufferRef& recordBuffer,
         const std::function<void(ExecutionContext& executionCtx, Record& record)>& executeChild);
 
 

--- a/nes-input-formatters/include/InputFormatters/InputFormatter.hpp
+++ b/nes-input-formatters/include/InputFormatters/InputFormatter.hpp
@@ -22,7 +22,7 @@
 #include <utility>
 #include <vector>
 
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
 #include <Interface/RecordBuffer.hpp>
 #include <Runtime/TupleBuffer.hpp>
@@ -57,11 +57,11 @@ struct IndexPhaseResult;
 /// raw buffer and its successor (the InputFormatter) and writes it to the task queue of the QueryEngine.
 /// The QueryEngine concurrently executes InputFormatters. Thus, even if the source writes the InputFormatters to the task queue sequentially,
 /// the QueryEngine may still execute them in any order.
-class InputFormatter : public TupleBufferRef
+class InputFormatter : public MemoryLayout
 {
 public:
-    explicit InputFormatter(std::unique_ptr<InputFormatIndexer> inputFormatIndexer, std::shared_ptr<TupleBufferRef> memoryProvider)
-        : TupleBufferRef(*memoryProvider)
+    explicit InputFormatter(std::unique_ptr<InputFormatIndexer> inputFormatIndexer, std::shared_ptr<MemoryLayout> memoryProvider)
+        : MemoryLayout(*memoryProvider)
         , inputFormatIndexer(std::move(inputFormatIndexer))
         , projections(memoryProvider->getAllFieldNames())
         , memoryProvider(std::move(memoryProvider))
@@ -101,7 +101,7 @@ public:
 private:
     std::unique_ptr<InputFormatIndexer> inputFormatIndexer;
     std::vector<Record::RecordFieldIdentifier> projections;
-    std::shared_ptr<TupleBufferRef> memoryProvider;
+    std::shared_ptr<MemoryLayout> memoryProvider;
     std::unique_ptr<SequenceShredder> sequenceShredder;
 };
 

--- a/nes-input-formatters/include/InputFormatters/InputFormatter.hpp
+++ b/nes-input-formatters/include/InputFormatters/InputFormatter.hpp
@@ -25,7 +25,7 @@
 #include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
 #include <Interface/TaskBufferRef.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Arena.hpp>
 #include <ExecutionContext.hpp>
@@ -78,8 +78,8 @@ public:
 
     Record readRecord(const std::vector<Record::RecordFieldIdentifier>&, const TaskBufferRef&, nautilus::val<uint64_t>&) const override;
 
-    WriteRecordResult
-    writeRecord(nautilus::val<uint64_t>&, const TaskBufferRef&, const Record&, const nautilus::val<AbstractBufferProvider*>&) const override;
+    WriteRecordResult writeRecord(
+        nautilus::val<uint64_t>&, const TaskBufferRef&, const Record&, const nautilus::val<AbstractBufferProvider*>&) const override;
 
     [[nodiscard]] std::vector<Record::RecordFieldIdentifier> getAllFieldNames() const override;
 

--- a/nes-input-formatters/include/InputFormatters/RawBufferIndex.hpp
+++ b/nes-input-formatters/include/InputFormatters/RawBufferIndex.hpp
@@ -18,7 +18,7 @@
 #include <cstdint>
 #include <vector>
 
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
 #include <RawTupleBuffer.hpp>
 #include <val_arith.hpp>
@@ -61,7 +61,7 @@ public:
         const nautilus::val<uint64_t>& recordIndex,
         const InputFormatIndexer& indexer,
         nautilus::val<RawBufferIndex*> rawBufferIndex,
-        const TupleBufferRef& bufferRef) const
+        const MemoryLayout& bufferRef) const
         = 0;
 
     [[nodiscard]] virtual TupleDelimiterOffsets getTupleDelimiterOffsets() const = 0;

--- a/nes-input-formatters/include/InputFormatters/RawTupleBuffer.hpp
+++ b/nes-input-formatters/include/InputFormatters/RawTupleBuffer.hpp
@@ -20,7 +20,7 @@
 #include <utility>
 
 #include <Identifiers/Identifiers.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <ErrorHandling.hpp>
 
 namespace NES
@@ -29,14 +29,14 @@ namespace NES
 using FieldIndex = uint32_t;
 using SequenceNumberType = SequenceNumber::Underlying;
 
-/// Wraps a TupleBuffer that contains raw, unformatted data. Exposes a string_view over the payload for indexers/parsers while keeping
-/// the underlying TupleBuffer reachable only to classes that legitimately need it (e.g. SpanningTupleBufferState).
+/// Wraps a Buffer that contains raw, unformatted data. Exposes a string_view over the payload for indexers/parsers while keeping
+/// the underlying Buffer reachable only to classes that legitimately need it (e.g. SpanningTupleBufferState).
 class RawTupleBuffer
 {
 public:
     RawTupleBuffer() = default;
     ~RawTupleBuffer() = default;
-    explicit RawTupleBuffer(TupleBuffer rawTupleBuffer)
+    explicit RawTupleBuffer(Buffer rawTupleBuffer)
         : rawBuffer(std::move(rawTupleBuffer))
         , bufferView(rawBuffer.getAvailableMemoryArea<char>().data(), rawBuffer.getNumberOfTuples()) { };
 
@@ -51,10 +51,10 @@ public:
 
     [[nodiscard]] std::string_view getBufferView() const noexcept { return bufferView; }
 
-    [[nodiscard]] const TupleBuffer& getRawBuffer() const noexcept { return rawBuffer; }
+    [[nodiscard]] const Buffer& getRawBuffer() const noexcept { return rawBuffer; }
 
 private:
-    TupleBuffer rawBuffer;
+    Buffer rawBuffer;
     std::string_view bufferView;
 };
 

--- a/nes-input-formatters/include/InputFormatters/SequenceShredder.hpp
+++ b/nes-input-formatters/include/InputFormatters/SequenceShredder.hpp
@@ -21,7 +21,7 @@
 #include <utility>
 #include <vector>
 #include <Identifiers/Identifiers.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Util/Logger/Formatter.hpp>
 #include <RawTupleBuffer.hpp>
 

--- a/nes-input-formatters/private/CSVInputFormatIndexer.hpp
+++ b/nes-input-formatters/private/CSVInputFormatIndexer.hpp
@@ -26,7 +26,7 @@
 
 #include <Configurations/Descriptor.hpp>
 #include <DataTypes/DataType.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Util/Strings.hpp>
@@ -100,7 +100,7 @@ public:
     }
 
     /// Delegate constructor that applies preconditions before safely calling the constructor
-    static std::unique_ptr<CSVInputFormatIndexer> create(const InputFormatterDescriptor& config, const TupleBufferRef& tupleBufferRef)
+    static std::unique_ptr<CSVInputFormatIndexer> create(const InputFormatterDescriptor& config, const MemoryLayout& tupleBufferRef)
     {
         return std::make_unique<CSVInputFormatIndexer>(
             Private{},

--- a/nes-input-formatters/private/FieldOffsetRawBufferIndex.hpp
+++ b/nes-input-formatters/private/FieldOffsetRawBufferIndex.hpp
@@ -20,7 +20,7 @@
 #include <cstdlib>
 #include <vector>
 
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
 #include <InputFormatter.hpp>
 #include <RawBufferIndex.hpp>
@@ -55,7 +55,7 @@ public:
         const nautilus::val<uint64_t>& recordIndex,
         const InputFormatIndexer& indexer,
         nautilus::val<RawBufferIndex*> rawBufferIndex,
-        const TupleBufferRef& bufferRef) const override;
+        const MemoryLayout& bufferRef) const override;
 
     [[nodiscard]] TupleDelimiterOffsets getTupleDelimiterOffsets() const override
     {

--- a/nes-input-formatters/private/SpanningTupleBuffer.hpp
+++ b/nes-input-formatters/private/SpanningTupleBuffer.hpp
@@ -24,7 +24,7 @@
 
 #include <Identifiers/Identifiers.hpp>
 #include <Identifiers/NESStrongType.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Util/Logger/Formatter.hpp>
 #include <RawTupleBuffer.hpp>
 #include <SequenceShredder.hpp>

--- a/nes-input-formatters/private/SpanningTupleBufferState.hpp
+++ b/nes-input-formatters/private/SpanningTupleBufferState.hpp
@@ -21,7 +21,7 @@
 #include <optional>
 #include <ostream>
 #include <span>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <RawTupleBuffer.hpp>
 
 #include <Identifiers/NESStrongType.hpp>
@@ -160,7 +160,7 @@ public:
     /// Checks if the current entry was used to construct both a leading and trailing spanning tuple (given it matches abaItNumber - 1)
     [[nodiscard]] bool isCurrentEntryUsedUp(ABAItNo abaItNumber) const;
 
-    /// Sets the TupleBuffer of the staged buffer for both uses (leading/spanning) and copies the offsets
+    /// Sets the Buffer of the staged buffer for both uses (leading/spanning) and copies the offsets
     void setBuffersAndOffsets(const StagedBuffer& indexedBuffer);
 
     /// Sets the indexed buffer as the new entry, if the prior entry is used up and its expected ABA iteration number is (abaItNumber - 1)
@@ -182,10 +182,10 @@ public:
         SpanningTupleBufferIdx bufferIdx, const SpanningTupleBufferEntry& nextEntry, SpanningTupleBufferIdx lastIdxOfBuffer) const;
 
 private:
-    /// 24 Bytes (TupleBuffer)
-    TupleBuffer leadingBufferRef;
-    /// 48 Bytes (TupleBuffer)
-    TupleBuffer trailingBufferRef;
+    /// 24 Bytes (Buffer)
+    Buffer leadingBufferRef;
+    /// 48 Bytes (Buffer)
+    Buffer trailingBufferRef;
     /// 56 Bytes (Atomic state)
     AtomicState atomicState;
     /// 60 Bytes (meta data)

--- a/nes-input-formatters/registry/include/InputFormatIndexerRegistry.hpp
+++ b/nes-input-formatters/registry/include/InputFormatIndexerRegistry.hpp
@@ -20,7 +20,7 @@
 #include <utility>
 
 #include <Identifiers/Identifiers.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Util/Registry.hpp>
 #include <InputFormatIndexer.hpp>
@@ -37,14 +37,14 @@ using InputFormatIndexerRegistryReturnType = std::unique_ptr<InputFormatter>;
 /// hands a `unique_ptr<InputFormatIndexer>` to `createInputFormatterWithIndexer()` to assemble a concrete `InputFormatter`.
 struct InputFormatIndexerRegistryArguments
 {
-    InputFormatIndexerRegistryArguments(const InputFormatterDescriptor& config, std::shared_ptr<TupleBufferRef> memoryProvider)
+    InputFormatIndexerRegistryArguments(const InputFormatterDescriptor& config, std::shared_ptr<MemoryLayout> memoryProvider)
         : inputFormatIndexerConfig(config), memoryProvider(std::move(memoryProvider))
     {
     }
 
     [[nodiscard]] const InputFormatterDescriptor& getInputFormatterConfig() const { return inputFormatIndexerConfig; }
 
-    [[nodiscard]] const TupleBufferRef& getInputMemoryProvider() const { return *memoryProvider; }
+    [[nodiscard]] const MemoryLayout& getInputMemoryProvider() const { return *memoryProvider; }
 
     /// Instantiates an InputFormatter with a specific input format indexer
     InputFormatIndexerRegistryReturnType createInputFormatterWithIndexer(std::unique_ptr<InputFormatIndexer> inputFormatIndexer)
@@ -58,7 +58,7 @@ private:
     /// Instead, an indexer receives it as a const meta-data object in its main 'indexRawBuffer' function
     /// While this does not prevent an indexer implementation from accessing the state of the meta-data object it helps to discourage it
     InputFormatterDescriptor inputFormatIndexerConfig;
-    std::shared_ptr<TupleBufferRef> memoryProvider;
+    std::shared_ptr<MemoryLayout> memoryProvider;
 };
 
 class InputFormatIndexerRegistry : public BaseRegistry<

--- a/nes-input-formatters/src/FieldOffsetRawBufferIndex.cpp
+++ b/nes-input-formatters/src/FieldOffsetRawBufferIndex.cpp
@@ -22,7 +22,7 @@
 #include <static.hpp>
 
 #include <DataTypes/DataTypesUtil.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
 #include <ErrorHandling.hpp>
 #include <InputFormatter.hpp>
@@ -66,7 +66,7 @@ Record FieldOffsetRawBufferIndex::readSpanningRecord(
     const nautilus::val<uint64_t>& recordIndex,
     const InputFormatIndexer& indexer,
     nautilus::val<RawBufferIndex*> rawBufferIndex,
-    const TupleBufferRef& bufferRef) const
+    const MemoryLayout& bufferRef) const
 {
     Record record;
     const auto indexBufferPtr = nautilus::invoke(getIndexValuesProxy, rawBufferIndex);

--- a/nes-input-formatters/src/InputFormatter.cpp
+++ b/nes-input-formatters/src/InputFormatter.cpp
@@ -30,7 +30,7 @@
 
 #include <DataTypes/DataType.hpp>
 #include <DataTypes/DataTypesUtil.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
 #include <Interface/RecordBuffer.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
@@ -330,7 +330,7 @@ void parseLeadingRecord(
     const nautilus::val<IndexPhaseResult*>& indexPhaseResult,
     const std::vector<Record::RecordFieldIdentifier>& projections,
     const InputFormatIndexer& indexer,
-    const TupleBufferRef& bufferRef)
+    const MemoryLayout& bufferRef)
 {
     if (*getMemberWithOffset<bool>(indexPhaseResult, offsetof(IndexPhaseResult, hasLeadingSpanningTupleBool)))
     {
@@ -352,7 +352,7 @@ void parseRecordsInRawBuffer(
     const nautilus::val<IndexPhaseResult*>& indexPhaseResult,
     const std::vector<Record::RecordFieldIdentifier>& projections,
     const InputFormatIndexer& indexer,
-    const TupleBufferRef& bufferRef)
+    const MemoryLayout& bufferRef)
 {
     nautilus::val<uint64_t> bufferRecordIdx = 0;
     auto rawBufferIndexVal = *getMemberWithOffset<RawBufferIndex*>(indexPhaseResult, offsetof(IndexPhaseResult, rawBufferIndex));
@@ -373,7 +373,7 @@ void parseTrailingRecord(
     const std::vector<Record::RecordFieldIdentifier>& projections,
     InputFormatIndexer& indexer,
     SequenceShredder& sequenceShredder,
-    const TupleBufferRef& bufferRef)
+    const MemoryLayout& bufferRef)
 {
     const nautilus::val<bool> hasTrailingSpanningTuple = invoke(
         indexTrailingSpanningTupleProxy,
@@ -408,7 +408,7 @@ Record InputFormatter::readRecord(const std::vector<Record::RecordFieldIdentifie
     std::unreachable();
 }
 
-TupleBufferRef::WriteRecordResult InputFormatter::writeRecord(
+MemoryLayout::WriteRecordResult InputFormatter::writeRecord(
     nautilus::val<uint64_t>&, const RecordBuffer&, const Record&, const nautilus::val<AbstractBufferProvider*>&) const
 {
     INVARIANT(false, "unsupported operation on InputFormatter");

--- a/nes-input-formatters/src/InputFormatter.cpp
+++ b/nes-input-formatters/src/InputFormatter.cpp
@@ -34,7 +34,7 @@
 #include <Interface/Record.hpp>
 #include <Interface/TaskBufferRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Arena.hpp>
 #include <ErrorHandling.hpp>
 #include <ExecutionContext.hpp>
@@ -174,7 +174,7 @@ public:
         tlOwnedRawBufferIndices = OwnedRawBufferIndices{};
     }
 
-    static IndexResult indexRawBuffer(InputFormatIndexer& indexer, const TupleBuffer& tupleBuffer)
+    static IndexResult indexRawBuffer(InputFormatIndexer& indexer, const Buffer& tupleBuffer)
     {
         auto result = indexer.indexRawBuffer({tupleBuffer.getAvailableMemoryArea<char>().data(), tupleBuffer.getNumberOfTuples()});
         const auto [offsetOfFirstTupleDelimiter, offsetOfLastTupleDelimiter] = result->getTupleDelimiterOffsets();
@@ -252,7 +252,7 @@ private:
 };
 
 bool indexTrailingSpanningTupleProxy(
-    const TupleBuffer* tupleBuffer, Arena* arenaRef, InputFormatIndexer* indexer, SequenceShredder* sequenceShredder)
+    const Buffer* tupleBuffer, Arena* arenaRef, InputFormatIndexer* indexer, SequenceShredder* sequenceShredder)
 {
     /// Value was stashed on tlIndexPhaseResult when the indexer returned its RawBufferIndex; max() means no delimiter in the buffer.
     const auto offsetOfLastTupleDelimiter = tlIndexPhaseResult.offsetOfLastTupleInRawBuffer;
@@ -280,7 +280,7 @@ bool indexTrailingSpanningTupleProxy(
 }
 
 IndexPhaseResult* indexLeadingSpanningTupleAndBufferProxy(
-    const TupleBuffer* tupleBuffer, Arena* arenaRef, InputFormatIndexer* indexer, SequenceShredder* sequenceShredder)
+    const Buffer* tupleBuffer, Arena* arenaRef, InputFormatIndexer* indexer, SequenceShredder* sequenceShredder)
 {
     IndexPhaseResultBuilder::startBuildingIndex();
     const auto [offsetOfFirstTupleDelimiter, offsetOfLastTupleDelimiter, hasTupleDelimiter]

--- a/nes-input-formatters/src/InputFormatter.cpp
+++ b/nes-input-formatters/src/InputFormatter.cpp
@@ -32,7 +32,7 @@
 #include <DataTypes/DataTypesUtil.hpp>
 #include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
 #include <Arena.hpp>
@@ -347,7 +347,7 @@ void parseLeadingRecord(
 
 void parseRecordsInRawBuffer(
     ExecutionContext& executionCtx,
-    const RecordBuffer& recordBuffer,
+    const TaskBufferRef& recordBuffer,
     const std::function<void(ExecutionContext& executionCtx, Record& record)>& executeChild,
     const nautilus::val<IndexPhaseResult*>& indexPhaseResult,
     const std::vector<Record::RecordFieldIdentifier>& projections,
@@ -367,7 +367,7 @@ void parseRecordsInRawBuffer(
 
 void parseTrailingRecord(
     ExecutionContext& executionCtx,
-    const RecordBuffer& recordBuffer,
+    const TaskBufferRef& recordBuffer,
     const std::function<void(ExecutionContext& executionCtx, Record& record)>& executeChild,
     const nautilus::val<IndexPhaseResult*>& indexPhaseResult,
     const std::vector<Record::RecordFieldIdentifier>& projections,
@@ -402,14 +402,14 @@ std::vector<DataType> InputFormatter::getAllDataTypes() const
     std::unreachable();
 }
 
-Record InputFormatter::readRecord(const std::vector<Record::RecordFieldIdentifier>&, const RecordBuffer&, nautilus::val<uint64_t>&) const
+Record InputFormatter::readRecord(const std::vector<Record::RecordFieldIdentifier>&, const TaskBufferRef&, nautilus::val<uint64_t>&) const
 {
     INVARIANT(false, "Does not implement 'readRecord()'");
     std::unreachable();
 }
 
 MemoryLayout::WriteRecordResult InputFormatter::writeRecord(
-    nautilus::val<uint64_t>&, const RecordBuffer&, const Record&, const nautilus::val<AbstractBufferProvider*>&) const
+    nautilus::val<uint64_t>&, const TaskBufferRef&, const Record&, const nautilus::val<AbstractBufferProvider*>&) const
 {
     INVARIANT(false, "unsupported operation on InputFormatter");
     std::unreachable();
@@ -421,7 +421,7 @@ std::vector<Record::RecordFieldIdentifier> InputFormatter::getAllFieldNames() co
     std::unreachable();
 }
 
-nautilus::val<bool> InputFormatter::indexBuffer(const RecordBuffer& recordBuffer, const ArenaRef& arenaRef) const
+nautilus::val<bool> InputFormatter::indexBuffer(const TaskBufferRef& recordBuffer, const ArenaRef& arenaRef) const
 {
     setDefaultRawBufferIndicesForTracing(*this->inputFormatIndexer);
     /// index raw tuple buffer, resolve and index spanning tuples(SequenceShredder) and return pointers to resolved spanning tuples, if exist
@@ -442,7 +442,7 @@ nautilus::val<bool> InputFormatter::indexBuffer(const RecordBuffer& recordBuffer
 
 void InputFormatter::readBuffer(
     ExecutionContext& executionCtx,
-    const RecordBuffer& recordBuffer,
+    const TaskBufferRef& recordBuffer,
     const std::function<void(ExecutionContext& executionCtx, Record& record)>& executeChild)
 {
     /// @Note: the order below is important

--- a/nes-input-formatters/src/InputFormatterProvider.cpp
+++ b/nes-input-formatters/src/InputFormatterProvider.cpp
@@ -17,7 +17,7 @@
 #include <memory>
 #include <utility>
 
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <ErrorHandling.hpp>
 #include <InputFormatIndexerRegistry.hpp>
@@ -27,8 +27,8 @@
 namespace NES
 {
 
-std::shared_ptr<TupleBufferRef>
-provideInputFormatter(const InputFormatterDescriptor& formatScanConfig, std::shared_ptr<TupleBufferRef> memoryProvider)
+std::shared_ptr<MemoryLayout>
+provideInputFormatter(const InputFormatterDescriptor& formatScanConfig, std::shared_ptr<MemoryLayout> memoryProvider)
 {
     if (auto inputFormatter = InputFormatIndexerRegistry::instance().create(
             formatScanConfig.getInputFormatterType(), InputFormatIndexerRegistryArguments(formatScanConfig, std::move(memoryProvider))))

--- a/nes-input-formatters/src/SpanningTupleBuffer.cpp
+++ b/nes-input-formatters/src/SpanningTupleBuffer.cpp
@@ -25,7 +25,7 @@
 
 #include <Identifiers/Identifiers.hpp>
 #include <Identifiers/NESStrongType.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Util/Ranges.hpp>
 #include <fmt/format.h>
 #include <RawTupleBuffer.hpp>

--- a/nes-input-formatters/src/SpanningTupleBufferState.cpp
+++ b/nes-input-formatters/src/SpanningTupleBufferState.cpp
@@ -140,7 +140,7 @@ void SpanningTupleBufferEntry::claimNoDelimiterBuffer(std::span<StagedBuffer> sp
     /// First claim buffer uses
     spanningTupleVector[spanningTupleIdx]
         = StagedBuffer(RawTupleBuffer{std::move(this->leadingBufferRef)}, firstDelimiterOffset, lastDelimiterOffset);
-    this->trailingBufferRef = NES::TupleBuffer{};
+    this->trailingBufferRef = NES::Buffer{};
 
     /// Then atomically mark buffer as used
     this->atomicState.setUsedLeadingAndTrailingBuffer();

--- a/nes-input-formatters/tests/UnitTests/ConcurrentSynchronizationTest.cpp
+++ b/nes-input-formatters/tests/UnitTests/ConcurrentSynchronizationTest.cpp
@@ -26,8 +26,8 @@
 #include <vector>
 
 #include <Runtime/Allocator/NesDefaultMemoryAllocator.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/BufferManager.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <gtest/gtest.h>
 #include <RawTupleBuffer.hpp>
@@ -58,7 +58,7 @@ public:
         TestThreadPool(
             const NES::SequenceNumberType upperBound,
             const std::optional<NES::SequenceNumberType> fixedSeed,
-            const NES::TupleBuffer& dummyBuffer)
+            const NES::Buffer& dummyBuffer)
             : currentSequenceNumber(1), completionLatch(NUM_THREADS)
         {
             for (size_t i = 0; i < NUM_THREADS; ++i)
@@ -116,7 +116,7 @@ public:
             const size_t upperBound,
             std::mt19937_64 sequenceNumberGen,
             std::bernoulli_distribution boolDistribution,
-            const NES::TupleBuffer& dummyBuffer)
+            const NES::Buffer& dummyBuffer)
         {
             threadLocalCheckSum.at(threadIdx) = 0;
 
@@ -187,7 +187,7 @@ public:
     static void executeTest(const uint32_t upperBound, const std::optional<NES::SequenceNumberType> fixedSeed)
     {
         PRECONDITION(upperBound <= std::numeric_limits<uint32_t>::max(), "Not supporting values larger than 4294967295");
-        /// To avoid (future) errors by creating a TupleBuffer without a valid control block, we create a single valid (dummy) tuple buffer
+        /// To avoid (future) errors by creating a Buffer without a valid control block, we create a single valid (dummy) tuple buffer
         /// All threads share the reference to that buffer throughout this test
         constexpr uint32_t dummyBufferSize = 1;
         constexpr NES::BufferAlignment bufferAlignment{64};

--- a/nes-input-formatters/tests/UnitTests/SmallFilesTest.cpp
+++ b/nes-input-formatters/tests/UnitTests/SmallFilesTest.cpp
@@ -37,8 +37,8 @@
 #include <Identifiers/Identifiers.hpp>
 #include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
 #include <Runtime/Allocator/NesDefaultMemoryAllocator.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/BufferManager.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Sources/SourceCatalog.hpp>
 #include <Sources/SourceHandle.hpp>
 #include <Sources/SourceReturnType.hpp>
@@ -195,7 +195,7 @@ public:
         return numberOfExpectedRawBuffers;
     }
 
-    SetupResult setupTest(const TestConfig& testConfig, InputFormatterTestUtil::ThreadSafeVector<TupleBuffer>& rawBuffers)
+    SetupResult setupTest(const TestConfig& testConfig, InputFormatterTestUtil::ThreadSafeVector<Buffer>& rawBuffers)
     {
         const auto currentTestFile = testFileMap.at(testConfig.testFileName);
         const auto schema = InputFormatterTestUtil::createSchema(
@@ -256,17 +256,17 @@ public:
 
     template <bool WriteExpectedResultsFile>
     bool compareResults(
-        const std::vector<std::vector<TupleBuffer>>& resultBuffers,
+        const std::vector<std::vector<Buffer>>& resultBuffers,
         const SetupResult& setupResult,
         const std::vector<size_t>& varSizedFieldOffsets,
         BufferManager& testBufferManager)
     {
         /// Combine results and sort them using (ascending on sequence-/chunknumbers)
         auto combinedThreadResults = std::ranges::views::join(resultBuffers);
-        std::vector<TupleBuffer> resultBufferVec(combinedThreadResults.begin(), combinedThreadResults.end());
+        std::vector<Buffer> resultBufferVec(combinedThreadResults.begin(), combinedThreadResults.end());
         std::ranges::sort(
             resultBufferVec,
-            [](const TupleBuffer& left, const TupleBuffer& right)
+            [](const Buffer& left, const Buffer& right)
             {
                 if (left.getSequenceNumber() == right.getSequenceNumber())
                 {
@@ -293,7 +293,7 @@ public:
     void runTest(const TestConfig& testConfig)
     {
         /// Create vector for result buffers and create emit function to collect buffers from source
-        InputFormatterTestUtil::ThreadSafeVector<TupleBuffer> rawBuffers;
+        InputFormatterTestUtil::ThreadSafeVector<Buffer> rawBuffers;
 
         const auto setupResult = setupTest(testConfig, rawBuffers);
 
@@ -324,7 +324,7 @@ public:
                 setupResult.sizeOfFormattedBuffers,
                 testConfig.isCompiled);
 
-            auto resultBuffers = std::make_shared<std::vector<std::vector<TupleBuffer>>>(testConfig.numberOfThreads);
+            auto resultBuffers = std::make_shared<std::vector<std::vector<Buffer>>>(testConfig.numberOfThreads);
             std::vector<TestPipelineTask> pipelineTasks;
             pipelineTasks.reserve(setupResult.numberOfExpectedRawBuffers);
             rawBuffers.modifyBuffer(

--- a/nes-input-formatters/tests/UnitTests/SmallFilesTest.cpp
+++ b/nes-input-formatters/tests/UnitTests/SmallFilesTest.cpp
@@ -35,7 +35,7 @@
 #include <DataTypes/UnboundField.hpp>
 #include <Identifiers/Identifier.hpp>
 #include <Identifiers/Identifiers.hpp>
-#include <Interface/BufferRef/LowerSchemaProvider.hpp>
+#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
 #include <Runtime/Allocator/NesDefaultMemoryAllocator.hpp>
 #include <Runtime/BufferManager.hpp>
 #include <Runtime/TupleBuffer.hpp>

--- a/nes-input-formatters/tests/UnitTests/SpecificSequenceTest.cpp
+++ b/nes-input-formatters/tests/UnitTests/SpecificSequenceTest.cpp
@@ -16,7 +16,7 @@
 #include <tuple>
 
 #include <Identifiers/Identifiers.hpp>
-#include <Interface/BufferRef/LowerSchemaProvider.hpp>
+#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <Util/Logger/impl/NesLogger.hpp>
 #include <gtest/gtest.h>

--- a/nes-input-formatters/tests/Util/FileUtil.hpp
+++ b/nes-input-formatters/tests/Util/FileUtil.hpp
@@ -28,7 +28,7 @@
 #include <DataTypes/SchemaFwd.hpp>
 #include <DataTypes/UnboundField.hpp>
 #include <Identifiers/Identifiers.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/VariableSizedAccess.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
@@ -137,7 +137,7 @@ inline void writePagedSizeBufferChunkToFile(
 inline std::string readVarSizedDataAsString(const TupleBuffer& tupleBuffer, VariableSizedAccess variableSizedAccess)
 {
     /// Retrieve the variable sized value as span over its bytes
-    const auto varSizedSpan = TupleBufferRef::loadAssociatedVarSizedValue(tupleBuffer, variableSizedAccess);
+    const auto varSizedSpan = MemoryLayout::loadAssociatedVarSizedValue(tupleBuffer, variableSizedAccess);
     const auto* const strPtrContent = reinterpret_cast<const char*>(varSizedSpan.data());
     return std::string{strPtrContent, variableSizedAccess.getSize().getRawSize()};
 }

--- a/nes-input-formatters/tests/Util/FileUtil.hpp
+++ b/nes-input-formatters/tests/Util/FileUtil.hpp
@@ -31,7 +31,7 @@
 #include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/VariableSizedAccess.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sequencing/SequenceData.hpp>
 #include <Util/Ranges.hpp>
 #include <ErrorHandling.hpp>
@@ -121,7 +121,7 @@ inline void writeFileHeaderToFile(const BinaryFileHeader& binaryFileHeader, cons
 inline void writePagedSizeBufferChunkToFile(
     const BinaryBufferHeader& binaryHeader,
     const size_t sizeOfSchemaInBytes,
-    const std::span<TupleBuffer> pagedSizeBufferChunk,
+    const std::span<Buffer> pagedSizeBufferChunk,
     std::ofstream& file)
 {
     file.write(std::bit_cast<const char*>(&binaryHeader), sizeof(BinaryBufferHeader));
@@ -134,7 +134,7 @@ inline void writePagedSizeBufferChunkToFile(
 }
 
 /// @return Variable sized data as a string
-inline std::string readVarSizedDataAsString(const TupleBuffer& tupleBuffer, VariableSizedAccess variableSizedAccess)
+inline std::string readVarSizedDataAsString(const Buffer& tupleBuffer, VariableSizedAccess variableSizedAccess)
 {
     /// Retrieve the variable sized value as span over its bytes
     const auto varSizedSpan = MemoryLayout::loadAssociatedVarSizedValue(tupleBuffer, variableSizedAccess);
@@ -143,7 +143,7 @@ inline std::string readVarSizedDataAsString(const TupleBuffer& tupleBuffer, Vari
 }
 
 inline void writePagedSizeTupleBufferChunkToFile(
-    std::span<TupleBuffer> pagedSizeBufferChunk,
+    std::span<Buffer> pagedSizeBufferChunk,
     const SequenceNumber::Underlying sequenceNumber,
     const size_t numTuplesInChunk,
     std::ofstream& appendFile,
@@ -186,12 +186,12 @@ struct TupleBufferChunk
     size_t numTuplesInChunk = 0;
 };
 
-inline void sortTupleBuffers(std::vector<TupleBuffer>& buffers)
+inline void sortTupleBuffers(std::vector<Buffer>& buffers)
 {
     std::ranges::sort(
         buffers.begin(),
         buffers.end(),
-        [](const TupleBuffer& left, const TupleBuffer& right)
+        [](const Buffer& left, const Buffer& right)
         {
             return SequenceData{left.getSequenceNumber(), left.getChunkNumber(), left.isLastChunk()}
             < SequenceData{right.getSequenceNumber(), right.getChunkNumber(), right.isLastChunk()};
@@ -199,7 +199,7 @@ inline void sortTupleBuffers(std::vector<TupleBuffer>& buffers)
 }
 
 inline void writeTupleBuffersToFile(
-    std::vector<TupleBuffer>& resultBufferVec,
+    std::vector<Buffer>& resultBufferVec,
     const Schema<QualifiedUnboundField, Ordered>& schema,
     const std::filesystem::path& actualResultFilePath,
     const std::vector<size_t>& varSizedFieldOffsets)
@@ -208,7 +208,7 @@ inline void writeTupleBuffersToFile(
     const auto sizeOfSchemaInBytes = schema.getSizeInBytes();
 
     const std::vector<TupleBufferChunk> pagedSizedChunkOffsets
-        = [](const std::vector<TupleBuffer>& resultBufferVec, const size_t sizeOfSchemaInBytes)
+        = [](const std::vector<Buffer>& resultBufferVec, const size_t sizeOfSchemaInBytes)
     {
         size_t numBytesInNextChunk = 0;
         size_t numTuplesInNextChunk = 0;
@@ -249,7 +249,7 @@ inline void writeTupleBuffersToFile(
 }
 
 inline void updateChildBufferIdx(
-    TupleBuffer& parentBuffer,
+    Buffer& parentBuffer,
     const VariableSizedAccess varSizedAccess,
     const std::vector<size_t>& varSizedFieldOffsets,
     const size_t sizeOfSchemaInBytes)
@@ -263,7 +263,7 @@ inline void updateChildBufferIdx(
     std::ranges::copy(combinedIndexOffsetBytes, parentBuffer.getAvailableMemoryArea().begin() + varSizedOffset);
 }
 
-inline std::vector<TupleBuffer> loadTupleBuffersFromFile(
+inline std::vector<Buffer> loadTupleBuffersFromFile(
     AbstractBufferProvider& bufferProvider,
     const Schema<QualifiedUnboundField, Ordered>& schema,
     const std::filesystem::path& filepath,
@@ -282,7 +282,7 @@ inline std::vector<TupleBuffer> loadTupleBuffersFromFile(
             throw FormattingError("Failed to read file header from file: {}", filepath.string());
         }(file, filepath);
 
-        std::vector<TupleBuffer> expectedResultBuffers(fileHeader.numberOfBuffers);
+        std::vector<Buffer> expectedResultBuffers(fileHeader.numberOfBuffers);
         for (size_t bufferIdx = 0; bufferIdx < fileHeader.numberOfBuffers; ++bufferIdx)
         {
             const auto bufferHeader = [](std::ifstream& file)

--- a/nes-input-formatters/tests/Util/InputFormatterTestUtil.cpp
+++ b/nes-input-formatters/tests/Util/InputFormatterTestUtil.cpp
@@ -41,8 +41,8 @@
 #include <Identifiers/Identifier.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Identifiers/NESStrongType.hpp>
-#include <Interface/BufferRef/LowerSchemaProvider.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Pipelines/CompiledExecutablePipelineStage.hpp>
 #include <Runtime/BufferManager.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>

--- a/nes-input-formatters/tests/Util/InputFormatterTestUtil.cpp
+++ b/nes-input-formatters/tests/Util/InputFormatterTestUtil.cpp
@@ -44,9 +44,9 @@
 #include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
 #include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Pipelines/CompiledExecutablePipelineStage.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/BufferManager.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Sources/SourceCatalog.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Sources/SourceHandle.hpp>
@@ -108,7 +108,7 @@ createSchema(const std::vector<TestDataTypes>& testDataTypes, const std::vector<
         | std::ranges::to<Schema<UnqualifiedUnboundField, Ordered>>();
 }
 
-SourceReturnType::EmitFunction getEmitFunction(ThreadSafeVector<TupleBuffer>& resultBuffers)
+SourceReturnType::EmitFunction getEmitFunction(ThreadSafeVector<Buffer>& resultBuffers)
 {
     return [&resultBuffers](
                const OriginId, SourceReturnType::SourceReturnType returnType, const std::stop_token&) -> SourceReturnType::EmitResult
@@ -147,7 +147,7 @@ std::pair<BackpressureController, std::unique_ptr<SourceHandle>> createFileSourc
     return {std::move(backpressureController), sourceProvider.lower(NES::OriginId(1), backpressureListener, sourceDescriptor.value())};
 }
 
-void waitForSource(const std::vector<TupleBuffer>& resultBuffers, const size_t numExpectedBuffers)
+void waitForSource(const std::vector<Buffer>& resultBuffers, const size_t numExpectedBuffers)
 {
     /// Wait for the file source to fill all expected tuple buffers. Timeout after 1 second (it should never take that long).
     const auto timeout = std::chrono::seconds(1);

--- a/nes-input-formatters/tests/Util/InputFormatterTestUtil.hpp
+++ b/nes-input-formatters/tests/Util/InputFormatterTestUtil.hpp
@@ -34,8 +34,8 @@
 #include <DataTypes/UnboundField.hpp>
 #include <Identifiers/Identifier.hpp>
 #include <Identifiers/Identifiers.hpp>
-#include <Interface/BufferRef/LowerSchemaProvider.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
 #include <Interface/RecordBuffer.hpp>
 #include <Interface/VariableSizedAccessRef.hpp>
@@ -259,7 +259,7 @@ private:
     nautilus::val<uint64_t> currentTupleIdx = 0;
     Schema<QualifiedUnboundField, Ordered> schema;
     std::vector<TupleBuffer> buffers;
-    std::shared_ptr<TupleBufferRef> bufferRef;
+    std::shared_ptr<MemoryLayout> bufferRef;
 };
 
 /// Expects tuple buffers with matching sequence numbers contain the same tuples in the same order
@@ -346,7 +346,7 @@ void writeFieldToBuffer(
     const T& fieldValue,
     const size_t fieldIndex,
     NES::TupleBuffer& tupleBuffer,
-    TupleBufferRef& tupleBufferRef,
+    MemoryLayout& tupleBufferRef,
     AbstractBufferProvider& bufferProvider)
 {
     Record record;
@@ -370,7 +370,7 @@ void writeFieldToBuffer(
     tupleBufferRef.writeRecord(recordIndex, recordBuffer, record, bufferProviderVal);
 }
 
-inline void printTupleBuffer(const std::string_view message, TupleBuffer& tupleBuffer, const TupleBufferRef& tupleBufferRef)
+inline void printTupleBuffer(const std::string_view message, TupleBuffer& tupleBuffer, const MemoryLayout& tupleBufferRef)
 {
     /// NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage) is fine as we are passing it ot a nautilus::val<>
     const nautilus::val<const char*> messageVal{message.data()};

--- a/nes-input-formatters/tests/Util/InputFormatterTestUtil.hpp
+++ b/nes-input-formatters/tests/Util/InputFormatterTestUtil.hpp
@@ -161,7 +161,7 @@ Schema<UnqualifiedUnboundField, Ordered>
 createSchema(const std::vector<TestDataTypes>& testDataTypes, const std::vector<Identifier>& testFieldNames);
 
 /// Creates an emit function that places buffers into 'resultBuffers' when there is data.
-SourceReturnType::EmitFunction getEmitFunction(ThreadSafeVector<TupleBuffer>& resultBuffers);
+SourceReturnType::EmitFunction getEmitFunction(ThreadSafeVector<Buffer>& resultBuffers);
 
 std::pair<BackpressureController, std::unique_ptr<SourceHandle>> createFileSource(
     SourceCatalog& sourceCatalog,
@@ -171,7 +171,7 @@ std::pair<BackpressureController, std::unique_ptr<SourceHandle>> createFileSourc
     size_t numberOfRequiredSourceBuffers);
 
 /// Waits until source reached EoS
-void waitForSource(const std::vector<TupleBuffer>& resultBuffers, size_t numExpectedBuffers);
+void waitForSource(const std::vector<Buffer>& resultBuffers, size_t numExpectedBuffers);
 
 /// Compares two files and returns true if they are equal on a byte level.
 bool compareFiles(const std::filesystem::path& file1, const std::filesystem::path& file2);
@@ -189,12 +189,12 @@ struct TestHandle
     TestConfig<TupleSchemaTemplate> testConfig;
     std::shared_ptr<BufferManager> testBufferManager;
     std::shared_ptr<BufferManager> formattedBufferManager;
-    std::shared_ptr<std::vector<std::vector<TupleBuffer>>> resultBuffers;
+    std::shared_ptr<std::vector<std::vector<Buffer>>> resultBuffers;
     Schema<UnqualifiedUnboundField, Ordered> schema;
     MemoryLayoutType memoryLayoutType;
     std::unique_ptr<SingleThreadedTestTaskQueue> testTaskQueue;
-    std::vector<TupleBuffer> inputBuffers;
-    std::vector<std::vector<TupleBuffer>> expectedResultVectors;
+    std::vector<Buffer> inputBuffers;
+    std::vector<std::vector<Buffer>> expectedResultVectors;
 
     void destroy()
     {
@@ -206,12 +206,12 @@ struct TestHandle
     }
 };
 
-inline void sortTupleBuffers(std::vector<TupleBuffer>& buffers)
+inline void sortTupleBuffers(std::vector<Buffer>& buffers)
 {
     std::ranges::sort(
         buffers.begin(),
         buffers.end(),
-        [](const TupleBuffer& left, const TupleBuffer& right)
+        [](const Buffer& left, const Buffer& right)
         {
             if (left.getSequenceNumber() == right.getSequenceNumber())
             {
@@ -225,7 +225,7 @@ inline void sortTupleBuffers(std::vector<TupleBuffer>& buffers)
 class TupleIterator
 {
 public:
-    TupleIterator(std::vector<TupleBuffer> buffers, Schema<QualifiedUnboundField, Ordered> schema, const MemoryLayoutType layoutType)
+    TupleIterator(std::vector<Buffer> buffers, Schema<QualifiedUnboundField, Ordered> schema, const MemoryLayoutType layoutType)
         : schema(std::move(schema))
         , buffers(std::move(buffers))
         , bufferRef(LowerSchemaProvider::lowerSchema(this->buffers.at(0).getBufferSize(), this->schema, layoutType))
@@ -258,13 +258,13 @@ private:
     size_t currentBufferIdx = 0;
     nautilus::val<uint64_t> currentTupleIdx = 0;
     Schema<QualifiedUnboundField, Ordered> schema;
-    std::vector<TupleBuffer> buffers;
+    std::vector<Buffer> buffers;
     std::shared_ptr<MemoryLayout> bufferRef;
 };
 
 /// Expects tuple buffers with matching sequence numbers contain the same tuples in the same order
 inline bool compareTestTupleBuffersOrderSensitive(
-    std::vector<TupleBuffer>& actualResult, std::vector<TupleBuffer>& expectedResult, const Schema<QualifiedUnboundField, Ordered>& schema)
+    std::vector<Buffer>& actualResult, std::vector<Buffer>& expectedResult, const Schema<QualifiedUnboundField, Ordered>& schema)
 {
     InputFormatterTestUtil::sortTupleBuffers(actualResult);
     InputFormatterTestUtil::sortTupleBuffers(expectedResult);
@@ -290,7 +290,7 @@ inline bool compareTestTupleBuffersOrderSensitive(
     return allTuplesMatch;
 }
 
-inline bool checkIfBuffersAreEqual(const TupleBuffer& leftBuffer, const TupleBuffer& rightBuffer, const uint64_t schemaSizeInByte)
+inline bool checkIfBuffersAreEqual(const Buffer& leftBuffer, const Buffer& rightBuffer, const uint64_t schemaSizeInByte)
 {
     NES_DEBUG("Checking if the buffers are equal, so if they contain the same tuples...");
     if (leftBuffer.getNumberOfTuples() != rightBuffer.getNumberOfTuples())
@@ -330,11 +330,11 @@ inline bool checkIfBuffersAreEqual(const TupleBuffer& leftBuffer, const TupleBuf
     return (sameTupleIndices.size() == leftBuffer.getNumberOfTuples());
 }
 
-inline void copyStringDataToTupleBuffer(const std::string_view rawData, TupleBuffer& tupleBuffer)
+inline void copyStringDataToTupleBuffer(const std::string_view rawData, Buffer& tupleBuffer)
 {
     PRECONDITION(
         tupleBuffer.getBufferSize() >= rawData.size(),
-        "{} < {}, size of TupleBuffer is not sufficient to contain string",
+        "{} < {}, size of Buffer is not sufficient to contain string",
         tupleBuffer.getBufferSize(),
         rawData.size());
     std::ranges::copy(rawData, reinterpret_cast<char*>(tupleBuffer.getAvailableMemoryArea().data()));
@@ -345,7 +345,7 @@ template <typename T>
 void writeFieldToBuffer(
     const T& fieldValue,
     const size_t fieldIndex,
-    NES::TupleBuffer& tupleBuffer,
+    NES::Buffer& tupleBuffer,
     MemoryLayout& tupleBufferRef,
     AbstractBufferProvider& bufferProvider)
 {
@@ -370,7 +370,7 @@ void writeFieldToBuffer(
     tupleBufferRef.writeRecord(recordIndex, recordBuffer, record, bufferProviderVal);
 }
 
-inline void printTupleBuffer(const std::string_view message, TupleBuffer& tupleBuffer, const MemoryLayout& tupleBufferRef)
+inline void printTupleBuffer(const std::string_view message, Buffer& tupleBuffer, const MemoryLayout& tupleBufferRef)
 {
     /// NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage) is fine as we are passing it ot a nautilus::val<>
     const nautilus::val<const char*> messageVal{message.data()};
@@ -395,7 +395,7 @@ inline void printTupleBuffer(const std::string_view message, TupleBuffer& tupleB
 ///     auto testTupleBuffer = TestUtil::createTupleBufferFromTuples(schema, *bufferManager,
 ///         TestTuple(42, true), TestTuple(43, false), TestTuple(44, true), TestTuple(45, false));
 template <typename TupleSchema, bool PrintDebug = false>
-TupleBuffer createTupleBufferFromTuples(
+Buffer createTupleBufferFromTuples(
     const Schema<QualifiedUnboundField, Ordered>& schema, BufferManager& bufferManager, const std::vector<TupleSchema>& tuples)
 {
     PRECONDITION(bufferManager.getNumberOfAvailableBuffers() != 0, "Cannot create a test tuple buffer, if there are no buffers available");
@@ -454,9 +454,9 @@ bool validateResult(TestHandle<TupleSchemaTemplate>& testHandle)
 }
 
 template <typename TupleSchemaTemplate, bool PrintDebug>
-std::vector<std::vector<TupleBuffer>> createExpectedResults(const TestHandle<TupleSchemaTemplate>& testHandle)
+std::vector<std::vector<Buffer>> createExpectedResults(const TestHandle<TupleSchemaTemplate>& testHandle)
 {
-    std::vector<std::vector<TupleBuffer>> expectedTupleBuffers(1);
+    std::vector<std::vector<Buffer>> expectedTupleBuffers(1);
     for (const auto& workerThreadResultVector : testHandle.testConfig.expectedResults)
     {
         /// expectedBuffersVector: vector<TupleSchemaTemplate>
@@ -491,7 +491,7 @@ TestHandle<TupleSchemaTemplate> setupTest(const TestConfig<TupleSchemaTemplate>&
         testConfig.sizeOfFormattedBuffers,
         std::make_shared<NesDefaultMemoryAllocator>());
 
-    auto resultBuffers = std::make_shared<std::vector<std::vector<TupleBuffer>>>(1);
+    auto resultBuffers = std::make_shared<std::vector<std::vector<Buffer>>>(1);
     auto schema = createSchema(testConfig.testSchema);
     return {
         testConfig,
@@ -524,9 +524,9 @@ std::vector<TestPipelineTask> createTasks(const TestHandle<TupleSchemaTemplate>&
 }
 
 template <typename TupleSchemaTemplate>
-std::vector<TupleBuffer> createTestTupleBuffers(const TestHandle<TupleSchemaTemplate>& testHandle)
+std::vector<Buffer> createTestTupleBuffers(const TestHandle<TupleSchemaTemplate>& testHandle)
 {
-    std::vector<TupleBuffer> rawTupleBuffers;
+    std::vector<Buffer> rawTupleBuffers;
     for (const auto& rawInputBuffer : testHandle.testConfig.rawBytesPerThread)
     {
         if (auto tupleBuffer = testHandle.testBufferManager->getBufferNoBlocking())

--- a/nes-input-formatters/tests/Util/InputFormatterTestUtil.hpp
+++ b/nes-input-formatters/tests/Util/InputFormatterTestUtil.hpp
@@ -37,7 +37,7 @@
 #include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
 #include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Interface/VariableSizedAccessRef.hpp>
 #include <Pipelines/CompiledExecutablePipelineStage.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
@@ -244,7 +244,7 @@ public:
             }
             currentTupleIdx = 0;
         }
-        const RecordBuffer recordBuffer{buffers.data() + currentBufferIdx};
+        const TaskBufferRef recordBuffer{buffers.data() + currentBufferIdx};
         auto record = bufferRef->readRecord(
             schema | std::views::transform([](const auto& field) { return field.getFullyQualifiedName(); })
                 | std::ranges::to<std::vector>(),
@@ -350,7 +350,7 @@ void writeFieldToBuffer(
     AbstractBufferProvider& bufferProvider)
 {
     Record record;
-    const RecordBuffer recordBuffer{std::addressof(tupleBuffer)};
+    const TaskBufferRef recordBuffer{std::addressof(tupleBuffer)};
     const auto fieldName = tupleBufferRef.getAllFieldNames().at(fieldIndex);
 
     /// Creating a Record containing the current field
@@ -376,7 +376,7 @@ inline void printTupleBuffer(const std::string_view message, TupleBuffer& tupleB
     const nautilus::val<const char*> messageVal{message.data()};
     nautilus::stringstream ss;
     ss << messageVal;
-    const RecordBuffer recordBuffer{std::addressof(tupleBuffer)};
+    const TaskBufferRef recordBuffer{std::addressof(tupleBuffer)};
     for (nautilus::val<uint64_t> recordIndex = 0; recordIndex < recordBuffer.getNumRecords(); ++recordIndex)
     {
         const auto record = tupleBufferRef.readRecord(tupleBufferRef.getAllFieldNames(), recordBuffer, recordIndex);

--- a/nes-memory/Buffer.cpp
+++ b/nes-memory/Buffer.cpp
@@ -12,7 +12,7 @@
     limitations under the License.
 */
 
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 
 #include <cstdint>
 #include <memory>
@@ -23,13 +23,13 @@
 #include <Identifiers/NESStrongTypeFormat.hpp> ///NOLINT: required for fmt
 #include <Time/Timestamp.hpp>
 #include <fmt/format.h>
+#include <BufferImpl.hpp>
 #include <ErrorHandling.hpp>
-#include <TupleBufferImpl.hpp>
 
 namespace NES
 {
 
-TupleBuffer::TupleBuffer(const TupleBuffer& other) noexcept : controlBlock(other.controlBlock), ptr(other.ptr), size(other.size)
+Buffer::Buffer(const Buffer& other) noexcept : controlBlock(other.controlBlock), ptr(other.ptr), size(other.size)
 {
     if (controlBlock != nullptr)
     {
@@ -37,7 +37,7 @@ TupleBuffer::TupleBuffer(const TupleBuffer& other) noexcept : controlBlock(other
     }
 }
 
-TupleBuffer& TupleBuffer::operator=(const TupleBuffer& other) noexcept
+Buffer& Buffer::operator=(const Buffer& other) noexcept
 {
     if PLACEHOLDER_UNLIKELY (this == std::addressof(other))
     {
@@ -61,7 +61,7 @@ TupleBuffer& TupleBuffer::operator=(const TupleBuffer& other) noexcept
     return *this;
 }
 
-TupleBuffer& TupleBuffer::operator=(TupleBuffer&& other) noexcept
+Buffer& Buffer::operator=(Buffer&& other) noexcept
 {
     /// Especially for rvalues, the following branch should most likely never be taken if the caller writes
     /// reasonable code. Therefore, this branch is considered unlikely.
@@ -78,12 +78,12 @@ TupleBuffer& TupleBuffer::operator=(TupleBuffer&& other) noexcept
     return *this;
 }
 
-TupleBuffer::~TupleBuffer() noexcept
+Buffer::~Buffer() noexcept
 {
     release();
 }
 
-TupleBuffer& TupleBuffer::retain() noexcept
+Buffer& Buffer::retain() noexcept
 {
     if (controlBlock)
     {
@@ -92,7 +92,7 @@ TupleBuffer& TupleBuffer::retain() noexcept
     return *this;
 }
 
-void TupleBuffer::release() noexcept
+void Buffer::release() noexcept
 {
     if (controlBlock)
     {
@@ -103,79 +103,79 @@ void TupleBuffer::release() noexcept
     size = 0;
 }
 
-uint32_t TupleBuffer::getReferenceCounter() const noexcept
+uint32_t Buffer::getReferenceCounter() const noexcept
 {
     return controlBlock ? controlBlock->getReferenceCount() : 0;
 }
 
-uint64_t TupleBuffer::getBufferSize() const noexcept
+uint64_t Buffer::getBufferSize() const noexcept
 {
     return size;
 }
 
-void TupleBuffer::setNumberOfTuples(const uint64_t numberOfTuples) const noexcept
+void Buffer::setNumberOfTuples(const uint64_t numberOfTuples) const noexcept
 {
     controlBlock->setNumberOfTuples(numberOfTuples);
 }
 
-Timestamp TupleBuffer::getWatermark() const noexcept
+Timestamp Buffer::getWatermark() const noexcept
 {
     return controlBlock->getWatermark();
 }
 
-void TupleBuffer::setWatermark(const Timestamp value) noexcept
+void Buffer::setWatermark(const Timestamp value) noexcept
 {
     controlBlock->setWatermark(value);
 }
 
-Timestamp TupleBuffer::getCreationTimestampInMS() const noexcept
+Timestamp Buffer::getCreationTimestampInMS() const noexcept
 {
     return controlBlock->getCreationTimestamp();
 }
 
-void TupleBuffer::setSequenceNumber(const SequenceNumber sequenceNumber) noexcept
+void Buffer::setSequenceNumber(const SequenceNumber sequenceNumber) noexcept
 {
     controlBlock->setSequenceNumber(sequenceNumber);
 }
 
-std::string TupleBuffer::getSequenceDataAsString() const noexcept
+std::string Buffer::getSequenceDataAsString() const noexcept
 {
     return fmt::format("SeqNumber: {}, ChunkNumber: {}, LastChunk: {}", getSequenceNumber(), getChunkNumber(), isLastChunk());
 }
 
-SequenceNumber TupleBuffer::getSequenceNumber() const noexcept
+SequenceNumber Buffer::getSequenceNumber() const noexcept
 {
     return controlBlock->getSequenceNumber();
 }
 
-void TupleBuffer::setChunkNumber(const ChunkNumber chunkNumber) noexcept
+void Buffer::setChunkNumber(const ChunkNumber chunkNumber) noexcept
 {
     controlBlock->setChunkNumber(chunkNumber);
 }
 
-void TupleBuffer::setLastChunk(const bool isLastChunk) noexcept
+void Buffer::setLastChunk(const bool isLastChunk) noexcept
 {
     controlBlock->setLastChunk(isLastChunk);
 }
 
-bool TupleBuffer::isLastChunk() const noexcept
+bool Buffer::isLastChunk() const noexcept
 {
     return controlBlock->isLastChunk();
 }
 
-void TupleBuffer::setCreationTimestampInMS(const Timestamp value) noexcept
+void Buffer::setCreationTimestampInMS(const Timestamp value) noexcept
 {
     controlBlock->setCreationTimestamp(value);
 }
 
-void TupleBuffer::setOriginId(const OriginId id) noexcept
+void Buffer::setOriginId(const OriginId id) noexcept
 {
     controlBlock->setOriginId(id);
 }
 
-ChildBufferIndex TupleBuffer::storeChildBuffer(TupleBuffer& buffer) noexcept
+ChildBufferIndex Buffer::storeChildBuffer(Buffer& buffer) noexcept
 {
-    TupleBuffer empty;
+    Buffer empty;
     auto* control = buffer.controlBlock;
     INVARIANT(controlBlock != control, "Cannot attach buffer to self");
     const auto index = controlBlock->storeChildBuffer(control);
@@ -183,9 +183,9 @@ ChildBufferIndex TupleBuffer::storeChildBuffer(TupleBuffer& buffer) noexcept
     return index;
 }
 
-TupleBuffer TupleBuffer::loadChildBuffer(ChildBufferIndex bufferIndex) const noexcept
+Buffer Buffer::loadChildBuffer(ChildBufferIndex bufferIndex) const noexcept
 {
-    TupleBuffer childBuffer;
+    Buffer childBuffer;
     const auto ret = controlBlock->loadChildBuffer(bufferIndex, childBuffer.controlBlock, childBuffer.ptr, childBuffer.size);
     INVARIANT(ret, "Cannot load tuple buffer with index={}", bufferIndex);
     return childBuffer;
@@ -199,7 +199,7 @@ bool recycleTupleBuffer(void* bufferPointer)
     return block->release();
 }
 
-void swap(TupleBuffer& lhs, TupleBuffer& rhs) noexcept
+void swap(Buffer& lhs, Buffer& rhs) noexcept
 {
     /// Enable ADL to spell out to onlookers how swap should be used.
     using std::swap;
@@ -209,27 +209,27 @@ void swap(TupleBuffer& lhs, TupleBuffer& rhs) noexcept
     swap(lhs.controlBlock, rhs.controlBlock);
 }
 
-std::ostream& operator<<(std::ostream& os, const TupleBuffer& buff) noexcept
+std::ostream& operator<<(std::ostream& os, const Buffer& buff) noexcept
 {
     return os << reinterpret_cast<std::uintptr_t>(buff.ptr);
 }
 
-uint64_t TupleBuffer::getNumberOfTuples() const noexcept
+uint64_t Buffer::getNumberOfTuples() const noexcept
 {
     return controlBlock->getNumberOfTuples();
 }
 
-OriginId TupleBuffer::getOriginId() const noexcept
+OriginId Buffer::getOriginId() const noexcept
 {
     return controlBlock->getOriginId();
 }
 
-uint32_t TupleBuffer::getNumberOfChildBuffers() const noexcept
+uint32_t Buffer::getNumberOfChildBuffers() const noexcept
 {
     return controlBlock->getNumberOfChildBuffers();
 }
 
-ChunkNumber TupleBuffer::getChunkNumber() const noexcept
+ChunkNumber Buffer::getChunkNumber() const noexcept
 {
     return controlBlock->getChunkNumber();
 }

--- a/nes-memory/BufferImpl.cpp
+++ b/nes-memory/BufferImpl.cpp
@@ -12,14 +12,14 @@
     limitations under the License.
 */
 
-#include <TupleBufferImpl.hpp>
+#include <BufferImpl.hpp>
 
 #include <cstdint>
 #include <functional>
 #include <memory>
 #include <utility>
 #include <Identifiers/Identifiers.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Time/Timestamp.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <magic_enum/magic_enum.hpp>
@@ -225,7 +225,7 @@ BufferControlBlock::ThreadOwnershipInfo::ThreadOwnershipInfo() : threadName("NOT
 #endif
 
 /// -----------------------------------------------------------------------------
-/// ------------------ Utility functions for TupleBuffer ------------------------
+/// ------------------ Utility functions for Buffer ------------------------
 /// -----------------------------------------------------------------------------
 
 uint64_t BufferControlBlock::getNumberOfTuples() const noexcept
@@ -299,7 +299,7 @@ void BufferControlBlock::setOriginId(const OriginId originId)
 }
 
 /// -----------------------------------------------------------------------------
-/// ------------------ VarLen fields support for TupleBuffer --------------------
+/// ------------------ VarLen fields support for Buffer --------------------
 /// -----------------------------------------------------------------------------
 
 ChildBufferIndex BufferControlBlock::storeChildBuffer(BufferControlBlock* control)

--- a/nes-memory/BufferImpl.hpp
+++ b/nes-memory/BufferImpl.hpp
@@ -22,7 +22,7 @@
 #include <memory>
 #include <vector>
 #include <Identifiers/Identifiers.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Time/Timestamp.hpp>
 #include <TaggedPointer.hpp>
 #ifdef NES_DEBUG_TUPLE_BUFFER_LEAKS
@@ -42,7 +42,7 @@ namespace NES
 {
 class BufferManager;
 class LocalBufferPool;
-class TupleBuffer;
+class Buffer;
 class FixedSizeBufferPool;
 class BufferRecycler;
 
@@ -58,8 +58,8 @@ class MemorySegment;
 
 /**
  * @brief This class provides a convenient way to track the reference counter as well metadata for its owning
- * MemorySegment/TupleBuffer. In particular, it stores the atomic reference counter that tracks how many
- * live reference exists of the owning MemorySegment/TupleBuffer and it also stores the callback to execute
+ * MemorySegment/Buffer. In particular, it stores the atomic reference counter that tracks how many
+ * live reference exists of the owning MemorySegment/Buffer and it also stores the callback to execute
  * when the reference counter reaches 0.
  *
  * Reminder: this class should be header-only to help inlining
@@ -71,9 +71,9 @@ public:
 
     [[nodiscard]] MemorySegment* getOwner() const;
 
-    /// This method must be called before the BufferManager hands out a TupleBuffer. It ensures that the internal
+    /// This method must be called before the BufferManager hands out a Buffer. It ensures that the internal
     /// reference counter is zero. If that's not the case, an exception is thrown.
-    /// Returns true if the mem segment can be used to create a TupleBuffer.
+    /// Returns true if the mem segment can be used to create a Buffer.
     bool prepare(const std::shared_ptr<BufferRecycler>& recycler);
 
     /// Increase the reference counter by one.
@@ -161,14 +161,14 @@ static_assert(alignof(BufferControlBlock) % 64 == 0);
  * (@see class BufferControlBlock). The MemorySegment is intended to be used **only** in the BufferManager.
  * The BufferManager is the only class that can store MemorySegments. A MemorySegment has no clue of what it's stored
  * inside its allocated memory and has no way to expose the pointer to outside world.
- * The public companion of a MemorySegment is the TupleBuffer, which can "leak" the pointer to the outside world.
+ * The public companion of a MemorySegment is the Buffer, which can "leak" the pointer to the outside world.
  *
  * Reminder: this class should be header-only to help inlining
  *
  */
 class MemorySegment
 {
-    friend class NES::TupleBuffer; /// needed, because not in NES::detail namespace
+    friend class NES::Buffer; /// needed, because not in NES::detail namespace
     friend class NES::LocalBufferPool;
     friend class NES::FixedSizeBufferPool;
     friend class NES::BufferManager;

--- a/nes-memory/BufferManager.cpp
+++ b/nes-memory/BufferManager.cpp
@@ -30,13 +30,13 @@
 #include <utility>
 #include <unistd.h>
 #include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/BufferRecycler.hpp>
 #include <Runtime/MemoryUtils.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <folly/MPMCQueue.h>
+#include <BufferImpl.hpp>
 #include <ErrorHandling.hpp>
-#include <TupleBufferImpl.hpp>
 
 namespace NES
 {
@@ -199,7 +199,7 @@ void BufferManager::initialize()
     NES_DEBUG("BufferManager configuration bufferSize={} numOfBuffers={}", this->bufferSize, this->numOfBuffers);
 }
 
-TupleBuffer BufferManager::getBufferBlocking()
+Buffer BufferManager::getBufferBlocking()
 {
     auto buffer = getBufferWithTimeout(GET_BUFFER_TIMEOUT);
     if (buffer.has_value())
@@ -210,7 +210,7 @@ TupleBuffer BufferManager::getBufferBlocking()
     throw BufferAllocationFailure("Global buffer pool could not allocate buffer before timeout({})", GET_BUFFER_TIMEOUT);
 }
 
-std::optional<TupleBuffer> BufferManager::getBufferNoBlocking()
+std::optional<Buffer> BufferManager::getBufferNoBlocking()
 {
     detail::MemorySegment* memSegment = nullptr;
     if (!availableBuffers.read(memSegment))
@@ -219,12 +219,12 @@ std::optional<TupleBuffer> BufferManager::getBufferNoBlocking()
     }
     if (memSegment->controlBlock->prepare(shared_from_this()))
     {
-        return TupleBuffer(memSegment->controlBlock.get(), memSegment->ptr, memSegment->size);
+        return Buffer(memSegment->controlBlock.get(), memSegment->ptr, memSegment->size);
     }
     throw InvalidRefCountForBuffer("[BufferManager] got buffer with invalid reference counter");
 }
 
-std::optional<TupleBuffer> BufferManager::getBufferWithTimeout(const std::chrono::milliseconds timeoutMs)
+std::optional<Buffer> BufferManager::getBufferWithTimeout(const std::chrono::milliseconds timeoutMs)
 {
     detail::MemorySegment* memSegment = nullptr;
     const auto deadline = std::chrono::steady_clock::now() + timeoutMs;
@@ -234,12 +234,12 @@ std::optional<TupleBuffer> BufferManager::getBufferWithTimeout(const std::chrono
     }
     if (memSegment->controlBlock->prepare(shared_from_this()))
     {
-        return TupleBuffer(memSegment->controlBlock.get(), memSegment->ptr, memSegment->size);
+        return Buffer(memSegment->controlBlock.get(), memSegment->ptr, memSegment->size);
     }
     throw InvalidRefCountForBuffer("[BufferManager] got buffer with invalid reference counter");
 }
 
-std::optional<TupleBuffer> BufferManager::getUnpooledBuffer(const size_t bufferSize)
+std::optional<Buffer> BufferManager::getUnpooledBuffer(const size_t bufferSize)
 {
     return unpooledChunksManager->getUnpooledBuffer(bufferSize, alignment, shared_from_this());
 }

--- a/nes-memory/CMakeLists.txt
+++ b/nes-memory/CMakeLists.txt
@@ -12,8 +12,8 @@
 
 add_library(nes-memory
         BufferManager.cpp
-        TupleBufferImpl.cpp
-        TupleBuffer.cpp
+        BufferImpl.cpp
+        Buffer.cpp
         NesDefaultMemoryAllocator.cpp
         TaggedPointer.cpp
         UnpooledChunksManager.cpp

--- a/nes-memory/MemoryUtils.cpp
+++ b/nes-memory/MemoryUtils.cpp
@@ -19,13 +19,13 @@
 #include <cstdint>
 #include <span>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <ErrorHandling.hpp>
 
 namespace NES
 {
 
-TupleBuffer getBuffer(const uint64_t size, AbstractBufferProvider& provider)
+Buffer getBuffer(const uint64_t size, AbstractBufferProvider& provider)
 {
     if (size == provider.getBufferSize())
     {
@@ -37,10 +37,10 @@ TupleBuffer getBuffer(const uint64_t size, AbstractBufferProvider& provider)
     {
         return bufferOpt.value();
     }
-    throw BufferAllocationFailure("No unpooled TupleBuffer of size {} available!", size);
+    throw BufferAllocationFailure("No unpooled Buffer of size {} available!", size);
 }
 
-TupleBuffer deepCopyBuffer(const TupleBuffer& buffer, AbstractBufferProvider& provider)
+Buffer deepCopyBuffer(const Buffer& buffer, AbstractBufferProvider& provider)
 {
     /// TODO #1582: you may need different size for the copy buffer, not always the default
     auto copiedBuffer = getBuffer(buffer.getBufferSize(), provider);

--- a/nes-memory/TaggedPointer.cpp
+++ b/nes-memory/TaggedPointer.cpp
@@ -15,8 +15,8 @@
 #include <TaggedPointer.hpp>
 
 #include <cstdint>
+#include <BufferImpl.hpp>
 #include <ErrorHandling.hpp>
-#include <TupleBufferImpl.hpp>
 
 namespace NES
 {

--- a/nes-memory/UnpooledChunksManager.cpp
+++ b/nes-memory/UnpooledChunksManager.cpp
@@ -26,13 +26,13 @@
 #include <ranges>
 #include <thread>
 #include <utility>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/MemoryUtils.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <fmt/format.h>
 #include <folly/Synchronized.h>
+#include <BufferImpl.hpp>
 #include <ErrorHandling.hpp>
-#include <TupleBufferImpl.hpp>
 
 namespace NES
 {
@@ -156,7 +156,7 @@ UnpooledChunksManager::allocateSpace(const std::thread::id threadId, const size_
     return {localKeyForUnpooledBufferChunk, localMemoryForNewTupleBuffer};
 }
 
-std::optional<TupleBuffer>
+std::optional<Buffer>
 UnpooledChunksManager::getUnpooledBuffer(const size_t neededSize, size_t alignment, const std::shared_ptr<BufferRecycler>& bufferRecycler)
 {
     const auto threadId = std::this_thread::get_id();
@@ -170,7 +170,7 @@ UnpooledChunksManager::getUnpooledBuffer(const size_t neededSize, size_t alignme
 
     /// allocateSpace returns a null pair when the budget is exhausted or the underlying allocation failed. Signal this
     /// to the caller as an empty optional (callers turn it into CannotAllocateBuffer/BufferAllocationFailure) instead of
-    /// constructing a TupleBuffer over a null payload.
+    /// constructing a Buffer over a null payload.
     if (localMemoryForNewTupleBuffer == nullptr)
     {
         return std::nullopt;
@@ -219,7 +219,7 @@ UnpooledChunksManager::getUnpooledBuffer(const size_t neededSize, size_t alignme
 
     if (leakedMemSegment->controlBlock->prepare(bufferRecycler))
     {
-        return TupleBuffer{leakedMemSegment->controlBlock.get(), leakedMemSegment->ptr, leakedMemSegment->size};
+        return Buffer{leakedMemSegment->controlBlock.get(), leakedMemSegment->ptr, leakedMemSegment->size};
     }
     throw InvalidRefCountForBuffer("[BufferManager] got buffer with invalid reference counter");
 }

--- a/nes-memory/include/Runtime/AbstractBufferProvider.hpp
+++ b/nes-memory/include/Runtime/AbstractBufferProvider.hpp
@@ -17,7 +17,7 @@
 #include <cstddef>
 #include <optional>
 #include <vector>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 
 /// This enum reflects the different types of buffer managers in the system
 /// global: overall buffer manager
@@ -44,14 +44,14 @@ public:
     virtual size_t getNumOfPooledBuffers() const = 0;
     virtual size_t getNumOfUnpooledBuffers() const = 0;
 
-    virtual TupleBuffer getBufferBlocking() = 0;
+    virtual Buffer getBufferBlocking() = 0;
 
-    virtual std::optional<TupleBuffer> getBufferNoBlocking() = 0;
+    virtual std::optional<Buffer> getBufferNoBlocking() = 0;
 
-    virtual std::optional<TupleBuffer> getBufferWithTimeout(std::chrono::milliseconds timeout_ms) = 0;
+    virtual std::optional<Buffer> getBufferWithTimeout(std::chrono::milliseconds timeout_ms) = 0;
 
     /// Returns an unpooled buffer of size bufferSize wrapped in an optional or an invalid option if an error
-    virtual std::optional<TupleBuffer> getUnpooledBuffer(size_t bufferSize) = 0;
+    virtual std::optional<Buffer> getUnpooledBuffer(size_t bufferSize) = 0;
 };
 
 }

--- a/nes-memory/include/Runtime/Buffer.hpp
+++ b/nes-memory/include/Runtime/Buffer.hpp
@@ -35,7 +35,7 @@ namespace NES
 {
 class UnpooledChunksManager;
 
-/// @brief Identifies a child TupleBuffer attached to a parent TupleBuffer by its position among the parent's children.
+/// @brief Identifies a child Buffer attached to a parent Buffer by its position among the parent's children.
 using ChildBufferIndex = NESStrongType<uint32_t, struct ChildBufferIndex_Tag, std::numeric_limits<uint32_t>::max(), 0>;
 }
 
@@ -48,28 +48,28 @@ class MemorySegment;
 }
 
 /**
- * @brief The TupleBuffer allows Runtime components to access memory to store records in a reference-counted and
+ * @brief The Buffer allows Runtime components to access memory to store records in a reference-counted and
  * thread-safe manner.
  *
- * The purpose of the TupleBuffer is to zero memory allocations and enable batching.
+ * The purpose of the Buffer is to zero memory allocations and enable batching.
  * In order to zero the memory allocation, a BufferManager keeps a fixed set of fixed-size buffers that it hands out to
  * components.
- * A TupleBuffer's content is automatically recycled or deleted once its reference count reaches zero.
+ * A Buffer's content is automatically recycled or deleted once its reference count reaches zero.
  *
- * Prefer passing the TupleBuffer by reference whenever possible, pass the TupleBuffer to another thread by value.
+ * Prefer passing the Buffer by reference whenever possible, pass the Buffer to another thread by value.
  *
- * Important note: when a component is done with a TupleBuffer, it must be released. Not returning a TupleBuffer will
+ * Important note: when a component is done with a Buffer, it must be released. Not returning a Buffer will
  * result in a Runtime error that the BufferManager will raise by the termination of the NES program.
  *
- * A TupleBuffer may store one or more child/nested TupleBuffer. As soon as a TupleBuffer is attached to a parent,
+ * A Buffer may store one or more child/nested Buffer. As soon as a Buffer is attached to a parent,
  * it loses ownership of its internal MemorySegment, whose lifecycle is linked to the lifecycle of the parent.
- * This means that when the parent TupleBuffer goes out of scope, no child TupleBuffer must be alive in the program.
+ * This means that when the parent Buffer goes out of scope, no child Buffer must be alive in the program.
  * If that occurs, an error is raised.
  *
  * Reminder: this class should be header-only to help inlining
  */
 
-class TupleBuffer
+class Buffer
 {
     /// Utilize the wrapped-memory constructor
     friend class BufferManager;
@@ -78,7 +78,7 @@ class TupleBuffer
     friend class LocalBufferPool;
     friend class detail::MemorySegment;
 
-    [[nodiscard]] explicit TupleBuffer(detail::BufferControlBlock* controlBlock, uint8_t* ptr, uint32_t size) noexcept
+    [[nodiscard]] explicit Buffer(detail::BufferControlBlock* controlBlock, uint8_t* ptr, uint32_t size) noexcept
         : controlBlock(controlBlock), ptr(ptr), size(size)
     {
         /// nop
@@ -90,39 +90,39 @@ public:
     inline static const ChildBufferIndex INVALID_CHILD_BUFFER_INDEX_VALUE{std::numeric_limits<ChildBufferIndex::Underlying>::max()};
 
     /// @brief Default constructor creates an empty wrapper around nullptr without controlBlock (nullptr) and size 0.
-    [[nodiscard]] TupleBuffer() noexcept = default;
+    [[nodiscard]] Buffer() noexcept = default;
 
 
     /// @brief Copy constructor: Increase the reference count associated to the control buffer.
-    [[nodiscard]] TupleBuffer(const TupleBuffer& other) noexcept;
+    [[nodiscard]] Buffer(const Buffer& other) noexcept;
 
     /// @brief Move constructor: Steal the resources from `other`. This does not affect the reference count.
     /// @dev In this constructor, `other` is cleared, because otherwise its destructor would release its old memory.
-    [[nodiscard]] TupleBuffer(TupleBuffer&& other) noexcept : controlBlock(other.controlBlock), ptr(other.ptr), size(other.size)
+    [[nodiscard]] Buffer(Buffer&& other) noexcept : controlBlock(other.controlBlock), ptr(other.ptr), size(other.size)
     {
         other.controlBlock = nullptr;
         other.ptr = nullptr;
         other.size = 0;
     }
 
-    /// @brief Assign the `other` resource to this TupleBuffer; increase and decrease reference count if necessary.
-    TupleBuffer& operator=(const TupleBuffer& other) noexcept;
+    /// @brief Assign the `other` resource to this Buffer; increase and decrease reference count if necessary.
+    Buffer& operator=(const Buffer& other) noexcept;
 
-    /// @brief Assign the `other` resource to this TupleBuffer; Might release the resource this currently points to.
-    TupleBuffer& operator=(TupleBuffer&& other) noexcept;
+    /// @brief Assign the `other` resource to this Buffer; Might release the resource this currently points to.
+    Buffer& operator=(Buffer&& other) noexcept;
 
     /// @brief Return if this is not valid.
     [[nodiscard]] auto operator!() const noexcept -> bool { return ptr == nullptr; }
 
     /// @brief release the resource if necessary.
-    ~TupleBuffer() noexcept;
+    ~Buffer() noexcept;
 
     /// @brief Swap `lhs` and `rhs`.
     /// @dev Accessible via ADL in an unqualified call.
-    friend void swap(TupleBuffer& lhs, TupleBuffer& rhs) noexcept;
+    friend void swap(Buffer& lhs, Buffer& rhs) noexcept;
 
     /// @brief Increases the internal reference counter by one and return this.
-    TupleBuffer& retain() noexcept;
+    Buffer& retain() noexcept;
 
     /// @brief Decrease internal reference counter by one and release the resource when the reference count reaches 0.
     void release() noexcept;
@@ -147,7 +147,7 @@ public:
 
     /// @brief Print the buffer's address.
     /// @dev TODO: consider changing the reinterpret_cast to  std::bit_cast in C++2a if possible.
-    friend std::ostream& operator<<(std::ostream& os, const TupleBuffer& buff) noexcept;
+    friend std::ostream& operator<<(std::ostream& os, const Buffer& buff) noexcept;
 
     [[nodiscard]] uint64_t getBufferSize() const noexcept;
 
@@ -179,10 +179,10 @@ public:
     void setOriginId(OriginId id) noexcept;
 
     ///@brief attach a child tuple buffer to the parent. the child tuple buffer is then identified via NestedTupleBufferKey
-    [[nodiscard]] ChildBufferIndex storeChildBuffer(TupleBuffer& buffer) noexcept;
+    [[nodiscard]] ChildBufferIndex storeChildBuffer(Buffer& buffer) noexcept;
 
     ///@brief retrieve a child tuple buffer via its NestedTupleBufferKey
-    [[nodiscard]] TupleBuffer loadChildBuffer(ChildBufferIndex bufferIndex) const noexcept;
+    [[nodiscard]] Buffer loadChildBuffer(ChildBufferIndex bufferIndex) const noexcept;
 
     [[nodiscard]] uint32_t getNumberOfChildBuffers() const noexcept;
 

--- a/nes-memory/include/Runtime/BufferManager.hpp
+++ b/nes-memory/include/Runtime/BufferManager.hpp
@@ -43,11 +43,11 @@ using BufferAlignment = NESStrongType<uint32_t, struct BufferAlignment_, 0, 0>;
  * 2. Unpooled Buffers: variable sized buffers that are allocated on-the-fly. They are also subject to reference
  * counting.
  *
- * The reference counting mechanism of the TupleBuffer is explained in TupleBuffer.hpp
+ * The reference counting mechanism of the Buffer is explained in Buffer.hpp
  *
  * The BufferManager stores the pooled buffers as MemorySegment-s. When a component asks for a Pooled buffer,
  * then the BufferManager retrieves an available buffer (it blocks the calling thread, if no buffer is available).
- * It then hands out a TupleBuffer that is constructed through the pointer stored inside a MemorySegment.
+ * It then hands out a Buffer that is constructed through the pointer stored inside a MemorySegment.
  * This is necessary because the BufferManager must keep all buffers stored to ensure that when its
  * destructor is called, all buffers that it has ever created are deallocated. Note the BufferManager will check also
  * that no reference counter is non-zero and will throw a fatal exception, if a component hasnt returned every buffers.
@@ -64,7 +64,7 @@ using BufferAlignment = NESStrongType<uint32_t, struct BufferAlignment_, 0, 0>;
  */
 class BufferManager final : public std::enable_shared_from_this<BufferManager>, public BufferRecycler, public AbstractBufferProvider
 {
-    friend class TupleBuffer;
+    friend class Buffer;
     friend class NES::detail::MemorySegment;
 
     /// Hide the BufferManager constructor and only allow creation via BufferManager::create().
@@ -113,10 +113,10 @@ private:
 
 public:
     /// This blocks until a buffer is available.
-    TupleBuffer getBufferBlocking() override;
+    Buffer getBufferBlocking() override;
 
     /// invalid optional if there is no buffer.
-    std::optional<TupleBuffer> getBufferNoBlocking() override;
+    std::optional<Buffer> getBufferNoBlocking() override;
 
     /**
      * @brief Returns a new Buffer wrapped in an optional or an invalid option if there is no buffer available within
@@ -124,9 +124,9 @@ public:
      * @param timeoutMs the amount of time to wait for a new buffer to be retuned
      * @return a new buffer
      */
-    std::optional<TupleBuffer> getBufferWithTimeout(std::chrono::milliseconds timeoutMs) override;
+    std::optional<Buffer> getBufferWithTimeout(std::chrono::milliseconds timeoutMs) override;
 
-    std::optional<TupleBuffer> getUnpooledBuffer(size_t bufferSize) override;
+    std::optional<Buffer> getUnpooledBuffer(size_t bufferSize) override;
 
 
     size_t getBufferSize() const override;

--- a/nes-memory/include/Runtime/MemoryUtils.hpp
+++ b/nes-memory/include/Runtime/MemoryUtils.hpp
@@ -16,16 +16,16 @@
 #include <cstddef>
 #include <cstdint>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 
 namespace NES
 {
-/// Deep-copies a TupleBuffer: copies the raw bytes, replicates all metadata, and recursively copies every child buffer into freshly allocated buffers obtained from `provider`.
-TupleBuffer deepCopyBuffer(const TupleBuffer& buffer, AbstractBufferProvider& provider);
+/// Deep-copies a Buffer: copies the raw bytes, replicates all metadata, and recursively copies every child buffer into freshly allocated buffers obtained from `provider`.
+Buffer deepCopyBuffer(const Buffer& buffer, AbstractBufferProvider& provider);
 
 /// Returns a buffer for the specified size and optimizes internally for either pooled or unpooled.
 /// TODO #1582: This logic will be refactored into the Buffer Provider
-TupleBuffer getBuffer(uint64_t size, AbstractBufferProvider& provider);
+Buffer getBuffer(uint64_t size, AbstractBufferProvider& provider);
 }
 
 /**

--- a/nes-memory/include/Runtime/UnpooledChunksManager.hpp
+++ b/nes-memory/include/Runtime/UnpooledChunksManager.hpp
@@ -25,8 +25,8 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/BufferRecycler.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Util/Logger/Formatter.hpp>
 #include <Util/RollingAverage.hpp>
 #include <fmt/format.h>
@@ -101,8 +101,7 @@ public:
     size_t getNumberOfUnpooledBuffers() const;
 
     /// Returns std::nullopt if the unpooled memory budget would be exceeded or the underlying allocation fails.
-    std::optional<TupleBuffer>
-    getUnpooledBuffer(size_t neededSize, size_t alignment, const std::shared_ptr<BufferRecycler>& bufferRecycler);
+    std::optional<Buffer> getUnpooledBuffer(size_t neededSize, size_t alignment, const std::shared_ptr<BufferRecycler>& bufferRecycler);
 };
 
 }

--- a/nes-memory/tests/BufferManagerDestroyTest.cpp
+++ b/nes-memory/tests/BufferManagerDestroyTest.cpp
@@ -16,8 +16,8 @@
 #include <cstdint>
 #include <memory>
 #include <Runtime/Allocator/NesDefaultMemoryAllocator.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/BufferManager.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <gtest/gtest.h>
 
 namespace NES

--- a/nes-memory/tests/BufferMemoryAccessTest.cpp
+++ b/nes-memory/tests/BufferMemoryAccessTest.cpp
@@ -21,8 +21,8 @@
 
 
 #include <Runtime/Allocator/NesDefaultMemoryAllocator.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/BufferManager.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <gtest/gtest.h>
 
@@ -36,7 +36,7 @@ constexpr double UNPOOLED_MEMORY_FRACTION = 0.9;
 using TestTypes = ::testing::Types<uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t>;
 
 template <typename T>
-class TupleBufferMemoryAccessTest : public ::testing::Test
+class BufferMemoryAccessTest : public ::testing::Test
 {
 protected:
     static constexpr size_t minBufferSize = 100;
@@ -53,11 +53,11 @@ protected:
 };
 
 template <typename T>
-size_t TupleBufferMemoryAccessTest<T>::bufferSize = 0;
+size_t BufferMemoryAccessTest<T>::bufferSize = 0;
 
-TYPED_TEST_SUITE(TupleBufferMemoryAccessTest, TestTypes);
+TYPED_TEST_SUITE(BufferMemoryAccessTest, TestTypes);
 
-TYPED_TEST(TupleBufferMemoryAccessTest, FillAndRetrieveFromSpan)
+TYPED_TEST(BufferMemoryAccessTest, FillAndRetrieveFromSpan)
 {
     using T = TypeParam;
     auto bufferManager = BufferManager::create(

--- a/nes-memory/tests/CMakeLists.txt
+++ b/nes-memory/tests/CMakeLists.txt
@@ -13,7 +13,7 @@
 add_nes_test(unpooled-buffer-test UnpooledBufferTests.cpp)
 target_link_libraries(unpooled-buffer-test nes-memory)
 
-add_nes_test(tuple-buffer-memory-access-tests TupleBufferMemoryAccessTest.cpp)
+add_nes_test(tuple-buffer-memory-access-tests BufferMemoryAccessTest.cpp)
 target_link_libraries(tuple-buffer-memory-access-tests nes-memory)
 
 add_nes_test(buffer-manager-destroy-test BufferManagerDestroyTest.cpp)

--- a/nes-memory/tests/ChildBufferTests.cpp
+++ b/nes-memory/tests/ChildBufferTests.cpp
@@ -20,8 +20,8 @@
 #include <random>
 
 #include <Runtime/Allocator/NesDefaultMemoryAllocator.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/BufferManager.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <gtest/gtest.h>
 

--- a/nes-memory/tests/UnpooledBufferTests.cpp
+++ b/nes-memory/tests/UnpooledBufferTests.cpp
@@ -22,8 +22,8 @@
 #include <utility>
 #include <vector>
 #include <Runtime/Allocator/NesDefaultMemoryAllocator.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/BufferManager.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <gtest/gtest.h>
 #include <ErrorHandling.hpp>
 
@@ -38,7 +38,7 @@ struct TestData
     explicit TestData(const size_t neededSize) : neededSize(neededSize) { }
 
     size_t neededSize;
-    std::optional<TupleBuffer> buffer;
+    std::optional<Buffer> buffer;
 };
 
 std::vector<TestData> createRandomSizeAllocations(const size_t numberOfRandomAllocationSizes, const size_t min, const size_t max)
@@ -177,7 +177,7 @@ TEST(UnpooledBufferTests, UnpooledMemoryBudgetIsEnforcedAndReleased)
     constexpr size_t allocationSize = 64 * 1024; /// 64 KiB
     constexpr size_t maxAllocations = 100 * 1000; /// generous upper bound; we expect rejection well before this
 
-    std::vector<TupleBuffer> heldBuffers;
+    std::vector<Buffer> heldBuffers;
     bool sawRejection = false;
     for (size_t i = 0; i < maxAllocations; ++i)
     {

--- a/nes-nautilus/include/Arena.hpp
+++ b/nes-nautilus/include/Arena.hpp
@@ -22,7 +22,7 @@
 #include <vector>
 #include <DataTypes/VariableSizedData.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <val.hpp>
 #include <val_arith.hpp>
 #include <val_ptr.hpp>
@@ -43,8 +43,8 @@ struct Arena
     std::span<std::byte> allocateMemory(size_t sizeInBytes);
 
     std::shared_ptr<AbstractBufferProvider> bufferProvider;
-    std::vector<TupleBuffer> fixedSizeBuffers;
-    std::vector<TupleBuffer> unpooledBuffers;
+    std::vector<Buffer> fixedSizeBuffers;
+    std::vector<Buffer> unpooledBuffers;
     size_t lastAllocationSize{0};
     size_t currentOffset{0};
 };

--- a/nes-nautilus/include/DataTypes/VarVal.hpp
+++ b/nes-nautilus/include/DataTypes/VarVal.hpp
@@ -173,7 +173,7 @@ public:
 
     /// Writes the underlying value to the given memory reference.
     /// We call the operator= after the cast to the underlying type.
-    /// This method does NOT take care of writing a potential null value, as this is taken care in the TupleBufferRef.
+    /// This method does NOT take care of writing a potential null value, as this is taken care in the MemoryLayout.
     void writeToMemory(const nautilus::val<int8_t*>& memRef) const;
     [[nodiscard]] nautilus::val<bool> isNull() const;
     [[nodiscard]] bool isNullable() const;

--- a/nes-nautilus/include/Interface/HashMap/ChainedHashMap/ChainedEntryMemoryProvider.hpp
+++ b/nes-nautilus/include/Interface/HashMap/ChainedHashMap/ChainedEntryMemoryProvider.hpp
@@ -26,7 +26,7 @@
 #include <Interface/HashMap/ChainedHashMap/ChainedHashMap.hpp>
 #include <Interface/Record.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <val_concepts.hpp>
 
 namespace NES
@@ -60,12 +60,12 @@ public:
     [[nodiscard]] Record readRecord(const nautilus::val<ChainedHashMapEntry*>& entryRef) const;
     void writeRecord(
         const nautilus::val<ChainedHashMapEntry*>& entryRef,
-        const nautilus::val<TupleBuffer*>& hashMapBuffer,
+        const nautilus::val<Buffer*>& hashMapBuffer,
         const nautilus::val<AbstractBufferProvider*>& bufferProvider,
         const Record& record) const;
     void writeEntryRef(
         const nautilus::val<ChainedHashMapEntry*>& entryRef,
-        const nautilus::val<TupleBuffer*>& hashMapBuffer,
+        const nautilus::val<Buffer*>& hashMapBuffer,
         const nautilus::val<AbstractBufferProvider*>& bufferProvider,
         const nautilus::val<ChainedHashMapEntry*>& otherEntryRef) const;
 

--- a/nes-nautilus/include/Interface/HashMap/ChainedHashMap/ChainedEntryMemoryProvider.hpp
+++ b/nes-nautilus/include/Interface/HashMap/ChainedHashMap/ChainedEntryMemoryProvider.hpp
@@ -41,7 +41,7 @@ struct FieldOffsets
 };
 
 /// ChainedHashMapEntry uses for reading and writing either the keys or values.
-/// Similar to TupleBufferRef, we store the null value as the first byte before the actual value.
+/// Similar to MemoryLayout, we store the null value as the first byte before the actual value.
 class ChainedEntryMemoryProvider
 {
 public:

--- a/nes-nautilus/include/Interface/HashMap/ChainedHashMap/ChainedHashMap.hpp
+++ b/nes-nautilus/include/Interface/HashMap/ChainedHashMap/ChainedHashMap.hpp
@@ -27,7 +27,7 @@
 #include <Interface/Hash/HashFunction.hpp>
 #include <Interface/HashMap/HashMap.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 
 namespace NES
 {
@@ -45,7 +45,7 @@ struct ChainedHashMapConfig
 
     [[nodiscard]] uint64_t bloomFilterMemAreaSize() const { return bloomFilter ? bloomFilter->allocationByteCount() : 0; }
 
-    /// Bytes the TupleBuffer backing a map with this config must provide.
+    /// Bytes the Buffer backing a map with this config must provide.
     [[nodiscard]] uint64_t bufferSize() const;
 };
 
@@ -88,22 +88,22 @@ public:
 class ChainedHashMap final : public HashMap
 {
 public:
-    /// @brief Use init to initialize a ChainedHashMap view on a pre-allocated TupleBuffer
+    /// @brief Use init to initialize a ChainedHashMap view on a pre-allocated Buffer
     /// Constructors are private
     /// The buffer must be at least config.bufferSize() bytes; entries built from a key/value split size their
     /// entrySize as sizeof(ChainedHashMapEntry) + keySize + valueSize.
-    static void init(TupleBuffer& tupleBuffer, const ChainedHashMapConfig& config);
+    static void init(Buffer& tupleBuffer, const ChainedHashMapConfig& config);
 
-    /// @brief Loads a ChainedHashMap view from a pre-filled TupleBuffer
-    static ChainedHashMap load(const TupleBuffer& tupleBuffer);
+    /// @brief Loads a ChainedHashMap view from a pre-filled Buffer
+    static ChainedHashMap load(const Buffer& tupleBuffer);
 
     std::span<std::byte> allocateSpaceForVarSized(AbstractBufferProvider* bufferProvider, size_t neededSize);
     AbstractHashMapEntry* insertEntry(HashFunction::HashValue::raw_type hash, AbstractBufferProvider* bufferProvider) override;
 
     [[nodiscard]] uint64_t getTotalNumberOfRecords() const override { return header().numRecords; }
 
-    [[nodiscard]] TupleBuffer getPage(uint64_t pageIndex) const;
-    [[nodiscard]] TupleBuffer getVarSizedPage(uint64_t pageIndex) const;
+    [[nodiscard]] Buffer getPage(uint64_t pageIndex) const;
+    [[nodiscard]] Buffer getVarSizedPage(uint64_t pageIndex) const;
 
     /// Size of the buffer a ChainedHashMap view needs: header, chains array and the in-map BloomFilter bit
     /// area. The bloom size is a parameter rather than an afterthought so no caller can allocate a buffer
@@ -140,9 +140,9 @@ public:
     /// is zeroed by init(), so it is valid from construction on. Returns nullptr when the filter is disabled.
     [[nodiscard]] uint64_t* getBloomFilterMemArea();
 
-    /// @warning Be super careful with this. Sometimes you need a pointer to the TupleBuffer but you should never alter it outside of this
+    /// @warning Be super careful with this. Sometimes you need a pointer to the Buffer but you should never alter it outside of this
     /// view and without using its access methods
-    [[nodiscard]] TupleBuffer* getBuffer() { return std::addressof(buffer); }
+    [[nodiscard]] Buffer* getBuffer() { return std::addressof(buffer); }
 
     /// HashMapSlice magic numbers
     static constexpr auto VALID_CHM = 82543427462775423;
@@ -156,7 +156,7 @@ protected:
 
 private:
     /// private constructor that takes a pre-filled buffer
-    explicit ChainedHashMap(TupleBuffer buffer) : buffer(std::move(buffer)) { }
+    explicit ChainedHashMap(Buffer buffer) : buffer(std::move(buffer)) { }
 
     friend class ChainedHashMapRef;
 
@@ -197,8 +197,8 @@ private:
             , entrySize(entrySize)
             , entriesPerPage(entriesPerPage)
             , mask(mask)
-            , storageSpaceIndex(TupleBuffer::INVALID_CHILD_BUFFER_INDEX_VALUE)
-            , varSizedSpaceIndex(TupleBuffer::INVALID_CHILD_BUFFER_INDEX_VALUE)
+            , storageSpaceIndex(Buffer::INVALID_CHILD_BUFFER_INDEX_VALUE)
+            , varSizedSpaceIndex(Buffer::INVALID_CHILD_BUFFER_INDEX_VALUE)
             , bloomFilter(bloomFilter)
         {
         }
@@ -240,6 +240,6 @@ private:
     }
 
     /// the main tuple buffer for this chained hash map
-    TupleBuffer buffer;
+    Buffer buffer;
 };
 }

--- a/nes-nautilus/include/Interface/HashMap/ChainedHashMap/ChainedHashMapRef.hpp
+++ b/nes-nautilus/include/Interface/HashMap/ChainedHashMap/ChainedHashMapRef.hpp
@@ -27,7 +27,7 @@
 #include <Interface/HashMap/HashMapRef.hpp>
 #include <Interface/Record.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <val.hpp>
 #include <val_concepts.hpp>
 #include <val_ptr.hpp>
@@ -56,13 +56,13 @@ public:
         [[nodiscard]] nautilus::val<ChainedHashMapEntry*> getNext() const;
         ChainedEntryRef(
             const nautilus::val<ChainedHashMapEntry*>& entryRef,
-            const nautilus::val<TupleBuffer*>& hashMapBuffer,
+            const nautilus::val<Buffer*>& hashMapBuffer,
             std::vector<FieldOffsets> fieldsKey,
             std::vector<FieldOffsets> fieldsValue);
 
         ChainedEntryRef(
             const nautilus::val<ChainedHashMapEntry*>& entryRef,
-            const nautilus::val<TupleBuffer*>& hashMapBuffer,
+            const nautilus::val<Buffer*>& hashMapBuffer,
             ChainedEntryMemoryProvider memoryProviderKeys,
             ChainedEntryMemoryProvider memoryProviderValues);
 
@@ -72,7 +72,7 @@ public:
         ~ChainedEntryRef() = default;
 
         nautilus::val<ChainedHashMapEntry*> entryRef;
-        nautilus::val<TupleBuffer*> hashMapBuffer;
+        nautilus::val<Buffer*> hashMapBuffer;
         ChainedEntryMemoryProvider memoryProviderKeys;
         ChainedEntryMemoryProvider memoryProviderValues;
     };
@@ -84,7 +84,7 @@ public:
     {
     public:
         EntryIterator(
-            const nautilus::val<TupleBuffer*>& buffer,
+            const nautilus::val<Buffer*>& buffer,
             const nautilus::val<ChainedHashMapEntry*>& currentEntry,
             const nautilus::val<uint64_t>& entrySize,
             const nautilus::val<uint64_t>& tupleIndex,
@@ -105,7 +105,7 @@ public:
         nautilus::val<ChainedHashMapEntry*> operator*() const;
 
     private:
-        nautilus::val<TupleBuffer*> buffer;
+        nautilus::val<Buffer*> buffer;
         nautilus::val<ChainedHashMapEntry*> currentEntry;
         nautilus::val<uint64_t> entrySize;
         nautilus::val<uint64_t> tupleIndex;
@@ -119,7 +119,7 @@ public:
     /// map was initialised, since the bit area only exists (and only has that size) when ChainedHashMapConfig
     /// requested one.
     ChainedHashMapRef(
-        const nautilus::val<TupleBuffer*>& buffer,
+        const nautilus::val<Buffer*>& buffer,
         std::vector<FieldOffsets> fieldsKey,
         std::vector<FieldOffsets> fieldsValue,
         const nautilus::val<uint64_t>& entriesPerPage,

--- a/nes-nautilus/include/Interface/HashMap/HashMapRef.hpp
+++ b/nes-nautilus/include/Interface/HashMap/HashMapRef.hpp
@@ -20,7 +20,7 @@
 #include <Interface/HashMap/HashMap.hpp>
 #include <Interface/Record.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <val_ptr.hpp>
 
 namespace NES
@@ -29,7 +29,7 @@ namespace NES
 class HashMapRef
 {
 public:
-    explicit HashMapRef(const nautilus::val<TupleBuffer*>& tupleBuffer) : buffer(tupleBuffer) { }
+    explicit HashMapRef(const nautilus::val<Buffer*>& tupleBuffer) : buffer(tupleBuffer) { }
 
     virtual ~HashMapRef() = default;
 
@@ -61,7 +61,7 @@ public:
     virtual nautilus::val<AbstractHashMapEntry*> findEntry(const nautilus::val<AbstractHashMapEntry*>& otherEntry) = 0;
 
 protected:
-    nautilus::val<TupleBuffer*> buffer;
+    nautilus::val<Buffer*> buffer;
 };
 
 }

--- a/nes-nautilus/include/Interface/MemoryLayout/ColumnLayout.hpp
+++ b/nes-nautilus/include/Interface/MemoryLayout/ColumnLayout.hpp
@@ -20,7 +20,7 @@
 #include <DataTypes/DataType.hpp>
 #include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <val_arith.hpp>
 #include <val_concepts.hpp>
@@ -62,12 +62,12 @@ public:
 
     Record readRecord(
         const std::vector<Record::RecordFieldIdentifier>& projections,
-        const RecordBuffer& recordBuffer,
+        const TaskBufferRef& recordBuffer,
         nautilus::val<uint64_t>& recordIndex) const override;
 
     WriteRecordResult writeRecord(
         nautilus::val<uint64_t>& recordIndex,
-        const RecordBuffer& recordBuffer,
+        const TaskBufferRef& recordBuffer,
         const Record& rec,
         const nautilus::val<AbstractBufferProvider*>& bufferProvider) const override;
 };

--- a/nes-nautilus/include/Interface/MemoryLayout/ColumnLayout.hpp
+++ b/nes-nautilus/include/Interface/MemoryLayout/ColumnLayout.hpp
@@ -16,13 +16,11 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <memory>
 #include <vector>
 #include <DataTypes/DataType.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
 #include <Interface/RecordBuffer.hpp>
-#include <OutputFormatters/OutputFormatter.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <val_arith.hpp>
 #include <val_concepts.hpp>
@@ -34,29 +32,32 @@ class LowerSchemaProvider;
 
 namespace NES
 {
-class OutputFormatterBufferRef final : public TupleBufferRef
+
+/// Implements MemoryLayout. Provides columnar memory access.
+class ColumnLayout final : public MemoryLayout
 {
     struct Field
     {
         Record::RecordFieldIdentifier name;
         DataType type;
+        size_t dataTypeSize;
+        uint64_t columnOffset;
     };
 
     std::vector<Field> fields;
-    std::shared_ptr<OutputFormatter> formatter;
 
-    explicit OutputFormatterBufferRef(std::vector<Field> fields, std::shared_ptr<OutputFormatter> formatter, uint64_t bufferSize);
+    /// Private constructor to prevent direct instantiation
+    explicit ColumnLayout(std::vector<Field> fields, uint64_t tupleSize, uint64_t bufferSize);
 
+    /// Allow LowerSchemaProvider::lowerSchema() access to private constructor and Field
     friend class NES::LowerSchemaProvider;
 
 public:
-    OutputFormatterBufferRef(const OutputFormatterBufferRef&) = default;
-    OutputFormatterBufferRef(OutputFormatterBufferRef&&) = default;
-
-    ~OutputFormatterBufferRef() override = default;
+    ColumnLayout(const ColumnLayout&) = default;
+    ColumnLayout(ColumnLayout&&) = default;
+    ~ColumnLayout() override = default;
 
     [[nodiscard]] std::vector<Record::RecordFieldIdentifier> getAllFieldNames() const override;
-
     [[nodiscard]] std::vector<DataType> getAllDataTypes() const override;
 
     Record readRecord(
@@ -65,9 +66,10 @@ public:
         nautilus::val<uint64_t>& recordIndex) const override;
 
     WriteRecordResult writeRecord(
-        nautilus::val<uint64_t>& bytesWritten,
+        nautilus::val<uint64_t>& recordIndex,
         const RecordBuffer& recordBuffer,
         const Record& rec,
         const nautilus::val<AbstractBufferProvider*>& bufferProvider) const override;
 };
+
 }

--- a/nes-nautilus/include/Interface/MemoryLayout/LowerSchemaProvider.hpp
+++ b/nes-nautilus/include/Interface/MemoryLayout/LowerSchemaProvider.hpp
@@ -23,7 +23,7 @@
 #include <DataTypes/SchemaFwd.hpp>
 #include <DataTypes/UnboundField.hpp>
 #include <Identifiers/Identifier.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 
 namespace NES
 {
@@ -35,19 +35,19 @@ enum class MemoryLayoutType : uint8_t
     COLUMNAR_LAYOUT = 1
 };
 
-/// Lowers a schema and its memory layout type to a specific TupleBufferRef
+/// Lowers a schema and its memory layout type to a specific MemoryLayout
 /// In case we provide the ref for an emit operator right before a sink, output formatting might be neccessary (CSV, JSON).
 /// For these cases we provide the name of the output format so that the corresponding formatter can be provided.
 class LowerSchemaProvider
 {
 public:
-    static std::shared_ptr<TupleBufferRef> lowerSchemaWithOutputFormat(
+    static std::shared_ptr<MemoryLayout> lowerSchemaWithOutputFormat(
         uint64_t bufferSize,
         const Schema<QualifiedUnboundField, Ordered>& schema,
         const std::string& outputFormatterType,
         const std::unordered_map<Identifier, std::string>& config);
 
-    static std::shared_ptr<TupleBufferRef>
+    static std::shared_ptr<MemoryLayout>
     lowerSchema(uint64_t bufferSize, const Schema<QualifiedUnboundField, Ordered>& schema, MemoryLayoutType layoutType);
 };
 

--- a/nes-nautilus/include/Interface/MemoryLayout/MemoryLayout.hpp
+++ b/nes-nautilus/include/Interface/MemoryLayout/MemoryLayout.hpp
@@ -35,10 +35,10 @@ namespace NES
 
 
 /// This class takes care of reading and writing data from/to a TupleBuffer.
-/// A TupleBufferRef is closely coupled with a memory layout, and we support row and column layouts, currently.
+/// A MemoryLayout is closely coupled with a memory layout, and we support row and column layouts, currently.
 /// We store multiple variable sized datas in one pooled buffer. If the pooled buffer is not large enough or there are no pooled buffer
 /// available, we fall back to an unpooled buffer.
-class TupleBufferRef
+class MemoryLayout
 {
 protected:
     uint64_t capacity;
@@ -46,8 +46,8 @@ protected:
     uint64_t tupleSize;
 
 public:
-    TupleBufferRef(uint64_t capacity, uint64_t bufferSize, uint64_t tupleSize);
-    virtual ~TupleBufferRef();
+    MemoryLayout(uint64_t capacity, uint64_t bufferSize, uint64_t tupleSize);
+    virtual ~MemoryLayout();
 
     /// @brief Writes the variable sized data to the buffer
     static VariableSizedAccess
@@ -70,7 +70,7 @@ public:
 
     /// Returned by writeRecord
     /// Will give information on whether the write operation was successful (record index was inbounds)
-    /// and the number of records (or bytes, in case of OutputFormatterBufferRef) that were written
+    /// and the number of records (or bytes, in case of OutputFormatterLayout) that were written
     struct WriteRecordResult
     {
         nautilus::val<bool> successful;

--- a/nes-nautilus/include/Interface/MemoryLayout/MemoryLayout.hpp
+++ b/nes-nautilus/include/Interface/MemoryLayout/MemoryLayout.hpp
@@ -25,7 +25,7 @@
 #include <Interface/TaskBufferRef.hpp>
 #include <Interface/VariableSizedAccess.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <val_bool.hpp>
 #include <val_concepts.hpp>
 #include <val_ptr.hpp>
@@ -34,7 +34,7 @@ namespace NES
 {
 
 
-/// This class takes care of reading and writing data from/to a TupleBuffer.
+/// This class takes care of reading and writing data from/to a Buffer.
 /// A MemoryLayout is closely coupled with a memory layout, and we support row and column layouts, currently.
 /// We store multiple variable sized datas in one pooled buffer. If the pooled buffer is not large enough or there are no pooled buffer
 /// available, we fall back to an unpooled buffer.
@@ -51,12 +51,11 @@ public:
 
     /// @brief Writes the variable sized data to the buffer
     static VariableSizedAccess
-    writeVarSized(TupleBuffer& tupleBuffer, AbstractBufferProvider& bufferProvider, std::span<const std::byte> varSizedValue);
+    writeVarSized(Buffer& tupleBuffer, AbstractBufferProvider& bufferProvider, std::span<const std::byte> varSizedValue);
 
     /// @brief Reads the variable sized data and returns the pointer to the var sized data
     /// @return Pointer to variable sized data
-    static std::span<std::byte>
-    loadAssociatedVarSizedValue(const TupleBuffer& tupleBuffer, VariableSizedAccess variableSizedAccess) noexcept;
+    static std::span<std::byte> loadAssociatedVarSizedValue(const Buffer& tupleBuffer, VariableSizedAccess variableSizedAccess) noexcept;
 
     /// Reads a record from the given bufferAddress and recordIndex.
     /// @param projections: Stores what fields, the Record should contain. If {}, then Record contains all fields available

--- a/nes-nautilus/include/Interface/MemoryLayout/MemoryLayout.hpp
+++ b/nes-nautilus/include/Interface/MemoryLayout/MemoryLayout.hpp
@@ -22,7 +22,7 @@
 #include <DataTypes/DataType.hpp>
 #include <DataTypes/VarVal.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Interface/VariableSizedAccess.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
@@ -64,7 +64,7 @@ public:
     /// @param recordIndex: Index of the record to be read
     virtual Record readRecord(
         const std::vector<Record::RecordFieldIdentifier>& projections,
-        const RecordBuffer& recordBuffer,
+        const TaskBufferRef& recordBuffer,
         nautilus::val<uint64_t>& recordIndex) const
         = 0;
 
@@ -83,7 +83,7 @@ public:
     /// @param rec: Record to be stored
     virtual WriteRecordResult writeRecord(
         nautilus::val<uint64_t>& recordIndex,
-        const RecordBuffer& recordBuffer,
+        const TaskBufferRef& recordBuffer,
         const Record& rec,
         const nautilus::val<AbstractBufferProvider*>& bufferProvider) const
         = 0;
@@ -98,14 +98,14 @@ protected:
     /// Currently, this method does not support Null handling. It loads an VarVal of type from the fieldReference
     /// We require the recordBuffer, as we store variable sized data in a childbuffer and therefore, we need access
     /// to the buffer if the type is of variable sized
-    static VarVal loadValue(const DataType& type, const RecordBuffer& recordBuffer, const nautilus::val<int8_t*>& fieldReference);
+    static VarVal loadValue(const DataType& type, const TaskBufferRef& recordBuffer, const nautilus::val<int8_t*>& fieldReference);
 
     /// Currently, this method does not support Null handling. It stores an VarVal of type to the fieldReference
     /// We require the recordBuffer, as we store variable sized data in a childbuffer and therefore, we need access
     /// to the buffer if the type is of variable sized
     static VarVal storeValue(
         const DataType& type,
-        const RecordBuffer& recordBuffer,
+        const TaskBufferRef& recordBuffer,
         const nautilus::val<int8_t*>& fieldReference,
         VarVal value,
         const nautilus::val<AbstractBufferProvider*>& bufferProvider);

--- a/nes-nautilus/include/Interface/MemoryLayout/OutputFormatterLayout.hpp
+++ b/nes-nautilus/include/Interface/MemoryLayout/OutputFormatterLayout.hpp
@@ -21,7 +21,7 @@
 #include <DataTypes/DataType.hpp>
 #include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <OutputFormatters/OutputFormatter.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <val_arith.hpp>
@@ -61,12 +61,12 @@ public:
 
     Record readRecord(
         const std::vector<Record::RecordFieldIdentifier>& projections,
-        const RecordBuffer& recordBuffer,
+        const TaskBufferRef& recordBuffer,
         nautilus::val<uint64_t>& recordIndex) const override;
 
     WriteRecordResult writeRecord(
         nautilus::val<uint64_t>& bytesWritten,
-        const RecordBuffer& recordBuffer,
+        const TaskBufferRef& recordBuffer,
         const Record& rec,
         const nautilus::val<AbstractBufferProvider*>& bufferProvider) const override;
 };

--- a/nes-nautilus/include/Interface/MemoryLayout/OutputFormatterLayout.hpp
+++ b/nes-nautilus/include/Interface/MemoryLayout/OutputFormatterLayout.hpp
@@ -14,13 +14,15 @@
 
 #pragma once
 
-
+#include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <vector>
 #include <DataTypes/DataType.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
 #include <Interface/RecordBuffer.hpp>
+#include <OutputFormatters/OutputFormatter.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <val_arith.hpp>
 #include <val_concepts.hpp>
@@ -32,30 +34,26 @@ class LowerSchemaProvider;
 
 namespace NES
 {
-
-/// Implements BufferRef. Provides row-wise memory access.
-class RowTupleBufferRef final : public TupleBufferRef
+class OutputFormatterLayout final : public MemoryLayout
 {
     struct Field
     {
         Record::RecordFieldIdentifier name;
         DataType type;
-        uint64_t fieldOffset;
     };
 
     std::vector<Field> fields;
+    std::shared_ptr<OutputFormatter> formatter;
 
-    /// Private constructor to prevent direct instantiation
-    explicit RowTupleBufferRef(std::vector<Field> fields, uint64_t tupleSize, uint64_t bufferSize);
+    explicit OutputFormatterLayout(std::vector<Field> fields, std::shared_ptr<OutputFormatter> formatter, uint64_t bufferSize);
 
-    /// Allow LowerSchemaProvider::lowerSchema() access to private constructor and Field
     friend class NES::LowerSchemaProvider;
 
 public:
-    RowTupleBufferRef(const RowTupleBufferRef&) = default;
-    RowTupleBufferRef(RowTupleBufferRef&&) = default;
+    OutputFormatterLayout(const OutputFormatterLayout&) = default;
+    OutputFormatterLayout(OutputFormatterLayout&&) = default;
 
-    ~RowTupleBufferRef() override = default;
+    ~OutputFormatterLayout() override = default;
 
     [[nodiscard]] std::vector<Record::RecordFieldIdentifier> getAllFieldNames() const override;
 
@@ -67,10 +65,9 @@ public:
         nautilus::val<uint64_t>& recordIndex) const override;
 
     WriteRecordResult writeRecord(
-        nautilus::val<uint64_t>& recordIndex,
+        nautilus::val<uint64_t>& bytesWritten,
         const RecordBuffer& recordBuffer,
         const Record& rec,
         const nautilus::val<AbstractBufferProvider*>& bufferProvider) const override;
 };
-
 }

--- a/nes-nautilus/include/Interface/MemoryLayout/RowLayout.hpp
+++ b/nes-nautilus/include/Interface/MemoryLayout/RowLayout.hpp
@@ -20,7 +20,7 @@
 #include <DataTypes/DataType.hpp>
 #include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <val_arith.hpp>
 #include <val_concepts.hpp>
@@ -63,12 +63,12 @@ public:
 
     Record readRecord(
         const std::vector<Record::RecordFieldIdentifier>& projections,
-        const RecordBuffer& recordBuffer,
+        const TaskBufferRef& recordBuffer,
         nautilus::val<uint64_t>& recordIndex) const override;
 
     WriteRecordResult writeRecord(
         nautilus::val<uint64_t>& recordIndex,
-        const RecordBuffer& recordBuffer,
+        const TaskBufferRef& recordBuffer,
         const Record& rec,
         const nautilus::val<AbstractBufferProvider*>& bufferProvider) const override;
 };

--- a/nes-nautilus/include/Interface/MemoryLayout/RowLayout.hpp
+++ b/nes-nautilus/include/Interface/MemoryLayout/RowLayout.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
-#include <cstddef>
+
 #include <cstdint>
 #include <vector>
 #include <DataTypes/DataType.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
 #include <Interface/RecordBuffer.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
@@ -33,31 +33,32 @@ class LowerSchemaProvider;
 namespace NES
 {
 
-/// Implements BufferRef. Provides columnar memory access.
-class ColumnTupleBufferRef final : public TupleBufferRef
+/// Implements MemoryLayout. Provides row-wise memory access.
+class RowLayout final : public MemoryLayout
 {
     struct Field
     {
         Record::RecordFieldIdentifier name;
         DataType type;
-        size_t dataTypeSize;
-        uint64_t columnOffset;
+        uint64_t fieldOffset;
     };
 
     std::vector<Field> fields;
 
     /// Private constructor to prevent direct instantiation
-    explicit ColumnTupleBufferRef(std::vector<Field> fields, uint64_t tupleSize, uint64_t bufferSize);
+    explicit RowLayout(std::vector<Field> fields, uint64_t tupleSize, uint64_t bufferSize);
 
     /// Allow LowerSchemaProvider::lowerSchema() access to private constructor and Field
     friend class NES::LowerSchemaProvider;
 
 public:
-    ColumnTupleBufferRef(const ColumnTupleBufferRef&) = default;
-    ColumnTupleBufferRef(ColumnTupleBufferRef&&) = default;
-    ~ColumnTupleBufferRef() override = default;
+    RowLayout(const RowLayout&) = default;
+    RowLayout(RowLayout&&) = default;
+
+    ~RowLayout() override = default;
 
     [[nodiscard]] std::vector<Record::RecordFieldIdentifier> getAllFieldNames() const override;
+
     [[nodiscard]] std::vector<DataType> getAllDataTypes() const override;
 
     Record readRecord(

--- a/nes-nautilus/include/Interface/NautilusBuffer.hpp
+++ b/nes-nautilus/include/Interface/NautilusBuffer.hpp
@@ -18,22 +18,22 @@
 #include <cstdint>
 #include <variant>
 #include <Interface/NESStrongTypeRef.hpp> /// NOLINT(misc-include-cleaner): re-exported so callers get the nautilus val<> specialization for ChildBufferIndex.
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <val_details.hpp>
 #include <val_ptr.hpp>
 #include <val_std.hpp>
 
-/// A NautilusBuffer is a Wrapper around a TupleBuffer. It can come in two different flavours:
-/// 1. The BorrowedNautilusBuffer requires that an instance of a TupleBuffer is kept alive outside the nautilus execution. This handle
+/// A NautilusBuffer is a Wrapper around a Buffer. It can come in two different flavours:
+/// 1. The BorrowedNautilusBuffer requires that an instance of a Buffer is kept alive outside the nautilus execution. This handle
 ///    should be accessed by a single thread, as the handle itself is not Threadsafe. A common use case for the Borrowed variant
-///    is the initial entry point into the nautilus pipeline which holds the TupleBuffer on the WorkerThreads stack.
+///    is the initial entry point into the nautilus pipeline which holds the Buffer on the WorkerThreads stack.
 ///    If these two things can be guaranteed, you should prefer the BorrowedNautilusBuffer, as it does not require additional buffer
 ///    lifetime management
 /// 2. The OwnedNautilusBuffer is allocated within the nautilus execution, and the lifetime is managed by the nautilus execution.
-///    A common usecase is keeping a TupleBuffer alive which was allocated in a `nautilus::invoke` or loaded as a child of a different buffer:
+///    A common usecase is keeping a Buffer alive which was allocated in a `nautilus::invoke` or loaded as a child of a different buffer:
 ///    ```c++
 ///    OwnedNautilusBuffer owned;
-///    nautilus::invoke(+[](AbstractBufferProvider* provider, TupleBuffer* owned){
+///    nautilus::invoke(+[](AbstractBufferProvider* provider, Buffer* owned){
 ///         *owned = provider->getBufferBlocking();
 ///    }, provider, owned.asArg());
 ///    /// owned keeps the buffer alive, and releases once it goes out of scope
@@ -47,10 +47,10 @@ class NautilusBuffer;
 
 class OwnedNautilusBuffer
 {
-    nautilus::val<TupleBuffer> buffer;
+    nautilus::val<Buffer> buffer;
 
 public:
-    /// Creates an owned buffer that holds a reference-counted copy of `source`'s underlying TupleBuffer. Works for both owned and
+    /// Creates an owned buffer that holds a reference-counted copy of `source`'s underlying Buffer. Works for both owned and
     /// borrowed sources, and is the way to promote a borrowed buffer into one whose lifetime is managed by the nautilus execution.
     static OwnedNautilusBuffer copy(const NautilusBuffer& source);
 
@@ -64,24 +64,24 @@ public:
     [[nodiscard]] OwnedNautilusBuffer getChild(const nautilus::val<ChildBufferIndex>& index) const;
     [[nodiscard]] nautilus::val<bool> isValid() const;
 
-    /// Returns a pointer to the wrapped TupleBuffer that is only valid for as long as this buffer is alive.
+    /// Returns a pointer to the wrapped Buffer that is only valid for as long as this buffer is alive.
     /// It is solely intended to be passed as an argument to a `nautilus::invoke` and MUST NOT be stored or used to outlive this buffer.
     /// The lvalue-ref qualifier prevents calling it on a temporary, which would return a dangling pointer into the destroyed buffer.
-    [[nodiscard]] nautilus::val<const TupleBuffer*> asArg() const&;
-    nautilus::val<TupleBuffer*> asArg() &;
+    [[nodiscard]] nautilus::val<const Buffer*> asArg() const&;
+    nautilus::val<Buffer*> asArg() &;
     /// Do not call asArg() on a temporary OwnedNautilusBuffer: the returned pointer would dangle.
-    [[nodiscard]] nautilus::val<const TupleBuffer*> asArg() const&& = delete;
-    nautilus::val<TupleBuffer*> asArg() && = delete;
+    [[nodiscard]] nautilus::val<const Buffer*> asArg() const&& = delete;
+    nautilus::val<Buffer*> asArg() && = delete;
 };
 
 class BorrowedNautilusBuffer
 {
-    nautilus::val<TupleBuffer*> buffer;
+    nautilus::val<Buffer*> buffer;
 
-    explicit BorrowedNautilusBuffer(const nautilus::val<TupleBuffer*>& buffer);
+    explicit BorrowedNautilusBuffer(const nautilus::val<Buffer*>& buffer);
 
 public:
-    static BorrowedNautilusBuffer from(const nautilus::val<const TupleBuffer*>& originalBuffer);
+    static BorrowedNautilusBuffer from(const nautilus::val<const Buffer*>& originalBuffer);
 
     nautilus::val<int8_t*> data();
     [[nodiscard]] nautilus::val<const int8_t*> data() const;
@@ -94,10 +94,10 @@ public:
 
     nautilus::val<ChildBufferIndex> storeChild(BorrowedNautilusBuffer&& child);
 
-    /// Returns a pointer to the wrapped TupleBuffer that is only valid for as long as this buffer is alive.
+    /// Returns a pointer to the wrapped Buffer that is only valid for as long as this buffer is alive.
     /// It is solely intended to be passed as an argument to a `nautilus::invoke` and MUST NOT be stored or used to outlive this buffer.
-    [[nodiscard]] nautilus::val<const TupleBuffer*> asArg() const;
-    [[nodiscard]] nautilus::val<TupleBuffer*> asArg();
+    [[nodiscard]] nautilus::val<const Buffer*> asArg() const;
+    [[nodiscard]] nautilus::val<Buffer*> asArg();
 };
 
 class NautilusBuffer
@@ -116,14 +116,14 @@ public:
 
     [[nodiscard]] nautilus::val<size_t> getNumberOfRecords() const;
 
-    /// Returns a pointer to the wrapped TupleBuffer that is only valid for as long as this buffer is alive.
+    /// Returns a pointer to the wrapped Buffer that is only valid for as long as this buffer is alive.
     /// It is solely intended to be passed as an argument to a `nautilus::invoke` and MUST NOT be stored or used to outlive this buffer.
     /// The lvalue-ref qualifier prevents calling it on a temporary, which would return a dangling pointer into the destroyed buffer.
-    [[nodiscard]] nautilus::val<const TupleBuffer*> asArg() const&;
-    nautilus::val<TupleBuffer*> asArg() &;
+    [[nodiscard]] nautilus::val<const Buffer*> asArg() const&;
+    nautilus::val<Buffer*> asArg() &;
     /// Do not call asArg() on a temporary NautilusBuffer: the returned pointer would dangle.
-    [[nodiscard]] nautilus::val<const TupleBuffer*> asArg() const&& = delete;
-    nautilus::val<TupleBuffer*> asArg() && = delete;
+    [[nodiscard]] nautilus::val<const Buffer*> asArg() const&& = delete;
+    nautilus::val<Buffer*> asArg() && = delete;
 
     /// returns true if the underlying buffer is a owned buffer. Notice, that this is a c++ bool, as this information is not runtime data
     /// dependent.

--- a/nes-nautilus/include/Interface/PagedVector/PagedVector.hpp
+++ b/nes-nautilus/include/Interface/PagedVector/PagedVector.hpp
@@ -20,8 +20,8 @@
 #include <utility>
 #include <vector>
 #include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/BufferManager.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <ErrorHandling.hpp>
 
 namespace NES
@@ -39,8 +39,8 @@ public:
     /// Each page contains the cumulative sum in its header.
     struct Page
     {
-        static void init(TupleBuffer buffer);
-        static Page load(TupleBuffer buffer);
+        static void init(Buffer buffer);
+        static Page load(Buffer buffer);
         static uint64_t getHeaderSize();
 
         [[nodiscard]] size_t getCumulativeSum() const;
@@ -49,7 +49,7 @@ public:
         [[nodiscard]] uint64_t getNumberOfTuples() const;
 
     private:
-        explicit Page(TupleBuffer buffer) : buffer(std::move(buffer)) { }
+        explicit Page(Buffer buffer) : buffer(std::move(buffer)) { }
 
         struct Header
         {
@@ -62,15 +62,15 @@ public:
 
         [[nodiscard]] const Header& header() const { return *buffer.getAvailableMemoryArea<Header>().data(); }
 
-        TupleBuffer buffer;
+        Buffer buffer;
     };
 
     /// Paged Vector magic numbers
     static constexpr auto VALID_PV = 8254372433832867;
     static constexpr auto INVALID_PV = 0;
 
-    static void init(TupleBuffer buffer, uint64_t pageBufferSize, uint64_t tupleSize);
-    static PagedVector load(const TupleBuffer& buffer);
+    static void init(Buffer buffer, uint64_t pageBufferSize, uint64_t tupleSize);
+    static PagedVector load(const Buffer& buffer);
 
     /// @brief Appends a new page to the pages vector if the last page is full.
     void appendPageIfFull(AbstractBufferProvider* bufferProvider);
@@ -79,7 +79,7 @@ public:
     void copyPagesFrom(AbstractBufferProvider& bufferProvider, const PagedVector& other);
 
     /// @brief Transfers ownership of `other`'s pages to this PagedVector by appending them as child buffers.
-    /// This is a *logical* move: the underlying page TupleBuffers are not physically detached from `other.buffer`;
+    /// This is a *logical* move: the underlying page Buffers are not physically detached from `other.buffer`;
     /// they remain refcount-pinned by `other.buffer.children` until `other.buffer` itself is destroyed.
     /// `other` is marked INVALID_PV after the call. The caller MUST drop `other` immediately after and MUST NOT
     /// access it again — any further operation on `other` is undefined.
@@ -117,7 +117,7 @@ private:
         }
     };
 
-    explicit PagedVector(TupleBuffer buffer) : buffer(std::move(buffer)) { }
+    explicit PagedVector(Buffer buffer) : buffer(std::move(buffer)) { }
 
     [[nodiscard]] Header& header() { return *buffer.getAvailableMemoryArea<Header>().data(); }
 
@@ -128,7 +128,7 @@ private:
     void updateCumulativeSumAllPages() const;
     void addNewPage(AbstractBufferProvider* bufferProvider, uint64_t bufferSize);
 
-    TupleBuffer buffer;
+    Buffer buffer;
 };
 
 }

--- a/nes-nautilus/include/Interface/TaskBufferRef.hpp
+++ b/nes-nautilus/include/Interface/TaskBufferRef.hpp
@@ -18,7 +18,7 @@
 #include <DataTypes/VarVal.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Interface/NESStrongTypeRef.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Time/Timestamp.hpp>
 #include <val.hpp>
 #include <val_concepts.hpp>
@@ -27,13 +27,13 @@ namespace NES
 {
 
 /// @brief The TaskBufferRef is a representation of a set of records that are stored together.
-/// In the common case this maps to a TupleBuffer, which stores the individual records in either a row or a columnar layout.
+/// In the common case this maps to a Buffer, which stores the individual records in either a row or a columnar layout.
 class TaskBufferRef
 {
 public:
     /// @brief Creates a new record buffer with a reference to a tuple buffer
     /// @param tupleBufferRef
-    explicit TaskBufferRef(const nautilus::val<TupleBuffer*>& tupleBufferRef);
+    explicit TaskBufferRef(const nautilus::val<Buffer*>& tupleBufferRef);
 
     void setNumRecords(const nautilus::val<uint64_t>& numRecordsValue);
     [[nodiscard]] nautilus::val<uint64_t> getNumRecords() const;
@@ -41,8 +41,8 @@ public:
     /// Retrieve the reference to the underling memory area from the record buffer.
     [[nodiscard]] nautilus::val<int8_t*> getMemArea() const;
 
-    /// Get the reference to the underlying TupleBuffer
-    const nautilus::val<TupleBuffer*>& getReference() const;
+    /// Get the reference to the underlying Buffer
+    const nautilus::val<Buffer*>& getReference() const;
 
     /// Get the origin ID of the underlying tuple buffer. The origin ID is a unique identifier for the origin of the tuple buffer.
     nautilus::val<OriginId> getOriginId();
@@ -71,7 +71,7 @@ public:
     ~TaskBufferRef() = default;
 
 private:
-    nautilus::val<TupleBuffer*> tupleBufferRef;
+    nautilus::val<Buffer*> tupleBufferRef;
 };
 
 }

--- a/nes-nautilus/include/Interface/TaskBufferRef.hpp
+++ b/nes-nautilus/include/Interface/TaskBufferRef.hpp
@@ -26,14 +26,14 @@
 namespace NES
 {
 
-/// @brief The RecordBuffer is a representation of a set of records that are stored together.
+/// @brief The TaskBufferRef is a representation of a set of records that are stored together.
 /// In the common case this maps to a TupleBuffer, which stores the individual records in either a row or a columnar layout.
-class RecordBuffer
+class TaskBufferRef
 {
 public:
     /// @brief Creates a new record buffer with a reference to a tuple buffer
     /// @param tupleBufferRef
-    explicit RecordBuffer(const nautilus::val<TupleBuffer*>& tupleBufferRef);
+    explicit TaskBufferRef(const nautilus::val<TupleBuffer*>& tupleBufferRef);
 
     void setNumRecords(const nautilus::val<uint64_t>& numRecordsValue);
     [[nodiscard]] nautilus::val<uint64_t> getNumRecords() const;
@@ -68,7 +68,7 @@ public:
     nautilus::val<Timestamp> getCreatingTs();
     void setCreationTs(const nautilus::val<Timestamp>& creationTs);
 
-    ~RecordBuffer() = default;
+    ~TaskBufferRef() = default;
 
 private:
     nautilus::val<TupleBuffer*> tupleBufferRef;

--- a/nes-nautilus/include/Interface/TupleBufferProxyFunctions.hpp
+++ b/nes-nautilus/include/Interface/TupleBufferProxyFunctions.hpp
@@ -16,87 +16,87 @@
 
 #include <cstdint>
 #include <Identifiers/Identifiers.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Time/Timestamp.hpp>
 
 namespace NES::ProxyFunctions
 {
-inline int8_t* NES_Memory_TupleBuffer_getMemArea(TupleBuffer* tupleBuffer)
+inline int8_t* NES_Memory_TupleBuffer_getMemArea(Buffer* tupleBuffer)
 {
     return reinterpret_cast<int8_t*>(tupleBuffer->getAvailableMemoryArea().data());
 };
 
-inline uint64_t NES_Memory_TupleBuffer_getBufferSize(const TupleBuffer* tupleBuffer)
+inline uint64_t NES_Memory_TupleBuffer_getBufferSize(const Buffer* tupleBuffer)
 {
     return tupleBuffer->getBufferSize();
 };
 
-inline uint64_t NES_Memory_TupleBuffer_getNumberOfTuples(const TupleBuffer* tupleBuffer)
+inline uint64_t NES_Memory_TupleBuffer_getNumberOfTuples(const Buffer* tupleBuffer)
 {
     return tupleBuffer->getNumberOfTuples();
 };
 
-void inline NES_Memory_TupleBuffer_setNumberOfTuples(TupleBuffer* tupleBuffer, const uint64_t numberOfTuples)
+void inline NES_Memory_TupleBuffer_setNumberOfTuples(Buffer* tupleBuffer, const uint64_t numberOfTuples)
 {
     tupleBuffer->setNumberOfTuples(numberOfTuples);
 }
 
-inline OriginId NES_Memory_TupleBuffer_getOriginId(const TupleBuffer* tupleBuffer)
+inline OriginId NES_Memory_TupleBuffer_getOriginId(const Buffer* tupleBuffer)
 {
     return tupleBuffer->getOriginId();
 };
 
-inline void NES_Memory_TupleBuffer_setOriginId(TupleBuffer* tupleBuffer, const OriginId value)
+inline void NES_Memory_TupleBuffer_setOriginId(Buffer* tupleBuffer, const OriginId value)
 {
     tupleBuffer->setOriginId(OriginId(value));
 };
 
-inline Timestamp NES_Memory_TupleBuffer_getWatermark(const TupleBuffer* tupleBuffer)
+inline Timestamp NES_Memory_TupleBuffer_getWatermark(const Buffer* tupleBuffer)
 {
     return tupleBuffer->getWatermark();
 };
 
-inline void NES_Memory_TupleBuffer_setWatermark(TupleBuffer* tupleBuffer, const Timestamp value)
+inline void NES_Memory_TupleBuffer_setWatermark(Buffer* tupleBuffer, const Timestamp value)
 {
     tupleBuffer->setWatermark(Timestamp(value));
 };
 
-inline Timestamp NES_Memory_TupleBuffer_getCreationTimestampInMS(const TupleBuffer* tupleBuffer)
+inline Timestamp NES_Memory_TupleBuffer_getCreationTimestampInMS(const Buffer* tupleBuffer)
 {
     return tupleBuffer->getCreationTimestampInMS();
 };
 
-inline void NES_Memory_TupleBuffer_setSequenceNumber(TupleBuffer* tupleBuffer, const SequenceNumber sequenceNumber)
+inline void NES_Memory_TupleBuffer_setSequenceNumber(Buffer* tupleBuffer, const SequenceNumber sequenceNumber)
 {
     tupleBuffer->setSequenceNumber(sequenceNumber);
 };
 
-inline SequenceNumber NES_Memory_TupleBuffer_getSequenceNumber(const TupleBuffer* tupleBuffer)
+inline SequenceNumber NES_Memory_TupleBuffer_getSequenceNumber(const Buffer* tupleBuffer)
 {
     return tupleBuffer->getSequenceNumber();
 }
 
-inline void NES_Memory_TupleBuffer_setCreationTimestampInMS(TupleBuffer* tupleBuffer, const Timestamp value)
+inline void NES_Memory_TupleBuffer_setCreationTimestampInMS(Buffer* tupleBuffer, const Timestamp value)
 {
     tupleBuffer->setCreationTimestampInMS(Timestamp(value));
 }
 
-inline void NES_Memory_TupleBuffer_setChunkNumber(TupleBuffer* tupleBuffer, const ChunkNumber chunkNumber)
+inline void NES_Memory_TupleBuffer_setChunkNumber(Buffer* tupleBuffer, const ChunkNumber chunkNumber)
 {
     tupleBuffer->setChunkNumber(ChunkNumber(chunkNumber));
 };
 
-inline void NES_Memory_TupleBuffer_setLastChunk(TupleBuffer* tupleBuffer, const bool isLastChunk)
+inline void NES_Memory_TupleBuffer_setLastChunk(Buffer* tupleBuffer, const bool isLastChunk)
 {
     tupleBuffer->setLastChunk(isLastChunk);
 };
 
-inline ChunkNumber NES_Memory_TupleBuffer_getChunkNumber(const TupleBuffer* tupleBuffer)
+inline ChunkNumber NES_Memory_TupleBuffer_getChunkNumber(const Buffer* tupleBuffer)
 {
     return tupleBuffer->getChunkNumber();
 };
 
-inline bool NES_Memory_TupleBuffer_isLastChunk(const TupleBuffer* tupleBuffer)
+inline bool NES_Memory_TupleBuffer_isLastChunk(const Buffer* tupleBuffer)
 {
     return tupleBuffer->isLastChunk();
 };

--- a/nes-nautilus/include/Interface/VariableSizedAccess.hpp
+++ b/nes-nautilus/include/Interface/VariableSizedAccess.hpp
@@ -17,7 +17,7 @@
 #include <compare>
 #include <cstdint>
 #include <ostream>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Util/Logger/Formatter.hpp>
 #include <ErrorHandling.hpp>
 

--- a/nes-nautilus/src/Interface/CMakeLists.txt
+++ b/nes-nautilus/src/Interface/CMakeLists.txt
@@ -12,7 +12,7 @@
 
 add_subdirectory(Hash)
 add_subdirectory(HashMap)
-add_subdirectory(BufferRef)
+add_subdirectory(MemoryLayout)
 add_subdirectory(PagedVector)
 
 add_source_files(nes-nautilus

--- a/nes-nautilus/src/Interface/CMakeLists.txt
+++ b/nes-nautilus/src/Interface/CMakeLists.txt
@@ -17,7 +17,7 @@ add_subdirectory(PagedVector)
 
 add_source_files(nes-nautilus
         Record.cpp
-        RecordBuffer.cpp
+        TaskBufferRef.cpp
         NautilusBuffer.cpp
         VariableSizedAccess.cpp
 )

--- a/nes-nautilus/src/Interface/HashMap/ChainedHashMap/ChainedEntryMemoryProvider.cpp
+++ b/nes-nautilus/src/Interface/HashMap/ChainedHashMap/ChainedEntryMemoryProvider.cpp
@@ -29,7 +29,7 @@
 #include <Interface/HashMap/ChainedHashMap/ChainedHashMap.hpp>
 #include <Interface/Record.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <nautilus/val_ptr.hpp>
 #include <ErrorHandling.hpp>
 #include <function.hpp>
@@ -126,13 +126,13 @@ Record ChainedEntryMemoryProvider::readRecord(const nautilus::val<ChainedHashMap
 namespace
 {
 void storeVarSized(
-    const nautilus::val<TupleBuffer*>& tupleBuffer,
+    const nautilus::val<Buffer*>& tupleBuffer,
     const nautilus::val<AbstractBufferProvider*>& bufferProviderRef,
     const nautilus::val<int8_t*>& memoryAddress,
     const VariableSizedData& variableSizedData)
 {
     nautilus::invoke(
-        +[](TupleBuffer* tupleBuffer,
+        +[](Buffer* tupleBuffer,
             AbstractBufferProvider* bufferProvider,
             const int8_t** memoryAddressInEntry,
             const int8_t* varSizedData,
@@ -157,7 +157,7 @@ void writeVarVal(
     const VarVal& value,
     const nautilus::val<int8_t*>& fieldAddress,
     const DataType& type,
-    const nautilus::val<TupleBuffer*>& hashMapTupleBuffer,
+    const nautilus::val<Buffer*>& hashMapTupleBuffer,
     const nautilus::val<AbstractBufferProvider*>& bufferProvider)
 {
     /// For now, we store the null byte before the actual VarVal
@@ -183,7 +183,7 @@ void writeVarVal(
 
 void ChainedEntryMemoryProvider::writeRecord(
     const nautilus::val<ChainedHashMapEntry*>& entryRef,
-    const nautilus::val<TupleBuffer*>& hashMapBuffer,
+    const nautilus::val<Buffer*>& hashMapBuffer,
     const nautilus::val<AbstractBufferProvider*>& bufferProvider,
     const Record& record) const
 {
@@ -197,7 +197,7 @@ void ChainedEntryMemoryProvider::writeRecord(
 
 void ChainedEntryMemoryProvider::writeEntryRef(
     const nautilus::val<ChainedHashMapEntry*>& entryRef,
-    const nautilus::val<TupleBuffer*>& hashMapBuffer,
+    const nautilus::val<Buffer*>& hashMapBuffer,
     const nautilus::val<AbstractBufferProvider*>& bufferProvider,
     const nautilus::val<ChainedHashMapEntry*>& otherEntryRef) const
 {

--- a/nes-nautilus/src/Interface/HashMap/ChainedHashMap/ChainedHashMap.cpp
+++ b/nes-nautilus/src/Interface/HashMap/ChainedHashMap/ChainedHashMap.cpp
@@ -28,7 +28,7 @@
 #include <Interface/Hash/HashFunction.hpp>
 #include <Interface/HashMap/HashMap.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <ErrorHandling.hpp>
 
 namespace NES
@@ -65,7 +65,7 @@ uint64_t ChainedHashMapConfig::bufferSize() const
     return ChainedHashMap::calculateBufferSizeFromBuckets(numberOfBuckets, bloomFilterMemAreaSize());
 }
 
-void ChainedHashMap::init(TupleBuffer& tupleBuffer, const ChainedHashMapConfig& config)
+void ChainedHashMap::init(Buffer& tupleBuffer, const ChainedHashMapConfig& config)
 {
     const auto [entrySize, numberOfBuckets, pageSize, bloomFilter] = config;
     PRECONDITION(entrySize > 0, "Entry size has to be greater than 0. Entry size is set to small for entry size {}", entrySize);
@@ -111,7 +111,7 @@ void ChainedHashMap::init(TupleBuffer& tupleBuffer, const ChainedHashMapConfig& 
     std::ranges::fill(chm.bloomBits(), uint64_t{0});
 }
 
-ChainedHashMap ChainedHashMap::load(const TupleBuffer& tupleBuffer)
+ChainedHashMap ChainedHashMap::load(const Buffer& tupleBuffer)
 {
     ChainedHashMap chm{tupleBuffer};
     const auto& hdr = chm.header();
@@ -135,7 +135,7 @@ ChainedHashMap ChainedHashMap::load(const TupleBuffer& tupleBuffer)
 
 void ChainedHashMap::allocateNewVarSizedPage(AbstractBufferProvider* bufferProvider, const size_t neededSize)
 {
-    TupleBuffer newPage;
+    Buffer newPage;
     if (neededSize <= bufferProvider->getBufferSize())
     {
         newPage = bufferProvider->getBufferBlocking();
@@ -153,7 +153,7 @@ void ChainedHashMap::allocateNewVarSizedPage(AbstractBufferProvider* bufferProvi
     }
 
     auto varSizedBufferIdx = getVarSizedBufferIdx();
-    if (varSizedBufferIdx != TupleBuffer::INVALID_CHILD_BUFFER_INDEX_VALUE)
+    if (varSizedBufferIdx != Buffer::INVALID_CHILD_BUFFER_INDEX_VALUE)
     {
         /// Storage buffer already exists - just add the new page
         auto varSizedBuffer = buffer.loadChildBuffer(varSizedBufferIdx);
@@ -207,7 +207,7 @@ std::span<std::byte> ChainedHashMap::allocateSpaceForVarSized(AbstractBufferProv
 void ChainedHashMap::appendPage(AbstractBufferProvider* bufferProvider)
 {
     /// create and initialize new page
-    TupleBuffer newPage;
+    Buffer newPage;
     if (bufferProvider->getBufferSize() == getPageSize())
     {
         newPage = bufferProvider->getBufferBlocking();
@@ -227,7 +227,7 @@ void ChainedHashMap::appendPage(AbstractBufferProvider* bufferProvider)
 
     /// get or create storage buffer
     auto storageBufferIdx = getStorageBufferIdx();
-    if (storageBufferIdx != TupleBuffer::INVALID_CHILD_BUFFER_INDEX_VALUE)
+    if (storageBufferIdx != Buffer::INVALID_CHILD_BUFFER_INDEX_VALUE)
     {
         /// storage buffer already exists
         auto storageBuffer = buffer.loadChildBuffer(storageBufferIdx);
@@ -311,28 +311,27 @@ uint64_t* ChainedHashMap::getBloomFilterMemArea()
     return bloomBits().data();
 }
 
-TupleBuffer ChainedHashMap::getPage(const uint64_t pageIndex) const
+Buffer ChainedHashMap::getPage(const uint64_t pageIndex) const
 {
     auto storageBufferIdx = getStorageBufferIdx();
-    PRECONDITION(storageBufferIdx != TupleBuffer::INVALID_CHILD_BUFFER_INDEX_VALUE, "Storage space not initialized during getPage()");
+    PRECONDITION(storageBufferIdx != Buffer::INVALID_CHILD_BUFFER_INDEX_VALUE, "Storage space not initialized during getPage()");
     auto storageBuffer = buffer.loadChildBuffer(storageBufferIdx);
     uint64_t numberOfPages = storageBuffer.getNumberOfChildBuffers();
     PRECONDITION(pageIndex < numberOfPages, "Page index {} is greater than the number of pages {}", pageIndex, numberOfPages);
     const ChildBufferIndex pageBufferIdx{static_cast<uint32_t>(pageIndex)};
-    TupleBuffer page = storageBuffer.loadChildBuffer(pageBufferIdx);
+    Buffer page = storageBuffer.loadChildBuffer(pageBufferIdx);
     return page;
 }
 
-TupleBuffer ChainedHashMap::getVarSizedPage(const uint64_t pageIndex) const
+Buffer ChainedHashMap::getVarSizedPage(const uint64_t pageIndex) const
 {
     auto varSizedSpaceIdx = getVarSizedBufferIdx();
-    PRECONDITION(
-        varSizedSpaceIdx != TupleBuffer::INVALID_CHILD_BUFFER_INDEX_VALUE, "VarSized space not initialized during getVarSizedPage()");
+    PRECONDITION(varSizedSpaceIdx != Buffer::INVALID_CHILD_BUFFER_INDEX_VALUE, "VarSized space not initialized during getVarSizedPage()");
     auto varSizedBuffer = buffer.loadChildBuffer(varSizedSpaceIdx);
     uint64_t numberOfPages = varSizedBuffer.getNumberOfChildBuffers();
     PRECONDITION(pageIndex < numberOfPages, "Page index {} is greater than the number of pages {}", pageIndex, numberOfPages);
     const ChildBufferIndex pageBufferIdx{static_cast<uint32_t>(pageIndex)};
-    TupleBuffer page = varSizedBuffer.loadChildBuffer(pageBufferIdx);
+    Buffer page = varSizedBuffer.loadChildBuffer(pageBufferIdx);
     return page;
 }
 
@@ -350,7 +349,7 @@ uint64_t ChainedHashMap::calculateBufferSizeFromChains(uint64_t numberOfChains, 
 [[nodiscard]] uint64_t ChainedHashMap::getNumberOfPages() const
 {
     auto storageBufferIdx = getStorageBufferIdx();
-    if (storageBufferIdx != TupleBuffer::INVALID_CHILD_BUFFER_INDEX_VALUE)
+    if (storageBufferIdx != Buffer::INVALID_CHILD_BUFFER_INDEX_VALUE)
     {
         auto storageBuffer = buffer.loadChildBuffer(storageBufferIdx);
         return storageBuffer.getNumberOfChildBuffers();
@@ -361,7 +360,7 @@ uint64_t ChainedHashMap::calculateBufferSizeFromChains(uint64_t numberOfChains, 
 [[nodiscard]] uint64_t ChainedHashMap::getNumberOfVarSizedPages() const
 {
     auto varSizedBufferIdx = getVarSizedBufferIdx();
-    if (varSizedBufferIdx != TupleBuffer::INVALID_CHILD_BUFFER_INDEX_VALUE)
+    if (varSizedBufferIdx != Buffer::INVALID_CHILD_BUFFER_INDEX_VALUE)
     {
         auto varSizedBuffer = buffer.loadChildBuffer(varSizedBufferIdx);
         return varSizedBuffer.getNumberOfChildBuffers();

--- a/nes-nautilus/src/Interface/HashMap/ChainedHashMap/ChainedHashMapRef.cpp
+++ b/nes-nautilus/src/Interface/HashMap/ChainedHashMap/ChainedHashMapRef.cpp
@@ -32,7 +32,7 @@
 #include <Interface/HashMap/HashMapRef.hpp>
 #include <Interface/Record.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <nautilus/function.hpp>
 #include <nautilus/static.hpp>
 #include <nautilus/val.hpp>
@@ -131,7 +131,7 @@ nautilus::val<ChainedHashMapEntry*> ChainedHashMapRef::ChainedEntryRef::getNext(
 
 ChainedHashMapRef::ChainedEntryRef::ChainedEntryRef(
     const nautilus::val<ChainedHashMapEntry*>& entryRef,
-    const nautilus::val<TupleBuffer*>& hashMapBuffer,
+    const nautilus::val<Buffer*>& hashMapBuffer,
     std::vector<FieldOffsets> fieldsKey,
     std::vector<FieldOffsets> fieldsValue)
     : entryRef(entryRef)
@@ -143,7 +143,7 @@ ChainedHashMapRef::ChainedEntryRef::ChainedEntryRef(
 
 ChainedHashMapRef::ChainedEntryRef::ChainedEntryRef(
     const nautilus::val<ChainedHashMapEntry*>& entryRef,
-    const nautilus::val<TupleBuffer*>& hashMapBuffer,
+    const nautilus::val<Buffer*>& hashMapBuffer,
     ChainedEntryMemoryProvider memoryProviderKeys,
     ChainedEntryMemoryProvider memoryProviderValues)
     : entryRef(entryRef)
@@ -267,7 +267,7 @@ ChainedHashMapRef::EntryIterator ChainedHashMapRef::begin() const
     const nautilus::val<uint64_t> pageIndex = 0;
     nautilus::val<EntryIterator::DynamicArgsWrapper> args;
     const auto currentEntry = nautilus::invoke(
-        +[](TupleBuffer* buffer, const uint64_t pageIndexVal, const uint64_t indexOnPageVal, EntryIterator::DynamicArgsWrapper* args)
+        +[](Buffer* buffer, const uint64_t pageIndexVal, const uint64_t indexOnPageVal, EntryIterator::DynamicArgsWrapper* args)
         {
             const auto chm = ChainedHashMap::load(*buffer);
             /// get number of pages in chained hash map
@@ -309,7 +309,7 @@ ChainedHashMapRef::EntryIterator ChainedHashMapRef::end() const
 {
     /// The iterator pointing to the end() should NEVER be advanced. Therefore, we do not need to set a lot of its members
     const auto numberOfTuples = invoke(
-        +[](TupleBuffer* buffer)
+        +[](Buffer* buffer)
         {
             const auto chm = ChainedHashMap::load(*buffer);
             return chm.getTotalNumberOfRecords();
@@ -327,7 +327,7 @@ nautilus::val<ChainedHashMapEntry*> ChainedHashMapRef::findChain(const HashFunct
         return nullptr;
     }
     return nautilus::invoke(
-        +[](const TupleBuffer* buffer, const HashFunction::HashValue::raw_type hashValue) -> ChainedHashMapEntry*
+        +[](const Buffer* buffer, const HashFunction::HashValue::raw_type hashValue) -> ChainedHashMapEntry*
         {
             ChainedHashMap chm = ChainedHashMap::load(*buffer);
             if (chm.getTotalNumberOfRecords() == 0)
@@ -345,7 +345,7 @@ nautilus::val<ChainedHashMapEntry*>
 ChainedHashMapRef::insert(const HashFunction::HashValue& hash, const nautilus::val<AbstractBufferProvider*>& bufferProvider)
 {
     const auto newEntry = invoke(
-        +[](TupleBuffer* buffer, const HashFunction::HashValue::raw_type hashValue, AbstractBufferProvider* bufferProviderVal)
+        +[](Buffer* buffer, const HashFunction::HashValue::raw_type hashValue, AbstractBufferProvider* bufferProviderVal)
         {
             auto chm = ChainedHashMap::load(*buffer);
             return chm.insertEntry(hashValue, bufferProviderVal);
@@ -393,7 +393,7 @@ nautilus::val<bool> ChainedHashMapRef::compareKeys(const ChainedEntryRef& entryR
 }
 
 ChainedHashMapRef::ChainedHashMapRef(
-    const nautilus::val<TupleBuffer*>& buffer,
+    const nautilus::val<Buffer*>& buffer,
     std::vector<FieldOffsets> fieldsKey,
     std::vector<FieldOffsets> fieldsValue,
     const nautilus::val<uint64_t>& entriesPerPage,
@@ -411,7 +411,7 @@ ChainedHashMapRef::ChainedHashMapRef(
     {
         bloomFilter.emplace(
             invoke(
-                +[](TupleBuffer* buffer IF_INVARIANT(, const uint64_t bitCount) IF_INVARIANT(, const uint64_t hashCount))
+                +[](Buffer* buffer IF_INVARIANT(, const uint64_t bitCount) IF_INVARIANT(, const uint64_t hashCount))
                 {
                     auto chm = ChainedHashMap::load(*buffer);
                     INVARIANT(chm.getBloomFilterParams().has_value(), "The hash map was initialised without a BloomFilter bit area");
@@ -456,7 +456,7 @@ ChainedHashMapRef& ChainedHashMapRef::operator=(const ChainedHashMapRef& other)
 }
 
 ChainedHashMapRef::EntryIterator::EntryIterator(
-    const nautilus::val<TupleBuffer*>& buffer,
+    const nautilus::val<Buffer*>& buffer,
     const nautilus::val<ChainedHashMapEntry*>& currentEntry,
     const nautilus::val<uint64_t>& entrySize,
     const nautilus::val<uint64_t>& tupleIndex,
@@ -490,7 +490,7 @@ ChainedHashMapRef::EntryIterator& ChainedHashMapRef::EntryIterator::operator++()
         ++pageIndex;
         nautilus::val<DynamicArgsWrapper> args;
         currentEntry = nautilus::invoke(
-            +[](TupleBuffer* buffer, const uint64_t pageIndexVal, const uint64_t indexOnPageVal, DynamicArgsWrapper* args)
+            +[](Buffer* buffer, const uint64_t pageIndexVal, const uint64_t indexOnPageVal, DynamicArgsWrapper* args)
             {
                 const auto chm = ChainedHashMap::load(*buffer);
                 /// get number of pages in chained hash map

--- a/nes-nautilus/src/Interface/MemoryLayout/CMakeLists.txt
+++ b/nes-nautilus/src/Interface/MemoryLayout/CMakeLists.txt
@@ -11,9 +11,9 @@
 # limitations under the License.
 
 add_source_files(nes-nautilus
-        TupleBufferRef.cpp
-        ColumnTupleBufferRef.cpp
-        RowTupleBufferRef.cpp
+        MemoryLayout.cpp
+        ColumnLayout.cpp
+        RowLayout.cpp
         LowerSchemaProvider.cpp
-        OutputFormatterBufferRef.cpp
+        OutputFormatterLayout.cpp
         )

--- a/nes-nautilus/src/Interface/MemoryLayout/ColumnLayout.cpp
+++ b/nes-nautilus/src/Interface/MemoryLayout/ColumnLayout.cpp
@@ -11,65 +11,68 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-#include <Interface/BufferRef/RowTupleBufferRef.hpp>
+#include <Interface/MemoryLayout/ColumnLayout.hpp>
 
-#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <ranges>
-#include <string>
 #include <utility>
 #include <vector>
 #include <DataTypes/DataType.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <DataTypes/VarVal.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
 #include <Interface/RecordBuffer.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
+#include <nautilus/static.hpp>
 #include <nautilus/val_ptr.hpp>
-#include <static.hpp>
 #include <val.hpp>
 #include <val_bool.hpp>
 
 namespace NES
 {
 
-RowTupleBufferRef::RowTupleBufferRef(std::vector<Field> fields, const uint64_t tupleSize, const uint64_t bufferSize)
-    : TupleBufferRef(bufferSize / tupleSize, bufferSize, tupleSize), fields(std::move(fields))
+ColumnLayout::ColumnLayout(std::vector<Field> fields, const uint64_t tupleSize, const uint64_t bufferSize)
+    : MemoryLayout(bufferSize / tupleSize, bufferSize, tupleSize), fields(std::move(fields))
 {
 }
 
 namespace
 {
-nautilus::val<int8_t*> calculateFieldAddress(const nautilus::val<int8_t*>& recordOffset, const uint64_t fieldOffset)
+nautilus::val<int8_t*> calculateFieldAddress(
+    const nautilus::val<int8_t*>& bufferAddress,
+    nautilus::val<uint64_t>& recordIndex,
+    const uint64_t fieldSize,
+    const uint64_t columnOffset)
 {
-    auto fieldAddress = recordOffset + nautilus::val<uint64_t>(fieldOffset);
+    const auto fieldOffset = recordIndex * fieldSize + columnOffset;
+    auto fieldAddress = bufferAddress + fieldOffset;
     return fieldAddress;
 }
 }
 
-Record RowTupleBufferRef::readRecord(
+Record ColumnLayout::readRecord(
     const std::vector<Record::RecordFieldIdentifier>& projections,
     const RecordBuffer& recordBuffer,
     nautilus::val<uint64_t>& recordIndex) const
 {
     Record record;
     const auto bufferAddress = recordBuffer.getMemArea();
-    const auto recordOffset = bufferAddress + (tupleSize * recordIndex);
     for (nautilus::static_val<uint64_t> i = 0; i < fields.size(); ++i)
     {
-        const auto& [name, type, fieldOffset] = fields.at(i);
+        const auto& [name, type, dataTypeSize, columnOffset] = fields.at(i);
         if (not includesField(projections, name))
         {
             continue;
         }
-        auto fieldAddress = calculateFieldAddress(recordOffset, fieldOffset);
-        auto value = loadValue(type, recordBuffer, fieldAddress);
+        auto fieldAddress = calculateFieldAddress(bufferAddress, recordIndex, dataTypeSize, columnOffset);
+        const auto& value = loadValue(type, recordBuffer, fieldAddress);
         record.write(name, value);
     }
     return record;
 }
 
-TupleBufferRef::WriteRecordResult RowTupleBufferRef::writeRecord(
+MemoryLayout::WriteRecordResult ColumnLayout::writeRecord(
     nautilus::val<uint64_t>& recordIndex,
     const RecordBuffer& recordBuffer,
     const Record& rec,
@@ -81,16 +84,15 @@ TupleBufferRef::WriteRecordResult RowTupleBufferRef::writeRecord(
     if (recordIndex < capacity)
     {
         const auto bufferAddress = recordBuffer.getMemArea();
-        const auto recordOffset = bufferAddress + (tupleSize * recordIndex);
         for (nautilus::static_val<uint64_t> i = 0; i < fields.size(); ++i)
         {
-            const auto& [name, type, fieldOffset] = fields.at(i);
+            const auto& [name, type, dataTypeSize, columnOffset] = fields.at(i);
             if (not rec.hasField(name))
             {
                 /// Skipping any fields that are not part of the record
                 continue;
             }
-            auto fieldAddress = calculateFieldAddress(recordOffset, fieldOffset);
+            auto fieldAddress = calculateFieldAddress(bufferAddress, recordIndex, dataTypeSize, columnOffset);
             const auto& value = rec.read(name);
             storeValue(type, recordBuffer, fieldAddress, value, bufferProvider);
         }
@@ -100,12 +102,12 @@ TupleBufferRef::WriteRecordResult RowTupleBufferRef::writeRecord(
     return {.successful = successful, .writtenRecords = writtenRecords};
 }
 
-std::vector<Record::RecordFieldIdentifier> RowTupleBufferRef::getAllFieldNames() const
+std::vector<Record::RecordFieldIdentifier> ColumnLayout::getAllFieldNames() const
 {
     return fields | std::views::transform([](const Field& field) { return field.name; }) | std::ranges::to<std::vector>();
 }
 
-std::vector<DataType> RowTupleBufferRef::getAllDataTypes() const
+std::vector<DataType> ColumnLayout::getAllDataTypes() const
 {
     return fields | std::views::transform([](const Field& field) { return field.type; }) | std::ranges::to<std::vector>();
 }

--- a/nes-nautilus/src/Interface/MemoryLayout/ColumnLayout.cpp
+++ b/nes-nautilus/src/Interface/MemoryLayout/ColumnLayout.cpp
@@ -22,7 +22,7 @@
 #include <DataTypes/VarVal.hpp>
 #include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <nautilus/static.hpp>
 #include <nautilus/val_ptr.hpp>
@@ -53,7 +53,7 @@ nautilus::val<int8_t*> calculateFieldAddress(
 
 Record ColumnLayout::readRecord(
     const std::vector<Record::RecordFieldIdentifier>& projections,
-    const RecordBuffer& recordBuffer,
+    const TaskBufferRef& recordBuffer,
     nautilus::val<uint64_t>& recordIndex) const
 {
     Record record;
@@ -74,7 +74,7 @@ Record ColumnLayout::readRecord(
 
 MemoryLayout::WriteRecordResult ColumnLayout::writeRecord(
     nautilus::val<uint64_t>& recordIndex,
-    const RecordBuffer& recordBuffer,
+    const TaskBufferRef& recordBuffer,
     const Record& rec,
     const nautilus::val<AbstractBufferProvider*>& bufferProvider) const
 {

--- a/nes-nautilus/src/Interface/MemoryLayout/LowerSchemaProvider.cpp
+++ b/nes-nautilus/src/Interface/MemoryLayout/LowerSchemaProvider.cpp
@@ -12,7 +12,7 @@
     limitations under the License.
 */
 
-#include <Interface/BufferRef/LowerSchemaProvider.hpp>
+#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
 
 #include <cstdint>
 #include <memory>
@@ -26,10 +26,10 @@
 #include <DataTypes/SchemaFwd.hpp>
 #include <DataTypes/UnboundField.hpp>
 #include <Identifiers/Identifier.hpp>
-#include <Interface/BufferRef/ColumnTupleBufferRef.hpp>
-#include <Interface/BufferRef/OutputFormatterBufferRef.hpp>
-#include <Interface/BufferRef/RowTupleBufferRef.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/ColumnLayout.hpp>
+#include <Interface/MemoryLayout/OutputFormatterLayout.hpp>
+#include <Interface/MemoryLayout/RowLayout.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
 #include <OutputFormatters/OutputFormatter.hpp>
 #include <OutputFormatters/OutputFormatterDescriptor.hpp>
@@ -40,13 +40,13 @@
 namespace NES
 {
 
-std::shared_ptr<TupleBufferRef> LowerSchemaProvider::lowerSchemaWithOutputFormat(
+std::shared_ptr<MemoryLayout> LowerSchemaProvider::lowerSchemaWithOutputFormat(
     const uint64_t bufferSize,
     const Schema<QualifiedUnboundField, Ordered>& schema,
     const std::string& outputFormatterType,
     const std::unordered_map<Identifier, std::string>& config)
 {
-    std::vector<OutputFormatterBufferRef::Field> fields;
+    std::vector<OutputFormatterLayout::Field> fields;
     std::vector<Record::RecordFieldIdentifier> fieldNames;
     fields.reserve(std::ranges::size(schema));
     fieldNames.reserve(std::ranges::size(schema));
@@ -65,10 +65,10 @@ std::shared_ptr<TupleBufferRef> LowerSchemaProvider::lowerSchemaWithOutputFormat
     const std::shared_ptr<OutputFormatter> outputFormatter
         = OutputFormatterProvider::provideOutputFormatter(outputFormatterType, fieldNames, descriptor);
 
-    return std::make_shared<OutputFormatterBufferRef>(OutputFormatterBufferRef{std::move(fields), outputFormatter, bufferSize});
+    return std::make_shared<OutputFormatterLayout>(OutputFormatterLayout{std::move(fields), outputFormatter, bufferSize});
 }
 
-std::shared_ptr<TupleBufferRef> LowerSchemaProvider::lowerSchema(
+std::shared_ptr<MemoryLayout> LowerSchemaProvider::lowerSchema(
     const uint64_t bufferSize, const Schema<QualifiedUnboundField, Ordered>& schema, const MemoryLayoutType layoutType)
 {
     PRECONDITION(!std::ranges::empty(schema), "We can not lower an empty schema!");
@@ -78,7 +78,7 @@ std::shared_ptr<TupleBufferRef> LowerSchemaProvider::lowerSchema(
     switch (layoutType)
     {
         case MemoryLayoutType::ROW_LAYOUT: {
-            std::vector<RowTupleBufferRef::Field> fields;
+            std::vector<RowLayout::Field> fields;
             fields.reserve(std::ranges::size(schema));
             uint64_t fieldOffset = 0;
             for (const auto& field : schema)
@@ -90,9 +90,9 @@ std::shared_ptr<TupleBufferRef> LowerSchemaProvider::lowerSchema(
                 fields.begin(),
                 fields.end(),
                 0UL,
-                [](auto size, const RowTupleBufferRef::Field& field) { return size + field.type.getSizeInBytesWithNull(); });
+                [](auto size, const RowLayout::Field& field) { return size + field.type.getSizeInBytesWithNull(); });
             INVARIANT(tupleSize > 0, "Tuplesize must be larger than 0B");
-            return std::make_shared<RowTupleBufferRef>(RowTupleBufferRef{std::move(fields), tupleSize, bufferSize});
+            return std::make_shared<RowLayout>(RowLayout{std::move(fields), tupleSize, bufferSize});
         }
 
         case MemoryLayoutType::COLUMNAR_LAYOUT: {
@@ -104,7 +104,7 @@ std::shared_ptr<TupleBufferRef> LowerSchemaProvider::lowerSchema(
             INVARIANT(tupleSize > 0, "Tuplesize must be larger than 0B");
 
             const uint64_t capacity = bufferSize / tupleSize;
-            std::vector<ColumnTupleBufferRef::Field> fields;
+            std::vector<ColumnLayout::Field> fields;
             fields.reserve(std::ranges::size(schema));
             uint64_t columnOffset = 0;
             for (const auto& field : schema)
@@ -114,7 +114,7 @@ std::shared_ptr<TupleBufferRef> LowerSchemaProvider::lowerSchema(
                 columnOffset += (field.getDataType().getSizeInBytesWithNull() * capacity);
             }
 
-            return std::make_shared<ColumnTupleBufferRef>(ColumnTupleBufferRef{std::move(fields), tupleSize, bufferSize});
+            return std::make_shared<ColumnLayout>(ColumnLayout{std::move(fields), tupleSize, bufferSize});
         }
     }
     std::unreachable();

--- a/nes-nautilus/src/Interface/MemoryLayout/LowerSchemaProvider.cpp
+++ b/nes-nautilus/src/Interface/MemoryLayout/LowerSchemaProvider.cpp
@@ -27,9 +27,9 @@
 #include <DataTypes/UnboundField.hpp>
 #include <Identifiers/Identifier.hpp>
 #include <Interface/MemoryLayout/ColumnLayout.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/MemoryLayout/OutputFormatterLayout.hpp>
 #include <Interface/MemoryLayout/RowLayout.hpp>
-#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
 #include <OutputFormatters/OutputFormatter.hpp>
 #include <OutputFormatters/OutputFormatterDescriptor.hpp>

--- a/nes-nautilus/src/Interface/MemoryLayout/MemoryLayout.cpp
+++ b/nes-nautilus/src/Interface/MemoryLayout/MemoryLayout.cpp
@@ -35,7 +35,7 @@
 #include <Interface/VariableSizedAccess.hpp>
 #include <Interface/VariableSizedAccessRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <magic_enum/magic_enum.hpp>
 #include <ErrorHandling.hpp>
 #include <function.hpp>
@@ -50,7 +50,7 @@ namespace NES
 
 namespace
 {
-TupleBuffer getNewBufferForVarSized(AbstractBufferProvider& tupleBufferProvider, const uint64_t newBufferSize)
+Buffer getNewBufferForVarSized(AbstractBufferProvider& tupleBufferProvider, const uint64_t newBufferSize)
 {
     /// If the fixed size buffers are not large enough, we get an unpooled buffer
     if (tupleBufferProvider.getBufferSize() > newBufferSize)
@@ -72,7 +72,7 @@ TupleBuffer getNewBufferForVarSized(AbstractBufferProvider& tupleBufferProvider,
 /// @brief Copies the varSizedValue to the specified location and then increments the number of tuples
 /// @return the new childBufferOffset
 void copyVarSizedAndIncrementMetaData(
-    TupleBuffer& childBuffer, const VariableSizedAccess::Offset childBufferOffset, const std::span<const std::byte> varSizedValue)
+    Buffer& childBuffer, const VariableSizedAccess::Offset childBufferOffset, const std::span<const std::byte> varSizedValue)
 {
     const auto spaceInChildBuffer = childBuffer.getAvailableMemoryArea().subspan(childBufferOffset.getRawOffset());
     PRECONDITION(spaceInChildBuffer.size() >= varSizedValue.size(), "SpaceInChildBuffer must be larger than varSizedValue");
@@ -84,8 +84,8 @@ void copyVarSizedAndIncrementMetaData(
 }
 }
 
-VariableSizedAccess MemoryLayout::writeVarSized(
-    TupleBuffer& tupleBuffer, AbstractBufferProvider& bufferProvider, const std::span<const std::byte> varSizedValue)
+VariableSizedAccess
+MemoryLayout::writeVarSized(Buffer& tupleBuffer, AbstractBufferProvider& bufferProvider, const std::span<const std::byte> varSizedValue)
 {
     const auto totalVarSizedLength = varSizedValue.size();
 
@@ -120,7 +120,7 @@ VariableSizedAccess MemoryLayout::writeVarSized(
 }
 
 std::span<std::byte>
-MemoryLayout::loadAssociatedVarSizedValue(const TupleBuffer& tupleBuffer, const VariableSizedAccess variableSizedAccess) noexcept
+MemoryLayout::loadAssociatedVarSizedValue(const Buffer& tupleBuffer, const VariableSizedAccess variableSizedAccess) noexcept
 {
     /// Loading the childbuffer containing the variable sized data.
     auto childBuffer = tupleBuffer.loadChildBuffer(variableSizedAccess.getIndex());
@@ -153,7 +153,7 @@ MemoryLayout::loadValue(const DataType& physicalType, const TaskBufferRef& recor
     auto variableSizedAccess = static_cast<nautilus::val<VariableSizedAccess*>>(varValRef);
     const auto varSizedPtr = invoke(
         {.modRefInfo = nautilus::ModRefInfo::Ref, .willReturn = true, .noUnwind = true},
-        +[](const TupleBuffer* tupleBuffer, const VariableSizedAccess* variableSizedAccessPtr)
+        +[](const Buffer* tupleBuffer, const VariableSizedAccess* variableSizedAccessPtr)
         {
             INVARIANT(tupleBuffer != nullptr, "Tuplebuffer MUST NOT be null at this point");
             INVARIANT(variableSizedAccessPtr != nullptr, "VariableSizedAccess MUST NOT be null at this point");
@@ -196,7 +196,7 @@ VarVal MemoryLayout::storeValue(
     auto refToIndex = static_cast<nautilus::val<VariableSizedAccess*>>(varValRef);
 
     invoke(
-        +[](TupleBuffer* tupleBuffer,
+        +[](Buffer* tupleBuffer,
             AbstractBufferProvider* bufferProvider,
             const int8_t* varSizedPtr,
             const uint64_t varSizedValueLength,

--- a/nes-nautilus/src/Interface/MemoryLayout/MemoryLayout.cpp
+++ b/nes-nautilus/src/Interface/MemoryLayout/MemoryLayout.cpp
@@ -12,7 +12,7 @@
     limitations under the License.
 */
 
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 
 #include <algorithm>
 #include <array>
@@ -84,7 +84,7 @@ void copyVarSizedAndIncrementMetaData(
 }
 }
 
-VariableSizedAccess TupleBufferRef::writeVarSized(
+VariableSizedAccess MemoryLayout::writeVarSized(
     TupleBuffer& tupleBuffer, AbstractBufferProvider& bufferProvider, const std::span<const std::byte> varSizedValue)
 {
     const auto totalVarSizedLength = varSizedValue.size();
@@ -120,7 +120,7 @@ VariableSizedAccess TupleBufferRef::writeVarSized(
 }
 
 std::span<std::byte>
-TupleBufferRef::loadAssociatedVarSizedValue(const TupleBuffer& tupleBuffer, const VariableSizedAccess variableSizedAccess) noexcept
+MemoryLayout::loadAssociatedVarSizedValue(const TupleBuffer& tupleBuffer, const VariableSizedAccess variableSizedAccess) noexcept
 {
     /// Loading the childbuffer containing the variable sized data.
     auto childBuffer = tupleBuffer.loadChildBuffer(variableSizedAccess.getIndex());
@@ -133,7 +133,7 @@ TupleBufferRef::loadAssociatedVarSizedValue(const TupleBuffer& tupleBuffer, cons
 }
 
 VarVal
-TupleBufferRef::loadValue(const DataType& physicalType, const RecordBuffer& recordBuffer, const nautilus::val<int8_t*>& fieldReference)
+MemoryLayout::loadValue(const DataType& physicalType, const RecordBuffer& recordBuffer, const nautilus::val<int8_t*>& fieldReference)
 {
     /// For now, we store the null byte before the actual VarVal
     nautilus::val<bool> null = false;
@@ -166,7 +166,7 @@ TupleBufferRef::loadValue(const DataType& physicalType, const RecordBuffer& reco
     return VarVal{VariableSizedData(varSizedPtr, size), physicalType.nullable, null};
 }
 
-VarVal TupleBufferRef::storeValue(
+VarVal MemoryLayout::storeValue(
     const DataType& physicalType,
     const RecordBuffer& recordBuffer,
     const nautilus::val<int8_t*>& fieldReference,
@@ -217,31 +217,31 @@ VarVal TupleBufferRef::storeValue(
     return value;
 }
 
-bool TupleBufferRef::includesField(
+bool MemoryLayout::includesField(
     const std::vector<Record::RecordFieldIdentifier>& projections, const Record::RecordFieldIdentifier& fieldIndex)
 {
     return std::ranges::find(projections, fieldIndex) != projections.end();
 }
 
-uint64_t TupleBufferRef::getCapacity() const
+uint64_t MemoryLayout::getCapacity() const
 {
     return capacity;
 }
 
-uint64_t TupleBufferRef::getBufferSize() const
+uint64_t MemoryLayout::getBufferSize() const
 {
     return bufferSize;
 }
 
-uint64_t TupleBufferRef::getTupleSize() const
+uint64_t MemoryLayout::getTupleSize() const
 {
     return tupleSize;
 }
 
-TupleBufferRef::TupleBufferRef(const uint64_t capacity, const uint64_t bufferSize, const uint64_t tupleSize)
+MemoryLayout::MemoryLayout(const uint64_t capacity, const uint64_t bufferSize, const uint64_t tupleSize)
     : capacity(capacity), bufferSize(bufferSize), tupleSize(tupleSize)
 {
 }
 
-TupleBufferRef::~TupleBufferRef() = default;
+MemoryLayout::~MemoryLayout() = default;
 }

--- a/nes-nautilus/src/Interface/MemoryLayout/MemoryLayout.cpp
+++ b/nes-nautilus/src/Interface/MemoryLayout/MemoryLayout.cpp
@@ -31,7 +31,7 @@
 #include <DataTypes/VarVal.hpp>
 #include <DataTypes/VariableSizedData.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Interface/VariableSizedAccess.hpp>
 #include <Interface/VariableSizedAccessRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
@@ -133,7 +133,7 @@ MemoryLayout::loadAssociatedVarSizedValue(const TupleBuffer& tupleBuffer, const 
 }
 
 VarVal
-MemoryLayout::loadValue(const DataType& physicalType, const RecordBuffer& recordBuffer, const nautilus::val<int8_t*>& fieldReference)
+MemoryLayout::loadValue(const DataType& physicalType, const TaskBufferRef& recordBuffer, const nautilus::val<int8_t*>& fieldReference)
 {
     /// For now, we store the null byte before the actual VarVal
     nautilus::val<bool> null = false;
@@ -168,7 +168,7 @@ MemoryLayout::loadValue(const DataType& physicalType, const RecordBuffer& record
 
 VarVal MemoryLayout::storeValue(
     const DataType& physicalType,
-    const RecordBuffer& recordBuffer,
+    const TaskBufferRef& recordBuffer,
     const nautilus::val<int8_t*>& fieldReference,
     VarVal value,
     const nautilus::val<AbstractBufferProvider*>& bufferProvider)

--- a/nes-nautilus/src/Interface/MemoryLayout/OutputFormatterLayout.cpp
+++ b/nes-nautilus/src/Interface/MemoryLayout/OutputFormatterLayout.cpp
@@ -23,7 +23,7 @@
 #include <DataTypes/DataType.hpp>
 #include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <OutputFormatters/OutputFormatter.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <nautilus/val_ptr.hpp>
@@ -43,7 +43,7 @@ OutputFormatterLayout::OutputFormatterLayout(
 }
 
 Record
-OutputFormatterLayout::readRecord(const std::vector<Record::RecordFieldIdentifier>&, const RecordBuffer&, nautilus::val<uint64_t>&) const
+OutputFormatterLayout::readRecord(const std::vector<Record::RecordFieldIdentifier>&, const TaskBufferRef&, nautilus::val<uint64_t>&) const
 {
     INVARIANT(false, "OutputFormatterLayout should not be able to read records.");
     std::unreachable();
@@ -51,7 +51,7 @@ OutputFormatterLayout::readRecord(const std::vector<Record::RecordFieldIdentifie
 
 MemoryLayout::WriteRecordResult OutputFormatterLayout::writeRecord(
     nautilus::val<uint64_t>& bytesWritten,
-    const RecordBuffer& recordBuffer,
+    const TaskBufferRef& recordBuffer,
     const Record& rec,
     const nautilus::val<AbstractBufferProvider*>& bufferProvider) const
 {

--- a/nes-nautilus/src/Interface/MemoryLayout/OutputFormatterLayout.cpp
+++ b/nes-nautilus/src/Interface/MemoryLayout/OutputFormatterLayout.cpp
@@ -11,7 +11,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-#include <Interface/BufferRef/OutputFormatterBufferRef.hpp>
+#include <Interface/MemoryLayout/OutputFormatterLayout.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -21,7 +21,7 @@
 #include <utility>
 #include <vector>
 #include <DataTypes/DataType.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
 #include <Interface/RecordBuffer.hpp>
 #include <OutputFormatters/OutputFormatter.hpp>
@@ -36,20 +36,20 @@
 namespace NES
 {
 /// There is no predetermined tuple size for output-formatted tuples, we pass 0 as placeholder
-OutputFormatterBufferRef::OutputFormatterBufferRef(
+OutputFormatterLayout::OutputFormatterLayout(
     std::vector<Field> fields, std::shared_ptr<OutputFormatter> formatter, const uint64_t bufferSize)
-    : TupleBufferRef(bufferSize, bufferSize, 0), fields(std::move(fields)), formatter(std::move(formatter))
+    : MemoryLayout(bufferSize, bufferSize, 0), fields(std::move(fields)), formatter(std::move(formatter))
 {
 }
 
 Record
-OutputFormatterBufferRef::readRecord(const std::vector<Record::RecordFieldIdentifier>&, const RecordBuffer&, nautilus::val<uint64_t>&) const
+OutputFormatterLayout::readRecord(const std::vector<Record::RecordFieldIdentifier>&, const RecordBuffer&, nautilus::val<uint64_t>&) const
 {
-    INVARIANT(false, "OutputFormatterBufferRef should not be able to read records.");
+    INVARIANT(false, "OutputFormatterLayout should not be able to read records.");
     std::unreachable();
 }
 
-TupleBufferRef::WriteRecordResult OutputFormatterBufferRef::writeRecord(
+MemoryLayout::WriteRecordResult OutputFormatterLayout::writeRecord(
     nautilus::val<uint64_t>& bytesWritten,
     const RecordBuffer& recordBuffer,
     const Record& rec,
@@ -82,12 +82,12 @@ TupleBufferRef::WriteRecordResult OutputFormatterBufferRef::writeRecord(
     return {.successful = successful, .writtenRecords = writtenForThisRecord};
 }
 
-std::vector<Record::RecordFieldIdentifier> OutputFormatterBufferRef::getAllFieldNames() const
+std::vector<Record::RecordFieldIdentifier> OutputFormatterLayout::getAllFieldNames() const
 {
     return fields | std::views::transform([](const Field& field) { return field.name; }) | std::ranges::to<std::vector>();
 }
 
-std::vector<DataType> OutputFormatterBufferRef::getAllDataTypes() const
+std::vector<DataType> OutputFormatterLayout::getAllDataTypes() const
 {
     return fields | std::views::transform([](const Field& field) { return field.type; }) | std::ranges::to<std::vector>();
 }

--- a/nes-nautilus/src/Interface/MemoryLayout/RowLayout.cpp
+++ b/nes-nautilus/src/Interface/MemoryLayout/RowLayout.cpp
@@ -11,68 +11,65 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-#include <Interface/BufferRef/ColumnTupleBufferRef.hpp>
+#include <Interface/MemoryLayout/RowLayout.hpp>
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <ranges>
+#include <string>
 #include <utility>
 #include <vector>
 #include <DataTypes/DataType.hpp>
-#include <DataTypes/VarVal.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
 #include <Interface/RecordBuffer.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <nautilus/static.hpp>
 #include <nautilus/val_ptr.hpp>
+#include <static.hpp>
 #include <val.hpp>
 #include <val_bool.hpp>
 
 namespace NES
 {
 
-ColumnTupleBufferRef::ColumnTupleBufferRef(std::vector<Field> fields, const uint64_t tupleSize, const uint64_t bufferSize)
-    : TupleBufferRef(bufferSize / tupleSize, bufferSize, tupleSize), fields(std::move(fields))
+RowLayout::RowLayout(std::vector<Field> fields, const uint64_t tupleSize, const uint64_t bufferSize)
+    : MemoryLayout(bufferSize / tupleSize, bufferSize, tupleSize), fields(std::move(fields))
 {
 }
 
 namespace
 {
-nautilus::val<int8_t*> calculateFieldAddress(
-    const nautilus::val<int8_t*>& bufferAddress,
-    nautilus::val<uint64_t>& recordIndex,
-    const uint64_t fieldSize,
-    const uint64_t columnOffset)
+nautilus::val<int8_t*> calculateFieldAddress(const nautilus::val<int8_t*>& recordOffset, const uint64_t fieldOffset)
 {
-    const auto fieldOffset = recordIndex * fieldSize + columnOffset;
-    auto fieldAddress = bufferAddress + fieldOffset;
+    auto fieldAddress = recordOffset + nautilus::val<uint64_t>(fieldOffset);
     return fieldAddress;
 }
 }
 
-Record ColumnTupleBufferRef::readRecord(
+Record RowLayout::readRecord(
     const std::vector<Record::RecordFieldIdentifier>& projections,
     const RecordBuffer& recordBuffer,
     nautilus::val<uint64_t>& recordIndex) const
 {
     Record record;
     const auto bufferAddress = recordBuffer.getMemArea();
+    const auto recordOffset = bufferAddress + (tupleSize * recordIndex);
     for (nautilus::static_val<uint64_t> i = 0; i < fields.size(); ++i)
     {
-        const auto& [name, type, dataTypeSize, columnOffset] = fields.at(i);
+        const auto& [name, type, fieldOffset] = fields.at(i);
         if (not includesField(projections, name))
         {
             continue;
         }
-        auto fieldAddress = calculateFieldAddress(bufferAddress, recordIndex, dataTypeSize, columnOffset);
-        const auto& value = loadValue(type, recordBuffer, fieldAddress);
+        auto fieldAddress = calculateFieldAddress(recordOffset, fieldOffset);
+        auto value = loadValue(type, recordBuffer, fieldAddress);
         record.write(name, value);
     }
     return record;
 }
 
-TupleBufferRef::WriteRecordResult ColumnTupleBufferRef::writeRecord(
+MemoryLayout::WriteRecordResult RowLayout::writeRecord(
     nautilus::val<uint64_t>& recordIndex,
     const RecordBuffer& recordBuffer,
     const Record& rec,
@@ -84,15 +81,16 @@ TupleBufferRef::WriteRecordResult ColumnTupleBufferRef::writeRecord(
     if (recordIndex < capacity)
     {
         const auto bufferAddress = recordBuffer.getMemArea();
+        const auto recordOffset = bufferAddress + (tupleSize * recordIndex);
         for (nautilus::static_val<uint64_t> i = 0; i < fields.size(); ++i)
         {
-            const auto& [name, type, dataTypeSize, columnOffset] = fields.at(i);
+            const auto& [name, type, fieldOffset] = fields.at(i);
             if (not rec.hasField(name))
             {
                 /// Skipping any fields that are not part of the record
                 continue;
             }
-            auto fieldAddress = calculateFieldAddress(bufferAddress, recordIndex, dataTypeSize, columnOffset);
+            auto fieldAddress = calculateFieldAddress(recordOffset, fieldOffset);
             const auto& value = rec.read(name);
             storeValue(type, recordBuffer, fieldAddress, value, bufferProvider);
         }
@@ -102,12 +100,12 @@ TupleBufferRef::WriteRecordResult ColumnTupleBufferRef::writeRecord(
     return {.successful = successful, .writtenRecords = writtenRecords};
 }
 
-std::vector<Record::RecordFieldIdentifier> ColumnTupleBufferRef::getAllFieldNames() const
+std::vector<Record::RecordFieldIdentifier> RowLayout::getAllFieldNames() const
 {
     return fields | std::views::transform([](const Field& field) { return field.name; }) | std::ranges::to<std::vector>();
 }
 
-std::vector<DataType> ColumnTupleBufferRef::getAllDataTypes() const
+std::vector<DataType> RowLayout::getAllDataTypes() const
 {
     return fields | std::views::transform([](const Field& field) { return field.type; }) | std::ranges::to<std::vector>();
 }

--- a/nes-nautilus/src/Interface/MemoryLayout/RowLayout.cpp
+++ b/nes-nautilus/src/Interface/MemoryLayout/RowLayout.cpp
@@ -23,7 +23,7 @@
 #include <DataTypes/DataType.hpp>
 #include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <nautilus/val_ptr.hpp>
 #include <static.hpp>
@@ -49,7 +49,7 @@ nautilus::val<int8_t*> calculateFieldAddress(const nautilus::val<int8_t*>& recor
 
 Record RowLayout::readRecord(
     const std::vector<Record::RecordFieldIdentifier>& projections,
-    const RecordBuffer& recordBuffer,
+    const TaskBufferRef& recordBuffer,
     nautilus::val<uint64_t>& recordIndex) const
 {
     Record record;
@@ -71,7 +71,7 @@ Record RowLayout::readRecord(
 
 MemoryLayout::WriteRecordResult RowLayout::writeRecord(
     nautilus::val<uint64_t>& recordIndex,
-    const RecordBuffer& recordBuffer,
+    const TaskBufferRef& recordBuffer,
     const Record& rec,
     const nautilus::val<AbstractBufferProvider*>& bufferProvider) const
 {

--- a/nes-nautilus/src/Interface/NautilusBuffer.cpp
+++ b/nes-nautilus/src/Interface/NautilusBuffer.cpp
@@ -20,7 +20,7 @@
 #include <utility>
 #include <variant>
 #include <Interface/NESStrongTypeRef.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Util/Overloaded.hpp>
 #include <ErrorHandling.hpp>
 #include <function.hpp>
@@ -33,18 +33,18 @@ namespace NES
 {
 nautilus::val<int8_t*> OwnedNautilusBuffer::data()
 {
-    return nautilus::invoke(+[](NES::TupleBuffer* buffer) { return buffer->getAvailableMemoryArea<int8_t>().data(); }, &buffer);
+    return nautilus::invoke(+[](NES::Buffer* buffer) { return buffer->getAvailableMemoryArea<int8_t>().data(); }, &buffer);
 }
 
 nautilus::val<const int8_t*> OwnedNautilusBuffer::data() const
 {
-    return nautilus::invoke(+[](const NES::TupleBuffer* buffer) { return buffer->getAvailableMemoryArea<int8_t>().data(); }, asArg());
+    return nautilus::invoke(+[](const NES::Buffer* buffer) { return buffer->getAvailableMemoryArea<int8_t>().data(); }, asArg());
 }
 
 nautilus::val<size_t> OwnedNautilusBuffer::getNumberOfRecords() const
 {
     return nautilus::invoke(
-        +[](const NES::TupleBuffer* buffer)
+        +[](const NES::Buffer* buffer)
         {
             INVARIANT(buffer->getAvailableMemoryArea<>().data() != nullptr, "Buffer is invalid for NautilusBuffer:getNumberOfRecords()");
             return buffer->getNumberOfTuples();
@@ -56,21 +56,21 @@ nautilus::val<size_t> OwnedNautilusBuffer::getNumberOfRecords() const
 nautilus::val<ChildBufferIndex> OwnedNautilusBuffer::storeChild(OwnedNautilusBuffer&& child)
 {
     return nautilus::invoke(
-        +[](NES::TupleBuffer* buffer, NES::TupleBuffer* child) { return buffer->storeChildBuffer(*child); }, &buffer, &child.buffer);
+        +[](NES::Buffer* buffer, NES::Buffer* child) { return buffer->storeChildBuffer(*child); }, &buffer, &child.buffer);
 }
 
 /// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved): && signals ownership transfer; the nautilus tracer only needs the buffer's address.
 nautilus::val<ChildBufferIndex> OwnedNautilusBuffer::storeChild(BorrowedNautilusBuffer&& child)
 {
     return nautilus::invoke(
-        +[](NES::TupleBuffer* buffer, NES::TupleBuffer* child) { return buffer->storeChildBuffer(*child); }, &buffer, child.asArg());
+        +[](NES::Buffer* buffer, NES::Buffer* child) { return buffer->storeChildBuffer(*child); }, &buffer, child.asArg());
 }
 
 OwnedNautilusBuffer OwnedNautilusBuffer::getChild(const nautilus::val<ChildBufferIndex>& index) const
 {
     OwnedNautilusBuffer child;
     nautilus::invoke(
-        +[](const TupleBuffer* self, TupleBuffer* child, ChildBufferIndex index) { *child = self->loadChildBuffer(index); },
+        +[](const Buffer* self, Buffer* child, ChildBufferIndex index) { *child = self->loadChildBuffer(index); },
         asArg(),
         child.asArg(),
         index);
@@ -79,68 +79,65 @@ OwnedNautilusBuffer OwnedNautilusBuffer::getChild(const nautilus::val<ChildBuffe
 
 nautilus::val<bool> OwnedNautilusBuffer::isValid() const
 {
-    return nautilus::invoke(+[](const NES::TupleBuffer* buffer) { return buffer->getAvailableMemoryArea<>().data() != nullptr; }, asArg());
+    return nautilus::invoke(+[](const NES::Buffer* buffer) { return buffer->getAvailableMemoryArea<>().data() != nullptr; }, asArg());
 }
 
-nautilus::val<const NES::TupleBuffer*> OwnedNautilusBuffer::asArg() const&
+nautilus::val<const NES::Buffer*> OwnedNautilusBuffer::asArg() const&
 {
     /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast): nautilus::val has no const-qualified conversion; we widen back to const through the return type.
-    return &const_cast<nautilus::val<NES::TupleBuffer>&>(buffer);
+    return &const_cast<nautilus::val<NES::Buffer>&>(buffer);
 }
 
-nautilus::val<NES::TupleBuffer*> OwnedNautilusBuffer::asArg() &
+nautilus::val<NES::Buffer*> OwnedNautilusBuffer::asArg() &
 {
     return &buffer;
 }
 
-BorrowedNautilusBuffer::BorrowedNautilusBuffer(const nautilus::val<NES::TupleBuffer*>& buffer) : buffer(buffer)
+BorrowedNautilusBuffer::BorrowedNautilusBuffer(const nautilus::val<NES::Buffer*>& buffer) : buffer(buffer)
 {
 }
 
-BorrowedNautilusBuffer BorrowedNautilusBuffer::from(const nautilus::val<const TupleBuffer*>& originalBuffer)
+BorrowedNautilusBuffer BorrowedNautilusBuffer::from(const nautilus::val<const Buffer*>& originalBuffer)
 {
     return BorrowedNautilusBuffer{originalBuffer};
 }
 
 nautilus::val<int8_t*> BorrowedNautilusBuffer::data()
 {
-    return nautilus::invoke(+[](NES::TupleBuffer* buffer) { return buffer->getAvailableMemoryArea<int8_t>().data(); }, buffer);
+    return nautilus::invoke(+[](NES::Buffer* buffer) { return buffer->getAvailableMemoryArea<int8_t>().data(); }, buffer);
 }
 
 nautilus::val<const int8_t*> BorrowedNautilusBuffer::data() const
 {
-    return nautilus::invoke(+[](const NES::TupleBuffer* buffer) { return buffer->getAvailableMemoryArea<int8_t>().data(); }, buffer);
+    return nautilus::invoke(+[](const NES::Buffer* buffer) { return buffer->getAvailableMemoryArea<int8_t>().data(); }, buffer);
 }
 
 nautilus::val<size_t> BorrowedNautilusBuffer::getNumberOfRecords() const
 {
-    return nautilus::invoke(+[](const NES::TupleBuffer* buffer) { return buffer->getNumberOfTuples(); }, buffer);
+    return nautilus::invoke(+[](const NES::Buffer* buffer) { return buffer->getNumberOfTuples(); }, buffer);
 }
 
 OwnedNautilusBuffer BorrowedNautilusBuffer::getChild(const nautilus::val<ChildBufferIndex>& index) const
 {
     OwnedNautilusBuffer child;
     nautilus::invoke(
-        +[](TupleBuffer* self, TupleBuffer* child, ChildBufferIndex index) { *child = self->loadChildBuffer(index); },
-        buffer,
-        child.asArg(),
-        index);
+        +[](Buffer* self, Buffer* child, ChildBufferIndex index) { *child = self->loadChildBuffer(index); }, buffer, child.asArg(), index);
     return child;
 }
 
 /// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved): && signals ownership transfer; the nautilus tracer only needs the buffer's address.
 nautilus::val<ChildBufferIndex> BorrowedNautilusBuffer::storeChild(OwnedNautilusBuffer&& child)
 {
-    return nautilus::invoke(+[](TupleBuffer* self, TupleBuffer* child) { return self->storeChildBuffer(*child); }, buffer, child.asArg());
+    return nautilus::invoke(+[](Buffer* self, Buffer* child) { return self->storeChildBuffer(*child); }, buffer, child.asArg());
 }
 
 /// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved): && signals ownership transfer; the nautilus tracer only needs the buffer's address.
 nautilus::val<ChildBufferIndex> BorrowedNautilusBuffer::storeChild(BorrowedNautilusBuffer&& child)
 {
-    return nautilus::invoke(+[](TupleBuffer* self, TupleBuffer* child) { return self->storeChildBuffer(*child); }, buffer, child.asArg());
+    return nautilus::invoke(+[](Buffer* self, Buffer* child) { return self->storeChildBuffer(*child); }, buffer, child.asArg());
 }
 
-nautilus::val<NES::TupleBuffer*> BorrowedNautilusBuffer::asArg()
+nautilus::val<NES::Buffer*> BorrowedNautilusBuffer::asArg()
 {
     return buffer;
 }
@@ -171,7 +168,7 @@ OwnedNautilusBuffer NautilusBuffer::getChild(const nautilus::val<ChildBufferInde
     return std::visit(Overloaded{[&](const auto& underlying) -> OwnedNautilusBuffer { return underlying.getChild(index); }}, underlying);
 }
 
-nautilus::val<const NES::TupleBuffer*> BorrowedNautilusBuffer::asArg() const
+nautilus::val<const NES::Buffer*> BorrowedNautilusBuffer::asArg() const
 {
     return buffer;
 }
@@ -189,12 +186,12 @@ nautilus::val<size_t> NautilusBuffer::getNumberOfRecords() const
     return std::visit(Overloaded{[](const auto& underlying) { return underlying.getNumberOfRecords(); }}, underlying);
 }
 
-nautilus::val<const TupleBuffer*> NautilusBuffer::asArg() const&
+nautilus::val<const Buffer*> NautilusBuffer::asArg() const&
 {
     return std::visit(Overloaded{[](const auto& underlying) { return underlying.asArg(); }}, underlying);
 }
 
-nautilus::val<TupleBuffer*> NautilusBuffer::asArg() &
+nautilus::val<Buffer*> NautilusBuffer::asArg() &
 {
     return std::visit(Overloaded{[](auto& underlying) { return underlying.asArg(); }}, underlying);
 }
@@ -207,9 +204,9 @@ bool NautilusBuffer::isOwned() const
 OwnedNautilusBuffer OwnedNautilusBuffer::copy(const NautilusBuffer& source)
 {
     OwnedNautilusBuffer owned;
-    /// Copy-assigning the TupleBuffer takes a reference-counted copy of the source's underlying buffer, so the new owned buffer keeps
+    /// Copy-assigning the Buffer takes a reference-counted copy of the source's underlying buffer, so the new owned buffer keeps
     /// it alive on its own. source.asArg() works uniformly for an owned or a borrowed source.
-    nautilus::invoke(+[](TupleBuffer* self, const TupleBuffer* src) { *self = *src; }, owned.asArg(), source.asArg());
+    nautilus::invoke(+[](Buffer* self, const Buffer* src) { *self = *src; }, owned.asArg(), source.asArg());
     return owned;
 }
 }

--- a/nes-nautilus/src/Interface/PagedVector/PagedVector.cpp
+++ b/nes-nautilus/src/Interface/PagedVector/PagedVector.cpp
@@ -26,20 +26,20 @@
 #include <vector>
 
 #include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/MemoryUtils.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <ErrorHandling.hpp>
 
 namespace NES
 {
 
-void PagedVector::Page::init(TupleBuffer buffer)
+void PagedVector::Page::init(Buffer buffer)
 {
     new (buffer.getAvailableMemoryArea<Header>().data()) Header(0);
 }
 
-PagedVector::Page PagedVector::Page::load(TupleBuffer buffer)
+PagedVector::Page PagedVector::Page::load(Buffer buffer)
 {
     return Page(std::move(buffer));
 }
@@ -64,12 +64,12 @@ uint64_t PagedVector::Page::getNumberOfTuples() const
     return buffer.getNumberOfTuples();
 }
 
-void PagedVector::init(TupleBuffer buffer, uint64_t pageBufferSize, uint64_t tupleSize)
+void PagedVector::init(Buffer buffer, uint64_t pageBufferSize, uint64_t tupleSize)
 {
     new (buffer.getAvailableMemoryArea<Header>().data()) Header(0, pageBufferSize, tupleSize);
 }
 
-PagedVector PagedVector::load(const TupleBuffer& buffer)
+PagedVector PagedVector::load(const Buffer& buffer)
 {
     PagedVector pagedVector(buffer);
     return pagedVector;
@@ -162,7 +162,7 @@ void PagedVector::addNewPage(AbstractBufferProvider* bufferProvider, const uint6
     }
     else
     {
-        throw BufferAllocationFailure("No unpooled TupleBuffer available!");
+        throw BufferAllocationFailure("No unpooled Buffer available!");
     }
 }
 

--- a/nes-nautilus/src/Interface/PagedVector/PagedVectorRef.cpp
+++ b/nes-nautilus/src/Interface/PagedVector/PagedVectorRef.cpp
@@ -34,7 +34,7 @@
 #include <Interface/TaskBufferRef.hpp>
 #include <Interface/VariableSizedAccess.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <nautilus/function.hpp>
 #include <nautilus/val.hpp>
 #include <ErrorHandling.hpp>
@@ -48,14 +48,14 @@ namespace NES
 {
 namespace
 {
-uint64_t getTotalNumberOfRecordsProxy(const TupleBuffer* pagedVectorBuffer)
+uint64_t getTotalNumberOfRecordsProxy(const Buffer* pagedVectorBuffer)
 {
     const PagedVector pagedVector = PagedVector::load(*pagedVectorBuffer);
     return pagedVector.getTotalNumberOfRecords();
 }
 
-/// Resolves the page containing `entryPos`, loads its TupleBuffer into `outPageBuffer`, and returns the in-page index.
-uint64_t loadPageForEntryProxy(const TupleBuffer* pagedVectorBuffer, const uint64_t entryPos, TupleBuffer* outPageBuffer)
+/// Resolves the page containing `entryPos`, loads its Buffer into `outPageBuffer`, and returns the in-page index.
+uint64_t loadPageForEntryProxy(const Buffer* pagedVectorBuffer, const uint64_t entryPos, Buffer* outPageBuffer)
 {
     const PagedVector pagedVector = PagedVector::load(*pagedVectorBuffer);
     PRECONDITION(pagedVector.getStatus() == PagedVector::VALID_PV, "Paged Vector must be valid for access.");
@@ -80,12 +80,12 @@ auto makeVarSizedLoadFunction(const NautilusBuffer& pageBuffer)
         auto variableSizedAccess = static_cast<nautilus::val<VariableSizedAccess*>>(fieldSlot);
         auto varSizedPtr = invoke(
             {.modRefInfo = nautilus::ModRefInfo::Ref, .willReturn = true, .noUnwind = true},
-            +[](TupleBuffer* pageBuffer, const VariableSizedAccess* access) -> int8_t*
+            +[](Buffer* pageBuffer, const VariableSizedAccess* access) -> int8_t*
             {
                 INVARIANT(pageBuffer != nullptr, "Page buffer MUST NOT be null");
                 INVARIANT(access != nullptr, "VariableSizedAccess MUST NOT be null");
                 auto varSizedPage = pageBuffer->loadChildBuffer(access->getIndex());
-                /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): TupleBuffer hands out int8_t spans by design.
+                /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): Buffer hands out int8_t spans by design.
                 return reinterpret_cast<int8_t*>(varSizedPage /// NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
                                                      .getAvailableMemoryArea<>()
                                                      .subspan(access->getOffset().getRawOffset())
@@ -116,7 +116,7 @@ auto makeVarSizedAllocFunction(const NautilusBuffer& lastPageBuffer, const nauti
          bufferProvider](const nautilus::val<int8_t*>& fieldSlot, const nautilus::val<uint64_t>& allocationSize) -> nautilus::val<int8_t*>
     {
         return invoke( /// NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
-            +[](TupleBuffer* pageBuffer, AbstractBufferProvider* bufferProvider, int8_t* fieldSlot, uint64_t allocationSize) -> int8_t*
+            +[](Buffer* pageBuffer, AbstractBufferProvider* bufferProvider, int8_t* fieldSlot, uint64_t allocationSize) -> int8_t*
             {
                 INVARIANT(pageBuffer != nullptr, "Page buffer must not be null");
                 INVARIANT(bufferProvider != nullptr, "BufferProvider must not be null");
@@ -125,7 +125,7 @@ auto makeVarSizedAllocFunction(const NautilusBuffer& lastPageBuffer, const nauti
                 if (numChildren > 0)
                 {
                     auto lastVarSizedBufferIndex = ChildBufferIndex{static_cast<uint32_t>(numChildren - 1)};
-                    TupleBuffer lastVarSizedBuffer = pageBuffer->loadChildBuffer(lastVarSizedBufferIndex);
+                    Buffer lastVarSizedBuffer = pageBuffer->loadChildBuffer(lastVarSizedBufferIndex);
                     const uint64_t lastVarSizedBufferSize = lastVarSizedBuffer.getBufferSize();
                     const uint64_t lastVarSizedBufferNumTuples = lastVarSizedBuffer.getNumberOfTuples();
                     if (lastVarSizedBufferNumTuples + allocationSize <= lastVarSizedBufferSize)
@@ -136,14 +136,14 @@ auto makeVarSizedAllocFunction(const NautilusBuffer& lastPageBuffer, const nauti
                             lastVarSizedBufferIndex,
                             VariableSizedAccess::Offset{lastVarSizedBufferNumTuples},
                             VariableSizedAccess::Size{allocationSize}};
-                        /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): TupleBuffer hands out int8_t spans by design.
+                        /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): Buffer hands out int8_t spans by design.
                         return reinterpret_cast<int8_t*>(lastVarSizedBuffer
                                                              .getAvailableMemoryArea<>() /// NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
                                                              .subspan(lastVarSizedBufferNumTuples)
                                                              .data());
                     }
                 }
-                TupleBuffer newVarSizedBuffer;
+                Buffer newVarSizedBuffer;
                 if (allocationSize <= bufferProvider->getBufferSize())
                 {
                     newVarSizedBuffer = bufferProvider->getBufferBlocking();
@@ -154,7 +154,7 @@ auto makeVarSizedAllocFunction(const NautilusBuffer& lastPageBuffer, const nauti
                     auto unpooledBuffer = bufferProvider->getUnpooledBuffer(allocationSize);
                     if (not unpooledBuffer.has_value())
                     {
-                        throw BufferAllocationFailure("No unpooled TupleBuffer available for oversized varsized value.");
+                        throw BufferAllocationFailure("No unpooled Buffer available for oversized varsized value.");
                     }
                     newVarSizedBuffer = std::move(unpooledBuffer.value());
                 }
@@ -292,7 +292,7 @@ void PagedVectorRef::pushBack(const Record& record, const nautilus::val<Abstract
     /// get the page of the paged vector to write to. Append new page if necessary
     OwnedNautilusBuffer lastPageBuffer;
     invoke(
-        +[](TupleBuffer* pagedVectorBuffer, AbstractBufferProvider* bufferProvider, TupleBuffer* currentPage)
+        +[](Buffer* pagedVectorBuffer, AbstractBufferProvider* bufferProvider, Buffer* currentPage)
         {
             PagedVector pagedVector = PagedVector::load(*pagedVectorBuffer);
             PRECONDITION(pagedVector.getStatus() == PagedVector::VALID_PV, "Paged Vector must be valid for push_back.");
@@ -307,7 +307,7 @@ void PagedVectorRef::pushBack(const Record& record, const nautilus::val<Abstract
 
     /// get the address in the page bufer to write the record to
     auto recordAddress = nautilus::invoke(
-        +[](TupleBuffer* pagedVectorBuffer, TupleBuffer* lastPageBuffer) -> int8_t*
+        +[](Buffer* pagedVectorBuffer, Buffer* lastPageBuffer) -> int8_t*
         {
             const PagedVector pagedVector = PagedVector::load(*pagedVectorBuffer);
             const auto totalTuplesNum = pagedVector.getTotalNumberOfRecords();
@@ -326,7 +326,7 @@ void PagedVectorRef::pushBack(const Record& record, const nautilus::val<Abstract
     tupleLayout->writeRecord(record, recordAddress, makeVarSizedAllocFunction(lastPageBuffer, bufferProvider));
     /// increase the entry count in the page
     nautilus::invoke(
-        +[](TupleBuffer* lastPageBuffer) { lastPageBuffer->setNumberOfTuples(lastPageBuffer->getNumberOfTuples() + 1); },
+        +[](Buffer* lastPageBuffer) { lastPageBuffer->setNumberOfTuples(lastPageBuffer->getNumberOfTuples() + 1); },
         lastPageBuffer.asArg());
 }
 
@@ -337,7 +337,7 @@ Record PagedVectorRef::at(const nautilus::val<uint64_t>& entryPos) const
     auto entryBufferPos = invoke(loadPageForEntryProxy, pagedVectorBuffer.asArg(), entryPos, pageBuffer.asArg());
 
     auto recordAddress = invoke(
-        +[](const TupleBuffer* pagedVectorBuffer, TupleBuffer* pageBuffer, const uint64_t entryBufferPos) -> int8_t*
+        +[](const Buffer* pagedVectorBuffer, Buffer* pageBuffer, const uint64_t entryBufferPos) -> int8_t*
         {
             const PagedVector pagedVector = PagedVector::load(*pagedVectorBuffer);
             const auto pageBufferAddress = pageBuffer->getAvailableMemoryArea<>();
@@ -387,7 +387,7 @@ Record PagedVectorRefIter::operator*() const
     }
     /// get the record's address in the page bufer
     auto recordAddress = invoke(
-        +[](const TupleBuffer* pagedVectorBuffer, TupleBuffer* pageBuffer, uint64_t entryBufferPos) -> int8_t*
+        +[](const Buffer* pagedVectorBuffer, Buffer* pageBuffer, uint64_t entryBufferPos) -> int8_t*
         {
             const PagedVector pagedVector = PagedVector::load(*pagedVectorBuffer);
             const auto pageBufferAddress = pageBuffer->getAvailableMemoryArea<>();

--- a/nes-nautilus/src/Interface/PagedVector/PagedVectorRef.cpp
+++ b/nes-nautilus/src/Interface/PagedVector/PagedVectorRef.cpp
@@ -27,7 +27,7 @@
 #include <DataTypes/DataTypesUtil.hpp>
 #include <DataTypes/Schema.hpp>
 #include <DataTypes/VarVal.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/NautilusBuffer.hpp>
 #include <Interface/PagedVector/PagedVector.hpp>
 #include <Interface/Record.hpp>

--- a/nes-nautilus/src/Interface/PagedVector/PagedVectorRef.cpp
+++ b/nes-nautilus/src/Interface/PagedVector/PagedVectorRef.cpp
@@ -31,7 +31,7 @@
 #include <Interface/NautilusBuffer.hpp>
 #include <Interface/PagedVector/PagedVector.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Interface/VariableSizedAccess.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>

--- a/nes-nautilus/src/Interface/TaskBufferRef.cpp
+++ b/nes-nautilus/src/Interface/TaskBufferRef.cpp
@@ -11,7 +11,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 
 #include <cstdint>
 #include <Identifiers/Identifiers.hpp>
@@ -27,86 +27,86 @@
 namespace NES
 {
 
-RecordBuffer::RecordBuffer(const nautilus::val<TupleBuffer*>& tupleBufferRef) : tupleBufferRef(tupleBufferRef)
+TaskBufferRef::TaskBufferRef(const nautilus::val<TupleBuffer*>& tupleBufferRef) : tupleBufferRef(tupleBufferRef)
 {
 }
 
-nautilus::val<uint64_t> RecordBuffer::getNumRecords() const
+nautilus::val<uint64_t> TaskBufferRef::getNumRecords() const
 {
     return invoke(ProxyFunctions::NES_Memory_TupleBuffer_getNumberOfTuples, tupleBufferRef);
 }
 
-void RecordBuffer::setNumRecords(const nautilus::val<uint64_t>& numRecordsValue)
+void TaskBufferRef::setNumRecords(const nautilus::val<uint64_t>& numRecordsValue)
 {
     invoke(ProxyFunctions::NES_Memory_TupleBuffer_setNumberOfTuples, tupleBufferRef, numRecordsValue);
 }
 
-nautilus::val<int8_t*> RecordBuffer::getMemArea() const
+nautilus::val<int8_t*> TaskBufferRef::getMemArea() const
 {
     return invoke(ProxyFunctions::NES_Memory_TupleBuffer_getMemArea, tupleBufferRef);
 }
 
-const nautilus::val<TupleBuffer*>& RecordBuffer::getReference() const
+const nautilus::val<TupleBuffer*>& TaskBufferRef::getReference() const
 {
     return tupleBufferRef;
 }
 
-nautilus::val<OriginId> RecordBuffer::getOriginId()
+nautilus::val<OriginId> TaskBufferRef::getOriginId()
 {
     return {invoke(ProxyFunctions::NES_Memory_TupleBuffer_getOriginId, tupleBufferRef)};
 }
 
-void RecordBuffer::setOriginId(const nautilus::val<OriginId>& originId)
+void TaskBufferRef::setOriginId(const nautilus::val<OriginId>& originId)
 {
     invoke(ProxyFunctions::NES_Memory_TupleBuffer_setOriginId, tupleBufferRef, originId);
 }
 
-void RecordBuffer::setSequenceNumber(const nautilus::val<SequenceNumber>& seqNumber)
+void TaskBufferRef::setSequenceNumber(const nautilus::val<SequenceNumber>& seqNumber)
 {
     invoke(ProxyFunctions::NES_Memory_TupleBuffer_setSequenceNumber, tupleBufferRef, seqNumber);
 }
 
-void RecordBuffer::setChunkNumber(const nautilus::val<ChunkNumber>& chunkNumber)
+void TaskBufferRef::setChunkNumber(const nautilus::val<ChunkNumber>& chunkNumber)
 {
     invoke(ProxyFunctions::NES_Memory_TupleBuffer_setChunkNumber, tupleBufferRef, chunkNumber);
 }
 
-nautilus::val<ChunkNumber> RecordBuffer::getChunkNumber()
+nautilus::val<ChunkNumber> TaskBufferRef::getChunkNumber()
 {
     return {invoke(ProxyFunctions::NES_Memory_TupleBuffer_getChunkNumber, tupleBufferRef)};
 }
 
-void RecordBuffer::setLastChunk(const nautilus::val<bool>& isLastChunk)
+void TaskBufferRef::setLastChunk(const nautilus::val<bool>& isLastChunk)
 {
     invoke(ProxyFunctions::NES_Memory_TupleBuffer_setLastChunk, tupleBufferRef, isLastChunk);
 }
 
-nautilus::val<bool> RecordBuffer::isLastChunk()
+nautilus::val<bool> TaskBufferRef::isLastChunk()
 {
     return {invoke(ProxyFunctions::NES_Memory_TupleBuffer_isLastChunk, tupleBufferRef)};
 }
 
-nautilus::val<Timestamp> RecordBuffer::getWatermarkTs()
+nautilus::val<Timestamp> TaskBufferRef::getWatermarkTs()
 {
     return {invoke(ProxyFunctions::NES_Memory_TupleBuffer_getWatermark, tupleBufferRef)};
 }
 
-void RecordBuffer::setWatermarkTs(const nautilus::val<Timestamp>& watermarkTs)
+void TaskBufferRef::setWatermarkTs(const nautilus::val<Timestamp>& watermarkTs)
 {
     invoke(ProxyFunctions::NES_Memory_TupleBuffer_setWatermark, tupleBufferRef, watermarkTs);
 }
 
-nautilus::val<SequenceNumber> RecordBuffer::getSequenceNumber()
+nautilus::val<SequenceNumber> TaskBufferRef::getSequenceNumber()
 {
     return {invoke(ProxyFunctions::NES_Memory_TupleBuffer_getSequenceNumber, tupleBufferRef)};
 }
 
-nautilus::val<Timestamp> RecordBuffer::getCreatingTs()
+nautilus::val<Timestamp> TaskBufferRef::getCreatingTs()
 {
     return {invoke(ProxyFunctions::NES_Memory_TupleBuffer_getCreationTimestampInMS, tupleBufferRef)};
 }
 
-void RecordBuffer::setCreationTs(const nautilus::val<Timestamp>& creationTs)
+void TaskBufferRef::setCreationTs(const nautilus::val<Timestamp>& creationTs)
 {
     invoke(ProxyFunctions::NES_Memory_TupleBuffer_setCreationTimestampInMS, tupleBufferRef, creationTs);
 }

--- a/nes-nautilus/src/Interface/TaskBufferRef.cpp
+++ b/nes-nautilus/src/Interface/TaskBufferRef.cpp
@@ -18,7 +18,7 @@
 #include <Interface/NESStrongTypeRef.hpp>
 #include <Interface/TimestampRef.hpp>
 #include <Interface/TupleBufferProxyFunctions.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Time/Timestamp.hpp>
 #include <nautilus/function.hpp>
 #include <val.hpp>
@@ -27,7 +27,7 @@
 namespace NES
 {
 
-TaskBufferRef::TaskBufferRef(const nautilus::val<TupleBuffer*>& tupleBufferRef) : tupleBufferRef(tupleBufferRef)
+TaskBufferRef::TaskBufferRef(const nautilus::val<Buffer*>& tupleBufferRef) : tupleBufferRef(tupleBufferRef)
 {
 }
 
@@ -46,7 +46,7 @@ nautilus::val<int8_t*> TaskBufferRef::getMemArea() const
     return invoke(ProxyFunctions::NES_Memory_TupleBuffer_getMemArea, tupleBufferRef);
 }
 
-const nautilus::val<TupleBuffer*>& TaskBufferRef::getReference() const
+const nautilus::val<Buffer*>& TaskBufferRef::getReference() const
 {
     return tupleBufferRef;
 }

--- a/nes-nautilus/tests/TestTupleBufferTest.cpp
+++ b/nes-nautilus/tests/TestTupleBufferTest.cpp
@@ -23,8 +23,8 @@
 #include <DataTypes/UnboundField.hpp>
 #include <Identifiers/Identifier.hpp>
 #include <Runtime/Allocator/NesDefaultMemoryAllocator.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/BufferManager.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Util/Logger/LogLevel.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <Util/Logger/impl/NesLogger.hpp>

--- a/nes-nautilus/tests/TestUtils/include/NautilusTestUtils.hpp
+++ b/nes-nautilus/tests/TestUtils/include/NautilusTestUtils.hpp
@@ -28,8 +28,8 @@
 #include <DataTypes/Schema.hpp>
 #include <DataTypes/SchemaFwd.hpp>
 #include <DataTypes/UnboundField.hpp>
-#include <Interface/BufferRef/LowerSchemaProvider.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Hash/HashFunction.hpp>
 #include <Interface/Hash/MurMur3HashFunction.hpp>
 #include <Interface/Record.hpp>
@@ -197,7 +197,7 @@ public:
         ExecutionMode backend,
         nautilus::engine::Options& options,
         const Schema<QualifiedUnboundField, Ordered>& schema,
-        const std::shared_ptr<TupleBufferRef>& memoryProviderInputBuffer);
+        const std::shared_ptr<MemoryLayout>& memoryProviderInputBuffer);
 
     /// Compares two records and if they are not equal returning a string. If the records are equal, return nullopt
     static std::optional<std::string>
@@ -217,8 +217,8 @@ public:
     static std::string compareRecordBuffers(
         const std::vector<TupleBuffer>& actualRecords,
         const std::vector<TupleBuffer>& expectedRecords,
-        const TupleBufferRef& memoryProviderActualBuffer,
-        const TupleBufferRef& memoryProviderInputBuffer);
+        const MemoryLayout& memoryProviderActualBuffer,
+        const MemoryLayout& memoryProviderInputBuffer);
 
 
 protected:

--- a/nes-nautilus/tests/TestUtils/include/NautilusTestUtils.hpp
+++ b/nes-nautilus/tests/TestUtils/include/NautilusTestUtils.hpp
@@ -28,13 +28,13 @@
 #include <DataTypes/Schema.hpp>
 #include <DataTypes/SchemaFwd.hpp>
 #include <DataTypes/UnboundField.hpp>
-#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
-#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Hash/HashFunction.hpp>
 #include <Interface/Hash/MurMur3HashFunction.hpp>
+#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/BufferManager.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Util/ExecutionMode.hpp>
 #include <nautilus/Engine.hpp>
 #include <ErrorHandling.hpp>
@@ -172,7 +172,7 @@ public:
     createSchemaFromBasicTypes(const std::vector<DataType::Type>& basicTypes, uint64_t typeIdxOffset);
 
     /// Creates monotonic increasing values for each field. This means that each field in each tuple has a new and increased value
-    std::vector<TupleBuffer> createMonotonicallyIncreasingValues(
+    std::vector<Buffer> createMonotonicallyIncreasingValues(
         const Schema<QualifiedUnboundField, Ordered>& schema,
         MemoryLayoutType layoutType,
         uint64_t numberOfTuples,
@@ -180,13 +180,13 @@ public:
         uint64_t seed,
         uint64_t minSizeVarSizedData,
         uint64_t maxSizeVarSizedData);
-    std::vector<TupleBuffer> createMonotonicallyIncreasingValues(
+    std::vector<Buffer> createMonotonicallyIncreasingValues(
         const Schema<QualifiedUnboundField, Ordered>& schema,
         MemoryLayoutType layoutType,
         uint64_t numberOfTuples,
         BufferManager& bufferManager,
         uint64_t minSizeVarSizedData);
-    std::vector<TupleBuffer> createMonotonicallyIncreasingValues(
+    std::vector<Buffer> createMonotonicallyIncreasingValues(
         const Schema<QualifiedUnboundField, Ordered>& schema,
         MemoryLayoutType layoutType,
         uint64_t numberOfTuples,
@@ -215,8 +215,8 @@ public:
 
     /// Compares two buffers and returns a string with the differences. If the buffers are equal, return an empty string
     static std::string compareRecordBuffers(
-        const std::vector<TupleBuffer>& actualRecords,
-        const std::vector<TupleBuffer>& expectedRecords,
+        const std::vector<Buffer>& actualRecords,
+        const std::vector<Buffer>& expectedRecords,
         const MemoryLayout& memoryProviderActualBuffer,
         const MemoryLayout& memoryProviderInputBuffer);
 

--- a/nes-nautilus/tests/TestUtils/include/TestTupleBuffer.hpp
+++ b/nes-nautilus/tests/TestUtils/include/TestTupleBuffer.hpp
@@ -32,7 +32,7 @@
 #include <DataTypes/UnboundField.hpp>
 #include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Util/TypeTraits.hpp>
 #include <ErrorHandling.hpp>
 
@@ -113,16 +113,16 @@ class TestTupleBuffer
 public:
     explicit TestTupleBuffer(TestSchema schema);
 
-    /// Wraps an existing TupleBuffer for schema-aware access.
+    /// Wraps an existing Buffer for schema-aware access.
     /// bufferProvider required for VARSIZED (string) field support.
     /// NOLINTNEXTLINE(fuchsia-default-arguments-declarations) convenience default for non-VARSIZED use
-    TestTupleBufferView open(TupleBuffer& buffer, AbstractBufferProvider* bufferProvider = nullptr);
+    TestTupleBufferView open(Buffer& buffer, AbstractBufferProvider* bufferProvider = nullptr);
 
 private:
     TestSchema schema;
 };
 
-/// View over a TupleBuffer. Supports append and indexed record access.
+/// View over a Buffer. Supports append and indexed record access.
 class TestTupleBufferView
 {
 public:
@@ -145,8 +145,8 @@ private:
     struct Impl
     {
         TestSchema schema;
-        TupleBuffer&
-            buffer; /// NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members) intentional reference: Impl always outlived by the TupleBuffer it wraps
+        Buffer&
+            buffer; /// NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members) intentional reference: Impl always outlived by the Buffer it wraps
         AbstractBufferProvider* bufferProvider;
         std::shared_ptr<MemoryLayout> bufRef;
     };

--- a/nes-nautilus/tests/TestUtils/include/TestTupleBuffer.hpp
+++ b/nes-nautilus/tests/TestUtils/include/TestTupleBuffer.hpp
@@ -30,7 +30,7 @@
 #include <DataTypes/Schema.hpp>
 #include <DataTypes/SchemaFwd.hpp>
 #include <DataTypes/UnboundField.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
 #include <Util/TypeTraits.hpp>
@@ -148,7 +148,7 @@ private:
         TupleBuffer&
             buffer; /// NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members) intentional reference: Impl always outlived by the TupleBuffer it wraps
         AbstractBufferProvider* bufferProvider;
-        std::shared_ptr<TupleBufferRef> bufRef;
+        std::shared_ptr<MemoryLayout> bufRef;
     };
 
     std::shared_ptr<Impl> impl;

--- a/nes-nautilus/tests/TestUtils/include/TestableChainedHashMap.hpp
+++ b/nes-nautilus/tests/TestUtils/include/TestableChainedHashMap.hpp
@@ -26,7 +26,7 @@
 #include <Interface/HashMap/ChainedHashMap/ChainedHashMap.hpp>
 #include <Interface/Record.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <nautilus/Engine.hpp>
 #include <DataStructureTestUtils.hpp>
 
@@ -88,7 +88,7 @@ private:
     uint64_t entrySize{0};
     uint64_t probeEntrySize{0};
     uint64_t entriesPerPage{0};
-    TupleBuffer chainedHashMapBuffer;
+    Buffer chainedHashMapBuffer;
     /// NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
     AbstractBufferProvider& bufferManager;
     /// Sizing for the optional in-map BloomFilter. Defaults to nullopt, so the CHM behaves exactly as
@@ -96,9 +96,9 @@ private:
     std::optional<Nautilus::Interface::BloomFilterParams> bloomFilterParams;
     std::vector<Record::RecordFieldIdentifier> projections;
     std::unique_ptr<nautilus::engine::NautilusEngine> engine;
-    std::optional<nautilus::engine::CompiledFunction<void(TupleBuffer*, AbstractBufferProvider*, AnyVec*)>> insertFn;
-    std::optional<nautilus::engine::CompiledFunction<bool(TupleBuffer*, TupleBuffer*, AbstractBufferProvider*, AnyVec*, AnyVec*)>> lookupFn;
-    std::optional<nautilus::engine::CompiledFunction<void(TupleBuffer*, std::vector<AnyVec>*)>> readAllFn;
+    std::optional<nautilus::engine::CompiledFunction<void(Buffer*, AbstractBufferProvider*, AnyVec*)>> insertFn;
+    std::optional<nautilus::engine::CompiledFunction<bool(Buffer*, Buffer*, AbstractBufferProvider*, AnyVec*, AnyVec*)>> lookupFn;
+    std::optional<nautilus::engine::CompiledFunction<void(Buffer*, std::vector<AnyVec>*)>> readAllFn;
 
     struct FieldOffsets
     {

--- a/nes-nautilus/tests/TestUtils/include/TestablePagedVector.hpp
+++ b/nes-nautilus/tests/TestUtils/include/TestablePagedVector.hpp
@@ -22,7 +22,7 @@
 #include <Interface/PagedVector/PagedVector.hpp>
 #include <Interface/Record.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <nautilus/Engine.hpp>
 #include <DataStructureTestUtils.hpp>
 
@@ -58,14 +58,14 @@ public:
 
 private:
     std::vector<DataType> dataTypes;
-    TupleBuffer pagedVector;
+    Buffer pagedVector;
     /// NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
     AbstractBufferProvider& bufferManager;
     std::vector<Record::RecordFieldIdentifier> projections;
     std::unique_ptr<nautilus::engine::NautilusEngine> engine;
-    std::optional<nautilus::engine::CompiledFunction<void(TupleBuffer*, AbstractBufferProvider*, AnyVec*)>> pushbackFn;
-    std::optional<nautilus::engine::CompiledFunction<void(TupleBuffer*, uint64_t, AnyVec*)>> readAtFn;
-    std::optional<nautilus::engine::CompiledFunction<void(TupleBuffer*, std::vector<AnyVec>*)>> readAll;
+    std::optional<nautilus::engine::CompiledFunction<void(Buffer*, AbstractBufferProvider*, AnyVec*)>> pushbackFn;
+    std::optional<nautilus::engine::CompiledFunction<void(Buffer*, uint64_t, AnyVec*)>> readAtFn;
+    std::optional<nautilus::engine::CompiledFunction<void(Buffer*, std::vector<AnyVec>*)>> readAll;
 };
 
 }

--- a/nes-nautilus/tests/TestUtils/src/NautilusTestUtils.cpp
+++ b/nes-nautilus/tests/TestUtils/src/NautilusTestUtils.cpp
@@ -34,14 +34,14 @@
 #include <DataTypes/VarVal.hpp>
 #include <DataTypes/VariableSizedData.hpp>
 #include <Identifiers/Identifier.hpp>
-#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
-#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Hash/HashFunction.hpp>
 #include <Interface/Hash/MurMur3HashFunction.hpp>
+#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
 #include <Interface/TaskBufferRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Util/ExecutionMode.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <Util/Ranges.hpp>
@@ -64,7 +64,7 @@ std::unique_ptr<HashFunction> NautilusTestUtils::getMurMurHashFunction()
     return std::make_unique<MurMur3HashFunction>();
 }
 
-std::vector<TupleBuffer> NautilusTestUtils::createMonotonicallyIncreasingValues(
+std::vector<Buffer> NautilusTestUtils::createMonotonicallyIncreasingValues(
     const Schema<QualifiedUnboundField, Ordered>& schema,
     const MemoryLayoutType memoryLayout,
     const uint64_t numberOfTuples,
@@ -80,7 +80,7 @@ std::vector<TupleBuffer> NautilusTestUtils::createMonotonicallyIncreasingValues(
         schema, memoryLayout, numberOfTuples, bufferManager, seed, minSizeVarSizedData, maxSizeVarSizedData);
 }
 
-std::vector<TupleBuffer> NautilusTestUtils::createMonotonicallyIncreasingValues(
+std::vector<Buffer> NautilusTestUtils::createMonotonicallyIncreasingValues(
     const Schema<QualifiedUnboundField, Ordered>& schema,
     const MemoryLayoutType memoryLayout,
     const uint64_t numberOfTuples,
@@ -90,7 +90,7 @@ std::vector<TupleBuffer> NautilusTestUtils::createMonotonicallyIncreasingValues(
     return createMonotonicallyIncreasingValues(schema, memoryLayout, numberOfTuples, bufferManager, minSizeVarSizedData);
 }
 
-std::vector<TupleBuffer> NautilusTestUtils::createMonotonicallyIncreasingValues(
+std::vector<Buffer> NautilusTestUtils::createMonotonicallyIncreasingValues(
     const Schema<QualifiedUnboundField, Ordered>& schema,
     const MemoryLayoutType memoryLayout,
     const uint64_t numberOfTuples,
@@ -131,7 +131,7 @@ std::vector<TupleBuffer> NautilusTestUtils::createMonotonicallyIncreasingValues(
     /// Now, we have to call the compiled function to fill the buffer with the values.
     /// We are using the buffer manager to get a buffer of a fixed size.
     /// Therefore, we have to iterate in a loop and fill multiple buffers until we have created the required numberofTuples.
-    std::vector<TupleBuffer> buffers;
+    std::vector<Buffer> buffers;
     const auto capacity = memoryProviderInputBuffer->getCapacity();
     INVARIANT(capacity > 0, "Capacity should be larger than 0");
 
@@ -142,7 +142,7 @@ std::vector<TupleBuffer> NautilusTestUtils::createMonotonicallyIncreasingValues(
         auto buffer = bufferManager.getBufferBlocking();
         auto outputBufferIndex = createShuffledVector(tuplesToFill);
         const auto sizeVarSizedData = (rand() % (maxSizeVarSizedData + 1 - minSizeVarSizedData)) + minSizeVarSizedData;
-        callCompiledFunction<void, TupleBuffer*, AbstractBufferProvider*, uint64_t, uint64_t, uint64_t, uint64_t*>(
+        callCompiledFunction<void, Buffer*, AbstractBufferProvider*, uint64_t, uint64_t, uint64_t, uint64_t*>(
             {FUNCTION_CREATE_MONOTONIC_VALUES_FOR_BUFFER, backend},
             std::addressof(buffer),
             std::addressof(bufferManager),
@@ -190,7 +190,7 @@ void NautilusTestUtils::compileFillBufferFunction(
 {
     /// We are not allowed to use const or const references for the lambda function params, as nautilus does not support this in the registerFunction method.
     /// NOLINTBEGIN(performance-unnecessary-value-param)
-    const std::function tmp = [=](nautilus::val<TupleBuffer*> buffer,
+    const std::function tmp = [=](nautilus::val<Buffer*> buffer,
                                   nautilus::val<AbstractBufferProvider*> bufferProvider,
                                   nautilus::val<uint64_t> numberOfTuplesToFill,
                                   nautilus::val<uint64_t> startForValues,
@@ -216,7 +216,7 @@ void NautilusTestUtils::compileFillBufferFunction(
                 else if (field.getDataType().isType(DataType::Type::VARSIZED))
                 {
                     const auto pointerToVarSizedData = nautilus::invoke(
-                        +[](TupleBuffer* inputBuffer, AbstractBufferProvider* bufferProviderVal, const uint64_t size)
+                        +[](Buffer* inputBuffer, AbstractBufferProvider* bufferProviderVal, const uint64_t size)
                         {
                             INVARIANT(inputBuffer != nullptr, "InputTuplebuffer MUST NOT be null at this point");
                             /// Creating a random string of the given size
@@ -261,7 +261,7 @@ void NautilusTestUtils::compileFillBufferFunction(
     auto compiledFunction = engine.registerFunction(tmp);
 
     compiledFunctions[{functionName, backend}]
-        = std::make_unique<FunctionWrapper<void, TupleBuffer*, AbstractBufferProvider*, uint64_t, uint64_t, uint64_t, uint64_t*>>(
+        = std::make_unique<FunctionWrapper<void, Buffer*, AbstractBufferProvider*, uint64_t, uint64_t, uint64_t, uint64_t*>>(
             std::move(compiledFunction));
 }
 

--- a/nes-nautilus/tests/TestUtils/src/NautilusTestUtils.cpp
+++ b/nes-nautilus/tests/TestUtils/src/NautilusTestUtils.cpp
@@ -39,7 +39,7 @@
 #include <Interface/Hash/HashFunction.hpp>
 #include <Interface/Hash/MurMur3HashFunction.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
 #include <Util/ExecutionMode.hpp>
@@ -197,7 +197,7 @@ void NautilusTestUtils::compileFillBufferFunction(
                                   nautilus::val<uint64_t> sizeVarSizedDataVal,
                                   nautilus::val<uint64_t*> outputIndex)
     {
-        RecordBuffer recordBuffer(buffer);
+        TaskBufferRef recordBuffer(buffer);
         nautilus::val<uint64_t> value = std::move(startForValues);
         for (nautilus::val<uint64_t> i = 0; i < numberOfTuplesToFill; i = i + 1)
         {

--- a/nes-nautilus/tests/TestUtils/src/NautilusTestUtils.cpp
+++ b/nes-nautilus/tests/TestUtils/src/NautilusTestUtils.cpp
@@ -34,8 +34,8 @@
 #include <DataTypes/VarVal.hpp>
 #include <DataTypes/VariableSizedData.hpp>
 #include <Identifiers/Identifier.hpp>
-#include <Interface/BufferRef/LowerSchemaProvider.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Hash/HashFunction.hpp>
 #include <Interface/Hash/MurMur3HashFunction.hpp>
 #include <Interface/Record.hpp>
@@ -186,7 +186,7 @@ void NautilusTestUtils::compileFillBufferFunction(
     ExecutionMode backend,
     nautilus::engine::Options& options,
     const Schema<QualifiedUnboundField, Ordered>& schema,
-    const std::shared_ptr<TupleBufferRef>& memoryProviderInputBuffer)
+    const std::shared_ptr<MemoryLayout>& memoryProviderInputBuffer)
 {
     /// We are not allowed to use const or const references for the lambda function params, as nautilus does not support this in the registerFunction method.
     /// NOLINTBEGIN(performance-unnecessary-value-param)
@@ -231,8 +231,8 @@ void NautilusTestUtils::compileFillBufferFunction(
 
                             /// Adding the random string to the buffer and returning the pointer to the data
                             const auto varSizedAccess
-                                = TupleBufferRef::writeVarSized(*inputBuffer, *bufferProviderVal, std::as_bytes(std::span{randomString}));
-                            return TupleBufferRef::loadAssociatedVarSizedValue(*inputBuffer, varSizedAccess).data();
+                                = MemoryLayout::writeVarSized(*inputBuffer, *bufferProviderVal, std::as_bytes(std::span{randomString}));
+                            return MemoryLayout::loadAssociatedVarSizedValue(*inputBuffer, varSizedAccess).data();
                         },
                         recordBuffer.getReference(),
                         bufferProvider,

--- a/nes-nautilus/tests/TestUtils/src/TestTupleBuffer.cpp
+++ b/nes-nautilus/tests/TestUtils/src/TestTupleBuffer.cpp
@@ -37,7 +37,7 @@
 #include <Interface/Record.hpp>
 #include <Interface/TaskBufferRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <ErrorHandling.hpp>
 #include <val_arith.hpp>
 #include <val_bool.hpp>
@@ -227,7 +227,7 @@ TestTupleBuffer::TestTupleBuffer(TestSchema schema) : schema(std::move(schema))
 {
 }
 
-TestTupleBufferView TestTupleBuffer::open(TupleBuffer& buffer, AbstractBufferProvider* bufferProvider)
+TestTupleBufferView TestTupleBuffer::open(Buffer& buffer, AbstractBufferProvider* bufferProvider)
 {
     auto bufRef = LowerSchemaProvider::lowerSchema(buffer.getBufferSize(), schema, MemoryLayoutType::ROW_LAYOUT);
 
@@ -264,7 +264,7 @@ void TestTupleBufferView::appendImpl(std::span<const std::optional<FieldValue>> 
     }
 
     auto tupleIndex = nautilus::val<uint64_t>(impl->buffer.getNumberOfTuples());
-    auto bufPtr = nautilus::val<TupleBuffer*>(std::addressof(impl->buffer));
+    auto bufPtr = nautilus::val<Buffer*>(std::addressof(impl->buffer));
     const TaskBufferRef recordBuffer(bufPtr);
     auto bufProviderVal = nautilus::val<AbstractBufferProvider*>(impl->bufferProvider);
 
@@ -311,7 +311,7 @@ FieldView& FieldView::operator=(const FieldValue& value)
     }
 
     auto recordIdx = nautilus::val<uint64_t>(recordIndex);
-    auto bufPtr = nautilus::val<TupleBuffer*>(std::addressof(locked->buffer));
+    auto bufPtr = nautilus::val<Buffer*>(std::addressof(locked->buffer));
     const TaskBufferRef recordBuffer(bufPtr);
     auto bufProviderVal = nautilus::val<AbstractBufferProvider*>(locked->bufferProvider);
 
@@ -335,7 +335,7 @@ FieldView& FieldView::operator=(std::nullopt_t)
     }
 
     auto recordIdx = nautilus::val<uint64_t>(recordIndex);
-    auto bufPtr = nautilus::val<TupleBuffer*>(std::addressof(locked->buffer));
+    auto bufPtr = nautilus::val<Buffer*>(std::addressof(locked->buffer));
     const TaskBufferRef recordBuffer(bufPtr);
     auto bufProviderVal = nautilus::val<AbstractBufferProvider*>(locked->bufferProvider);
 
@@ -355,7 +355,7 @@ std::optional<FieldValue> FieldView::readFieldValue() const
     }
 
     auto recordIdx = nautilus::val<uint64_t>(recordIndex);
-    auto bufPtr = nautilus::val<TupleBuffer*>(std::addressof(locked->buffer));
+    auto bufPtr = nautilus::val<Buffer*>(std::addressof(locked->buffer));
     const TaskBufferRef recordBuffer(bufPtr);
 
     const auto fieldId = QualifiedIdentifierBase<1>{Identifier::parse(fieldName)};

--- a/nes-nautilus/tests/TestUtils/src/TestTupleBuffer.cpp
+++ b/nes-nautilus/tests/TestUtils/src/TestTupleBuffer.cpp
@@ -33,7 +33,7 @@
 #include <DataTypes/VarVal.hpp>
 #include <DataTypes/VariableSizedData.hpp>
 #include <Identifiers/Identifier.hpp>
-#include <Interface/BufferRef/LowerSchemaProvider.hpp>
+#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
 #include <Interface/Record.hpp>
 #include <Interface/RecordBuffer.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>

--- a/nes-nautilus/tests/TestUtils/src/TestTupleBuffer.cpp
+++ b/nes-nautilus/tests/TestUtils/src/TestTupleBuffer.cpp
@@ -35,7 +35,7 @@
 #include <Identifiers/Identifier.hpp>
 #include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
 #include <ErrorHandling.hpp>
@@ -265,7 +265,7 @@ void TestTupleBufferView::appendImpl(std::span<const std::optional<FieldValue>> 
 
     auto tupleIndex = nautilus::val<uint64_t>(impl->buffer.getNumberOfTuples());
     auto bufPtr = nautilus::val<TupleBuffer*>(std::addressof(impl->buffer));
-    const RecordBuffer recordBuffer(bufPtr);
+    const TaskBufferRef recordBuffer(bufPtr);
     auto bufProviderVal = nautilus::val<AbstractBufferProvider*>(impl->bufferProvider);
 
     Record record;
@@ -312,7 +312,7 @@ FieldView& FieldView::operator=(const FieldValue& value)
 
     auto recordIdx = nautilus::val<uint64_t>(recordIndex);
     auto bufPtr = nautilus::val<TupleBuffer*>(std::addressof(locked->buffer));
-    const RecordBuffer recordBuffer(bufPtr);
+    const TaskBufferRef recordBuffer(bufPtr);
     auto bufProviderVal = nautilus::val<AbstractBufferProvider*>(locked->bufferProvider);
 
     Record record;
@@ -336,7 +336,7 @@ FieldView& FieldView::operator=(std::nullopt_t)
 
     auto recordIdx = nautilus::val<uint64_t>(recordIndex);
     auto bufPtr = nautilus::val<TupleBuffer*>(std::addressof(locked->buffer));
-    const RecordBuffer recordBuffer(bufPtr);
+    const TaskBufferRef recordBuffer(bufPtr);
     auto bufProviderVal = nautilus::val<AbstractBufferProvider*>(locked->bufferProvider);
 
     Record record;
@@ -356,7 +356,7 @@ std::optional<FieldValue> FieldView::readFieldValue() const
 
     auto recordIdx = nautilus::val<uint64_t>(recordIndex);
     auto bufPtr = nautilus::val<TupleBuffer*>(std::addressof(locked->buffer));
-    const RecordBuffer recordBuffer(bufPtr);
+    const TaskBufferRef recordBuffer(bufPtr);
 
     const auto fieldId = QualifiedIdentifierBase<1>{Identifier::parse(fieldName)};
     auto record = locked->bufRef->readRecord({fieldId}, recordBuffer, recordIdx);

--- a/nes-nautilus/tests/TestUtils/src/TestableChainedHashMap.cpp
+++ b/nes-nautilus/tests/TestUtils/src/TestableChainedHashMap.cpp
@@ -33,7 +33,7 @@
 #include <Interface/HashMap/HashMap.hpp>
 #include <Interface/Record.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <nautilus/Engine.hpp>
 #include <DataStructureTestUtils.hpp>
 #include <ErrorHandling.hpp>
@@ -110,7 +110,7 @@ TestableChainedHashMap::TestableChainedHashMap(
     auto chainedHashMapBufferOpt = bufferManager.getUnpooledBuffer(hashMapConfig.bufferSize());
     if (not chainedHashMapBufferOpt.has_value())
     {
-        throw BufferAllocationFailure("No unpooled TupleBuffer of size {} available!", hashMapConfig.bufferSize());
+        throw BufferAllocationFailure("No unpooled Buffer of size {} available!", hashMapConfig.bufferSize());
     }
     chainedHashMapBuffer = chainedHashMapBufferOpt.value();
     ChainedHashMap::init(chainedHashMapBuffer, hashMapConfig);
@@ -124,7 +124,7 @@ TestableChainedHashMap::TestableChainedHashMap(
          capturedEntrySize = entrySize,
          bloomFilterParams = bloomFilterParams,
          hashFn = MurMur3HashFunction{}](
-            nautilus::val<TupleBuffer*> chainedHashMapBuffer, nautilus::val<AbstractBufferProvider*> bm, nautilus::val<AnyVec*> rec)
+            nautilus::val<Buffer*> chainedHashMapBuffer, nautilus::val<AbstractBufferProvider*> bm, nautilus::val<AnyVec*> rec)
         {
             const Record record = buildRecordFromAnyVec(rec, projections, dataTypes);
             ChainedHashMapRef chmRef{
@@ -163,8 +163,8 @@ TestableChainedHashMap::TestableChainedHashMap(
          capturedProbeEntrySize = probeEntrySize,
          bloomFilterParams = bloomFilterParams,
          hashFn = MurMur3HashFunction{}](
-            nautilus::val<TupleBuffer*> chainedHashMapBuffer,
-            nautilus::val<TupleBuffer*> probeBuffer,
+            nautilus::val<Buffer*> chainedHashMapBuffer,
+            nautilus::val<Buffer*> probeBuffer,
             nautilus::val<AbstractBufferProvider*> bm,
             nautilus::val<AnyVec*> keyIn,
             nautilus::val<AnyVec*> out) -> nautilus::val<bool>
@@ -204,12 +204,11 @@ TestableChainedHashMap::TestableChainedHashMap(
          fieldValueTypes = fieldValueTypes,
          capturedEntriesPerPage = entriesPerPage,
          capturedEntrySize = entrySize,
-         bloomFilterParams
-         = bloomFilterParams](nautilus::val<TupleBuffer*> chainedHashMapBuffer, nautilus::val<std::vector<AnyVec>*> outVector)
+         bloomFilterParams = bloomFilterParams](nautilus::val<Buffer*> chainedHashMapBuffer, nautilus::val<std::vector<AnyVec>*> outVector)
         {
             /// begin() calls getPage(0) via invoke which fails on an empty CHM, so guard first.
-            const auto numTuples = nautilus::invoke(
-                +[](TupleBuffer* buf) { return ChainedHashMap::load(*buf).getTotalNumberOfRecords(); }, chainedHashMapBuffer);
+            const auto numTuples
+                = nautilus::invoke(+[](Buffer* buf) { return ChainedHashMap::load(*buf).getTotalNumberOfRecords(); }, chainedHashMapBuffer);
             if (numTuples == nautilus::val<uint64_t>(0))
             {
                 return;
@@ -257,7 +256,7 @@ std::optional<AnyVec> TestableChainedHashMap::at(const AnyVec& key)
     auto probeBufferOpt = bufferManager.getUnpooledBuffer(probeConfig.bufferSize());
     if (not probeBufferOpt.has_value())
     {
-        throw BufferAllocationFailure("No unpooled TupleBuffer of size {} available!", probeConfig.bufferSize());
+        throw BufferAllocationFailure("No unpooled Buffer of size {} available!", probeConfig.bufferSize());
     }
     auto probeBuffer = probeBufferOpt.value();
     ChainedHashMap::init(probeBuffer, probeConfig);

--- a/nes-nautilus/tests/TestUtils/src/TestablePagedVector.cpp
+++ b/nes-nautilus/tests/TestUtils/src/TestablePagedVector.cpp
@@ -27,7 +27,7 @@
 #include <Interface/PagedVector/PagedVectorRef.hpp>
 #include <Interface/Record.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <nautilus/Engine.hpp>
 #include <DataStructureTestUtils.hpp>
 #include <options.hpp>
@@ -57,7 +57,7 @@ TestablePagedVector::TestablePagedVector(const std::vector<DataType>& fieldTypes
 
     pushbackFn.emplace(engine->registerFunction(std::function(
         [layout, dataTypes = dataTypes, projections = projections](
-            nautilus::val<TupleBuffer*> pagedVector, nautilus::val<AbstractBufferProvider*> bm, nautilus::val<AnyVec*> rec)
+            nautilus::val<Buffer*> pagedVector, nautilus::val<AbstractBufferProvider*> bm, nautilus::val<AnyVec*> rec)
         {
             const Record record = buildRecordFromAnyVec(rec, projections, dataTypes);
             PagedVectorRef pvRef{BorrowedNautilusBuffer::from(pagedVector), layout};
@@ -66,7 +66,7 @@ TestablePagedVector::TestablePagedVector(const std::vector<DataType>& fieldTypes
 
     readAtFn.emplace(engine->registerFunction(std::function(
         [layout, dataTypes = dataTypes, projections = projections](
-            nautilus::val<TupleBuffer*> pagedVector, nautilus::val<uint64_t> index, nautilus::val<AnyVec*> out)
+            nautilus::val<Buffer*> pagedVector, nautilus::val<uint64_t> index, nautilus::val<AnyVec*> out)
         {
             const PagedVectorRef pvRef{BorrowedNautilusBuffer::from(pagedVector), layout};
             auto record = pvRef.at(index);
@@ -75,7 +75,7 @@ TestablePagedVector::TestablePagedVector(const std::vector<DataType>& fieldTypes
 
     readAll.emplace(engine->registerFunction(std::function(
         [layout, dataTypes = dataTypes, projections = projections](
-            nautilus::val<TupleBuffer*> pagedVector, nautilus::val<std::vector<AnyVec>*> outVector)
+            nautilus::val<Buffer*> pagedVector, nautilus::val<std::vector<AnyVec>*> outVector)
         {
             const PagedVectorRef pvRef{BorrowedNautilusBuffer::from(pagedVector), layout};
             for (const auto& record : pvRef)

--- a/nes-nautilus/tests/UnitTests/ChainedHashMapTest.cpp
+++ b/nes-nautilus/tests/UnitTests/ChainedHashMapTest.cpp
@@ -28,8 +28,8 @@
 #include <Interface/Hash/BloomFilterRef.hpp>
 #include <Interface/HashMap/ChainedHashMap/ChainedHashMap.hpp>
 #include <Interface/HashMap/ChainedHashMap/ChainedHashMapRef.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/BufferManager.hpp> /// NOLINT(misc-include-cleaner)
-#include <Runtime/TupleBuffer.hpp>
 #include <Util/Logger/LogLevel.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <Util/Logger/impl/NesLogger.hpp>
@@ -82,7 +82,7 @@ KeyValueReference makeEmptyReference(const TestUtils::TestableChainedHashMap& ch
 
 /// Sizing inputs bracketing the collision spectrum: saturated (mightContain constant-true, so every chain is
 /// traversed) through near-empty (~0.2% FP at the 500-entry cap, so negatives take the skip path).
-/// Capped at ~2^18 bits (32KB): the bit area is inline in the map's unpooled TupleBuffer and the allocator
+/// Capped at ~2^18 bits (32KB): the bit area is inline in the map's unpooled Buffer and the allocator
 /// reserves 10x the rolling average per chunk, so a larger map buffer blows the tests' unpooled budget.
 /// Not constexpr: the validating constructor is not a constant expression.
 const std::array<Nautilus::Interface::BloomFilterParams, 4> BLOOM_COLLISION_EXTREMES = {
@@ -467,7 +467,7 @@ TEST(ChainedHashMapIteratorTest, emptyMapIsAnEmptyRange)
     auto engine = TestUtils::makeEngine(TestUtils::EngineMode::Interpreter);
     auto iterate = engine.registerFunction(std::function(
         /// NOLINTNEXTLINE(performance-unnecessary-value-param): registerFunction requires val<FunctionArguments> by value.
-        [](nautilus::val<TupleBuffer*> buffer)
+        [](nautilus::val<Buffer*> buffer)
         {
             const ChainedHashMapRef ref{
                 buffer, {}, {}, nautilus::val<uint64_t>{entriesPerPage}, nautilus::val<uint64_t>{entrySize}, std::nullopt};

--- a/nes-nautilus/tests/UnitTests/NautilusBufferTest.cpp
+++ b/nes-nautilus/tests/UnitTests/NautilusBufferTest.cpp
@@ -22,8 +22,8 @@
 #include <utility>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/Allocator/NesDefaultMemoryAllocator.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/BufferManager.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Util/Logger/LogLevel.hpp>
 #include <Util/Logger/impl/NesLogger.hpp>
 #include <fmt/format.h>
@@ -48,7 +48,7 @@ constexpr size_t TEST_NUMBER_OF_BUFFERS = 16;
 constexpr NES::BufferAlignment BUFFER_ALIGNMENT{64};
 constexpr double UNPOOLED_MEMORY_FRACTION = 0.9;
 constexpr size_t TOTAL_MEMORY_IN_BYTES = 10 * TEST_NUMBER_OF_BUFFERS * TEST_BUFFER_SIZE;
-/// Number of records pre-set on the on-stack TupleBuffer, so that reads through a BorrowedNautilusBuffer can be verified.
+/// Number of records pre-set on the on-stack Buffer, so that reads through a BorrowedNautilusBuffer can be verified.
 constexpr uint64_t ON_STACK_RECORD_COUNT = 11;
 
 enum class EngineMode : std::uint8_t
@@ -74,15 +74,15 @@ public:
     static void SetUpTestSuite() { Logger::setupLogging("NautilusBufferTest.log", LogLevel::LOG_DEBUG); }
 
 protected:
-    /// Compiles and runs `body` in the backend selected by the test parameter. The body receives a pointer to a TupleBuffer that lives
+    /// Compiles and runs `body` in the backend selected by the test parameter. The body receives a pointer to a Buffer that lives
     /// on the (C++) stack of this function - mimicking the WorkerThread stack that owns the entry buffer of a pipeline - and a buffer
     /// provider it can allocate owned buffers from. Lifetime correctness is verified implicitly: BufferManager::destroy() asserts that
     /// every buffer handed out has been returned, so a leaked owned buffer aborts the test.
-    static void runInNautilus(const std::function<void(nautilus::val<TupleBuffer*>, nautilus::val<AbstractBufferProvider*>)>& body)
+    static void runInNautilus(const std::function<void(nautilus::val<Buffer*>, nautilus::val<AbstractBufferProvider*>)>& body)
     {
         auto engine = makeEngine(GetParam());
         auto function = engine.registerFunction(
-            std::function([&body](nautilus::val<TupleBuffer*> onStackBuffer, nautilus::val<AbstractBufferProvider*> provider)
+            std::function([&body](nautilus::val<Buffer*> onStackBuffer, nautilus::val<AbstractBufferProvider*> provider)
                           { body(onStackBuffer, provider); }));
 
         const auto bufferManager = BufferManager::create(
@@ -92,7 +92,7 @@ protected:
             TEST_BUFFER_SIZE,
             std::make_shared<NesDefaultMemoryAllocator>());
         {
-            TupleBuffer onStackBuffer = bufferManager->getBufferBlocking();
+            Buffer onStackBuffer = bufferManager->getBufferBlocking();
             onStackBuffer.setNumberOfTuples(ON_STACK_RECORD_COUNT);
             function(&onStackBuffer, bufferManager.get());
         }
@@ -121,12 +121,12 @@ void expectValid(const nautilus::val<bool>& valid)
 }
 
 /// Allocates a fresh owned buffer from `provider` following the intended pattern: empty-initialize on the stack, then assign inside a
-/// `nautilus::invoke`. The returned buffer keeps its TupleBuffer alive until it goes out of scope.
+/// `nautilus::invoke`. The returned buffer keeps its Buffer alive until it goes out of scope.
 OwnedNautilusBuffer allocateOwned(const nautilus::val<AbstractBufferProvider*>& provider, const nautilus::val<uint64_t>& numberOfRecords)
 {
     OwnedNautilusBuffer owned;
     nautilus::invoke(
-        +[](AbstractBufferProvider* bufferProvider, TupleBuffer* out, uint64_t records)
+        +[](AbstractBufferProvider* bufferProvider, Buffer* out, uint64_t records)
         {
             *out = bufferProvider->getBufferBlocking();
             out->setNumberOfTuples(records);
@@ -139,17 +139,17 @@ OwnedNautilusBuffer allocateOwned(const nautilus::val<AbstractBufferProvider*>& 
 
 /// A consumer that is agnostic to buffer ownership: it works for OwnedNautilusBuffer, BorrowedNautilusBuffer and NautilusBuffer alike,
 /// since all three expose the same read-only interface. This is the API shape the design intends most code to use.
-template <typename Buffer>
-nautilus::val<size_t> consume(const Buffer& buffer)
+template <typename NautilusBufferType>
+nautilus::val<size_t> consume(const NautilusBufferType& buffer)
 {
     /// Uses asArg() in its intended role - as an argument to a nautilus::invoke - which compiles for all three buffer types.
-    return nautilus::invoke(+[](const TupleBuffer* tupleBuffer) { return tupleBuffer->getNumberOfTuples(); }, buffer.asArg());
+    return nautilus::invoke(+[](const Buffer* tupleBuffer) { return tupleBuffer->getNumberOfTuples(); }, buffer.asArg());
 }
 
-/// A BorrowedNautilusBuffer reads through to the on-stack TupleBuffer it does not own.
+/// A BorrowedNautilusBuffer reads through to the on-stack Buffer it does not own.
 TEST_P(NautilusBufferTest, BorrowedBufferReadsThroughToTupleBuffer)
 {
-    runInNautilus([](nautilus::val<TupleBuffer*> onStackBuffer, nautilus::val<AbstractBufferProvider*>)
+    runInNautilus([](nautilus::val<Buffer*> onStackBuffer, nautilus::val<AbstractBufferProvider*>)
                   { expectRecordCount(BorrowedNautilusBuffer::from(onStackBuffer).getNumberOfRecords(), ON_STACK_RECORD_COUNT); });
 }
 
@@ -157,23 +157,23 @@ TEST_P(NautilusBufferTest, BorrowedBufferReadsThroughToTupleBuffer)
 TEST_P(NautilusBufferTest, OwnedBufferEmptyInitThenAssignInInvoke)
 {
     runInNautilus(
-        [](nautilus::val<TupleBuffer*>, nautilus::val<AbstractBufferProvider*> provider)
+        [](nautilus::val<Buffer*>, nautilus::val<AbstractBufferProvider*> provider)
         {
             OwnedNautilusBuffer owned;
             expectValid(!owned.isValid());
             nautilus::invoke(
-                +[](AbstractBufferProvider* bufferProvider, TupleBuffer* out) { *out = bufferProvider->getBufferBlocking(); },
+                +[](AbstractBufferProvider* bufferProvider, Buffer* out) { *out = bufferProvider->getBufferBlocking(); },
                 provider,
                 owned.asArg());
             expectValid(owned.isValid());
         });
 }
 
-/// Move-constructing an OwnedNautilusBuffer transfers the wrapped TupleBuffer to the moved-into buffer.
+/// Move-constructing an OwnedNautilusBuffer transfers the wrapped Buffer to the moved-into buffer.
 TEST_P(NautilusBufferTest, OwnedBufferMoveConstruction)
 {
     runInNautilus(
-        [](nautilus::val<TupleBuffer*>, nautilus::val<AbstractBufferProvider*> provider)
+        [](nautilus::val<Buffer*>, nautilus::val<AbstractBufferProvider*> provider)
         {
             auto owned = allocateOwned(provider, 7);
             const OwnedNautilusBuffer movedInto = std::move(owned);
@@ -181,11 +181,11 @@ TEST_P(NautilusBufferTest, OwnedBufferMoveConstruction)
         });
 }
 
-/// Copy-constructing an OwnedNautilusBuffer shares the reference-counted TupleBuffer, so the copy observes the same records.
+/// Copy-constructing an OwnedNautilusBuffer shares the reference-counted Buffer, so the copy observes the same records.
 TEST_P(NautilusBufferTest, OwnedBufferCopyConstruction)
 {
     runInNautilus(
-        [](nautilus::val<TupleBuffer*>, nautilus::val<AbstractBufferProvider*> provider)
+        [](nautilus::val<Buffer*>, nautilus::val<AbstractBufferProvider*> provider)
         {
             const auto owned = allocateOwned(provider, 7);
             const OwnedNautilusBuffer copied = owned;
@@ -197,7 +197,7 @@ TEST_P(NautilusBufferTest, OwnedBufferCopyConstruction)
 TEST_P(NautilusBufferTest, OwnedBufferStoreAndGetChild)
 {
     runInNautilus(
-        [](nautilus::val<TupleBuffer*>, nautilus::val<AbstractBufferProvider*> provider)
+        [](nautilus::val<Buffer*>, nautilus::val<AbstractBufferProvider*> provider)
         {
             auto parent = allocateOwned(provider, 7);
             const auto childIndex = parent.storeChild(allocateOwned(provider, 3));
@@ -209,7 +209,7 @@ TEST_P(NautilusBufferTest, OwnedBufferStoreAndGetChild)
 TEST_P(NautilusBufferTest, NautilusBufferFromBorrowed)
 {
     runInNautilus(
-        [](nautilus::val<TupleBuffer*> onStackBuffer, nautilus::val<AbstractBufferProvider*>)
+        [](nautilus::val<Buffer*> onStackBuffer, nautilus::val<AbstractBufferProvider*>)
         {
             const NautilusBuffer fromBorrowed{BorrowedNautilusBuffer::from(onStackBuffer)};
             expectRecordCount(fromBorrowed.getNumberOfRecords(), ON_STACK_RECORD_COUNT);
@@ -221,7 +221,7 @@ TEST_P(NautilusBufferTest, NautilusBufferFromBorrowed)
 TEST_P(NautilusBufferTest, NautilusBufferFromOwned)
 {
     runInNautilus(
-        [](nautilus::val<TupleBuffer*>, nautilus::val<AbstractBufferProvider*> provider)
+        [](nautilus::val<Buffer*>, nautilus::val<AbstractBufferProvider*> provider)
         {
             const NautilusBuffer fromOwned{allocateOwned(provider, 5)};
             expectRecordCount(fromOwned.getNumberOfRecords(), 5);
@@ -232,40 +232,40 @@ TEST_P(NautilusBufferTest, NautilusBufferFromOwned)
 /// The ownership-agnostic consumer works on a BorrowedNautilusBuffer.
 TEST_P(NautilusBufferTest, ConsumerOnBorrowed)
 {
-    runInNautilus([](nautilus::val<TupleBuffer*> onStackBuffer, nautilus::val<AbstractBufferProvider*>)
+    runInNautilus([](nautilus::val<Buffer*> onStackBuffer, nautilus::val<AbstractBufferProvider*>)
                   { expectRecordCount(consume(BorrowedNautilusBuffer::from(onStackBuffer)), ON_STACK_RECORD_COUNT); });
 }
 
 /// The ownership-agnostic consumer works on an OwnedNautilusBuffer.
 TEST_P(NautilusBufferTest, ConsumerOnOwned)
 {
-    runInNautilus([](nautilus::val<TupleBuffer*>, nautilus::val<AbstractBufferProvider*> provider)
+    runInNautilus([](nautilus::val<Buffer*>, nautilus::val<AbstractBufferProvider*> provider)
                   { expectRecordCount(consume(allocateOwned(provider, 5)), 5); });
 }
 
 /// The ownership-agnostic consumer works on a type-erased NautilusBuffer.
 TEST_P(NautilusBufferTest, ConsumerOnNautilusBuffer)
 {
-    runInNautilus([](nautilus::val<TupleBuffer*> onStackBuffer, nautilus::val<AbstractBufferProvider*>)
+    runInNautilus([](nautilus::val<Buffer*> onStackBuffer, nautilus::val<AbstractBufferProvider*>)
                   { expectRecordCount(consume(NautilusBuffer{BorrowedNautilusBuffer::from(onStackBuffer)}), ON_STACK_RECORD_COUNT); });
 }
 
-/// OwnedNautilusBuffer::copy promotes a borrowed buffer into an owned one that references the same TupleBuffer.
+/// OwnedNautilusBuffer::copy promotes a borrowed buffer into an owned one that references the same Buffer.
 TEST_P(NautilusBufferTest, CopyFromBorrowed)
 {
     runInNautilus(
-        [](nautilus::val<TupleBuffer*> onStackBuffer, nautilus::val<AbstractBufferProvider*>)
+        [](nautilus::val<Buffer*> onStackBuffer, nautilus::val<AbstractBufferProvider*>)
         {
             const auto owned = OwnedNautilusBuffer::copy(NautilusBuffer{BorrowedNautilusBuffer::from(onStackBuffer)});
             expectRecordCount(owned.getNumberOfRecords(), ON_STACK_RECORD_COUNT);
         });
 }
 
-/// OwnedNautilusBuffer::copy of an owned source yields an owned buffer referencing the same TupleBuffer.
+/// OwnedNautilusBuffer::copy of an owned source yields an owned buffer referencing the same Buffer.
 TEST_P(NautilusBufferTest, CopyFromOwned)
 {
     runInNautilus(
-        [](nautilus::val<TupleBuffer*>, nautilus::val<AbstractBufferProvider*> provider)
+        [](nautilus::val<Buffer*>, nautilus::val<AbstractBufferProvider*> provider)
         {
             const auto owned = OwnedNautilusBuffer::copy(NautilusBuffer{allocateOwned(provider, 5)});
             expectRecordCount(owned.getNumberOfRecords(), 5);

--- a/nes-nautilus/tests/UnitTests/PagedVectorTest.cpp
+++ b/nes-nautilus/tests/UnitTests/PagedVectorTest.cpp
@@ -35,8 +35,8 @@
 #include <Interface/Record.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/Allocator/NesDefaultMemoryAllocator.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/BufferManager.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Util/Logger/LogLevel.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <Util/Logger/impl/NesLogger.hpp>
@@ -95,7 +95,7 @@ struct DirtyBufferProvider : AbstractBufferProvider
 
     [[nodiscard]] size_t getNumOfUnpooledBuffers() const override { return bm->getNumOfUnpooledBuffers(); }
 
-    TupleBuffer getBufferBlocking() override
+    Buffer getBufferBlocking() override
     {
         /// Tests are single-threaded; nothing releases buffers concurrently, so a blocking get on an exhausted pool would hang.
         /// Fail fast instead so rapidcheck can shrink the offending case quickly.
@@ -111,7 +111,7 @@ struct DirtyBufferProvider : AbstractBufferProvider
         return std::move(*buffer);
     }
 
-    std::optional<TupleBuffer> getBufferNoBlocking() override
+    std::optional<Buffer> getBufferNoBlocking() override
     {
         auto buffer = bm->getBufferNoBlocking();
         if (buffer)
@@ -124,7 +124,7 @@ struct DirtyBufferProvider : AbstractBufferProvider
         return buffer;
     }
 
-    std::optional<TupleBuffer> getBufferWithTimeout(std::chrono::milliseconds timeoutMs) override
+    std::optional<Buffer> getBufferWithTimeout(std::chrono::milliseconds timeoutMs) override
     {
         auto buffer = bm->getBufferWithTimeout(timeoutMs);
         if (buffer)
@@ -137,7 +137,7 @@ struct DirtyBufferProvider : AbstractBufferProvider
         return buffer;
     }
 
-    std::optional<TupleBuffer> getUnpooledBuffer(size_t bufferSize) override
+    std::optional<Buffer> getUnpooledBuffer(size_t bufferSize) override
     {
         auto buffer = bm->getUnpooledBuffer(bufferSize);
         if (buffer)
@@ -170,16 +170,13 @@ struct NoOversizedUnpooledBufferProvider : AbstractBufferProvider
 
     [[nodiscard]] size_t getNumOfUnpooledBuffers() const override { return bm->getNumOfUnpooledBuffers(); }
 
-    TupleBuffer getBufferBlocking() override { return bm->getBufferBlocking(); }
+    Buffer getBufferBlocking() override { return bm->getBufferBlocking(); }
 
-    std::optional<TupleBuffer> getBufferNoBlocking() override { return bm->getBufferNoBlocking(); }
+    std::optional<Buffer> getBufferNoBlocking() override { return bm->getBufferNoBlocking(); }
 
-    std::optional<TupleBuffer> getBufferWithTimeout(std::chrono::milliseconds timeoutMs) override
-    {
-        return bm->getBufferWithTimeout(timeoutMs);
-    }
+    std::optional<Buffer> getBufferWithTimeout(std::chrono::milliseconds timeoutMs) override { return bm->getBufferWithTimeout(timeoutMs); }
 
-    std::optional<TupleBuffer> getUnpooledBuffer(size_t bufferSize) override
+    std::optional<Buffer> getUnpooledBuffer(size_t bufferSize) override
     {
         if (bufferSize > bm->getBufferSize())
         {

--- a/nes-network/nes-rust-bindings/network/include/NetworkBindings.hpp
+++ b/nes-network/nes-rust-bindings/network/include/NetworkBindings.hpp
@@ -18,18 +18,18 @@
 #include <rust/cxx.h>
 
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 
 struct SerializedTupleBufferHeader;
 
 /// The TupleBufferBuilder is a wrapper around a tuple buffer with methods exposed to rust.
-/// This allows the rust code to set metadata on a tuple buffer without directly exposing the TupleBuffer and its control block
+/// This allows the rust code to set metadata on a tuple buffer without directly exposing the Buffer and its control block
 /// to rust.
-/// It is important that the underlying TupleBuffer outlives the TupleBufferBuilder
+/// It is important that the underlying Buffer outlives the TupleBufferBuilder
 class TupleBufferBuilder
 {
 public:
-    explicit TupleBufferBuilder(NES::TupleBuffer& buffer, NES::AbstractBufferProvider& bufferProvider)
+    explicit TupleBufferBuilder(NES::Buffer& buffer, NES::AbstractBufferProvider& bufferProvider)
         : buffer(buffer), bufferProvider(bufferProvider)
     {
     }
@@ -40,7 +40,7 @@ public:
 
 private:
     /// The wrapper is only a temporary object and thus does not store anything by value.
-    NES::TupleBuffer& buffer; ///NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+    NES::Buffer& buffer; ///NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     NES::AbstractBufferProvider& bufferProvider; ///NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
 };
 

--- a/nes-network/nes-rust-bindings/network/lib.rs
+++ b/nes-network/nes-rust-bindings/network/lib.rs
@@ -12,7 +12,7 @@
     limitations under the License.
 */
 
-use nes_network::protocol::{ConnectionIdentifier, ThisConnectionIdentifier, TupleBuffer};
+use nes_network::protocol::{Buffer, ConnectionIdentifier, ThisConnectionIdentifier};
 use nes_network::receiver::{ReceiverChannel, ReceiverChannelResult};
 use nes_network::sender::{SenderChannel, TrySendDataResult};
 use nes_network::*;
@@ -462,7 +462,7 @@ fn send_buffer(
     data: &[u8],
     children: &[&[u8]],
 ) -> ffi::SendResult {
-    let buffer = TupleBuffer {
+    let buffer = Buffer {
         sequence_number: metadata.sequence_number,
         origin_id: metadata.origin_id,
         chunk_number: metadata.chunk_number,

--- a/nes-network/network/src/protocol.rs
+++ b/nes-network/network/src/protocol.rs
@@ -100,7 +100,7 @@ pub enum ControlChannelResponse {
 }
 #[derive(Debug, Serialize, Deserialize)]
 pub enum DataChannelRequest {
-    Data(TupleBuffer),
+    Data(Buffer),
     Close,
 }
 
@@ -117,7 +117,7 @@ pub enum DataChannelResponse {
 }
 
 #[derive(Eq, PartialEq, Clone, Serialize, Deserialize)]
-pub struct TupleBuffer {
+pub struct Buffer {
     pub sequence_number: u64,
     pub origin_id: u64,
     pub watermark: u64,
@@ -128,15 +128,15 @@ pub struct TupleBuffer {
     pub child_buffers: Vec<Vec<u8>>,
 }
 
-impl TupleBuffer {
+impl Buffer {
     pub fn sequence(&self) -> OriginSequenceNumber {
         (self.origin_id, self.sequence_number, self.chunk_number)
     }
 }
 
-impl Debug for TupleBuffer {
+impl Debug for Buffer {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("TupleBuffer{{ sequence_number: {}, origin_id: {}, chunk_number: {}, watermark: {}, number_of_tuples: {}, bufferSize: {}, children: {:?}}}", self.sequence_number, self.origin_id, self.chunk_number, self.watermark, self.number_of_tuples, self.data.len(), self.child_buffers.iter().map(|buffer| buffer.len()).collect::<Vec<_>>()))
+        f.write_fmt(format_args!("Buffer{{ sequence_number: {}, origin_id: {}, chunk_number: {}, watermark: {}, number_of_tuples: {}, bufferSize: {}, children: {:?}}}", self.sequence_number, self.origin_id, self.chunk_number, self.watermark, self.number_of_tuples, self.data.len(), self.child_buffers.iter().map(|buffer| buffer.len()).collect::<Vec<_>>()))
     }
 }
 

--- a/nes-network/network/src/receiver/channel.rs
+++ b/nes-network/network/src/receiver/channel.rs
@@ -38,7 +38,7 @@ enum ChannelHandlerStatus {
     /// NetworkService shutdown or the control connection stopped.
     Cancelled,
 }
-pub(super) type DataQueue = async_channel::Sender<TupleBuffer>;
+pub(super) type DataQueue = async_channel::Sender<Buffer>;
 
 async fn channel_handler<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     cancellation_token: CancellationToken,
@@ -46,7 +46,7 @@ async fn channel_handler<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     mut connection_reader: DataChannelReceiverReader<R>,
     mut connection_writer: DataChannelReceiverWriter<W>,
 ) -> Result<ChannelHandlerStatus> {
-    let mut pending_buffer: Option<TupleBuffer> = None;
+    let mut pending_buffer: Option<Buffer> = None;
     loop {
         // First: Push received data to the registered channel. The channel handler will not receive
         // further data from the network if the registered channel cannot accept it. This implements

--- a/nes-network/network/src/receiver/receiver.rs
+++ b/nes-network/network/src/receiver/receiver.rs
@@ -27,11 +27,11 @@ use super::control::*;
 const RUNTIME_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 
 pub struct ReceiverChannel {
-    queue: async_channel::Receiver<TupleBuffer>,
+    queue: async_channel::Receiver<Buffer>,
 }
 
 pub enum ReceiverChannelResult {
-    Ok(TupleBuffer),
+    Ok(Buffer),
     Closed,
     Error(Error),
 }

--- a/nes-network/network/src/sender/channel.rs
+++ b/nes-network/network/src/sender/channel.rs
@@ -94,7 +94,7 @@ async fn create_channel<C: Communication>(
 /// Commands sent from `SenderChannel` to the channel handler task.
 pub(super) enum ChannelCommand {
     /// Send a data buffer through the channel.
-    Data(TupleBuffer),
+    Data(Buffer),
     /// Flush the network writer and report whether all data has been acknowledged.
     /// The boolean sent through the oneshot indicates: true if both pending and
     /// in-flight queues are empty, false otherwise.
@@ -136,8 +136,8 @@ pub(super) type ChannelCommandQueueListener = async_channel::Receiver<ChannelCom
 /// - Unrecoverable error occurs
 pub(super) struct ChannelHandler<R: AsyncRead + Unpin, W: AsyncWrite + Unpin> {
     cancellation_token: CancellationToken,
-    pending_writes: VecDeque<TupleBuffer>,
-    wait_for_ack: HashMap<OriginSequenceNumber, TupleBuffer>,
+    pending_writes: VecDeque<Buffer>,
+    wait_for_ack: HashMap<OriginSequenceNumber, Buffer>,
     writer: DataChannelSenderWriter<W>,
     reader: DataChannelSenderReader<R>,
     queue: ChannelCommandQueueListener,
@@ -232,7 +232,7 @@ impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin> ChannelHandler<R, W> {
         Ok(())
     }
 
-    /// Attempts to send the next pending TupleBuffer to the receiver.
+    /// Attempts to send the next pending Buffer to the receiver.
     ///
     /// # Behavior
     ///
@@ -257,8 +257,8 @@ impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin> ChannelHandler<R, W> {
     async fn send_pending(
         cancel_token: &CancellationToken,
         writer: &mut DataChannelSenderWriter<W>,
-        pending_writes: &mut VecDeque<TupleBuffer>,
-        wait_for_ack: &mut HashMap<OriginSequenceNumber, TupleBuffer>,
+        pending_writes: &mut VecDeque<Buffer>,
+        wait_for_ack: &mut HashMap<OriginSequenceNumber, Buffer>,
     ) -> InternalResult<()> {
         let Some(buffer) = pending_writes.front() else {
             return Ok(());

--- a/nes-network/network/src/sender/sender.rs
+++ b/nes-network/network/src/sender/sender.rs
@@ -87,9 +87,9 @@ pub enum TrySendDataResult {
     /// The buffer was successfully queued for sending.
     Ok,
     /// The channel's internal queue is full. The buffer is returned to the caller.
-    Full(TupleBuffer),
+    Full(Buffer),
     /// The channel is closed. The buffer is returned to the caller.
-    Closed(TupleBuffer),
+    Closed(Buffer),
 }
 impl SenderChannel {
     /// Attempts to send a tuple buffer through this channel without blocking.
@@ -104,7 +104,7 @@ impl SenderChannel {
     /// When `Full` is returned, the caller should apply backpressure to avoid
     /// unbounded memory growth. The buffer is returned so it can be retried later
     /// or handled appropriately.
-    pub fn try_send_data(&self, buffer: TupleBuffer) -> TrySendDataResult {
+    pub fn try_send_data(&self, buffer: Buffer) -> TrySendDataResult {
         let result = self.queue.try_send(ChannelCommand::Data(buffer));
         match result {
             Ok(()) => TrySendDataResult::Ok,

--- a/nes-output-formatters/include/OutputFormatters/OutputFormatter.hpp
+++ b/nes-output-formatters/include/OutputFormatters/OutputFormatter.hpp
@@ -22,7 +22,7 @@
 #include <DataTypes/DataType.hpp>
 #include <DataTypes/VarVal.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <fmt/base.h>
 #include <fmt/ostream.h>
@@ -57,7 +57,7 @@ public:
         uint64_t fieldIndex,
         const nautilus::val<int8_t*>& fieldPointer,
         const nautilus::val<uint64_t>& remainingSize,
-        const RecordBuffer& recordBuffer,
+        const TaskBufferRef& recordBuffer,
         const nautilus::val<AbstractBufferProvider*>& bufferProvider) const
         = 0;
 

--- a/nes-output-formatters/include/OutputFormatters/OutputFormatter.hpp
+++ b/nes-output-formatters/include/OutputFormatters/OutputFormatter.hpp
@@ -36,7 +36,7 @@ namespace NES
 
 /// The output formatter is responsible for converting a Record into a string of a given Output Format like CSV or JSON
 /// Output formatters are stateless, meaning that they must be able to produce valid output in a streaming fashion.
-/// Output formatters are used by the OutputFormatterBufferRef during the last emit before a sink.
+/// Output formatters are used by the OutputFormatterLayout during the last emit before a sink.
 class OutputFormatter
 {
 public:

--- a/nes-output-formatters/include/OutputFormatters/OutputFormatterUtil.hpp
+++ b/nes-output-formatters/include/OutputFormatters/OutputFormatterUtil.hpp
@@ -25,7 +25,7 @@
 
 #include <DataTypes/DataType.hpp>
 #include <DataTypes/VarVal.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
 #include <Util/Strings.hpp>
@@ -133,7 +133,7 @@ inline nautilus::val<uint64_t> formatAndWriteVal(
     const DataType& fieldType,
     const nautilus::val<int8_t*>& address,
     const nautilus::val<uint64_t>& remainingSize,
-    const RecordBuffer& recordBuffer,
+    const TaskBufferRef& recordBuffer,
     const nautilus::val<AbstractBufferProvider*>& bufferProvider)
 {
     nautilus::val<uint64_t> writtenBytes = 0;

--- a/nes-output-formatters/include/OutputFormatters/OutputFormatterUtil.hpp
+++ b/nes-output-formatters/include/OutputFormatters/OutputFormatterUtil.hpp
@@ -27,7 +27,7 @@
 #include <DataTypes/VarVal.hpp>
 #include <Interface/TaskBufferRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Util/Strings.hpp>
 #include <ErrorHandling.hpp>
 #include <function.hpp>
@@ -46,7 +46,7 @@ namespace NES
 inline uint64_t writeValueToBuffer(
     const char* value,
     const uint64_t remainingSpace,
-    TupleBuffer* tupleBuffer,
+    Buffer* tupleBuffer,
     AbstractBufferProvider* bufferProvider,
     int8_t* bufferStartingAddress)
 {
@@ -92,11 +92,7 @@ inline uint64_t writeValueToBuffer(
 
 template <typename T>
 static uint64_t writeValAsString(
-    const T val,
-    int8_t* bufferStartingAddress,
-    const uint64_t remainingSpace,
-    TupleBuffer* tupleBuffer,
-    AbstractBufferProvider* bufferProvider)
+    const T val, int8_t* bufferStartingAddress, const uint64_t remainingSpace, Buffer* tupleBuffer, AbstractBufferProvider* bufferProvider)
 {
     /// Convert val to a string
     /// Depending on the type, we need to perform additional transformations besides the direct conversion to string

--- a/nes-output-formatters/private/CSVOutputFormatter.hpp
+++ b/nes-output-formatters/private/CSVOutputFormatter.hpp
@@ -26,7 +26,7 @@
 #include <DataTypes/DataType.hpp>
 #include <DataTypes/VarVal.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <OutputFormatters/OutputFormatterDescriptor.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Util/Logger/Formatter.hpp>
@@ -48,7 +48,7 @@ public:
         uint64_t fieldIndex,
         const nautilus::val<int8_t*>& fieldPointer,
         const nautilus::val<uint64_t>& remainingSize,
-        const RecordBuffer& recordBuffer,
+        const TaskBufferRef& recordBuffer,
         const nautilus::val<AbstractBufferProvider*>& bufferProvider) const override;
 
     std::ostream& toString(std::ostream& os) const override { return os << *this; }

--- a/nes-output-formatters/src/CSVOutputFormatter.cpp
+++ b/nes-output-formatters/src/CSVOutputFormatter.cpp
@@ -37,7 +37,7 @@
 
 #include <OutputFormatters/OutputFormatterDescriptor.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <OutputFormatterRegistry.hpp>
 #include <OutputFormatterValidationRegistry.hpp>
 #include <function.hpp>
@@ -58,7 +58,7 @@ uint64_t writeVarsized(
     const bool quoteStrings,
     const int8_t* varSizedContent,
     const uint64_t contentSize,
-    TupleBuffer* tupleBuffer,
+    Buffer* tupleBuffer,
     AbstractBufferProvider* bufferProvider)
 {
     std::string stringFormattedValue{reinterpret_cast<const char*>(varSizedContent), contentSize};

--- a/nes-output-formatters/src/CSVOutputFormatter.cpp
+++ b/nes-output-formatters/src/CSVOutputFormatter.cpp
@@ -29,7 +29,7 @@
 #include <DataTypes/VarVal.hpp>
 #include <DataTypes/VariableSizedData.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <OutputFormatters/OutputFormatter.hpp>
 #include <OutputFormatters/OutputFormatterUtil.hpp>
 #include <fmt/format.h>
@@ -86,7 +86,7 @@ void writeValue(
     const VarVal& value,
     const DataType& fieldType,
     const nautilus::val<int8_t*>& fieldPointer,
-    const RecordBuffer& recordBuffer,
+    const TaskBufferRef& recordBuffer,
     const nautilus::val<AbstractBufferProvider*>& bufferProvider,
     const nautilus::val<bool>& quoteStrings,
     nautilus::val<uint64_t>& written,
@@ -151,7 +151,7 @@ nautilus::val<uint64_t> CSVOutputFormatter::writeFormattedValue(
     uint64_t fieldIndex,
     const nautilus::val<int8_t*>& fieldPointer,
     const nautilus::val<uint64_t>& remainingSize,
-    const RecordBuffer& recordBuffer,
+    const TaskBufferRef& recordBuffer,
     const nautilus::val<AbstractBufferProvider*>& bufferProvider) const
 {
     nautilus::val<uint64_t> written{0};

--- a/nes-physical-operators/include/Aggregation/AggregationProbePhysicalOperator.hpp
+++ b/nes-physical-operators/include/Aggregation/AggregationProbePhysicalOperator.hpp
@@ -17,7 +17,7 @@
 #include <memory>
 #include <vector>
 #include <Aggregation/Function/AggregationPhysicalFunction.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Operators/Windows/WindowMetaData.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <HashMapOptions.hpp>
@@ -34,7 +34,7 @@ public:
         std::vector<std::shared_ptr<AggregationPhysicalFunction>> aggregationPhysicalFunctions,
         OperatorHandlerId operatorHandlerId,
         WindowMetaData windowMetaData);
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    void open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const override;
 
 private:
     std::vector<std::shared_ptr<AggregationPhysicalFunction>> aggregationPhysicalFunctions;

--- a/nes-physical-operators/include/Aggregation/AggregationSlice.hpp
+++ b/nes-physical-operators/include/Aggregation/AggregationSlice.hpp
@@ -18,7 +18,7 @@
 #include <Identifiers/Identifiers.hpp>
 #include <Interface/HashMap/HashMap.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <SliceStore/Slice.hpp>
 #include <HashMapSlice.hpp>
 
@@ -34,9 +34,8 @@ public:
     AggregationSlice(
         SliceStart sliceStart, SliceEnd sliceEnd, const CreateNewHashMapSliceArgs& createNewHashMapSliceArgs, uint64_t numberOfHashMaps);
 
-    [[nodiscard]] const TupleBuffer* getHashMapBufferRefForWorker(WorkerThreadId workerThreadId) const;
-    [[nodiscard]] const TupleBuffer*
-    getOrCreateHashMapBufferRefForWorker(AbstractBufferProvider& bufferProvider, WorkerThreadId workerThreadId);
+    [[nodiscard]] const Buffer* getHashMapBufferRefForWorker(WorkerThreadId workerThreadId) const;
+    [[nodiscard]] const Buffer* getOrCreateHashMapBufferRefForWorker(AbstractBufferProvider& bufferProvider, WorkerThreadId workerThreadId);
 };
 
 }

--- a/nes-physical-operators/include/Aggregation/Function/AggregationPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Aggregation/Function/AggregationPhysicalFunction.hpp
@@ -20,7 +20,7 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/Record.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <ExecutionContext.hpp>
 #include <val_bool.hpp>
 #include <val_concepts.hpp>
@@ -49,7 +49,7 @@ public:
     /// Adds the incoming record to the existing aggregation state
     virtual void lift(
         const nautilus::val<AggregationState*>& aggregationState,
-        nautilus::val<TupleBuffer*> parentBuffer,
+        nautilus::val<Buffer*> parentBuffer,
         PipelineMemoryProvider& bufferProvider,
         const Record& record)
         = 0;
@@ -57,9 +57,9 @@ public:
     /// Combines two aggregation states into one. After calling this method, aggregationState1 contains the combined state
     virtual void combine(
         nautilus::val<AggregationState*> aggregationState1,
-        nautilus::val<TupleBuffer*> parentBuffer1,
+        nautilus::val<Buffer*> parentBuffer1,
         nautilus::val<AggregationState*> aggregationState2,
-        nautilus::val<TupleBuffer*> parentBuffer2,
+        nautilus::val<Buffer*> parentBuffer2,
         PipelineMemoryProvider& pipelineMemoryProvider)
         = 0;
 
@@ -67,14 +67,14 @@ public:
     /// It will NOT contain any other metadata fields, e.g., window start and end fields
     virtual Record lower(
         nautilus::val<AggregationState*> aggregationState,
-        nautilus::val<TupleBuffer*> parentBuffer,
+        nautilus::val<Buffer*> parentBuffer,
         PipelineMemoryProvider& pipelineMemoryProvider)
         = 0;
 
     /// Resets the aggregation state to its initial state. For a sum, this would be 0, for a min aggregation, this would be the maximum possible value, etc.
     virtual void reset(
         nautilus::val<AggregationState*> aggregationState,
-        nautilus::val<TupleBuffer*> parentBuffer,
+        nautilus::val<Buffer*> parentBuffer,
         PipelineMemoryProvider& pipelineMemoryProvider)
         = 0;
 

--- a/nes-physical-operators/include/Aggregation/Function/AvgAggregationPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Aggregation/Function/AvgAggregationPhysicalFunction.hpp
@@ -21,7 +21,7 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/Record.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <val_concepts.hpp>
 #include <val_ptr.hpp>
 
@@ -39,23 +39,19 @@ public:
         bool includeNullValues);
     void lift(
         const nautilus::val<AggregationState*>& aggregationState,
-        nautilus::val<TupleBuffer*>,
+        nautilus::val<Buffer*>,
         PipelineMemoryProvider& pipelineMemoryProvider,
         const Record& record) override;
     void combine(
         nautilus::val<AggregationState*> aggregationState1,
-        nautilus::val<TupleBuffer*>,
+        nautilus::val<Buffer*>,
         nautilus::val<AggregationState*> aggregationState2,
-        nautilus::val<TupleBuffer*>,
+        nautilus::val<Buffer*>,
         PipelineMemoryProvider& pipelineMemoryProvider) override;
     Record lower(
-        nautilus::val<AggregationState*> aggregationState,
-        nautilus::val<TupleBuffer*>,
-        PipelineMemoryProvider& pipelineMemoryProvider) override;
+        nautilus::val<AggregationState*> aggregationState, nautilus::val<Buffer*>, PipelineMemoryProvider& pipelineMemoryProvider) override;
     void reset(
-        nautilus::val<AggregationState*> aggregationState,
-        nautilus::val<TupleBuffer*>,
-        PipelineMemoryProvider& pipelineMemoryProvider) override;
+        nautilus::val<AggregationState*> aggregationState, nautilus::val<Buffer*>, PipelineMemoryProvider& pipelineMemoryProvider) override;
     void cleanup(nautilus::val<AggregationState*> aggregationState) override;
     [[nodiscard]] size_t getSizeOfStateInBytes() const override;
     ~AvgAggregationPhysicalFunction() override = default;

--- a/nes-physical-operators/include/Aggregation/Function/CountAggregationPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Aggregation/Function/CountAggregationPhysicalFunction.hpp
@@ -21,7 +21,7 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/Record.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <val_concepts.hpp>
 #include <val_ptr.hpp>
 
@@ -39,23 +39,19 @@ public:
         bool includeNullValues);
     void lift(
         const nautilus::val<AggregationState*>& aggregationState,
-        nautilus::val<TupleBuffer*>,
+        nautilus::val<Buffer*>,
         PipelineMemoryProvider& pipelineMemoryProvider,
         const Record& record) override;
     void combine(
         nautilus::val<AggregationState*> aggregationState1,
-        nautilus::val<TupleBuffer*>,
+        nautilus::val<Buffer*>,
         nautilus::val<AggregationState*> aggregationState2,
-        nautilus::val<TupleBuffer*>,
+        nautilus::val<Buffer*>,
         PipelineMemoryProvider& pipelineMemoryProvider) override;
     Record lower(
-        nautilus::val<AggregationState*> aggregationState,
-        nautilus::val<TupleBuffer*>,
-        PipelineMemoryProvider& pipelineMemoryProvider) override;
+        nautilus::val<AggregationState*> aggregationState, nautilus::val<Buffer*>, PipelineMemoryProvider& pipelineMemoryProvider) override;
     void reset(
-        nautilus::val<AggregationState*> aggregationState,
-        nautilus::val<TupleBuffer*>,
-        PipelineMemoryProvider& pipelineMemoryProvider) override;
+        nautilus::val<AggregationState*> aggregationState, nautilus::val<Buffer*>, PipelineMemoryProvider& pipelineMemoryProvider) override;
     void cleanup(nautilus::val<AggregationState*> aggregationState) override;
     [[nodiscard]] size_t getSizeOfStateInBytes() const override;
     ~CountAggregationPhysicalFunction() override = default;

--- a/nes-physical-operators/include/Aggregation/Function/MaxAggregationPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Aggregation/Function/MaxAggregationPhysicalFunction.hpp
@@ -21,7 +21,7 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/Record.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <val_concepts.hpp>
 #include <val_ptr.hpp>
 
@@ -35,23 +35,19 @@ public:
         DataType inputType, DataType resultType, PhysicalFunction inputFunction, Record::RecordFieldIdentifier resultFieldIdentifier);
     void lift(
         const nautilus::val<AggregationState*>& aggregationState,
-        nautilus::val<TupleBuffer*>,
+        nautilus::val<Buffer*>,
         PipelineMemoryProvider& pipelineMemoryProvider,
         const Record& record) override;
     void combine(
         nautilus::val<AggregationState*> aggregationState1,
-        nautilus::val<TupleBuffer*>,
+        nautilus::val<Buffer*>,
         nautilus::val<AggregationState*> aggregationState2,
-        nautilus::val<TupleBuffer*>,
+        nautilus::val<Buffer*>,
         PipelineMemoryProvider& pipelineMemoryProvider) override;
     Record lower(
-        nautilus::val<AggregationState*> aggregationState,
-        nautilus::val<TupleBuffer*>,
-        PipelineMemoryProvider& pipelineMemoryProvider) override;
+        nautilus::val<AggregationState*> aggregationState, nautilus::val<Buffer*>, PipelineMemoryProvider& pipelineMemoryProvider) override;
     void reset(
-        nautilus::val<AggregationState*> aggregationState,
-        nautilus::val<TupleBuffer*>,
-        PipelineMemoryProvider& pipelineMemoryProvider) override;
+        nautilus::val<AggregationState*> aggregationState, nautilus::val<Buffer*>, PipelineMemoryProvider& pipelineMemoryProvider) override;
     void cleanup(nautilus::val<AggregationState*> aggregationState) override;
     [[nodiscard]] size_t getSizeOfStateInBytes() const override;
     ~MaxAggregationPhysicalFunction() override = default;

--- a/nes-physical-operators/include/Aggregation/Function/MedianAggregationPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Aggregation/Function/MedianAggregationPhysicalFunction.hpp
@@ -22,7 +22,7 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/PagedVector/PagedVectorRef.hpp>
 #include <Interface/Record.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <val_concepts.hpp>
 #include <val_ptr.hpp>
 
@@ -40,22 +40,22 @@ public:
         std::shared_ptr<PagedVectorTupleLayout> tupleLayout);
     void lift(
         const nautilus::val<AggregationState*>& aggregationState,
-        nautilus::val<TupleBuffer*> parentBuffer,
+        nautilus::val<Buffer*> parentBuffer,
         PipelineMemoryProvider& pipelineMemoryProvider,
         const Record& record) override;
     void combine(
         nautilus::val<AggregationState*> aggregationState1,
-        nautilus::val<TupleBuffer*> parentBuffer1,
+        nautilus::val<Buffer*> parentBuffer1,
         nautilus::val<AggregationState*> aggregationState2,
-        nautilus::val<TupleBuffer*> parentBuffer2,
+        nautilus::val<Buffer*> parentBuffer2,
         PipelineMemoryProvider& pipelineMemoryProvider) override;
     Record lower(
         nautilus::val<AggregationState*> aggregationState,
-        nautilus::val<TupleBuffer*> parentBuffer,
+        nautilus::val<Buffer*> parentBuffer,
         PipelineMemoryProvider& pipelineMemoryProvider) override;
     void reset(
         nautilus::val<AggregationState*> aggregationState,
-        nautilus::val<TupleBuffer*> parentBuffer,
+        nautilus::val<Buffer*> parentBuffer,
         PipelineMemoryProvider& pipelineMemoryProvider) override;
     void cleanup(nautilus::val<AggregationState*> aggregationState) override;
     [[nodiscard]] size_t getSizeOfStateInBytes() const override;

--- a/nes-physical-operators/include/Aggregation/Function/MinAggregationPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Aggregation/Function/MinAggregationPhysicalFunction.hpp
@@ -21,7 +21,7 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/Record.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <val_concepts.hpp>
 #include <val_ptr.hpp>
 
@@ -35,23 +35,19 @@ public:
         DataType inputType, DataType resultType, PhysicalFunction inputFunction, Record::RecordFieldIdentifier resultFieldIdentifier);
     void lift(
         const nautilus::val<AggregationState*>& aggregationState,
-        nautilus::val<TupleBuffer*>,
+        nautilus::val<Buffer*>,
         PipelineMemoryProvider& pipelineMemoryProvider,
         const Record& record) override;
     void combine(
         nautilus::val<AggregationState*> aggregationState1,
-        nautilus::val<TupleBuffer*>,
+        nautilus::val<Buffer*>,
         nautilus::val<AggregationState*> aggregationState2,
-        nautilus::val<TupleBuffer*>,
+        nautilus::val<Buffer*>,
         PipelineMemoryProvider& pipelineMemoryProvider) override;
     Record lower(
-        nautilus::val<AggregationState*> aggregationState,
-        nautilus::val<TupleBuffer*>,
-        PipelineMemoryProvider& pipelineMemoryProvider) override;
+        nautilus::val<AggregationState*> aggregationState, nautilus::val<Buffer*>, PipelineMemoryProvider& pipelineMemoryProvider) override;
     void reset(
-        nautilus::val<AggregationState*> aggregationState,
-        nautilus::val<TupleBuffer*>,
-        PipelineMemoryProvider& pipelineMemoryProvider) override;
+        nautilus::val<AggregationState*> aggregationState, nautilus::val<Buffer*>, PipelineMemoryProvider& pipelineMemoryProvider) override;
     void cleanup(nautilus::val<AggregationState*> aggregationState) override;
     [[nodiscard]] size_t getSizeOfStateInBytes() const override;
     ~MinAggregationPhysicalFunction() override = default;

--- a/nes-physical-operators/include/Aggregation/Function/SumAggregationPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Aggregation/Function/SumAggregationPhysicalFunction.hpp
@@ -21,7 +21,7 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/Record.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <val_concepts.hpp>
 #include <val_ptr.hpp>
 
@@ -35,23 +35,19 @@ public:
         DataType inputType, DataType resultType, PhysicalFunction inputFunction, Record::RecordFieldIdentifier resultFieldIdentifier);
     void lift(
         const nautilus::val<AggregationState*>& aggregationState,
-        nautilus::val<TupleBuffer*>,
+        nautilus::val<Buffer*>,
         PipelineMemoryProvider& pipelineMemoryProvider,
         const Record& record) override;
     void combine(
         nautilus::val<AggregationState*> aggregationState1,
-        nautilus::val<TupleBuffer*>,
+        nautilus::val<Buffer*>,
         nautilus::val<AggregationState*> aggregationState2,
-        nautilus::val<TupleBuffer*>,
+        nautilus::val<Buffer*>,
         PipelineMemoryProvider& pipelineMemoryProvider) override;
     Record lower(
-        nautilus::val<AggregationState*> aggregationState,
-        nautilus::val<TupleBuffer*>,
-        PipelineMemoryProvider& pipelineMemoryProvider) override;
+        nautilus::val<AggregationState*> aggregationState, nautilus::val<Buffer*>, PipelineMemoryProvider& pipelineMemoryProvider) override;
     void reset(
-        nautilus::val<AggregationState*> aggregationState,
-        nautilus::val<TupleBuffer*>,
-        PipelineMemoryProvider& pipelineMemoryProvider) override;
+        nautilus::val<AggregationState*> aggregationState, nautilus::val<Buffer*>, PipelineMemoryProvider& pipelineMemoryProvider) override;
     void cleanup(nautilus::val<AggregationState*> aggregationState) override;
     [[nodiscard]] size_t getSizeOfStateInBytes() const override;
     ~SumAggregationPhysicalFunction() override = default;

--- a/nes-physical-operators/include/EmitOperatorHandler.hpp
+++ b/nes-physical-operators/include/EmitOperatorHandler.hpp
@@ -19,9 +19,9 @@
 #include <ostream>
 #include <Identifiers/Identifiers.hpp>
 #include <Identifiers/NESStrongType.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Runtime/QueryTerminationType.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Util/Logger/Formatter.hpp>
 #include <folly/Synchronized.h>
 
@@ -58,7 +58,7 @@ struct SequenceState
 class EmitOperatorHandler final : public OperatorHandler
 {
 public:
-    void setChunkNumber(bool isEndOfIncomingChunk, ChunkNumber incomingChunkNumber, bool isIncomingBufferTheLastChunk, TupleBuffer& buffer);
+    void setChunkNumber(bool isEndOfIncomingChunk, ChunkNumber incomingChunkNumber, bool isIncomingBufferTheLastChunk, Buffer& buffer);
 
     void start(PipelineExecutionContext& pipelineExecutionContext, uint32_t localStateVariableId) override;
     void stop(QueryTerminationType terminationType, PipelineExecutionContext& pipelineExecutionContext) override;

--- a/nes-physical-operators/include/EmitPhysicalOperator.hpp
+++ b/nes-physical-operators/include/EmitPhysicalOperator.hpp
@@ -17,7 +17,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
 #include <Interface/RecordBuffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
@@ -34,7 +34,7 @@ namespace NES
 class EmitPhysicalOperator final : public PhysicalOperatorConcept
 {
 public:
-    explicit EmitPhysicalOperator(OperatorHandlerId operatorHandlerId, std::shared_ptr<TupleBufferRef> bufferRef);
+    explicit EmitPhysicalOperator(OperatorHandlerId operatorHandlerId, std::shared_ptr<MemoryLayout> bufferRef);
 
     void setup(ExecutionContext&, CompilationContext&) const override { /*noop*/ }
 
@@ -56,7 +56,7 @@ private:
     [[nodiscard]] uint64_t getMaxRecordsPerBuffer() const;
 
     std::optional<PhysicalOperator> child;
-    std::shared_ptr<TupleBufferRef> bufferRef;
+    std::shared_ptr<MemoryLayout> bufferRef;
     OperatorHandlerId operatorHandlerId;
 };
 

--- a/nes-physical-operators/include/EmitPhysicalOperator.hpp
+++ b/nes-physical-operators/include/EmitPhysicalOperator.hpp
@@ -19,7 +19,7 @@
 #include <optional>
 #include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <nautilus/val.hpp>
 #include <CompilationContext.hpp>
@@ -40,12 +40,12 @@ public:
 
     void terminate(ExecutionContext&) const override { /*noop*/ }
 
-    void open(ExecutionContext& ctx, RecordBuffer& recordBuffer) const override;
+    void open(ExecutionContext& ctx, TaskBufferRef& recordBuffer) const override;
     void execute(ExecutionContext& ctx, Record& record) const override;
-    void close(ExecutionContext& ctx, RecordBuffer& recordBuffer) const override;
+    void close(ExecutionContext& ctx, TaskBufferRef& recordBuffer) const override;
     void emitRecordBuffer(
         ExecutionContext& ctx,
-        RecordBuffer& recordBuffer,
+        TaskBufferRef& recordBuffer,
         const nautilus::val<uint64_t>& numRecords,
         const nautilus::val<bool>& potentialLastChunk) const;
 

--- a/nes-physical-operators/include/HashMapSlice.hpp
+++ b/nes-physical-operators/include/HashMapSlice.hpp
@@ -26,7 +26,7 @@
 #include <Interface/HashMap/ChainedHashMap/ChainedHashMap.hpp>
 #include <Interface/HashMap/HashMap.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <SliceStore/Slice.hpp>
 #include <CompilationContext.hpp>
 
@@ -111,10 +111,10 @@ protected:
     /// otherwise. Never allocates, so it is safe to call without synchronization: it only ever reads state that
     /// is either not-yet-written (nullptr) or was already fully written by whichever thread first-touched this
     /// index via getOrCreateHashMapBufferRef.
-    [[nodiscard]] const TupleBuffer* getHashMapBufferRef(ChildBufferIndex childBufferIndex) const;
+    [[nodiscard]] const Buffer* getHashMapBufferRef(ChildBufferIndex childBufferIndex) const;
 
     /// @brief Loads a specific hash map from the slice based on the index, lazily allocating it on first access.
-    [[nodiscard]] const TupleBuffer* getOrCreateHashMapBufferRef(AbstractBufferProvider& bufferProvider, ChildBufferIndex childBufferIndex);
+    [[nodiscard]] const Buffer* getOrCreateHashMapBufferRef(AbstractBufferProvider& bufferProvider, ChildBufferIndex childBufferIndex);
 
     /// metadata
     uint64_t numHashMaps;
@@ -122,7 +122,7 @@ protected:
     uint64_t numHashmapsPerInputStream;
     ChainedHashMapConfig hashMapConfig;
     /// the hash map buffers for the hash map slice
-    std::vector<TupleBuffer> hashMapBuffers;
+    std::vector<Buffer> hashMapBuffers;
     /// Holds the state of whether individual tuplebuffers have been allocated.
     std::vector<HashMapBufferState> hashMapBuffersState;
 };

--- a/nes-physical-operators/include/Join/HashJoin/HJBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJBuildPhysicalOperator.hpp
@@ -14,7 +14,7 @@
 
 #pragma once
 #include <memory>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/PagedVector/PagedVectorRef.hpp>
 #include <Interface/Record.hpp>
 #include <Join/StreamJoinBuildPhysicalOperator.hpp>

--- a/nes-physical-operators/include/Join/HashJoin/HJInnerProbePhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJInnerProbePhysicalOperator.hpp
@@ -17,7 +17,7 @@
 #include <memory>
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/PagedVector/PagedVectorRef.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Join/HashJoin/HJProbePhysicalOperatorBase.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Operators/Windows/JoinLogicalOperator.hpp>
@@ -43,7 +43,7 @@ public:
         HashMapOptions leftHashMapBasedOptions,
         HashMapOptions rightHashMapBasedOptions);
 
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    void open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const override;
 
     static constexpr bool supportsJoinType(JoinLogicalOperator::JoinType joinType) noexcept
     {

--- a/nes-physical-operators/include/Join/HashJoin/HJOuterProbePhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJOuterProbePhysicalOperator.hpp
@@ -25,8 +25,8 @@
 #include <Join/StreamJoinUtil.hpp>
 #include <Operators/Windows/JoinLogicalOperator.hpp>
 #include <Operators/Windows/WindowMetaData.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Time/Timestamp.hpp>
 #include <ExecutionContext.hpp>
 #include <HashMapOptions.hpp>
@@ -64,7 +64,7 @@ private:
     /// `outerOffset`/`innerOffset` are the absolute child-buffer indices (on the record buffer) at which the outer's
     /// resp. inner's hash map buffers start; left hash maps are stored before right ones.
     void performNullFillProbe(
-        const nautilus::val<TupleBuffer*>& recordBufferRef,
+        const nautilus::val<Buffer*>& recordBufferRef,
         nautilus::val<uint64_t> outerOffset,
         nautilus::val<uint64_t> outerNumberOfHashMaps,
         nautilus::val<uint64_t> innerOffset,

--- a/nes-physical-operators/include/Join/HashJoin/HJOuterProbePhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJOuterProbePhysicalOperator.hpp
@@ -19,7 +19,7 @@
 #include <DataTypes/Schema.hpp>
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/PagedVector/PagedVectorRef.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Interface/TimestampRef.hpp>
 #include <Join/HashJoin/HJProbePhysicalOperatorBase.hpp>
 #include <Join/StreamJoinUtil.hpp>
@@ -52,7 +52,7 @@ public:
         HashMapOptions leftHashMapBasedOptions,
         HashMapOptions rightHashMapBasedOptions);
 
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    void open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const override;
 
     static constexpr bool supportsJoinType(JoinLogicalOperator::JoinType joinType) noexcept
     {

--- a/nes-physical-operators/include/Join/HashJoin/HJProbePhysicalOperatorBase.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJProbePhysicalOperatorBase.hpp
@@ -23,8 +23,8 @@
 #include <Join/StreamJoinProbePhysicalOperator.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Operators/Windows/WindowMetaData.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Time/Timestamp.hpp>
 #include <ExecutionContext.hpp>
 #include <HashMapOptions.hpp>
@@ -56,14 +56,14 @@ public:
         HashMapOptions rightHashMapOptions);
 
 protected:
-    /// Pins the hash map TupleBuffer stored as the `index`-th child buffer of the record buffer that `recordBufferRef` points to.
-    static OwnedNautilusBuffer pinHashMapBuffer(const nautilus::val<TupleBuffer*>& recordBufferRef, const nautilus::val<uint64_t>& index);
+    /// Pins the hash map Buffer stored as the `index`-th child buffer of the record buffer that `recordBufferRef` points to.
+    static OwnedNautilusBuffer pinHashMapBuffer(const nautilus::val<Buffer*>& recordBufferRef, const nautilus::val<uint64_t>& index);
 
     /// Match-pairs probe: iterates all left hash maps against all right hash maps and emits joined records.
     /// Left hash map buffers are stored as child buffers [0, leftNumberOfHashMaps) of the record buffer, right ones follow at
     /// [leftNumberOfHashMaps, leftNumberOfHashMaps + rightNumberOfHashMaps).
     void performMatchPairsProbe(
-        const nautilus::val<TupleBuffer*>& recordBufferRef,
+        const nautilus::val<Buffer*>& recordBufferRef,
         nautilus::val<uint64_t> leftNumberOfHashMaps,
         nautilus::val<uint64_t> rightNumberOfHashMaps,
         ExecutionContext& executionCtx,
@@ -71,7 +71,7 @@ protected:
         const nautilus::val<Timestamp>& windowEnd) const;
 
     /// Builds a ChainedHashMapRef view over the hash map stored in `hashMapBufferRef` using the key/value layout described by `options`.
-    static ChainedHashMapRef makeChainedHashMapRef(const nautilus::val<TupleBuffer*>& hashMapBufferRef, const HashMapOptions& options);
+    static ChainedHashMapRef makeChainedHashMapRef(const nautilus::val<Buffer*>& hashMapBufferRef, const HashMapOptions& options);
 
     std::shared_ptr<PagedVectorTupleLayout> leftTupleLayout, rightTupleLayout;
     HashMapOptions leftHashMapOptions, rightHashMapOptions;

--- a/nes-physical-operators/include/Join/HashJoin/HJSlice.hpp
+++ b/nes-physical-operators/include/Join/HashJoin/HJSlice.hpp
@@ -21,7 +21,7 @@
 #include <Interface/HashMap/HashMap.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <SliceStore/Slice.hpp>
 #include <HashMapSlice.hpp>
 
@@ -54,8 +54,8 @@ class HJSlice final : public HashMapSlice
 public:
     HJSlice(
         SliceStart sliceStart, SliceEnd sliceEnd, const CreateNewHashMapSliceArgs& createNewHashMapSliceArgs, uint64_t numberOfHashMaps);
-    [[nodiscard]] const TupleBuffer* getHashMapBufferRefForSide(WorkerThreadId workerThreadId, const JoinBuildSideType& buildSide) const;
-    [[nodiscard]] const TupleBuffer* getOrCreateHashMapBufferRefForSide(
+    [[nodiscard]] const Buffer* getHashMapBufferRefForSide(WorkerThreadId workerThreadId, const JoinBuildSideType& buildSide) const;
+    [[nodiscard]] const Buffer* getOrCreateHashMapBufferRefForSide(
         WorkerThreadId workerThreadId, const JoinBuildSideType& buildSide, AbstractBufferProvider& bufferProvider);
     [[nodiscard]] uint64_t getNumberOfHashMapsForSide() const;
 };

--- a/nes-physical-operators/include/Join/NestedLoopJoin/NLJInnerProbePhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/NestedLoopJoin/NLJInnerProbePhysicalOperator.hpp
@@ -19,7 +19,7 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/PagedVector/PagedVectorRef.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Join/NestedLoopJoin/NLJProbePhysicalOperatorBase.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Operators/Windows/JoinLogicalOperator.hpp>
@@ -44,7 +44,7 @@ public:
         std::vector<Record::RecordFieldIdentifier> leftKeyFieldNames,
         std::vector<Record::RecordFieldIdentifier> rightKeyFieldNames);
 
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    void open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const override;
 
     static constexpr bool supportsJoinType(JoinLogicalOperator::JoinType joinType) noexcept
     {

--- a/nes-physical-operators/include/Join/NestedLoopJoin/NLJOuterProbePhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/NestedLoopJoin/NLJOuterProbePhysicalOperator.hpp
@@ -21,7 +21,7 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/PagedVector/PagedVectorRef.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Interface/TimestampRef.hpp>
 #include <Join/NestedLoopJoin/NLJProbePhysicalOperatorBase.hpp>
 #include <Join/StreamJoinUtil.hpp>
@@ -53,7 +53,7 @@ public:
         std::vector<Record::RecordFieldIdentifier> leftKeyFieldNames,
         std::vector<Record::RecordFieldIdentifier> rightKeyFieldNames);
 
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    void open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const override;
 
     static constexpr bool supportsJoinType(JoinLogicalOperator::JoinType joinType) noexcept
     {

--- a/nes-physical-operators/include/Join/NestedLoopJoin/NLJProbePhysicalOperatorBase.hpp
+++ b/nes-physical-operators/include/Join/NestedLoopJoin/NLJProbePhysicalOperatorBase.hpp
@@ -21,7 +21,7 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/PagedVector/PagedVectorRef.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Interface/TimestampRef.hpp>
 #include <Join/StreamJoinProbePhysicalOperator.hpp>
 #include <Join/StreamJoinUtil.hpp>

--- a/nes-physical-operators/include/Join/NestedLoopJoin/NLJProbePhysicalOperatorBase.hpp
+++ b/nes-physical-operators/include/Join/NestedLoopJoin/NLJProbePhysicalOperatorBase.hpp
@@ -35,7 +35,7 @@ namespace NES
 {
 
 /// Forward declaration suffices: only named as a pointer in getPagedVectorBufferRef's return type below.
-class TupleBuffer;
+class Buffer;
 
 /// Shared base for all NLJ probe operators (inner, outer).
 /// Holds the NLJ-specific state (memory providers, key field names) and the match-pairs nested-loop logic.
@@ -71,7 +71,7 @@ protected:
     /// Resolves the slice owning `sliceEnd` via the operator handler and returns the buffer ref backing its
     /// `side` PagedVector (worker-thread 0, where all pages are consolidated at trigger time). Wrap the result
     /// in BorrowedNautilusBuffer::from(...) together with the matching tuple layout to build a PagedVectorRef.
-    nautilus::val<const TupleBuffer*> getPagedVectorBufferRef(
+    nautilus::val<const Buffer*> getPagedVectorBufferRef(
         const nautilus::val<OperatorHandler*>& operatorHandlerRef, const nautilus::val<SliceEnd>& sliceEnd, JoinBuildSideType side) const;
 
     std::shared_ptr<PagedVectorTupleLayout> leftTupleLayout;

--- a/nes-physical-operators/include/Join/NestedLoopJoin/NLJSlice.hpp
+++ b/nes-physical-operators/include/Join/NestedLoopJoin/NLJSlice.hpp
@@ -21,7 +21,7 @@
 #include <Interface/PagedVector/PagedVector.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <SliceStore/Slice.hpp>
 
 namespace NES
@@ -58,16 +58,16 @@ public:
     [[nodiscard]] uint64_t getNumberOfTuplesRight() const;
 
     /// Returns the pointer to the PagedVector on either side.
-    [[nodiscard]] const TupleBuffer* getPagedVectorRefLeft(WorkerThreadId workerThreadId) const;
-    [[nodiscard]] const TupleBuffer* getPagedVectorRefRight(WorkerThreadId workerThreadId) const;
-    [[nodiscard]] const TupleBuffer* getPagedVectorTupleBufferRef(WorkerThreadId workerThreadId, JoinBuildSideType joinBuildSide) const;
+    [[nodiscard]] const Buffer* getPagedVectorRefLeft(WorkerThreadId workerThreadId) const;
+    [[nodiscard]] const Buffer* getPagedVectorRefRight(WorkerThreadId workerThreadId) const;
+    [[nodiscard]] const Buffer* getPagedVectorTupleBufferRef(WorkerThreadId workerThreadId, JoinBuildSideType joinBuildSide) const;
 
     /// Moves all tuples in this slice to the PagedVector at 0th index on both sides.
     void combinePagedVectors();
 
 private:
-    std::vector<TupleBuffer> leftPagedVectorBuffers;
-    std::vector<TupleBuffer> rightPagedVectorBuffers;
+    std::vector<Buffer> leftPagedVectorBuffers;
+    std::vector<Buffer> rightPagedVectorBuffers;
     std::mutex combinePagedVectorsMutex;
 };
 }

--- a/nes-physical-operators/include/Join/StreamJoinProbePhysicalOperator.hpp
+++ b/nes-physical-operators/include/Join/StreamJoinProbePhysicalOperator.hpp
@@ -20,7 +20,7 @@
 #include <DataTypes/Schema.hpp>
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Operators/Windows/WindowMetaData.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
@@ -45,7 +45,7 @@ public:
     /// Shared open() for all probe operators: copies the record-buffer metadata into the execution
     /// context (this operator acts as a scan) and opens the child pipeline. Concrete probe operators
     /// override open(), call this base version first, then run their probe-specific logic.
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    void open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const override;
 
 protected:
     /// Creates a joined record out of the outer and inner record

--- a/nes-physical-operators/include/PhysicalOperator.hpp
+++ b/nes-physical-operators/include/PhysicalOperator.hpp
@@ -27,7 +27,7 @@
 #include <DataTypes/SchemaFwd.hpp>
 #include <DataTypes/UnboundField.hpp>
 #include <Identifiers/Identifiers.hpp>
-#include <Interface/BufferRef/LowerSchemaProvider.hpp>
+#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
 #include <Interface/Record.hpp>
 #include <Interface/RecordBuffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>

--- a/nes-physical-operators/include/PhysicalOperator.hpp
+++ b/nes-physical-operators/include/PhysicalOperator.hpp
@@ -29,7 +29,7 @@
 #include <Identifiers/Identifiers.hpp>
 #include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Util/Logger/Formatter.hpp>
 #include <Util/PlanRenderer.hpp>
@@ -66,11 +66,11 @@ struct PhysicalOperatorConcept
 
     /// Opens the operator for processing records.
     /// This is called before each batch of records is processed.
-    virtual void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
+    virtual void open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const;
 
     /// Closes the operator after processing records.
     /// This is called after each batch of records is processed.
-    virtual void close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
+    virtual void close(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const;
 
     /// Terminates the operator.
     /// This is called once after all records have been processed.
@@ -85,8 +85,8 @@ struct PhysicalOperatorConcept
 protected:
     /// Helper classes to propagate to the child
     void setupChild(ExecutionContext& executionCtx, CompilationContext& compilationContext) const;
-    void openChild(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
-    void closeChild(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
+    void openChild(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const;
+    void closeChild(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const;
     void executeChild(ExecutionContext& executionCtx, Record& record) const;
     void terminateChild(ExecutionContext& executionCtx) const;
 };
@@ -121,8 +121,8 @@ struct PhysicalOperator
     [[nodiscard]] PhysicalOperator withChild(PhysicalOperator child) const;
 
     void setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const;
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
-    void close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
+    void open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const;
+    void close(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const;
     void terminate(ExecutionContext& executionCtx) const;
     void execute(ExecutionContext& executionCtx, Record& record) const;
     [[nodiscard]] std::string toString() const;
@@ -193,9 +193,9 @@ private:
             data.setup(executionCtx, compilationContext);
         }
 
-        void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override { data.open(executionCtx, recordBuffer); }
+        void open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const override { data.open(executionCtx, recordBuffer); }
 
-        void close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override { data.close(executionCtx, recordBuffer); }
+        void close(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const override { data.close(executionCtx, recordBuffer); }
 
         void terminate(ExecutionContext& executionCtx) const override { data.terminate(executionCtx); }
 

--- a/nes-physical-operators/include/ScanPhysicalOperator.hpp
+++ b/nes-physical-operators/include/ScanPhysicalOperator.hpp
@@ -19,7 +19,7 @@
 #include <vector>
 #include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <PhysicalOperator.hpp>
 
 namespace NES
@@ -32,7 +32,7 @@ class ScanPhysicalOperator final : public PhysicalOperatorConcept
 public:
     explicit ScanPhysicalOperator(std::shared_ptr<MemoryLayout> bufferRef, std::vector<Record::RecordFieldIdentifier> projections);
 
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    void open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const override;
     [[nodiscard]] std::optional<PhysicalOperator> getChild() const override;
     void setChild(PhysicalOperator child) override;
 
@@ -42,7 +42,7 @@ private:
     std::optional<PhysicalOperator> child;
     bool isRawScan = false;
 
-    void rawScan(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const;
+    void rawScan(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const;
 };
 
 }

--- a/nes-physical-operators/include/ScanPhysicalOperator.hpp
+++ b/nes-physical-operators/include/ScanPhysicalOperator.hpp
@@ -17,7 +17,7 @@
 #include <memory>
 #include <optional>
 #include <vector>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
 #include <Interface/RecordBuffer.hpp>
 #include <PhysicalOperator.hpp>
@@ -30,14 +30,14 @@ namespace NES
 class ScanPhysicalOperator final : public PhysicalOperatorConcept
 {
 public:
-    explicit ScanPhysicalOperator(std::shared_ptr<TupleBufferRef> bufferRef, std::vector<Record::RecordFieldIdentifier> projections);
+    explicit ScanPhysicalOperator(std::shared_ptr<MemoryLayout> bufferRef, std::vector<Record::RecordFieldIdentifier> projections);
 
     void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
     [[nodiscard]] std::optional<PhysicalOperator> getChild() const override;
     void setChild(PhysicalOperator child) override;
 
 private:
-    std::shared_ptr<TupleBufferRef> bufferRef;
+    std::shared_ptr<MemoryLayout> bufferRef;
     std::vector<Record::RecordFieldIdentifier> projections;
     std::optional<PhysicalOperator> child;
     bool isRawScan = false;

--- a/nes-physical-operators/include/SliceStore/DefaultTimeBasedSliceStore.hpp
+++ b/nes-physical-operators/include/SliceStore/DefaultTimeBasedSliceStore.hpp
@@ -29,7 +29,7 @@
 
 #include <Identifiers/Identifiers.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <SliceStore/Slice.hpp>
 #include <SliceStore/SliceAssigner.hpp>
 #include <SliceStore/SliceStoreRef.hpp>
@@ -78,7 +78,7 @@ public:
 
 private:
     SliceCacheConfiguration sliceCacheConfiguration;
-    folly::Synchronized<std::unordered_map<PipelineId, std::unique_ptr<TupleBuffer>>> pipelineIdToSliceCacheStarts;
+    folly::Synchronized<std::unordered_map<PipelineId, std::unique_ptr<Buffer>>> pipelineIdToSliceCacheStarts;
 
     /// We need to store the windows and slices in two separate maps. This is necessary as we need to access the slices during the join build phase,
     /// while we need to access windows during the triggering of windows.

--- a/nes-physical-operators/include/SliceStore/DefaultTimeBasedSliceStoreRef.hpp
+++ b/nes-physical-operators/include/SliceStore/DefaultTimeBasedSliceStoreRef.hpp
@@ -24,8 +24,8 @@
 #include <Interface/NautilusBuffer.hpp>
 #include <Interface/TimestampRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <SliceStore/Slice.hpp>
 #include <SliceStore/SliceCache/SliceCache.hpp>
 #include <SliceStore/SliceStoreRef.hpp>
@@ -43,8 +43,8 @@ class DefaultTimeBasedSliceStore;
 class DefaultTimeBasedSliceStoreRef final : public SliceStoreRef
 {
 public:
-    /// Extracts the operator-specific data structure (TupleBuffer) from a Slice.
-    using DataStructureExtractor = std::function<const TupleBuffer*(Slice&, WorkerThreadId, AbstractBufferProvider&)>;
+    /// Extracts the operator-specific data structure (Buffer) from a Slice.
+    using DataStructureExtractor = std::function<const Buffer*(Slice&, WorkerThreadId, AbstractBufferProvider&)>;
 
     /// The function that creates new slices given a start and end timestamp.
     using SliceCreateFunction = std::function<std::vector<std::shared_ptr<Slice>>(SliceStart, SliceEnd)>;

--- a/nes-physical-operators/include/SliceStore/SliceCache/SliceCache.hpp
+++ b/nes-physical-operators/include/SliceStore/SliceCache/SliceCache.hpp
@@ -24,7 +24,7 @@
 #include <Interface/NautilusBuffer.hpp>
 #include <Interface/TimestampRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Time/Timestamp.hpp>
 #include <SliceCacheConfiguration.hpp>
 #include <val_concepts.hpp>
@@ -36,7 +36,7 @@ namespace NES
 /// Represents the C++ struct that is stored in the SliceCache
 struct SliceCacheEntry
 {
-    using DataStructure = const TupleBuffer*;
+    using DataStructure = const Buffer*;
 
     /// As we are doing everything in Nautilus, we do not care about the initialization of these values
     SliceCacheEntry() : sliceStart(0), sliceEnd(0), dataStructure(nullptr) { }

--- a/nes-physical-operators/include/Watermark/EventTimeWatermarkAssignerPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Watermark/EventTimeWatermarkAssignerPhysicalOperator.hpp
@@ -27,9 +27,9 @@ class EventTimeWatermarkAssignerPhysicalOperator : public PhysicalOperatorConcep
 {
 public:
     explicit EventTimeWatermarkAssignerPhysicalOperator(EventTimeFunction timeFunction);
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    void open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const override;
     void execute(ExecutionContext& ctx, Record& record) const override;
-    void close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    void close(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const override;
     [[nodiscard]] std::optional<PhysicalOperator> getChild() const override;
     void setChild(PhysicalOperator child) override;
 

--- a/nes-physical-operators/include/Watermark/IngestionTimeWatermarkAssignerPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Watermark/IngestionTimeWatermarkAssignerPhysicalOperator.hpp
@@ -24,7 +24,7 @@ class IngestionTimeWatermarkAssignerPhysicalOperator : public PhysicalOperatorCo
 {
 public:
     explicit IngestionTimeWatermarkAssignerPhysicalOperator(IngestionTimeFunction timeFunction);
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    void open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const override;
     void execute(ExecutionContext& ctx, Record& record) const override;
     [[nodiscard]] std::optional<PhysicalOperator> getChild() const override;
     void setChild(PhysicalOperator child) override;

--- a/nes-physical-operators/include/Watermark/TimeFunction.hpp
+++ b/nes-physical-operators/include/Watermark/TimeFunction.hpp
@@ -18,7 +18,7 @@
 #include <DataTypes/VarVal.hpp>
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Interface/TimestampRef.hpp>
 #include <Time/Timestamp.hpp>
 #include <WindowTypes/Measures/TimeCharacteristic.hpp>
@@ -37,7 +37,7 @@ namespace NES
 class TimeFunction
 {
 public:
-    virtual void open(ExecutionContext& ctx, RecordBuffer& buffer) const = 0;
+    virtual void open(ExecutionContext& ctx, TaskBufferRef& buffer) const = 0;
     virtual nautilus::val<Timestamp> getTs(ExecutionContext& ctx, Record& record) const = 0;
     virtual ~TimeFunction() = default;
 
@@ -49,7 +49,7 @@ class EventTimeFunction final : public TimeFunction
 {
 public:
     explicit EventTimeFunction(PhysicalFunction timestampFunction, const Windowing::TimeUnit& unit);
-    void open(ExecutionContext& ctx, RecordBuffer& buffer) const override;
+    void open(ExecutionContext& ctx, TaskBufferRef& buffer) const override;
     nautilus::val<Timestamp> getTs(ExecutionContext& ctx, Record& record) const override;
 
     [[nodiscard]] std::unique_ptr<TimeFunction> clone() const override
@@ -65,7 +65,7 @@ private:
 class IngestionTimeFunction final : public TimeFunction
 {
 public:
-    void open(ExecutionContext& ctx, RecordBuffer& buffer) const override;
+    void open(ExecutionContext& ctx, TaskBufferRef& buffer) const override;
     nautilus::val<Timestamp> getTs(ExecutionContext& ctx, Record& record) const override;
 
     [[nodiscard]] std::unique_ptr<TimeFunction> clone() const override { return std::make_unique<IngestionTimeFunction>(); }

--- a/nes-physical-operators/include/WindowBasedOperatorHandler.hpp
+++ b/nes-physical-operators/include/WindowBasedOperatorHandler.hpp
@@ -32,7 +32,7 @@
 namespace NES
 {
 
-/// Stores the metadata for a RecordBuffer
+/// Stores the metadata for a TaskBufferRef
 struct BufferMetaData
 {
     BufferMetaData(const Timestamp watermarkTs, const SequenceData seqNumber, const OriginId originId)

--- a/nes-physical-operators/include/WindowBuildPhysicalOperator.hpp
+++ b/nes-physical-operators/include/WindowBuildPhysicalOperator.hpp
@@ -56,10 +56,10 @@ public:
     void setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const override;
 
     /// Initializes the time function, e.g., method that extracts the timestamp from a record
-    void open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    void open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const override;
 
     /// Passes emits slices that are ready to the second phase (probe) for further processing
-    void close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    void close(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const override;
 
     /// Emits/Flushes all slices and windows, as the query will be terminated
     void terminate(ExecutionContext& executionCtx) const override;

--- a/nes-physical-operators/include/WindowProbePhysicalOperator.hpp
+++ b/nes-physical-operators/include/WindowProbePhysicalOperator.hpp
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <optional>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Operators/Windows/WindowMetaData.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <CompilationContext.hpp>
@@ -37,7 +37,7 @@ public:
     void setup(ExecutionContext& executionCtx, CompilationContext& compilationContext) const override;
 
     /// Checks the current watermark and then deletes all slices and windows that are not valid anymore
-    void close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const override;
+    void close(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const override;
 
     void terminate(ExecutionContext& executionCtx) const override;
 

--- a/nes-physical-operators/src/Aggregation/AggregationOperatorHandler.cpp
+++ b/nes-physical-operators/src/Aggregation/AggregationOperatorHandler.cpp
@@ -29,7 +29,7 @@
 #include <Identifiers/Identifiers.hpp>
 #include <Interface/HashMap/ChainedHashMap/ChainedHashMap.hpp>
 #include <Interface/HashMap/HashMap.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <SliceStore/Slice.hpp>
 #include <SliceStore/WindowSlicesStoreInterface.hpp>
 #include <Util/Logger/Logger.hpp>
@@ -75,7 +75,7 @@ void AggregationOperatorHandler::triggerSlices(
     for (const auto& [windowInfo, allSlices] : slicesAndWindowInfo)
     {
         /// Getting all hashmaps for each slice that has at least one tuple
-        std::vector<TupleBuffer> allHashMapBuffers;
+        std::vector<Buffer> allHashMapBuffers;
         uint64_t totalNumberOfTuples = 0;
         for (const auto& slice : allSlices)
         {
@@ -85,7 +85,7 @@ void AggregationOperatorHandler::triggerSlices(
                 /// Read-only: a hash map no build worker ever touched for this slice is simply skipped rather than
                 /// lazily created here. Trigger-time must never allocate, since that would race with a build worker
                 /// concurrently first-touching the same slot (see HashMapSlice::getOrCreateHashMapBufferRef).
-                const TupleBuffer* hashMapBuffer = aggregationSlice->getHashMapBufferRefForWorker(WorkerThreadId(hashMapIdx));
+                const Buffer* hashMapBuffer = aggregationSlice->getHashMapBufferRefForWorker(WorkerThreadId(hashMapIdx));
                 if (hashMapBuffer == nullptr)
                 {
                     continue;

--- a/nes-physical-operators/src/Aggregation/AggregationProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/Aggregation/AggregationProbePhysicalOperator.cpp
@@ -26,7 +26,7 @@
 #include <Interface/HashMap/HashMap.hpp>
 #include <Interface/NautilusBuffer.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Interface/TimestampRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
@@ -46,7 +46,7 @@
 namespace NES
 {
 
-void AggregationProbePhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void AggregationProbePhysicalOperator::open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const
 {
     /// As this operator functions as a scan, we have to set the execution context for this pipeline
     executionCtx.watermarkTs = recordBuffer.getWatermarkTs();

--- a/nes-physical-operators/src/Aggregation/AggregationProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/Aggregation/AggregationProbePhysicalOperator.cpp
@@ -29,8 +29,8 @@
 #include <Interface/TaskBufferRef.hpp>
 #include <Interface/TimestampRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <SliceStore/WindowSlicesStoreInterface.hpp>
 #include <Time/Timestamp.hpp>
 #include <Util/Logger/Logger.hpp>
@@ -68,7 +68,7 @@ void AggregationProbePhysicalOperator::open(ExecutionContext& executionCtx, Task
     /// create final hash map and pin it
     OwnedNautilusBuffer finalHashMapNautilusBuffer;
     nautilus::invoke(
-        +[](const TupleBuffer* parent, AbstractBufferProvider* bufferProvider, TupleBuffer* finalHashMapBuffer)
+        +[](const Buffer* parent, AbstractBufferProvider* bufferProvider, Buffer* finalHashMapBuffer)
         {
             INVARIANT(parent != nullptr, "Parent Tuplebuffer MUST NOT be null at this point");
             /// load the first hash map
@@ -83,7 +83,7 @@ void AggregationProbePhysicalOperator::open(ExecutionContext& executionCtx, Task
                 .bloomFilter = chm.getBloomFilterParams()};
             auto neededFinalBufferSize
                 = ChainedHashMap::calculateBufferSizeFromChains(chm.getNumberOfChains(), finalConfig.bloomFilterMemAreaSize());
-            std::optional<TupleBuffer> finalHashMapTupleBuffer = bufferProvider->getUnpooledBuffer(neededFinalBufferSize);
+            std::optional<Buffer> finalHashMapTupleBuffer = bufferProvider->getUnpooledBuffer(neededFinalBufferSize);
             if (not finalHashMapTupleBuffer.has_value())
             {
                 throw CannotAllocateBuffer("{}B for the hash join window trigger were requested", neededFinalBufferSize);
@@ -112,7 +112,7 @@ void AggregationProbePhysicalOperator::open(ExecutionContext& executionCtx, Task
         /// Use NautilusBuffer to persist the chained hash map buffer
         OwnedNautilusBuffer hashMapNautilusBuffer;
         nautilus::invoke(
-            +[](TupleBuffer* parent, uint32_t curHashMapIdx, TupleBuffer* hashMapBuffer)
+            +[](Buffer* parent, uint32_t curHashMapIdx, Buffer* hashMapBuffer)
             {
                 INVARIANT(parent != nullptr, "Parent Tuplebuffer MUST NOT be null at this point");
                 const ChildBufferIndex bufferIndex{curHashMapIdx};

--- a/nes-physical-operators/src/Aggregation/AggregationSlice.cpp
+++ b/nes-physical-operators/src/Aggregation/AggregationSlice.cpp
@@ -20,7 +20,7 @@
 #include <Interface/HashMap/ChainedHashMap/ChainedHashMap.hpp>
 #include <Interface/HashMap/HashMap.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <SliceStore/Slice.hpp>
 #include <ErrorHandling.hpp>
 #include <HashMapSlice.hpp>
@@ -36,14 +36,14 @@ AggregationSlice::AggregationSlice(
 {
 }
 
-const TupleBuffer* AggregationSlice::getHashMapBufferRefForWorker(const WorkerThreadId workerThreadId) const
+const Buffer* AggregationSlice::getHashMapBufferRefForWorker(const WorkerThreadId workerThreadId) const
 {
     const auto hashMapIndex = workerThreadId % getNumberOfHashMaps();
     INVARIANT(hashMapIndex < getNumberOfHashMaps(), "The worker thread id should be smaller than the number of hashmaps");
     return getHashMapBufferRef(ChildBufferIndex{static_cast<uint32_t>(hashMapIndex)});
 }
 
-const TupleBuffer*
+const Buffer*
 AggregationSlice::getOrCreateHashMapBufferRefForWorker(AbstractBufferProvider& bufferProvider, const WorkerThreadId workerThreadId)
 {
     const auto hashMapIndex = workerThreadId % getNumberOfHashMaps();

--- a/nes-physical-operators/src/Aggregation/Function/AvgAggregationPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Aggregation/Function/AvgAggregationPhysicalFunction.cpp
@@ -23,7 +23,7 @@
 #include <DataTypes/VarVal.hpp>
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/Record.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <nautilus/std/cstring.h>
 #include <AggregationPhysicalFunctionRegistry.hpp>
 #include <ExecutionContext.hpp>
@@ -50,7 +50,7 @@ AvgAggregationPhysicalFunction::AvgAggregationPhysicalFunction(
 
 void AvgAggregationPhysicalFunction::lift(
     const nautilus::val<AggregationState*>& aggregationState,
-    nautilus::val<TupleBuffer*>,
+    nautilus::val<Buffer*>,
     PipelineMemoryProvider& pipelineMemoryProvider,
     const Record& record)
 {
@@ -99,9 +99,9 @@ void AvgAggregationPhysicalFunction::lift(
 
 void AvgAggregationPhysicalFunction::combine(
     const nautilus::val<AggregationState*> aggregationState1,
-    nautilus::val<TupleBuffer*>,
+    nautilus::val<Buffer*>,
     const nautilus::val<AggregationState*> aggregationState2,
-    nautilus::val<TupleBuffer*>,
+    nautilus::val<Buffer*>,
     PipelineMemoryProvider&)
 {
     if (inputType.nullable)
@@ -156,7 +156,7 @@ void AvgAggregationPhysicalFunction::combine(
 }
 
 Record AvgAggregationPhysicalFunction::lower(
-    const nautilus::val<AggregationState*> aggregationState, nautilus::val<TupleBuffer*>, PipelineMemoryProvider&)
+    const nautilus::val<AggregationState*> aggregationState, nautilus::val<Buffer*>, PipelineMemoryProvider&)
 {
     if (inputType.nullable)
     {
@@ -192,7 +192,7 @@ Record AvgAggregationPhysicalFunction::lower(
 }
 
 void AvgAggregationPhysicalFunction::reset(
-    const nautilus::val<AggregationState*> aggregationState, nautilus::val<TupleBuffer*>, PipelineMemoryProvider&)
+    const nautilus::val<AggregationState*> aggregationState, nautilus::val<Buffer*>, PipelineMemoryProvider&)
 {
     /// Resetting the isNull, sum, and count to 0
     const auto memArea = static_cast<nautilus::val<int8_t*>>(aggregationState);

--- a/nes-physical-operators/src/Aggregation/Function/CountAggregationPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Aggregation/Function/CountAggregationPhysicalFunction.cpp
@@ -23,7 +23,7 @@
 #include <DataTypes/VarVal.hpp>
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/Record.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <nautilus/std/cstring.h>
 #include <AggregationPhysicalFunctionRegistry.hpp>
 #include <ExecutionContext.hpp>
@@ -48,7 +48,7 @@ CountAggregationPhysicalFunction::CountAggregationPhysicalFunction(
 
 void CountAggregationPhysicalFunction::lift(
     const nautilus::val<AggregationState*>& aggregationState,
-    nautilus::val<TupleBuffer*>,
+    nautilus::val<Buffer*>,
     PipelineMemoryProvider& pipelineMemoryProvider,
     const Record& record)
 {
@@ -67,9 +67,9 @@ void CountAggregationPhysicalFunction::lift(
 
 void CountAggregationPhysicalFunction::combine(
     const nautilus::val<AggregationState*> aggregationState1,
-    nautilus::val<TupleBuffer*>,
+    nautilus::val<Buffer*>,
     const nautilus::val<AggregationState*> aggregationState2,
-    nautilus::val<TupleBuffer*>,
+    nautilus::val<Buffer*>,
     PipelineMemoryProvider&)
 {
     /// Reading the count from the first aggregation state
@@ -88,7 +88,7 @@ void CountAggregationPhysicalFunction::combine(
 }
 
 Record CountAggregationPhysicalFunction::lower(
-    const nautilus::val<AggregationState*> aggregationState, nautilus::val<TupleBuffer*>, PipelineMemoryProvider&)
+    const nautilus::val<AggregationState*> aggregationState, nautilus::val<Buffer*>, PipelineMemoryProvider&)
 {
     /// Reading the count from the aggregation state
     const auto memAreaCount = static_cast<nautilus::val<int8_t*>>(aggregationState);
@@ -102,7 +102,7 @@ Record CountAggregationPhysicalFunction::lower(
 }
 
 void CountAggregationPhysicalFunction::reset(
-    const nautilus::val<AggregationState*> aggregationState, nautilus::val<TupleBuffer*>, PipelineMemoryProvider&)
+    const nautilus::val<AggregationState*> aggregationState, nautilus::val<Buffer*>, PipelineMemoryProvider&)
 {
     /// Resetting the count and count to 0
     const auto memArea = static_cast<nautilus::val<int8_t*>>(aggregationState);

--- a/nes-physical-operators/src/Aggregation/Function/MaxAggregationPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Aggregation/Function/MaxAggregationPhysicalFunction.cpp
@@ -23,7 +23,7 @@
 #include <DataTypes/VarVal.hpp>
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/Record.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <AggregationPhysicalFunctionRegistry.hpp>
 #include <ExecutionContext.hpp>
 #include <Util.hpp>
@@ -42,7 +42,7 @@ MaxAggregationPhysicalFunction::MaxAggregationPhysicalFunction(
 
 void MaxAggregationPhysicalFunction::lift(
     const nautilus::val<AggregationState*>& aggregationState,
-    nautilus::val<TupleBuffer*>,
+    nautilus::val<Buffer*>,
     PipelineMemoryProvider& pipelineMemoryProvider,
     const Record& record)
 {
@@ -79,9 +79,9 @@ void MaxAggregationPhysicalFunction::lift(
 
 void MaxAggregationPhysicalFunction::combine(
     const nautilus::val<AggregationState*> aggregationState1,
-    nautilus::val<TupleBuffer*>,
+    nautilus::val<Buffer*>,
     const nautilus::val<AggregationState*> aggregationState2,
-    nautilus::val<TupleBuffer*>,
+    nautilus::val<Buffer*>,
     PipelineMemoryProvider&)
 {
     if (not inputType.nullable)
@@ -118,7 +118,7 @@ void MaxAggregationPhysicalFunction::combine(
 }
 
 Record MaxAggregationPhysicalFunction::lower(
-    const nautilus::val<AggregationState*> aggregationState, nautilus::val<TupleBuffer*>, PipelineMemoryProvider&)
+    const nautilus::val<AggregationState*> aggregationState, nautilus::val<Buffer*>, PipelineMemoryProvider&)
 {
     if (not inputType.nullable)
     {
@@ -144,7 +144,7 @@ Record MaxAggregationPhysicalFunction::lower(
 }
 
 void MaxAggregationPhysicalFunction::reset(
-    const nautilus::val<AggregationState*> aggregationState, nautilus::val<TupleBuffer*>, PipelineMemoryProvider&)
+    const nautilus::val<AggregationState*> aggregationState, nautilus::val<Buffer*>, PipelineMemoryProvider&)
 {
     /// Initialize the null flag to "no value seen yet" so the first non-null input becomes the running max
     if (inputType.nullable)

--- a/nes-physical-operators/src/Aggregation/Function/MedianAggregationPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Aggregation/Function/MedianAggregationPhysicalFunction.cpp
@@ -29,7 +29,7 @@
 #include <nautilus/function.hpp>
 
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <nautilus/std/cstring.h>
 #include <AggregationPhysicalFunctionRegistry.hpp>
 #include <ErrorHandling.hpp>
@@ -55,7 +55,7 @@ MedianAggregationPhysicalFunction::MedianAggregationPhysicalFunction(
 
 void MedianAggregationPhysicalFunction::lift(
     const nautilus::val<AggregationState*>& aggregationState,
-    nautilus::val<TupleBuffer*> parentBuffer,
+    nautilus::val<Buffer*> parentBuffer,
     PipelineMemoryProvider& pipelineMemoryProvider,
     const Record& record)
 {
@@ -72,8 +72,7 @@ void MedianAggregationPhysicalFunction::lift(
             const auto memArea = static_cast<nautilus::val<int8_t*>>(aggregationState + nautilus::val<uint64_t>{1});
             OwnedNautilusBuffer pagedVecBuffer;
             nautilus::invoke(
-                +[](TupleBuffer* parent, TupleBuffer* out, const uint32_t* indexPtr)
-                { *out = parent->loadChildBuffer(ChildBufferIndex{*indexPtr}); },
+                +[](Buffer* parent, Buffer* out, const uint32_t* indexPtr) { *out = parent->loadChildBuffer(ChildBufferIndex{*indexPtr}); },
                 parentBuffer,
                 pagedVecBuffer.asArg(),
                 static_cast<nautilus::val<uint32_t*>>(memArea));
@@ -88,8 +87,7 @@ void MedianAggregationPhysicalFunction::lift(
         const auto memArea = static_cast<nautilus::val<int8_t*>>(aggregationState);
         OwnedNautilusBuffer pagedVecBuffer;
         nautilus::invoke(
-            +[](TupleBuffer* parent, TupleBuffer* out, const uint32_t* indexPtr)
-            { *out = parent->loadChildBuffer(ChildBufferIndex{*indexPtr}); },
+            +[](Buffer* parent, Buffer* out, const uint32_t* indexPtr) { *out = parent->loadChildBuffer(ChildBufferIndex{*indexPtr}); },
             parentBuffer,
             pagedVecBuffer.asArg(),
             static_cast<nautilus::val<uint32_t*>>(memArea));
@@ -101,9 +99,9 @@ void MedianAggregationPhysicalFunction::lift(
 
 void MedianAggregationPhysicalFunction::combine(
     const nautilus::val<AggregationState*> aggregationState1,
-    nautilus::val<TupleBuffer*> parentBuffer1,
+    nautilus::val<Buffer*> parentBuffer1,
     const nautilus::val<AggregationState*> aggregationState2,
-    nautilus::val<TupleBuffer*> parentBuffer2,
+    nautilus::val<Buffer*> parentBuffer2,
     PipelineMemoryProvider& pipelineMemoryProvider)
 {
     auto memArea1 = static_cast<nautilus::val<int8_t*>>(aggregationState1);
@@ -123,14 +121,11 @@ void MedianAggregationPhysicalFunction::combine(
 
     /// Load both paged vector buffers via their stored child indices, then copy pages from source into destination
     nautilus::invoke(
-        +[](AbstractBufferProvider* bufferProvider,
-            TupleBuffer* parent1,
-            const uint32_t* indexPtr1,
-            TupleBuffer* parent2,
-            const uint32_t* indexPtr2) -> void
+        +[](AbstractBufferProvider* bufferProvider, Buffer* parent1, const uint32_t* indexPtr1, Buffer* parent2, const uint32_t* indexPtr2)
+            -> void
         {
-            const TupleBuffer vec1Buf = parent1->loadChildBuffer(ChildBufferIndex{*indexPtr1});
-            const TupleBuffer vec2Buf = parent2->loadChildBuffer(ChildBufferIndex{*indexPtr2});
+            const Buffer vec1Buf = parent1->loadChildBuffer(ChildBufferIndex{*indexPtr1});
+            const Buffer vec2Buf = parent2->loadChildBuffer(ChildBufferIndex{*indexPtr2});
             auto vector1 = PagedVector::load(vec1Buf);
             const auto vector2 = PagedVector::load(vec2Buf);
             vector1.copyPagesFrom(*bufferProvider, vector2);
@@ -144,7 +139,7 @@ void MedianAggregationPhysicalFunction::combine(
 
 Record MedianAggregationPhysicalFunction::lower(
     const nautilus::val<AggregationState*> aggregationState,
-    nautilus::val<TupleBuffer*> parentBuffer,
+    nautilus::val<Buffer*> parentBuffer,
     PipelineMemoryProvider& pipelineMemoryProvider)
 {
     /// If it contains null values, we simply return a null value
@@ -164,14 +159,13 @@ Record MedianAggregationPhysicalFunction::lower(
             = static_cast<nautilus::val<int8_t*>>(aggregationState + nautilus::val<uint64_t>{static_cast<uint64_t>(inputType.nullable)});
         OwnedNautilusBuffer pagedVecBuffer;
         nautilus::invoke(
-            +[](TupleBuffer* parent, TupleBuffer* out, const uint32_t* indexPtr)
-            { *out = parent->loadChildBuffer(ChildBufferIndex{*indexPtr}); },
+            +[](Buffer* parent, Buffer* out, const uint32_t* indexPtr) { *out = parent->loadChildBuffer(ChildBufferIndex{*indexPtr}); },
             parentBuffer,
             pagedVecBuffer.asArg(),
             static_cast<nautilus::val<uint32_t*>>(memArea));
 
         const auto numberOfEntries = invoke(
-            +[](const TupleBuffer* pagedVectorBuffer)
+            +[](const Buffer* pagedVectorBuffer)
             {
                 const auto pagedVector = PagedVector::load(*pagedVectorBuffer);
                 const auto numberOfEntriesVal = pagedVector.getTotalNumberOfRecords();
@@ -258,14 +252,14 @@ Record MedianAggregationPhysicalFunction::lower(
 
 void MedianAggregationPhysicalFunction::reset(
     const nautilus::val<AggregationState*> aggregationState,
-    nautilus::val<TupleBuffer*> parentBuffer,
+    nautilus::val<Buffer*> parentBuffer,
     PipelineMemoryProvider& pipelineMemoryProvider)
 {
     const nautilus::val<uint64_t> tupleSize = tupleLayout->getSchema().getSizeInBytes();
     const nautilus::val<uint32_t> childBufferIndexVal = nautilus::invoke(
-        +[](TupleBuffer* parentBuffer, AbstractBufferProvider* bufferProvider, uint64_t tupleSize)
+        +[](Buffer* parentBuffer, AbstractBufferProvider* bufferProvider, uint64_t tupleSize)
         {
-            /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): aggregation state stores a TupleBuffer at this slot.
+            /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): aggregation state stores a Buffer at this slot.
             if (auto pagedVectorBufferOpt = bufferProvider->getUnpooledBuffer(PagedVector::getMainBufferSize()))
             {
                 /// initialize paged vector buffer
@@ -274,7 +268,7 @@ void MedianAggregationPhysicalFunction::reset(
                 auto childBufferIndex = parentBuffer->storeChildBuffer(pagedVectorBuffer);
                 return childBufferIndex.getRawValue();
             }
-            throw BufferAllocationFailure("No unpooled TupleBuffer available for median aggregation paged vector!");
+            throw BufferAllocationFailure("No unpooled Buffer available for median aggregation paged vector!");
         },
         parentBuffer,
         pipelineMemoryProvider.bufferProvider,
@@ -294,7 +288,7 @@ void MedianAggregationPhysicalFunction::reset(
 
 void MedianAggregationPhysicalFunction::cleanup(nautilus::val<AggregationState*> /*aggregationState*/)
 {
-    /// No-op: the paged vector buffer is stored as a child of the parent hash map TupleBuffer and
+    /// No-op: the paged vector buffer is stored as a child of the parent hash map Buffer and
     /// is released automatically when the parent is released.
 }
 

--- a/nes-physical-operators/src/Aggregation/Function/MinAggregationPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Aggregation/Function/MinAggregationPhysicalFunction.cpp
@@ -23,7 +23,7 @@
 #include <DataTypes/VarVal.hpp>
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/Record.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <AggregationPhysicalFunctionRegistry.hpp>
 #include <ExecutionContext.hpp>
 #include <Util.hpp>
@@ -42,7 +42,7 @@ MinAggregationPhysicalFunction::MinAggregationPhysicalFunction(
 
 void MinAggregationPhysicalFunction::lift(
     const nautilus::val<AggregationState*>& aggregationState,
-    nautilus::val<TupleBuffer*>,
+    nautilus::val<Buffer*>,
     PipelineMemoryProvider& pipelineMemoryProvider,
     const Record& record)
 {
@@ -79,9 +79,9 @@ void MinAggregationPhysicalFunction::lift(
 
 void MinAggregationPhysicalFunction::combine(
     const nautilus::val<AggregationState*> aggregationState1,
-    nautilus::val<TupleBuffer*>,
+    nautilus::val<Buffer*>,
     const nautilus::val<AggregationState*> aggregationState2,
-    nautilus::val<TupleBuffer*>,
+    nautilus::val<Buffer*>,
     PipelineMemoryProvider&)
 {
     if (not inputType.nullable)
@@ -118,7 +118,7 @@ void MinAggregationPhysicalFunction::combine(
 }
 
 Record MinAggregationPhysicalFunction::lower(
-    const nautilus::val<AggregationState*> aggregationState, nautilus::val<TupleBuffer*>, PipelineMemoryProvider&)
+    const nautilus::val<AggregationState*> aggregationState, nautilus::val<Buffer*>, PipelineMemoryProvider&)
 {
     if (not inputType.nullable)
     {
@@ -144,7 +144,7 @@ Record MinAggregationPhysicalFunction::lower(
 }
 
 void MinAggregationPhysicalFunction::reset(
-    const nautilus::val<AggregationState*> aggregationState, nautilus::val<TupleBuffer*>, PipelineMemoryProvider&)
+    const nautilus::val<AggregationState*> aggregationState, nautilus::val<Buffer*>, PipelineMemoryProvider&)
 {
     /// Initialize the null flag to "no value seen yet" so the first non-null input becomes the running min
     if (inputType.nullable)

--- a/nes-physical-operators/src/Aggregation/Function/SumAggregationPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Aggregation/Function/SumAggregationPhysicalFunction.cpp
@@ -23,7 +23,7 @@
 #include <DataTypes/VarVal.hpp>
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/Record.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <nautilus/std/cstring.h>
 #include <AggregationPhysicalFunctionRegistry.hpp>
 #include <ExecutionContext.hpp>
@@ -43,7 +43,7 @@ SumAggregationPhysicalFunction::SumAggregationPhysicalFunction(
 
 void SumAggregationPhysicalFunction::lift(
     const nautilus::val<AggregationState*>& aggregationState,
-    nautilus::val<TupleBuffer*>,
+    nautilus::val<Buffer*>,
     PipelineMemoryProvider& pipelineMemoryProvider,
     const Record& record)
 {
@@ -76,9 +76,9 @@ void SumAggregationPhysicalFunction::lift(
 
 void SumAggregationPhysicalFunction::combine(
     const nautilus::val<AggregationState*> aggregationState1,
-    nautilus::val<TupleBuffer*>,
+    nautilus::val<Buffer*>,
     const nautilus::val<AggregationState*> aggregationState2,
-    nautilus::val<TupleBuffer*>,
+    nautilus::val<Buffer*>,
     PipelineMemoryProvider&)
 {
     if (inputType.nullable)
@@ -117,7 +117,7 @@ void SumAggregationPhysicalFunction::combine(
 }
 
 Record SumAggregationPhysicalFunction::lower(
-    const nautilus::val<AggregationState*> aggregationState, nautilus::val<TupleBuffer*>, PipelineMemoryProvider&)
+    const nautilus::val<AggregationState*> aggregationState, nautilus::val<Buffer*>, PipelineMemoryProvider&)
 {
     if (inputType.nullable)
     {
@@ -144,7 +144,7 @@ Record SumAggregationPhysicalFunction::lower(
 }
 
 void SumAggregationPhysicalFunction::reset(
-    const nautilus::val<AggregationState*> aggregationState, nautilus::val<TupleBuffer*>, PipelineMemoryProvider&)
+    const nautilus::val<AggregationState*> aggregationState, nautilus::val<Buffer*>, PipelineMemoryProvider&)
 {
     /// Resetting the sum to 0
     const auto memArea = static_cast<nautilus::val<int8_t*>>(aggregationState);

--- a/nes-physical-operators/src/EmitOperatorHandler.cpp
+++ b/nes-physical-operators/src/EmitOperatorHandler.cpp
@@ -17,8 +17,8 @@
 #include <cstdint>
 #include <Identifiers/Identifiers.hpp>
 #include <Identifiers/NESStrongType.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/QueryTerminationType.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <ErrorHandling.hpp>
 #include <PipelineExecutionContext.hpp>
@@ -27,7 +27,7 @@ namespace NES
 {
 
 void EmitOperatorHandler::setChunkNumber(
-    bool isEndOfIncomingChunk, ChunkNumber incomingChunkNumber, bool isIncomingBufferTheLastChunk, TupleBuffer& buffer)
+    bool isEndOfIncomingChunk, ChunkNumber incomingChunkNumber, bool isIncomingBufferTheLastChunk, Buffer& buffer)
 {
     /// The SequenceState tracks how many chunks have been seen per Sequence/OriginId pair.
     /// This allows to reason about completeness of a SequenceNumber and assign unique ChunkNumbers to every produced buffer aswell

--- a/nes-physical-operators/src/EmitPhysicalOperator.cpp
+++ b/nes-physical-operators/src/EmitPhysicalOperator.cpp
@@ -22,7 +22,7 @@
 #include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/NESStrongTypeRef.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <nautilus/val.hpp>
@@ -40,18 +40,18 @@ namespace NES
 class EmitState : public OperatorState
 {
 public:
-    explicit EmitState(const RecordBuffer& resultBuffer) : resultBuffer(resultBuffer), bufferMemoryArea(resultBuffer.getMemArea()) { }
+    explicit EmitState(const TaskBufferRef& resultBuffer) : resultBuffer(resultBuffer), bufferMemoryArea(resultBuffer.getMemArea()) { }
 
     nautilus::val<uint64_t> outputIndex = 0;
-    RecordBuffer resultBuffer;
+    TaskBufferRef resultBuffer;
     nautilus::val<int8_t*> bufferMemoryArea;
 };
 
-void EmitPhysicalOperator::open(ExecutionContext& ctx, RecordBuffer&) const
+void EmitPhysicalOperator::open(ExecutionContext& ctx, TaskBufferRef&) const
 {
     /// initialize state variable and create new buffer
     const auto resultBufferRef = ctx.allocateBuffer();
-    const auto resultBuffer = RecordBuffer(resultBufferRef);
+    const auto resultBuffer = TaskBufferRef(resultBufferRef);
     auto emitState = std::make_unique<EmitState>(resultBuffer);
     ctx.setLocalOperatorState(id, std::move(emitState));
 }
@@ -71,7 +71,7 @@ void EmitPhysicalOperator::execute(ExecutionContext& ctx, Record& record) const
     {
         emitRecordBuffer(ctx, emitState->resultBuffer, emitState->outputIndex, false);
         const auto resultBufferRef = ctx.allocateBuffer();
-        emitState->resultBuffer = RecordBuffer(resultBufferRef);
+        emitState->resultBuffer = TaskBufferRef(resultBufferRef);
         emitState->bufferMemoryArea = emitState->resultBuffer.getMemArea();
         emitState->outputIndex = uint64_t{0};
 
@@ -82,7 +82,7 @@ void EmitPhysicalOperator::execute(ExecutionContext& ctx, Record& record) const
     emitState->outputIndex = emitState->outputIndex + writeResult.writtenRecords;
 }
 
-void EmitPhysicalOperator::close(ExecutionContext& ctx, RecordBuffer&) const
+void EmitPhysicalOperator::close(ExecutionContext& ctx, TaskBufferRef&) const
 {
     /// emit current buffer and set the metadata
     auto* const emitState = dynamic_cast<EmitState*>(ctx.getLocalState(id));
@@ -123,7 +123,7 @@ void setChunkNumber(
 
 void EmitPhysicalOperator::emitRecordBuffer(
     ExecutionContext& ctx,
-    RecordBuffer& recordBuffer,
+    TaskBufferRef& recordBuffer,
     const nautilus::val<uint64_t>& numRecords,
     const nautilus::val<bool>& potentialLastChunk) const
 {

--- a/nes-physical-operators/src/EmitPhysicalOperator.cpp
+++ b/nes-physical-operators/src/EmitPhysicalOperator.cpp
@@ -19,7 +19,7 @@
 #include <optional>
 #include <utility>
 #include <Identifiers/Identifiers.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/NESStrongTypeRef.hpp>
 #include <Interface/Record.hpp>
 #include <Interface/RecordBuffer.hpp>
@@ -138,7 +138,7 @@ void EmitPhysicalOperator::emitRecordBuffer(
     ctx.emitBuffer(recordBuffer);
 }
 
-EmitPhysicalOperator::EmitPhysicalOperator(OperatorHandlerId operatorHandlerId, std::shared_ptr<TupleBufferRef> memoryProvider)
+EmitPhysicalOperator::EmitPhysicalOperator(OperatorHandlerId operatorHandlerId, std::shared_ptr<MemoryLayout> memoryProvider)
     : bufferRef(std::move(memoryProvider)), operatorHandlerId(operatorHandlerId)
 {
 }

--- a/nes-physical-operators/src/EmitPhysicalOperator.cpp
+++ b/nes-physical-operators/src/EmitPhysicalOperator.cpp
@@ -97,14 +97,10 @@ void setChunkNumber(
     const nautilus::val<bool>& closesChunk,
     const nautilus::val<ChunkNumber>& currentChunkNumber,
     const nautilus::val<bool>& isCurrentBufferTheLastChunk,
-    const nautilus::val<TupleBuffer*>& newBuffer)
+    const nautilus::val<Buffer*>& newBuffer)
 {
     nautilus::invoke(
-        +[](OperatorHandler* handler,
-            bool closesChunk,
-            ChunkNumber currentChunkNumber,
-            bool isCurrentBufferTheLastChunk,
-            TupleBuffer* newBuffer)
+        +[](OperatorHandler* handler, bool closesChunk, ChunkNumber currentChunkNumber, bool isCurrentBufferTheLastChunk, Buffer* newBuffer)
         {
             PRECONDITION(handler != nullptr, "Expects a valid handler");
             PRECONDITION(newBuffer != nullptr, "Expects a valid buffer");

--- a/nes-physical-operators/src/HashMapSlice.cpp
+++ b/nes-physical-operators/src/HashMapSlice.cpp
@@ -26,7 +26,7 @@
 #include <Interface/HashMap/ChainedHashMap/ChainedHashMap.hpp>
 #include <Interface/HashMap/HashMap.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <SliceStore/Slice.hpp>
 #include <ErrorHandling.hpp>
 
@@ -64,15 +64,14 @@ uint64_t HashMapSlice::getNumHashMapsPerInputStream() const
     return numHashmapsPerInputStream;
 }
 
-const TupleBuffer* HashMapSlice::getHashMapBufferRef(const ChildBufferIndex childBufferIndex) const
+const Buffer* HashMapSlice::getHashMapBufferRef(const ChildBufferIndex childBufferIndex) const
 {
     PRECONDITION(childBufferIndex.getRawValue() < numHashMaps, "Hash Map index out of range in hash map slice getHashMapBufferRef!");
     const auto pos = childBufferIndex.getRawValue();
     return hashMapBuffersState[pos] == HashMapBufferState::INITIALIZED ? &hashMapBuffers[pos] : nullptr;
 }
 
-const TupleBuffer*
-HashMapSlice::getOrCreateHashMapBufferRef(AbstractBufferProvider& bufferProvider, const ChildBufferIndex childBufferIndex)
+const Buffer* HashMapSlice::getOrCreateHashMapBufferRef(AbstractBufferProvider& bufferProvider, const ChildBufferIndex childBufferIndex)
 {
     PRECONDITION(childBufferIndex.getRawValue() < numHashMaps, "Hash Map index out of range in hash map slice loadHashMapBuffer!");
     const auto pos = childBufferIndex.getRawValue();
@@ -90,7 +89,7 @@ HashMapSlice::getOrCreateHashMapBufferRef(AbstractBufferProvider& bufferProvider
         }
         else
         {
-            throw BufferAllocationFailure("No unpooled TupleBuffer available for chained hash map child buffer!");
+            throw BufferAllocationFailure("No unpooled Buffer available for chained hash map child buffer!");
         }
     }
     return &hashMapBuffers[pos];

--- a/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
@@ -19,9 +19,9 @@
 #include <memory>
 #include <utility>
 #include <Identifiers/Identifiers.hpp>
-#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/HashMap/ChainedHashMap/ChainedHashMapRef.hpp>
 #include <Interface/HashMap/HashMap.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/NautilusBuffer.hpp>
 #include <Interface/PagedVector/PagedVector.hpp>
 #include <Interface/PagedVector/PagedVectorRef.hpp>
@@ -31,7 +31,7 @@
 #include <Join/StreamJoinBuildPhysicalOperator.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Time/Timestamp.hpp>
 #include <ErrorHandling.hpp>
 #include <ExecutionContext.hpp>
@@ -94,7 +94,7 @@ void HJBuildPhysicalOperator::execute(ExecutionContext& ctx, Record& record) con
                 const auto state = entryRefReset.getValueMemArea();
                 const nautilus::val<uint64_t> tupleSize = tupleLayout->getSchema().getSizeInBytes();
                 nautilus::invoke(
-                    +[](TupleBuffer* hashMapBuf, uint32_t* valueMemArea, AbstractBufferProvider* bufferProvider, uint64_t tupleSize) -> void
+                    +[](Buffer* hashMapBuf, uint32_t* valueMemArea, AbstractBufferProvider* bufferProvider, uint64_t tupleSize) -> void
                     {
                         if (auto pagedVectorBuffer = bufferProvider->getUnpooledBuffer(PagedVector::getMainBufferSize()))
                         {
@@ -103,7 +103,7 @@ void HJBuildPhysicalOperator::execute(ExecutionContext& ctx, Record& record) con
                             *valueMemArea = childIndex.getRawValue();
                             return;
                         }
-                        throw BufferAllocationFailure("No unpooled TupleBuffer available for chained hash map entry's paged vector!");
+                        throw BufferAllocationFailure("No unpooled Buffer available for chained hash map entry's paged vector!");
                     },
                     hashMapBuffer.asArg(),
                     static_cast<nautilus::val<uint32_t*>>(state),
@@ -118,7 +118,7 @@ void HJBuildPhysicalOperator::execute(ExecutionContext& ctx, Record& record) con
         auto entryMemArea = entryRef.getValueMemArea();
         OwnedNautilusBuffer pagedVecBuffer;
         nautilus::invoke(
-            +[](TupleBuffer* hashMapBuf, TupleBuffer* out, const uint32_t* indexPtr)
+            +[](Buffer* hashMapBuf, Buffer* out, const uint32_t* indexPtr)
             { *out = hashMapBuf->loadChildBuffer(ChildBufferIndex{*indexPtr}); },
             hashMapBuffer.asArg(),
             pagedVecBuffer.asArg(),

--- a/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
@@ -19,7 +19,7 @@
 #include <memory>
 #include <utility>
 #include <Identifiers/Identifiers.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/HashMap/ChainedHashMap/ChainedHashMapRef.hpp>
 #include <Interface/HashMap/HashMap.hpp>
 #include <Interface/NautilusBuffer.hpp>

--- a/nes-physical-operators/src/Join/HashJoin/HJInnerProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJInnerProbePhysicalOperator.cpp
@@ -20,7 +20,7 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/HashMap/HashMap.hpp>
 #include <Interface/PagedVector/PagedVectorRef.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Interface/TimestampRef.hpp>
 #include <Join/HashJoin/HJOperatorHandler.hpp>
 #include <Join/HashJoin/HJProbePhysicalOperatorBase.hpp>
@@ -58,7 +58,7 @@ HJInnerProbePhysicalOperator::HJInnerProbePhysicalOperator(
 {
 }
 
-void HJInnerProbePhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void HJInnerProbePhysicalOperator::open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const
 {
     StreamJoinProbePhysicalOperator::open(executionCtx, recordBuffer);
 

--- a/nes-physical-operators/src/Join/HashJoin/HJOperatorHandler.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJOperatorHandler.cpp
@@ -31,7 +31,7 @@
 #include <Join/HashJoin/HJSlice.hpp>
 #include <Join/StreamJoinOperatorHandler.hpp>
 #include <Join/StreamJoinUtil.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sequencing/SequenceData.hpp>
 #include <SliceStore/Slice.hpp>
 #include <SliceStore/WindowSlicesStoreInterface.hpp>
@@ -48,9 +48,9 @@ namespace
 /// build worker ever touched for this slice is simply skipped, exactly as an untouched slot would be, rather
 /// than being lazily created here. Trigger-time must never allocate, since that would race with a build worker
 /// concurrently first-touching the same slot (see HashMapSlice::getOrCreateHashMapBufferRef).
-std::vector<TupleBuffer> getHashMapsFromSlice(const Slice& slice, JoinBuildSideType side)
+std::vector<Buffer> getHashMapsFromSlice(const Slice& slice, JoinBuildSideType side)
 {
-    std::vector<TupleBuffer> buffers;
+    std::vector<Buffer> buffers;
     const auto* hjSlice = dynamic_cast<const HJSlice*>(&slice);
     INVARIANT(hjSlice != nullptr, "Slice must be of type HJSlice!");
     for (uint64_t i = 0; i < hjSlice->getNumberOfHashMapsForSide(); ++i)
@@ -65,9 +65,9 @@ std::vector<TupleBuffer> getHashMapsFromSlice(const Slice& slice, JoinBuildSideT
 }
 
 /// Collects non-empty hash map buffers from multiple slices for one build side
-std::vector<TupleBuffer> getHashMapsFromSlices(const std::vector<std::shared_ptr<Slice>>& slices, JoinBuildSideType side)
+std::vector<Buffer> getHashMapsFromSlices(const std::vector<std::shared_ptr<Slice>>& slices, JoinBuildSideType side)
 {
-    std::vector<TupleBuffer> allBuffers;
+    std::vector<Buffer> allBuffers;
     for (const auto& slice : slices)
     {
         for (auto& buffer : getHashMapsFromSlice(*slice, side))

--- a/nes-physical-operators/src/Join/HashJoin/HJOuterProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJOuterProbePhysicalOperator.cpp
@@ -23,7 +23,7 @@
 #include <Interface/HashMap/HashMap.hpp>
 #include <Interface/NautilusBuffer.hpp>
 #include <Interface/PagedVector/PagedVectorRef.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Interface/TimestampRef.hpp>
 #include <Join/HashJoin/HJOperatorHandler.hpp>
 #include <Join/HashJoin/HJProbePhysicalOperatorBase.hpp>
@@ -145,7 +145,7 @@ void HJOuterProbePhysicalOperator::performNullFillProbe(
 }
 
 /// NOLINTNEXTLINE(readability-function-cognitive-complexity) outer join dispatches by task type and delegates to inner/null-fill probes
-void HJOuterProbePhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void HJOuterProbePhysicalOperator::open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const
 {
     StreamJoinProbePhysicalOperator::open(executionCtx, recordBuffer);
 

--- a/nes-physical-operators/src/Join/HashJoin/HJOuterProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJOuterProbePhysicalOperator.cpp
@@ -31,8 +31,8 @@
 #include <Join/StreamJoinUtil.hpp>
 #include <Operators/Windows/JoinLogicalOperator.hpp>
 #include <Operators/Windows/WindowMetaData.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <SliceStore/WindowSlicesStoreInterface.hpp>
 #include <Time/Timestamp.hpp>
 #include <magic_enum/magic_enum.hpp>
@@ -58,8 +58,7 @@ loadEntryPagedVector(const ChainedHashMapRef::ChainedEntryRef& entryRef, const s
     auto valueMemArea = entryRef.getValueMemArea();
     OwnedNautilusBuffer pagedVectorBuffer;
     nautilus::invoke(
-        +[](TupleBuffer* hashMapBuf, TupleBuffer* out, const uint32_t* indexPtr)
-        { *out = hashMapBuf->loadChildBuffer(ChildBufferIndex{*indexPtr}); },
+        +[](Buffer* hashMapBuf, Buffer* out, const uint32_t* indexPtr) { *out = hashMapBuf->loadChildBuffer(ChildBufferIndex{*indexPtr}); },
         entryRef.hashMapBuffer,
         pagedVectorBuffer.asArg(),
         static_cast<nautilus::val<uint32_t*>>(valueMemArea));
@@ -91,7 +90,7 @@ HJOuterProbePhysicalOperator::HJOuterProbePhysicalOperator(
 }
 
 void HJOuterProbePhysicalOperator::performNullFillProbe(
-    const nautilus::val<TupleBuffer*>& recordBufferRef,
+    const nautilus::val<Buffer*>& recordBufferRef,
     nautilus::val<uint64_t> outerOffset,
     nautilus::val<uint64_t> outerNumberOfHashMaps,
     nautilus::val<uint64_t> innerOffset,

--- a/nes-physical-operators/src/Join/HashJoin/HJProbePhysicalOperatorBase.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJProbePhysicalOperatorBase.cpp
@@ -26,8 +26,8 @@
 #include <Join/StreamJoinProbePhysicalOperator.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Operators/Windows/WindowMetaData.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Time/Timestamp.hpp>
 #include <ErrorHandling.hpp>
 #include <ExecutionContext.hpp>
@@ -57,13 +57,13 @@ HJProbePhysicalOperatorBase::HJProbePhysicalOperatorBase(
 }
 
 OwnedNautilusBuffer
-HJProbePhysicalOperatorBase::pinHashMapBuffer(const nautilus::val<TupleBuffer*>& recordBufferRef, const nautilus::val<uint64_t>& index)
+HJProbePhysicalOperatorBase::pinHashMapBuffer(const nautilus::val<Buffer*>& recordBufferRef, const nautilus::val<uint64_t>& index)
 {
     OwnedNautilusBuffer hashMapBuffer;
     nautilus::invoke(
-        +[](TupleBuffer* parent, uint32_t idx, TupleBuffer* out)
+        +[](Buffer* parent, uint32_t idx, Buffer* out)
         {
-            INVARIANT(parent != nullptr, "Parent TupleBuffer must not be null when pinning a hash map child buffer");
+            INVARIANT(parent != nullptr, "Parent Buffer must not be null when pinning a hash map child buffer");
             *out = parent->loadChildBuffer(ChildBufferIndex{idx});
         },
         recordBufferRef,
@@ -73,7 +73,7 @@ HJProbePhysicalOperatorBase::pinHashMapBuffer(const nautilus::val<TupleBuffer*>&
 }
 
 ChainedHashMapRef
-HJProbePhysicalOperatorBase::makeChainedHashMapRef(const nautilus::val<TupleBuffer*>& hashMapBufferRef, const HashMapOptions& options)
+HJProbePhysicalOperatorBase::makeChainedHashMapRef(const nautilus::val<Buffer*>& hashMapBufferRef, const HashMapOptions& options)
 {
     return ChainedHashMapRef{
         hashMapBufferRef, options.fieldKeys, options.fieldValues, options.entriesPerPage, options.entrySize, options.bloomFilterParams};
@@ -88,8 +88,7 @@ loadEntryPagedVector(const ChainedHashMapRef::ChainedEntryRef& entryRef, const s
     auto valueMemArea = entryRef.getValueMemArea();
     OwnedNautilusBuffer pagedVectorBuffer;
     nautilus::invoke(
-        +[](TupleBuffer* hashMapBuf, TupleBuffer* out, const uint32_t* indexPtr)
-        { *out = hashMapBuf->loadChildBuffer(ChildBufferIndex{*indexPtr}); },
+        +[](Buffer* hashMapBuf, Buffer* out, const uint32_t* indexPtr) { *out = hashMapBuf->loadChildBuffer(ChildBufferIndex{*indexPtr}); },
         entryRef.hashMapBuffer,
         pagedVectorBuffer.asArg(),
         static_cast<nautilus::val<uint32_t*>>(valueMemArea));
@@ -101,7 +100,7 @@ loadEntryPagedVector(const ChainedHashMapRef::ChainedEntryRef& entryRef, const s
 
 /// NOLINTNEXTLINE(readability-function-cognitive-complexity) inner join's N x N hash-map iteration is inherently deeply nested
 void HJProbePhysicalOperatorBase::performMatchPairsProbe(
-    const nautilus::val<TupleBuffer*>& recordBufferRef,
+    const nautilus::val<Buffer*>& recordBufferRef,
     nautilus::val<uint64_t> leftNumberOfHashMaps,
     nautilus::val<uint64_t> rightNumberOfHashMaps,
     ExecutionContext& executionCtx,

--- a/nes-physical-operators/src/Join/HashJoin/HJSlice.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJSlice.cpp
@@ -22,7 +22,7 @@
 #include <Interface/HashMap/HashMap.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <SliceStore/Slice.hpp>
 #include <ErrorHandling.hpp>
 #include <HashMapSlice.hpp>
@@ -35,7 +35,7 @@ HJSlice::HJSlice(
 {
 }
 
-[[nodiscard]] const TupleBuffer*
+[[nodiscard]] const Buffer*
 HJSlice::getHashMapBufferRefForSide(const WorkerThreadId workerThreadId, const JoinBuildSideType& buildSide) const
 {
     /// Hashmaps of the left build side come before right
@@ -51,7 +51,7 @@ HJSlice::getHashMapBufferRefForSide(const WorkerThreadId workerThreadId, const J
     return getHashMapBufferRef(ChildBufferIndex(pos));
 }
 
-[[nodiscard]] const TupleBuffer* HJSlice::getOrCreateHashMapBufferRefForSide(
+[[nodiscard]] const Buffer* HJSlice::getOrCreateHashMapBufferRefForSide(
     WorkerThreadId workerThreadId, const JoinBuildSideType& buildSide, AbstractBufferProvider& bufferProvider)
 {
     /// Hashmaps of the left build side come before right

--- a/nes-physical-operators/src/Join/NestedLoopJoin/NLJBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/NestedLoopJoin/NLJBuildPhysicalOperator.cpp
@@ -15,7 +15,7 @@
 
 #include <memory>
 #include <utility>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/NautilusBuffer.hpp>
 #include <Interface/PagedVector/PagedVectorRef.hpp>
 #include <Interface/Record.hpp>

--- a/nes-physical-operators/src/Join/NestedLoopJoin/NLJInnerProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/NestedLoopJoin/NLJInnerProbePhysicalOperator.cpp
@@ -25,7 +25,7 @@
 #include <Interface/NautilusBuffer.hpp>
 #include <Interface/PagedVector/PagedVectorRef.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Interface/TimestampRef.hpp>
 #include <Join/NestedLoopJoin/NLJOperatorHandler.hpp>
 #include <Join/NestedLoopJoin/NLJProbePhysicalOperatorBase.hpp>
@@ -65,7 +65,7 @@ NLJInnerProbePhysicalOperator::NLJInnerProbePhysicalOperator(
 {
 }
 
-void NLJInnerProbePhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void NLJInnerProbePhysicalOperator::open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const
 {
     StreamJoinProbePhysicalOperator::open(executionCtx, recordBuffer);
 

--- a/nes-physical-operators/src/Join/NestedLoopJoin/NLJOuterProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/NestedLoopJoin/NLJOuterProbePhysicalOperator.cpp
@@ -26,7 +26,7 @@
 #include <Interface/NautilusBuffer.hpp>
 #include <Interface/PagedVector/PagedVectorRef.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Interface/TimestampRef.hpp>
 #include <Join/NestedLoopJoin/NLJOperatorHandler.hpp>
 #include <Join/NestedLoopJoin/NLJProbePhysicalOperatorBase.hpp>
@@ -123,7 +123,7 @@ void NLJOuterProbePhysicalOperator::performNullFillProbe(
 }
 
 /// NOLINTNEXTLINE(readability-function-cognitive-complexity) outer join dispatches by task type and handles multiple slices
-void NLJOuterProbePhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void NLJOuterProbePhysicalOperator::open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const
 {
     StreamJoinProbePhysicalOperator::open(executionCtx, recordBuffer);
 

--- a/nes-physical-operators/src/Join/NestedLoopJoin/NLJProbePhysicalOperatorBase.cpp
+++ b/nes-physical-operators/src/Join/NestedLoopJoin/NLJProbePhysicalOperatorBase.cpp
@@ -102,7 +102,7 @@ void NLJProbePhysicalOperatorBase::performNLJ(
     }
 }
 
-nautilus::val<const TupleBuffer*> NLJProbePhysicalOperatorBase::getPagedVectorBufferRef(
+nautilus::val<const Buffer*> NLJProbePhysicalOperatorBase::getPagedVectorBufferRef(
     const nautilus::val<OperatorHandler*>& operatorHandlerRef, const nautilus::val<SliceEnd>& sliceEnd, const JoinBuildSideType side) const
 {
     /// During triggering, all pages of all local copies are appended to a single PagedVector at worker-thread 0.

--- a/nes-physical-operators/src/Join/NestedLoopJoin/NLJSlice.cpp
+++ b/nes-physical-operators/src/Join/NestedLoopJoin/NLJSlice.cpp
@@ -50,7 +50,7 @@ NLJSlice::NLJSlice(
         }
         else
         {
-            throw BufferAllocationFailure("No unpooled TupleBuffer available for NLJ left paged vector main buffer");
+            throw BufferAllocationFailure("No unpooled Buffer available for NLJ left paged vector main buffer");
         }
     }
 
@@ -64,7 +64,7 @@ NLJSlice::NLJSlice(
         }
         else
         {
-            throw BufferAllocationFailure("No unpooled TupleBuffer available for NLJ right paged vector main buffer");
+            throw BufferAllocationFailure("No unpooled Buffer available for NLJ right paged vector main buffer");
         }
     }
 }
@@ -75,7 +75,7 @@ uint64_t NLJSlice::getNumberOfTuplesLeft() const
         leftPagedVectorBuffers.begin(),
         leftPagedVectorBuffers.end(),
         0,
-        [](uint64_t sum, const TupleBuffer& buf)
+        [](uint64_t sum, const Buffer& buf)
         {
             auto pagedVector = PagedVector::load(buf);
             return sum + pagedVector.getTotalNumberOfRecords();
@@ -88,26 +88,26 @@ uint64_t NLJSlice::getNumberOfTuplesRight() const
         rightPagedVectorBuffers.begin(),
         rightPagedVectorBuffers.end(),
         0,
-        [](uint64_t sum, const TupleBuffer& buf)
+        [](uint64_t sum, const Buffer& buf)
         {
             auto pagedVector = PagedVector::load(buf);
             return sum + pagedVector.getTotalNumberOfRecords();
         });
 }
 
-const TupleBuffer* NLJSlice::getPagedVectorRefLeft(const WorkerThreadId workerThreadId) const
+const Buffer* NLJSlice::getPagedVectorRefLeft(const WorkerThreadId workerThreadId) const
 {
     const auto pos = workerThreadId % leftPagedVectorBuffers.size();
     return &leftPagedVectorBuffers[pos];
 }
 
-const TupleBuffer* NLJSlice::getPagedVectorRefRight(const WorkerThreadId workerThreadId) const
+const Buffer* NLJSlice::getPagedVectorRefRight(const WorkerThreadId workerThreadId) const
 {
     const auto pos = workerThreadId % rightPagedVectorBuffers.size();
     return &rightPagedVectorBuffers[pos];
 }
 
-const TupleBuffer* NLJSlice::getPagedVectorTupleBufferRef(const WorkerThreadId workerThreadId, const JoinBuildSideType joinBuildSide) const
+const Buffer* NLJSlice::getPagedVectorTupleBufferRef(const WorkerThreadId workerThreadId, const JoinBuildSideType joinBuildSide) const
 {
     switch (joinBuildSide)
     {

--- a/nes-physical-operators/src/Join/StreamJoinBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/StreamJoinBuildPhysicalOperator.cpp
@@ -15,7 +15,7 @@
 
 #include <memory>
 #include <utility>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/PagedVector/PagedVectorRef.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>

--- a/nes-physical-operators/src/Join/StreamJoinProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/StreamJoinProbePhysicalOperator.cpp
@@ -25,7 +25,7 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Interface/TimestampRef.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Operators/Windows/WindowMetaData.hpp>
@@ -92,7 +92,7 @@ StreamJoinProbePhysicalOperator::StreamJoinProbePhysicalOperator(
 {
 }
 
-void StreamJoinProbePhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void StreamJoinProbePhysicalOperator::open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const
 {
     executionCtx.watermarkTs = recordBuffer.getWatermarkTs();
     executionCtx.currentTs = recordBuffer.getCreatingTs();

--- a/nes-physical-operators/src/PhysicalOperator.cpp
+++ b/nes-physical-operators/src/PhysicalOperator.cpp
@@ -24,7 +24,7 @@
 #include <DataTypes/UnboundField.hpp>
 #include <DataTypes/UnboundSchema.hpp> /// NOLINT(misc-include-cleaner)
 #include <Identifiers/Identifiers.hpp>
-#include <Interface/BufferRef/LowerSchemaProvider.hpp>
+#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
 #include <Interface/Record.hpp>
 #include <Interface/RecordBuffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>

--- a/nes-physical-operators/src/PhysicalOperator.cpp
+++ b/nes-physical-operators/src/PhysicalOperator.cpp
@@ -26,7 +26,7 @@
 #include <Identifiers/Identifiers.hpp>
 #include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Util/PlanRenderer.hpp>
 #include <fmt/format.h>
@@ -51,12 +51,12 @@ void PhysicalOperatorConcept::setup(ExecutionContext& executionCtx, CompilationC
     setupChild(executionCtx, compilationContext);
 }
 
-void PhysicalOperatorConcept::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void PhysicalOperatorConcept::open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const
 {
     openChild(executionCtx, recordBuffer);
 }
 
-void PhysicalOperatorConcept::close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void PhysicalOperatorConcept::close(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const
 {
     closeChild(executionCtx, recordBuffer);
 }
@@ -77,13 +77,13 @@ void PhysicalOperatorConcept::setupChild(ExecutionContext& executionCtx, Compila
     getChild().value().setup(executionCtx, compilationContext);
 }
 
-void PhysicalOperatorConcept::openChild(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void PhysicalOperatorConcept::openChild(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const
 {
     INVARIANT(getChild().has_value(), "Child operator is not set");
     getChild().value().open(executionCtx, recordBuffer);
 }
 
-void PhysicalOperatorConcept::closeChild(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void PhysicalOperatorConcept::closeChild(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const
 {
     INVARIANT(getChild().has_value(), "Child operator is not set");
     getChild().value().close(executionCtx, recordBuffer);
@@ -133,12 +133,12 @@ void PhysicalOperator::setup(ExecutionContext& executionCtx, CompilationContext&
     self->setup(executionCtx, compilationContext);
 }
 
-void PhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void PhysicalOperator::open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const
 {
     self->open(executionCtx, recordBuffer);
 }
 
-void PhysicalOperator::close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void PhysicalOperator::close(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const
 {
     self->close(executionCtx, recordBuffer);
 }

--- a/nes-physical-operators/src/ScanPhysicalOperator.cpp
+++ b/nes-physical-operators/src/ScanPhysicalOperator.cpp
@@ -33,8 +33,7 @@
 namespace NES
 {
 
-ScanPhysicalOperator::ScanPhysicalOperator(
-    std::shared_ptr<MemoryLayout> bufferRef, std::vector<Record::RecordFieldIdentifier> projections)
+ScanPhysicalOperator::ScanPhysicalOperator(std::shared_ptr<MemoryLayout> bufferRef, std::vector<Record::RecordFieldIdentifier> projections)
     : bufferRef(std::move(bufferRef))
     , projections(std::move(projections))
     , isRawScan(std::dynamic_pointer_cast<InputFormatter>(this->bufferRef) != nullptr)

--- a/nes-physical-operators/src/ScanPhysicalOperator.cpp
+++ b/nes-physical-operators/src/ScanPhysicalOperator.cpp
@@ -23,7 +23,7 @@
 
 #include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <ExecutionContext.hpp>
 #include <InputFormatter.hpp>
 #include <PhysicalOperator.hpp>
@@ -41,7 +41,7 @@ ScanPhysicalOperator::ScanPhysicalOperator(
 {
 }
 
-void ScanPhysicalOperator::rawScan(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void ScanPhysicalOperator::rawScan(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const
 {
     auto inputFormatterBufferRef = std::dynamic_pointer_cast<InputFormatter>(this->bufferRef);
 
@@ -59,7 +59,7 @@ void ScanPhysicalOperator::rawScan(ExecutionContext& executionCtx, RecordBuffer&
     inputFormatterBufferRef->readBuffer(executionCtx, recordBuffer, executeChildLambda);
 }
 
-void ScanPhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void ScanPhysicalOperator::open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const
 {
     /// initialize global state variables to keep track of the watermark ts and the origin id
     executionCtx.watermarkTs = recordBuffer.getWatermarkTs();

--- a/nes-physical-operators/src/ScanPhysicalOperator.cpp
+++ b/nes-physical-operators/src/ScanPhysicalOperator.cpp
@@ -21,7 +21,7 @@
 #include <utility>
 #include <vector>
 
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
 #include <Interface/RecordBuffer.hpp>
 #include <ExecutionContext.hpp>
@@ -34,7 +34,7 @@ namespace NES
 {
 
 ScanPhysicalOperator::ScanPhysicalOperator(
-    std::shared_ptr<TupleBufferRef> bufferRef, std::vector<Record::RecordFieldIdentifier> projections)
+    std::shared_ptr<MemoryLayout> bufferRef, std::vector<Record::RecordFieldIdentifier> projections)
     : bufferRef(std::move(bufferRef))
     , projections(std::move(projections))
     , isRawScan(std::dynamic_pointer_cast<InputFormatter>(this->bufferRef) != nullptr)

--- a/nes-physical-operators/src/SliceStore/DefaultTimeBasedSliceStore.cpp
+++ b/nes-physical-operators/src/SliceStore/DefaultTimeBasedSliceStore.cpp
@@ -27,7 +27,7 @@
 #include <Identifiers/Identifiers.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <SliceStore/DefaultTimeBasedSliceStoreRef.hpp>
 #include <SliceStore/Slice.hpp>
 #include <SliceStore/SliceAssigner.hpp>
@@ -302,7 +302,7 @@ std::span<std::byte> DefaultTimeBasedSliceStore::allocateSpaceForSliceCache(
 
     /// We set everything to 0, as there might be old data in the tuple buffer
     std::ranges::fill(buffer.value().getAvailableMemoryArea(), std::byte{0});
-    auto sliceCacheStartBuffer = std::make_unique<TupleBuffer>(buffer.value());
+    auto sliceCacheStartBuffer = std::make_unique<Buffer>(buffer.value());
     const auto& memArea = sliceCacheStartBuffer->getAvailableMemoryArea();
     pipelineIdToSliceCacheStarts.wlock()->emplace(pipelineId, std::move(sliceCacheStartBuffer));
     return memArea;

--- a/nes-physical-operators/src/Watermark/EventTimeWatermarkAssignerPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Watermark/EventTimeWatermarkAssignerPhysicalOperator.cpp
@@ -17,7 +17,7 @@
 #include <optional>
 #include <utility>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Interface/TimestampRef.hpp>
 #include <Time/Timestamp.hpp>
 #include <Watermark/TimeFunction.hpp>
@@ -30,7 +30,7 @@ namespace NES
 EventTimeWatermarkAssignerPhysicalOperator::EventTimeWatermarkAssignerPhysicalOperator(EventTimeFunction timeFunction)
     : timeFunction(std::move(timeFunction)) { };
 
-void EventTimeWatermarkAssignerPhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void EventTimeWatermarkAssignerPhysicalOperator::open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const
 {
     openChild(executionCtx, recordBuffer);
     executionCtx.watermarkTs = nautilus::val<Timestamp>(Timestamp(Timestamp::INITIAL_VALUE));
@@ -48,7 +48,7 @@ void EventTimeWatermarkAssignerPhysicalOperator::execute(ExecutionContext& ctx, 
     executeChild(ctx, record);
 }
 
-void EventTimeWatermarkAssignerPhysicalOperator::close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void EventTimeWatermarkAssignerPhysicalOperator::close(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const
 {
     PhysicalOperatorConcept::close(executionCtx, recordBuffer);
 }

--- a/nes-physical-operators/src/Watermark/IngestionTimeWatermarkAssignerPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Watermark/IngestionTimeWatermarkAssignerPhysicalOperator.cpp
@@ -17,7 +17,7 @@
 #include <optional>
 #include <utility>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Watermark/TimeFunction.hpp>
 #include <ExecutionContext.hpp>
 #include <PhysicalOperator.hpp>
@@ -28,7 +28,7 @@ namespace NES
 IngestionTimeWatermarkAssignerPhysicalOperator::IngestionTimeWatermarkAssignerPhysicalOperator(IngestionTimeFunction timeFunction)
     : timeFunction(std::move(timeFunction)) { };
 
-void IngestionTimeWatermarkAssignerPhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void IngestionTimeWatermarkAssignerPhysicalOperator::open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const
 {
     openChild(executionCtx, recordBuffer);
     timeFunction.open(executionCtx, recordBuffer);

--- a/nes-physical-operators/src/Watermark/TimeFunction.cpp
+++ b/nes-physical-operators/src/Watermark/TimeFunction.cpp
@@ -22,7 +22,7 @@
 #include <Functions/FieldAccessPhysicalFunction.hpp>
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Interface/TimestampRef.hpp>
 #include <Time/Timestamp.hpp>
 #include <Util/Overloaded.hpp>
@@ -47,7 +47,7 @@ std::unique_ptr<TimeFunction> TimeFunction::create(const Windowing::BoundTimeCha
         timeCharacteristic);
 }
 
-void EventTimeFunction::open(ExecutionContext&, RecordBuffer&) const
+void EventTimeFunction::open(ExecutionContext&, TaskBufferRef&) const
 {
     /// nop
 }
@@ -66,7 +66,7 @@ nautilus::val<Timestamp> EventTimeFunction::getTs(ExecutionContext& ctx, Record&
     return tsInMs;
 }
 
-void IngestionTimeFunction::open(ExecutionContext& ctx, RecordBuffer& buffer) const
+void IngestionTimeFunction::open(ExecutionContext& ctx, TaskBufferRef& buffer) const
 {
     ctx.currentTs = buffer.getCreatingTs();
 }

--- a/nes-physical-operators/src/WindowBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/WindowBuildPhysicalOperator.cpp
@@ -17,7 +17,7 @@
 #include <optional>
 #include <utility>
 #include <Identifiers/Identifiers.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <SliceStore/SliceStoreRef.hpp>
@@ -68,7 +68,7 @@ void registerActivePipeline(OperatorHandler* ptrOpHandler)
     opHandler->getSliceAndWindowStore().incrementNumberOfInputPipelines();
 }
 
-void WindowBuildPhysicalOperator::close(ExecutionContext& executionCtx, RecordBuffer&) const
+void WindowBuildPhysicalOperator::close(ExecutionContext& executionCtx, TaskBufferRef&) const
 {
     /// Update the watermark for the nlj operator and trigger slices
     auto operatorHandlerMemRef = executionCtx.getGlobalOperatorHandler(operatorHandlerId);
@@ -91,7 +91,7 @@ void WindowBuildPhysicalOperator::setup(ExecutionContext& executionCtx, Compilat
     sliceStoreRef->setupSliceStore(executionCtx.pipelineContext);
 }
 
-void WindowBuildPhysicalOperator::open(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void WindowBuildPhysicalOperator::open(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const
 {
     /// Initializing the time function
     timeFunction->open(executionCtx, recordBuffer);

--- a/nes-physical-operators/src/WindowProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/WindowProbePhysicalOperator.cpp
@@ -16,7 +16,7 @@
 #include <optional>
 #include <utility>
 #include <Identifiers/Identifiers.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Join/StreamJoinUtil.hpp>
 #include <Operators/Windows/WindowMetaData.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
@@ -81,7 +81,7 @@ void WindowProbePhysicalOperator::setup(ExecutionContext& executionCtx, Compilat
     invoke(setupProxy, executionCtx.getGlobalOperatorHandler(operatorHandlerId), executionCtx.pipelineContext);
 }
 
-void WindowProbePhysicalOperator::close(ExecutionContext& executionCtx, RecordBuffer& recordBuffer) const
+void WindowProbePhysicalOperator::close(ExecutionContext& executionCtx, TaskBufferRef& recordBuffer) const
 {
     /// Update the watermark for the probe and delete all slices that can be deleted
     const auto operatorHandlerMemRef = executionCtx.getGlobalOperatorHandler(operatorHandlerId);

--- a/nes-physical-operators/tests/AndOrPhysicalFunctionTest.cpp
+++ b/nes-physical-operators/tests/AndOrPhysicalFunctionTest.cpp
@@ -25,8 +25,8 @@
 #include <Identifiers/Identifier.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/Allocator/NesDefaultMemoryAllocator.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/BufferManager.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Util/Logger/LogLevel.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <Util/Logger/impl/NesLogger.hpp>

--- a/nes-physical-operators/tests/EmitPhysicalOperatorTest.cpp
+++ b/nes-physical-operators/tests/EmitPhysicalOperatorTest.cpp
@@ -36,7 +36,7 @@
 #include <Identifiers/NESStrongType.hpp>
 #include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
 #include <Interface/MemoryLayout/RowLayout.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/Allocator/NesDefaultMemoryAllocator.hpp>
 #include <Runtime/BufferManager.hpp>
@@ -146,7 +146,7 @@ public:
         return emit;
     }
 
-    void run(const std::function<void(ExecutionContext&, RecordBuffer&)>& test, TupleBuffer buffer)
+    void run(const std::function<void(ExecutionContext&, TaskBufferRef&)>& test, TupleBuffer buffer)
     {
         MockedPipelineContext pec{buffers, bm};
         pec.setOperatorHandlers(handlers);
@@ -157,7 +157,7 @@ public:
         executionContext.sequenceNumber = buffer.getSequenceNumber(), executionContext.lastChunk = buffer.isLastChunk();
         executionContext.originId = buffer.getOriginId();
 
-        RecordBuffer recordBuffer(std::addressof(buffer));
+        TaskBufferRef recordBuffer(std::addressof(buffer));
         test(executionContext, recordBuffer);
     }
 

--- a/nes-physical-operators/tests/EmitPhysicalOperatorTest.cpp
+++ b/nes-physical-operators/tests/EmitPhysicalOperatorTest.cpp
@@ -39,9 +39,9 @@
 #include <Interface/TaskBufferRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/Allocator/NesDefaultMemoryAllocator.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/BufferManager.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Sequencing/SequenceData.hpp>
 #include <Util/Logger/LogLevel.hpp>
 #include <Util/Logger/Logger.hpp>
@@ -76,17 +76,17 @@ class EmitPhysicalOperatorTest : public Testing::BaseUnitTest
 {
     struct MockedPipelineContext final : PipelineExecutionContext
     {
-        bool emitBuffer(const TupleBuffer& buffer, ContinuationPolicy) override
+        bool emitBuffer(const Buffer& buffer, ContinuationPolicy) override
         {
             buffers.wlock()->emplace_back(buffer);
             return true;
         }
 
-        TupleBuffer allocateTupleBuffer() override { return bufferManager->getBufferBlocking(); }
+        Buffer allocateTupleBuffer() override { return bufferManager->getBufferBlocking(); }
 
-        TupleBuffer& pinBuffer(TupleBuffer&& tupleBuffer) override
+        Buffer& pinBuffer(Buffer&& tupleBuffer) override
         {
-            pinnedBuffers.emplace_back(std::make_unique<TupleBuffer>(tupleBuffer));
+            pinnedBuffers.emplace_back(std::make_unique<Buffer>(tupleBuffer));
             return *pinnedBuffers.back();
         }
 
@@ -108,20 +108,20 @@ class EmitPhysicalOperatorTest : public Testing::BaseUnitTest
             operatorHandlers = &opHandlers;
         }
 
-        MockedPipelineContext(folly::Synchronized<std::vector<TupleBuffer>>& buffers, std::shared_ptr<BufferManager> bufferManager)
+        MockedPipelineContext(folly::Synchronized<std::vector<Buffer>>& buffers, std::shared_ptr<BufferManager> bufferManager)
             : buffers(buffers), bufferManager(std::move(bufferManager))
         {
         }
 
-        void repeatTask(const TupleBuffer&, std::chrono::milliseconds) override { INVARIANT(false, "This function should not be called"); }
+        void repeatTask(const Buffer&, std::chrono::milliseconds) override { INVARIANT(false, "This function should not be called"); }
 
         ///NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members) lifetime is ensured by the `run` method.
-        folly::Synchronized<std::vector<TupleBuffer>>& buffers;
+        folly::Synchronized<std::vector<Buffer>>& buffers;
         std::shared_ptr<BufferManager> bufferManager;
         std::unordered_map<OperatorHandlerId, std::shared_ptr<OperatorHandler>>* operatorHandlers = nullptr;
-        /// We want to ensure that the address of the TupleBuffer is always the same. If we would simply store the object directly in the vector,
+        /// We want to ensure that the address of the Buffer is always the same. If we would simply store the object directly in the vector,
         /// the address might change as the vector might be resized and thus, the object have a different address.
-        std::vector<std::unique_ptr<TupleBuffer>> pinnedBuffers;
+        std::vector<std::unique_ptr<Buffer>> pinnedBuffers;
     };
 
 public:
@@ -146,7 +146,7 @@ public:
         return emit;
     }
 
-    void run(const std::function<void(ExecutionContext&, TaskBufferRef&)>& test, TupleBuffer buffer)
+    void run(const std::function<void(ExecutionContext&, TaskBufferRef&)>& test, Buffer buffer)
     {
         MockedPipelineContext pec{buffers, bm};
         pec.setOperatorHandlers(handlers);
@@ -229,7 +229,7 @@ public:
         }
     }
 
-    TupleBuffer createBuffer(
+    Buffer createBuffer(
         SequenceNumber::Underlying sequence,
         ChunkNumber::Underlying chunkNumber,
         bool isLastChunk = false,
@@ -250,7 +250,7 @@ public:
 
     void reset() { buffers.wlock()->clear(); }
 
-    folly::Synchronized<std::vector<TupleBuffer>> buffers;
+    folly::Synchronized<std::vector<Buffer>> buffers;
     std::shared_ptr<BufferManager> bm = BufferManager::create(
         TOTAL_MEMORY_IN_BYTES,
         UNPOOLED_MEMORY_FRACTION,
@@ -282,7 +282,7 @@ TEST_F(EmitPhysicalOperatorTest, BasicTest)
 
 TEST_F(EmitPhysicalOperatorTest, ChunkNumberTest)
 {
-    std::vector<TupleBuffer> inputBuffers;
+    std::vector<Buffer> inputBuffers;
     inputBuffers.emplace_back(createBuffer(SequenceNumber::INITIAL, ChunkNumber::INITIAL, false));
     inputBuffers.emplace_back(createBuffer(SequenceNumber::INITIAL, ChunkNumber::INITIAL + 1, false));
     inputBuffers.emplace_back(createBuffer(SequenceNumber::INITIAL, ChunkNumber::INITIAL + 2, false));
@@ -313,7 +313,7 @@ TEST_F(EmitPhysicalOperatorTest, ChunkNumberTest)
         hasMorePermutations = std::ranges::next_permutation(
                                   inputBuffers,
                                   std::less{},
-                                  [](const TupleBuffer& buffer)
+                                  [](const Buffer& buffer)
                                   { return SequenceData(buffer.getSequenceNumber(), buffer.getChunkNumber(), buffer.isLastChunk()); })
                                   .found;
     }
@@ -324,7 +324,7 @@ TEST_F(EmitPhysicalOperatorTest, ChunkNumberTest)
 /// marked as the last chunk, and no duplicates.
 TEST_F(EmitPhysicalOperatorTest, SequenceChunkNumberTest)
 {
-    std::vector<TupleBuffer> inputBuffers;
+    std::vector<Buffer> inputBuffers;
     inputBuffers.emplace_back(createBuffer(SequenceNumber::INITIAL, ChunkNumber::INITIAL, false));
     inputBuffers.emplace_back(createBuffer(SequenceNumber::INITIAL, ChunkNumber::INITIAL + 1, false));
     inputBuffers.emplace_back(createBuffer(SequenceNumber::INITIAL, ChunkNumber::INITIAL + 2, true));
@@ -357,7 +357,7 @@ TEST_F(EmitPhysicalOperatorTest, SequenceChunkNumberTest)
         hasMorePermutations = std::ranges::next_permutation(
                                   inputBuffers,
                                   std::less{},
-                                  [](const TupleBuffer& buffer)
+                                  [](const Buffer& buffer)
                                   { return SequenceData(buffer.getSequenceNumber(), buffer.getChunkNumber(), buffer.isLastChunk()); })
                                   .found;
     };
@@ -369,7 +369,7 @@ TEST_F(EmitPhysicalOperatorTest, ConcurrentSequenceChunkNumberTest)
          std::initializer_list<std::tuple<size_t, size_t, size_t>>{{2, 10, 2}, {1000, 2, 4}, {10, 100, 4}, {1000, 20, 10}})
     {
         reset();
-        std::vector<TupleBuffer> inputBuffers;
+        std::vector<Buffer> inputBuffers;
         for (size_t seq = 0; seq < numberOfSequences; seq++)
         {
             std::uniform_int_distribution chunkNumbers(ChunkNumber::INITIAL + 1, maxChunksPerSequence);

--- a/nes-physical-operators/tests/EmitPhysicalOperatorTest.cpp
+++ b/nes-physical-operators/tests/EmitPhysicalOperatorTest.cpp
@@ -34,8 +34,8 @@
 #include <DataTypes/DataType.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Identifiers/NESStrongType.hpp>
-#include <Interface/BufferRef/LowerSchemaProvider.hpp>
-#include <Interface/BufferRef/RowTupleBufferRef.hpp>
+#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
+#include <Interface/MemoryLayout/RowLayout.hpp>
 #include <Interface/RecordBuffer.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/Allocator/NesDefaultMemoryAllocator.hpp>

--- a/nes-physical-operators/tests/InferModelPhysicalOperatorTest.cpp
+++ b/nes-physical-operators/tests/InferModelPhysicalOperatorTest.cpp
@@ -48,9 +48,9 @@
 #include <Pipelines/CompiledExecutablePipelineStage.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/Allocator/NesDefaultMemoryAllocator.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/BufferManager.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Util/Logger/LogLevel.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <Util/Logger/impl/NesLogger.hpp>
@@ -78,13 +78,13 @@ class InferModelPhysicalOperatorTest : public Testing::BaseUnitTest
 protected:
     struct MockedPipelineContext final : PipelineExecutionContext
     {
-        bool emitBuffer(const TupleBuffer& buffer, ContinuationPolicy) override
+        bool emitBuffer(const Buffer& buffer, ContinuationPolicy) override
         {
             buffers.wlock()->emplace_back(buffer);
             return true;
         }
 
-        TupleBuffer allocateTupleBuffer() override { return bufferManager->getBufferBlocking(); }
+        Buffer allocateTupleBuffer() override { return bufferManager->getBufferBlocking(); }
 
         [[nodiscard]] WorkerThreadId getWorkerThreadId() const override { return threadId; }
 
@@ -104,24 +104,24 @@ protected:
             operatorHandlers = &opHandlers;
         }
 
-        void repeatTask(const TupleBuffer&, std::chrono::milliseconds) override { INVARIANT(false, "This function should not be called"); }
+        void repeatTask(const Buffer&, std::chrono::milliseconds) override { INVARIANT(false, "This function should not be called"); }
 
-        TupleBuffer& pinBuffer(TupleBuffer&& tupleBuffer) override
+        Buffer& pinBuffer(Buffer&& tupleBuffer) override
         {
-            pinnedBuffers.emplace_back(std::make_unique<TupleBuffer>(std::move(tupleBuffer)));
+            pinnedBuffers.emplace_back(std::make_unique<Buffer>(std::move(tupleBuffer)));
             return *pinnedBuffers.back();
         }
 
         ///NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members) lifetime is ensured by the fixture
-        folly::Synchronized<std::vector<TupleBuffer>>& buffers;
+        folly::Synchronized<std::vector<Buffer>>& buffers;
         std::shared_ptr<BufferManager> bufferManager;
         std::unordered_map<OperatorHandlerId, std::shared_ptr<OperatorHandler>>* operatorHandlers = nullptr;
-        std::vector<std::unique_ptr<TupleBuffer>> pinnedBuffers;
+        std::vector<std::unique_ptr<Buffer>> pinnedBuffers;
         WorkerThreadId threadId = INITIAL<WorkerThreadId>;
         uint64_t numWorkerThreads = 1;
 
         MockedPipelineContext(
-            folly::Synchronized<std::vector<TupleBuffer>>& buffers,
+            folly::Synchronized<std::vector<Buffer>>& buffers,
             std::shared_ptr<BufferManager> bufferManager,
             WorkerThreadId threadId = INITIAL<WorkerThreadId>,
             uint64_t numWorkerThreads = 1)
@@ -267,8 +267,8 @@ public:
         return {.pipeline = std::move(pipeline), .handlers = std::move(handlers)};
     }
 
-    /// Creates an input TupleBuffer with VARSIZED records, each containing packed floats.
-    static TupleBuffer createInputBuffer(const TestSchema& inputSchema, const std::vector<std::vector<float>>& recordFloats)
+    /// Creates an input Buffer with VARSIZED records, each containing packed floats.
+    static Buffer createInputBuffer(const TestSchema& inputSchema, const std::vector<std::vector<float>>& recordFloats)
     {
         auto bufMgr = BufferManager::create(
             TOTAL_MEMORY_IN_BYTES, UNPOOLED_MEMORY_FRACTION, BUFFER_ALIGNMENT, bufferSize, std::make_shared<NesDefaultMemoryAllocator>());
@@ -317,7 +317,7 @@ TEST_F(InferModelPhysicalOperatorTest, IdentityModelCorrectness)
                 return opt;
             }());
 
-        folly::Synchronized<std::vector<TupleBuffer>> emittedBuffers;
+        folly::Synchronized<std::vector<Buffer>> emittedBuffers;
         emittedBuffers.wlock()->reserve(16);
         auto bufMgr = BufferManager::create(
             TOTAL_MEMORY_IN_BYTES, UNPOOLED_MEMORY_FRACTION, BUFFER_ALIGNMENT, bufferSize, std::make_shared<NesDefaultMemoryAllocator>());
@@ -372,7 +372,7 @@ TEST_F(InferModelPhysicalOperatorTest, ReductionModelCorrectness)
                 return opt;
             }());
 
-        folly::Synchronized<std::vector<TupleBuffer>> emittedBuffers;
+        folly::Synchronized<std::vector<Buffer>> emittedBuffers;
         emittedBuffers.wlock()->reserve(16);
         auto bufMgr = BufferManager::create(
             TOTAL_MEMORY_IN_BYTES, UNPOOLED_MEMORY_FRACTION, BUFFER_ALIGNMENT, bufferSize, std::make_shared<NesDefaultMemoryAllocator>());
@@ -427,7 +427,7 @@ TEST_F(InferModelPhysicalOperatorTest, ExpansionModelCorrectness)
                 return opt;
             }());
 
-        folly::Synchronized<std::vector<TupleBuffer>> emittedBuffers;
+        folly::Synchronized<std::vector<Buffer>> emittedBuffers;
         emittedBuffers.wlock()->reserve(16);
         auto bufMgr = BufferManager::create(
             TOTAL_MEMORY_IN_BYTES, UNPOOLED_MEMORY_FRACTION, BUFFER_ALIGNMENT, bufferSize, std::make_shared<NesDefaultMemoryAllocator>());
@@ -490,7 +490,7 @@ TEST_F(InferModelPhysicalOperatorTest, MultiRecordIdentity)
                 return opt;
             }());
 
-        folly::Synchronized<std::vector<TupleBuffer>> emittedBuffers;
+        folly::Synchronized<std::vector<Buffer>> emittedBuffers;
         emittedBuffers.wlock()->reserve(16);
         auto bufMgr = BufferManager::create(
             TOTAL_MEMORY_IN_BYTES, UNPOOLED_MEMORY_FRACTION, BUFFER_ALIGNMENT, bufferSize, std::make_shared<NesDefaultMemoryAllocator>());
@@ -546,7 +546,7 @@ TEST_F(InferModelPhysicalOperatorTest, ZeroRecordBuffer)
                 return opt;
             }());
 
-        folly::Synchronized<std::vector<TupleBuffer>> emittedBuffers;
+        folly::Synchronized<std::vector<Buffer>> emittedBuffers;
         emittedBuffers.wlock()->reserve(16);
         auto bufMgr = BufferManager::create(
             TOTAL_MEMORY_IN_BYTES, UNPOOLED_MEMORY_FRACTION, BUFFER_ALIGNMENT, bufferSize, std::make_shared<NesDefaultMemoryAllocator>());
@@ -588,7 +588,7 @@ TEST_F(InferModelPhysicalOperatorTest, ConcurrentStressTest)
     options.setOption("engine.compilationStrategy", std::string("legacy"));
     CompiledExecutablePipelineStage stage(pipeline, handlers, options);
 
-    folly::Synchronized<std::vector<TupleBuffer>> emittedBuffers;
+    folly::Synchronized<std::vector<Buffer>> emittedBuffers;
     emittedBuffers.wlock()->reserve(numThreads * buffersPerThread * 2);
     auto bufMgr = BufferManager::create(
         10 * static_cast<size_t>(numThreads) * buffersPerThread * 4 * bufferSize,
@@ -605,7 +605,7 @@ TEST_F(InferModelPhysicalOperatorTest, ConcurrentStressTest)
     const auto inputFloats = makeFloats(numFloats);
 
     /// Pre-create input buffers with unique sequence numbers
-    std::vector<std::vector<TupleBuffer>> threadInputBuffers(numThreads);
+    std::vector<std::vector<Buffer>> threadInputBuffers(numThreads);
     for (size_t tid = 0; tid < numThreads; ++tid)
     {
         threadInputBuffers[tid].reserve(buffersPerThread);
@@ -709,7 +709,7 @@ TEST_F(InferModelPhysicalOperatorTest, VarsizedOutputCorrectness)
                 return opt;
             }());
 
-        folly::Synchronized<std::vector<TupleBuffer>> emittedBuffers;
+        folly::Synchronized<std::vector<Buffer>> emittedBuffers;
         emittedBuffers.wlock()->reserve(16);
         auto bufMgr = BufferManager::create(
             TOTAL_MEMORY_IN_BYTES, UNPOOLED_MEMORY_FRACTION, BUFFER_ALIGNMENT, bufferSize, std::make_shared<NesDefaultMemoryAllocator>());

--- a/nes-physical-operators/tests/InferModelPhysicalOperatorTest.cpp
+++ b/nes-physical-operators/tests/InferModelPhysicalOperatorTest.cpp
@@ -44,7 +44,7 @@
 #include <Identifiers/Identifiers.hpp>
 #include <Identifiers/NESStrongType.hpp>
 #include <Identifiers/QualifiedIdentifier.hpp>
-#include <Interface/BufferRef/LowerSchemaProvider.hpp>
+#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
 #include <Pipelines/CompiledExecutablePipelineStage.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/Allocator/NesDefaultMemoryAllocator.hpp>

--- a/nes-physical-operators/tests/SliceCacheTest.cpp
+++ b/nes-physical-operators/tests/SliceCacheTest.cpp
@@ -50,9 +50,9 @@
 #include <Identifiers/NESStrongType.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/Allocator/NesDefaultMemoryAllocator.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/BufferManager.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <ErrorHandling.hpp>
 #include <PipelineExecutionContext.hpp>
 
@@ -149,16 +149,16 @@ class SliceCacheTestBase : public Testing::BaseUnitTest
 public:
     struct MockedPipelineContext final : PipelineExecutionContext
     {
-        bool emitBuffer(const TupleBuffer&, ContinuationPolicy) override
+        bool emitBuffer(const Buffer&, ContinuationPolicy) override
         {
             INVARIANT(false, "This function should not be called");
             std::unreachable();
         }
 
-        TupleBuffer allocateTupleBuffer() override { return bufferManager->getBufferBlocking(); }
+        Buffer allocateTupleBuffer() override { return bufferManager->getBufferBlocking(); }
 
         /// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved): unreachable stub; parameter matches the overridden signature.
-        TupleBuffer& pinBuffer(TupleBuffer&&) override
+        Buffer& pinBuffer(Buffer&&) override
         {
             INVARIANT(false, "This function should not be called");
             std::unreachable();
@@ -186,7 +186,7 @@ public:
 
         explicit MockedPipelineContext(std::shared_ptr<AbstractBufferProvider> bufferManager) : bufferManager(std::move(bufferManager)) { }
 
-        void repeatTask(const TupleBuffer&, std::chrono::milliseconds) override { INVARIANT(false, "This function should not be called"); }
+        void repeatTask(const Buffer&, std::chrono::milliseconds) override { INVARIANT(false, "This function should not be called"); }
 
         std::shared_ptr<AbstractBufferProvider> bufferManager;
     };

--- a/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONInputFormatIndexer.hpp
+++ b/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONInputFormatIndexer.hpp
@@ -29,7 +29,7 @@
 #include <Configurations/Descriptor.hpp>
 #include <DataTypes/DataType.hpp>
 #include <Identifiers/Identifier.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Util/Strings.hpp>
@@ -99,7 +99,7 @@ public:
     }
 
     /// Delegate constructor that applies preconditions before safely calling the constructor
-    static std::unique_ptr<SIMDJSONInputFormatIndexer> create(const InputFormatterDescriptor& config, const TupleBufferRef& tupleBufferRef)
+    static std::unique_ptr<SIMDJSONInputFormatIndexer> create(const InputFormatterDescriptor& config, const MemoryLayout& tupleBufferRef)
     {
         /// JSON keys are unqualified — take the trailing identifier of each (possibly source-qualified) name.
         /// Precompute each field's JSON Pointer (RFC 6901) once: prepend '/' and escape literal '~' as

--- a/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONRawBufferIndex.cpp
+++ b/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONRawBufferIndex.cpp
@@ -34,7 +34,7 @@
 #include <DataTypes/VarVal.hpp>
 #include <DataTypes/VariableSizedData.hpp>
 #include <Identifiers/QualifiedIdentifier.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
 #include <Arena.hpp>
 #include <ErrorHandling.hpp>
@@ -140,7 +140,7 @@ Record SIMDJSONRawBufferIndex::readSpanningRecord(
     const nautilus::val<uint64_t>&,
     const InputFormatIndexer& indexer,
     nautilus::val<RawBufferIndex*> rawBufferIndex,
-    const TupleBufferRef& bufferRef) const
+    const MemoryLayout& bufferRef) const
 {
     Record record;
     const auto numberOfFields = bufferRef.getAllDataTypes().size();

--- a/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONRawBufferIndex.hpp
+++ b/nes-plugins/InputFormatters/JSONInputFormatter/SIMDJSONRawBufferIndex.hpp
@@ -25,7 +25,7 @@
 #include <vector>
 
 #include <simdjson.h>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Interface/Record.hpp>
 #include <InputFormatIndexer.hpp>
 #include <RawBufferIndex.hpp>
@@ -53,7 +53,7 @@ public:
         const nautilus::val<uint64_t>& /*recordIndex*/,
         const InputFormatIndexer& indexer,
         nautilus::val<RawBufferIndex*> rawBufferIndex,
-        const TupleBufferRef& bufferRef) const override;
+        const MemoryLayout& bufferRef) const override;
 
     [[nodiscard]] TupleDelimiterOffsets getTupleDelimiterOffsets() const override
     {

--- a/nes-plugins/OutputFormatters/JSONOutputFormatter/JSONOutputFormatter.cpp
+++ b/nes-plugins/OutputFormatters/JSONOutputFormatter/JSONOutputFormatter.cpp
@@ -38,7 +38,7 @@
 
 #include <Configurations/Descriptor.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <OutputFormatterRegistry.hpp>
 #include <OutputFormatterValidationRegistry.hpp>
 #include <function.hpp>
@@ -66,7 +66,7 @@ uint64_t writePreValueContents(
     const bool isFirstField,
     const char* fieldIdentifier,
     const uint64_t remainingSpace,
-    TupleBuffer* buffer,
+    Buffer* buffer,
     AbstractBufferProvider* bufferProvider,
     int8_t* bufferAddress)
 {
@@ -82,7 +82,7 @@ uint64_t writeChar(
     int8_t* bufferStartingAddress,
     const uint64_t remainingSpace,
     const char content,
-    TupleBuffer* tupleBuffer,
+    Buffer* tupleBuffer,
     AbstractBufferProvider* bufferProvider)
 {
     /// Chars are treated as strings in JSON
@@ -95,7 +95,7 @@ uint64_t writeVarsized(
     const uint64_t remainingSpace,
     const int8_t* varSizedContent,
     const uint64_t contentSize,
-    TupleBuffer* tupleBuffer,
+    Buffer* tupleBuffer,
     AbstractBufferProvider* bufferProvider)
 {
     /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- int8_t buffer reinterpreted as char* for string_view

--- a/nes-plugins/OutputFormatters/JSONOutputFormatter/JSONOutputFormatter.cpp
+++ b/nes-plugins/OutputFormatters/JSONOutputFormatter/JSONOutputFormatter.cpp
@@ -30,7 +30,7 @@
 #include <DataTypes/VarVal.hpp>
 #include <DataTypes/VariableSizedData.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <OutputFormatters/OutputFormatter.hpp>
 #include <OutputFormatters/OutputFormatterUtil.hpp>
 #include <fmt/format.h>
@@ -108,7 +108,7 @@ void writeValue(
     const DataType& fieldType,
     const VarVal& value,
     const nautilus::val<int8_t*>& fieldPointer,
-    const RecordBuffer& recordBuffer,
+    const TaskBufferRef& recordBuffer,
     const nautilus::val<AbstractBufferProvider*>& bufferProvider,
     nautilus::val<uint64_t>& written,
     nautilus::val<uint64_t>& currentRemainingSize)
@@ -179,7 +179,7 @@ nautilus::val<uint64_t> JSONOutputFormatter::writeFormattedValue(
     uint64_t fieldIndex,
     const nautilus::val<int8_t*>& fieldPointer,
     const nautilus::val<uint64_t>& remainingSize,
-    const RecordBuffer& recordBuffer,
+    const TaskBufferRef& recordBuffer,
     const nautilus::val<AbstractBufferProvider*>& bufferProvider) const
 {
     nautilus::val<uint64_t> written{0};

--- a/nes-plugins/OutputFormatters/JSONOutputFormatter/JSONOutputFormatter.hpp
+++ b/nes-plugins/OutputFormatters/JSONOutputFormatter/JSONOutputFormatter.hpp
@@ -24,7 +24,7 @@
 #include <DataTypes/DataType.hpp>
 #include <DataTypes/VarVal.hpp>
 #include <Interface/Record.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <OutputFormatters/OutputFormatter.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Util/Logger/Formatter.hpp>
@@ -45,7 +45,7 @@ public:
         uint64_t fieldIndex,
         const nautilus::val<int8_t*>& fieldPointer,
         const nautilus::val<uint64_t>& remainingSize,
-        const RecordBuffer& recordBuffer,
+        const TaskBufferRef& recordBuffer,
         const nautilus::val<AbstractBufferProvider*>& bufferProvider) const override;
 
     static DescriptorConfig::Config validateAndFormat(std::unordered_map<std::string, std::string> config);

--- a/nes-plugins/Sinks/ChecksumSink/ChecksumSink.cpp
+++ b/nes-plugins/Sinks/ChecksumSink/ChecksumSink.cpp
@@ -25,7 +25,7 @@
 #include <utility>
 #include <Configurations/Descriptor.hpp>
 #include <DataTypes/DataType.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sinks/Sink.hpp>
 #include <Sinks/SinkDescriptor.hpp>
 #include <SinksParsing/BufferIterator.hpp>
@@ -87,7 +87,7 @@ void ChecksumSink::stop(PipelineExecutionContext&)
     isOpen = false;
 }
 
-void ChecksumSink::execute(const TupleBuffer& inputBuffer, PipelineExecutionContext&)
+void ChecksumSink::execute(const Buffer& inputBuffer, PipelineExecutionContext&)
 {
     PRECONDITION(inputBuffer, "Invalid input buffer in ChecksumSink.");
     /// Create a buffer iterator to help iterate through the tuplebuffer and its children

--- a/nes-plugins/Sinks/ChecksumSink/ChecksumSink.hpp
+++ b/nes-plugins/Sinks/ChecksumSink/ChecksumSink.hpp
@@ -23,7 +23,7 @@
 #include <string_view>
 #include <unordered_map>
 #include <Configurations/Descriptor.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sinks/Sink.hpp>
 #include <Sinks/SinkDescriptor.hpp>
 #include <Util/Logger/Formatter.hpp>
@@ -46,7 +46,7 @@ public:
     /// Opens file and writes schema to file, if the file is empty.
     void start(PipelineExecutionContext&) override;
     void stop(PipelineExecutionContext&) override;
-    void execute(const TupleBuffer& inputBuffer, PipelineExecutionContext&) override;
+    void execute(const Buffer& inputBuffer, PipelineExecutionContext&) override;
     static DescriptorConfig::Config validateAndFormat(std::unordered_map<std::string, std::string> config);
 
 protected:

--- a/nes-plugins/Sinks/MQTTSink/MQTTSink.cpp
+++ b/nes-plugins/Sinks/MQTTSink/MQTTSink.cpp
@@ -24,7 +24,7 @@
 #include <utility>
 #include <MQTTAsync.h>
 #include <Configurations/Descriptor.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sinks/Sink.hpp>
 #include <Sinks/SinkDescriptor.hpp>
 #include <Util/Logger/Logger.hpp>
@@ -108,7 +108,7 @@ void MQTTSink::start(PipelineExecutionContext&)
     }
 }
 
-MQTTSink::PublishResult MQTTSink::tryPublish(const TupleBuffer& buffer)
+MQTTSink::PublishResult MQTTSink::tryPublish(const Buffer& buffer)
 {
     size_t messageSize = buffer.getNumberOfTuples();
     for (size_t index = 0; index < buffer.getNumberOfChildBuffers(); index++)
@@ -142,7 +142,7 @@ MQTTSink::PublishResult MQTTSink::tryPublish(const TupleBuffer& buffer)
     return PublishResult::Ok;
 }
 
-void MQTTSink::execute(const TupleBuffer& inputTupleBuffer, PipelineExecutionContext& pec)
+void MQTTSink::execute(const Buffer& inputTupleBuffer, PipelineExecutionContext& pec)
 {
     PRECONDITION(client, "MQTTSink client is not initialized");
     PRECONDITION(inputTupleBuffer, "Invalid input buffer in MQTTSink.");

--- a/nes-plugins/Sinks/MQTTSink/MQTTSink.hpp
+++ b/nes-plugins/Sinks/MQTTSink/MQTTSink.hpp
@@ -23,7 +23,7 @@
 #include <string_view>
 #include <unordered_map>
 #include <Configurations/Descriptor.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sinks/BackpressureHandler.hpp>
 #include <Sinks/Sink.hpp>
 #include <Sinks/SinkDescriptor.hpp>
@@ -39,7 +39,7 @@ namespace NES
 
 constexpr std::string_view GENERATE_CLIENT_ID_TOKEN = "HACK_GENERATED_TOKEN_SENTINEL_VALUE";
 
-/// A sink that publishes the bytes of every incoming TupleBuffer as an MQTT
+/// A sink that publishes the bytes of every incoming Buffer as an MQTT
 /// message to the configured broker/topic.
 class MQTTSink final : public Sink
 {
@@ -51,7 +51,7 @@ public:
 
     void start(PipelineExecutionContext&) override;
     void stop(PipelineExecutionContext&) override;
-    void execute(const TupleBuffer& inputTupleBuffer, PipelineExecutionContext&) override;
+    void execute(const Buffer& inputTupleBuffer, PipelineExecutionContext&) override;
 
     static DescriptorConfig::Config validateAndFormat(std::unordered_map<std::string, std::string> config);
 
@@ -70,7 +70,7 @@ private:
         Closed,
     };
 
-    PublishResult tryPublish(const TupleBuffer& buffer);
+    PublishResult tryPublish(const Buffer& buffer);
 
     std::string serverURI;
     std::string clientId;

--- a/nes-plugins/Sinks/VoidSink/VoidSink.cpp
+++ b/nes-plugins/Sinks/VoidSink/VoidSink.cpp
@@ -18,7 +18,7 @@
 #include <unordered_map>
 #include <utility>
 #include <Configurations/Descriptor.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sinks/SinkDescriptor.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <ErrorHandling.hpp>
@@ -42,7 +42,7 @@ void VoidSink::stop(PipelineExecutionContext&)
     NES_INFO("Void Sink completed.")
 }
 
-void VoidSink::execute([[maybe_unused]] const TupleBuffer& inputTupleBuffer, PipelineExecutionContext&)
+void VoidSink::execute([[maybe_unused]] const Buffer& inputTupleBuffer, PipelineExecutionContext&)
 {
     PRECONDITION(inputTupleBuffer, "Invalid input buffer in VoidSink.");
 }

--- a/nes-plugins/Sinks/VoidSink/VoidSink.hpp
+++ b/nes-plugins/Sinks/VoidSink/VoidSink.hpp
@@ -21,7 +21,7 @@
 #include <string_view>
 #include <unordered_map>
 #include <Configurations/Descriptor.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sinks/Sink.hpp>
 #include <Sinks/SinkDescriptor.hpp>
 #include <Util/Logger/Formatter.hpp>
@@ -41,7 +41,7 @@ public:
 
     void start(PipelineExecutionContext&) override;
     void stop(PipelineExecutionContext&) override;
-    void execute(const TupleBuffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext) override;
+    void execute(const Buffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext) override;
     static DescriptorConfig::Config validateAndFormat(std::unordered_map<std::string, std::string> config);
 
 protected:

--- a/nes-plugins/Sources/GeneratorSource/GeneratorSource.cpp
+++ b/nes-plugins/Sources/GeneratorSource/GeneratorSource.cpp
@@ -27,7 +27,7 @@
 #include <utility>
 #include <Configurations/Descriptor.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sources/Source.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Util/Logger/Logger.hpp>
@@ -89,7 +89,7 @@ void GeneratorSource::close()
     }
 }
 
-Source::FillTupleBufferResult GeneratorSource::fillTupleBuffer(TupleBuffer& tupleBuffer, const std::stop_token&)
+Source::FillTupleBufferResult GeneratorSource::fillTupleBuffer(Buffer& tupleBuffer, const std::stop_token&)
 {
     /// the generator indicated that it will not produce anymore data and the tupleStream is empty.
     if (this->generator.shouldStop() && tuplesStream.tellp() == 0)
@@ -170,7 +170,7 @@ Source::FillTupleBufferResult GeneratorSource::fillTupleBuffer(TupleBuffer& tupl
     }
     catch (const std::exception& e)
     {
-        NES_ERROR("Failed to fill the TupleBuffer. Error: {}", e.what());
+        NES_ERROR("Failed to fill the Buffer. Error: {}", e.what());
         throw e;
     }
 }

--- a/nes-plugins/Sources/GeneratorSource/GeneratorSource.hpp
+++ b/nes-plugins/Sources/GeneratorSource/GeneratorSource.hpp
@@ -30,7 +30,7 @@
 #include <Configurations/Descriptor.hpp>
 #include <Configurations/Enums/EnumWrapper.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sources/Source.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Util/Logger/Logger.hpp>
@@ -58,7 +58,7 @@ public:
     GeneratorSource(GeneratorSource&&) = delete;
     GeneratorSource& operator=(GeneratorSource&&) = delete;
 
-    FillTupleBufferResult fillTupleBuffer(TupleBuffer& tupleBuffer, const std::stop_token& stopToken) override;
+    FillTupleBufferResult fillTupleBuffer(Buffer& tupleBuffer, const std::stop_token& stopToken) override;
 
     [[nodiscard]] std::ostream& toString(std::ostream& str) const override;
 

--- a/nes-plugins/Sources/MQTTSource/MQTTSource.cpp
+++ b/nes-plugins/Sources/MQTTSource/MQTTSource.cpp
@@ -30,7 +30,7 @@
 
 #include <Configurations/Descriptor.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sources/Source.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Util/Logger/Logger.hpp>
@@ -114,7 +114,7 @@ void MQTTSource::open(std::shared_ptr<AbstractBufferProvider>)
     }
 }
 
-Source::FillTupleBufferResult MQTTSource::fillTupleBuffer(NES::TupleBuffer& tupleBuffer, const std::stop_token& stopToken)
+Source::FillTupleBufferResult MQTTSource::fillTupleBuffer(NES::Buffer& tupleBuffer, const std::stop_token& stopToken)
 {
     size_t tbOffset = 0;
     const auto tbSize = tupleBuffer.getBufferSize();
@@ -193,7 +193,7 @@ Source::FillTupleBufferResult MQTTSource::fillTupleBuffer(NES::TupleBuffer& tupl
 
 /// Write the message payload to the tuple buffer
 /// @return the offset in the TB after writing the payload
-void MQTTSource::writePayloadToBuffer(const std::string_view payload, TupleBuffer& tb, size_t& tbOffset)
+void MQTTSource::writePayloadToBuffer(const std::string_view payload, Buffer& tb, size_t& tbOffset)
 {
     const auto tbSize = tb.getBufferSize();
     /// If the payload fits into the TB, write it

--- a/nes-plugins/Sources/MQTTSource/MQTTSource.hpp
+++ b/nes-plugins/Sources/MQTTSource/MQTTSource.hpp
@@ -26,7 +26,7 @@
 #include <unordered_map>
 #include <Configurations/Descriptor.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sources/Source.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Util/Logger/Logger.hpp>
@@ -53,7 +53,7 @@ public:
     /// Open connection to MQTT broker.
     void open(std::shared_ptr<AbstractBufferProvider>) override;
 
-    FillTupleBufferResult fillTupleBuffer(TupleBuffer& tupleBuffer, const std::stop_token& stopToken) override;
+    FillTupleBufferResult fillTupleBuffer(Buffer& tupleBuffer, const std::stop_token& stopToken) override;
 
     /// Close connection to MQTT broker.
     void close() override;
@@ -75,7 +75,7 @@ private:
 
     PayloadStash payloadStash;
 
-    void writePayloadToBuffer(std::string_view payload, TupleBuffer& tb, size_t& tbOffset);
+    void writePayloadToBuffer(std::string_view payload, Buffer& tb, size_t& tbOffset);
 };
 
 constexpr std::string_view GENERATE_CLIENT_ID_TOKEN = "HACK_GENERATED_TOKEN_SENTINEL_VALUE";

--- a/nes-plugins/Sources/TCPSource/TCPSource.cpp
+++ b/nes-plugins/Sources/TCPSource/TCPSource.cpp
@@ -35,7 +35,7 @@
 #include <Configurations/Descriptor.hpp>
 #include <Identifiers/Identifier.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sources/Source.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Util/Logger/Logger.hpp>
@@ -204,7 +204,7 @@ void TCPSource::open(std::shared_ptr<AbstractBufferProvider>)
     NES_TRACE("TCPSource::open: Connected to server.");
 }
 
-Source::FillTupleBufferResult TCPSource::fillTupleBuffer(TupleBuffer& tupleBuffer, const std::stop_token&)
+Source::FillTupleBufferResult TCPSource::fillTupleBuffer(Buffer& tupleBuffer, const std::stop_token&)
 {
     try
     {
@@ -221,12 +221,12 @@ Source::FillTupleBufferResult TCPSource::fillTupleBuffer(TupleBuffer& tupleBuffe
     }
     catch (const std::exception& e)
     {
-        NES_ERROR("Failed to fill the TupleBuffer. Error: {}.", e.what());
+        NES_ERROR("Failed to fill the Buffer. Error: {}.", e.what());
         throw;
     }
 }
 
-bool TCPSource::fillBuffer(TupleBuffer& tupleBuffer, size_t& numReceivedBytes)
+bool TCPSource::fillBuffer(Buffer& tupleBuffer, size_t& numReceivedBytes)
 {
     const auto flushIntervalTimerStart = std::chrono::system_clock::now();
     bool flushIntervalPassed = false;
@@ -258,12 +258,12 @@ bool TCPSource::fillBuffer(TupleBuffer& tupleBuffer, size_t& numReceivedBytes)
         }
         /// If bufferFlushIntervalMs was defined by the user (> 0), we check whether the time on receiving
         /// and writing data exceeds the user defined limit (bufferFlushIntervalMs).
-        /// If so, we flush the current TupleBuffer(TB) and proceed with the next TB.
+        /// If so, we flush the current Buffer(TB) and proceed with the next TB.
         if ((flushIntervalInMs > 0
              && std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - flushIntervalTimerStart).count()
                  >= flushIntervalInMs))
         {
-            NES_DEBUG("Reached TupleBuffer flush interval. Finishing writing to current TupleBuffer.");
+            NES_DEBUG("Reached Buffer flush interval. Finishing writing to current Buffer.");
             flushIntervalPassed = true;
         }
     }

--- a/nes-plugins/Sources/TCPSource/TCPSource.hpp
+++ b/nes-plugins/Sources/TCPSource/TCPSource.hpp
@@ -29,7 +29,7 @@
 #include <Configurations/Descriptor.hpp>
 #include <Configurations/Enums/EnumWrapper.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sources/Source.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Util/Logger/Logger.hpp>
@@ -179,7 +179,7 @@ public:
     TCPSource(TCPSource&&) = delete;
     TCPSource& operator=(TCPSource&&) = delete;
 
-    FillTupleBufferResult fillTupleBuffer(TupleBuffer& tupleBuffer, const std::stop_token& stopToken) override;
+    FillTupleBufferResult fillTupleBuffer(Buffer& tupleBuffer, const std::stop_token& stopToken) override;
 
     /// Open TCP connection.
     void open(std::shared_ptr<AbstractBufferProvider> bufferProvider) override;
@@ -192,7 +192,7 @@ public:
 
 private:
     bool tryToConnect(const addrinfo* result, int flags);
-    bool fillBuffer(TupleBuffer& tupleBuffer, size_t& numReceivedBytes);
+    bool fillBuffer(Buffer& tupleBuffer, size_t& numReceivedBytes);
 
     int connection = -1;
     int sockfd = -1;

--- a/nes-query-compiler/src/LoweringRules/LowerToPhysical/LowerToPhysicalProjection.cpp
+++ b/nes-query-compiler/src/LoweringRules/LowerToPhysical/LowerToPhysicalProjection.cpp
@@ -27,7 +27,7 @@
 #include <DataTypes/UnboundField.hpp>
 #include <Functions/FunctionProvider.hpp>
 #include <Identifiers/QualifiedIdentifier.hpp>
-#include <Interface/BufferRef/LowerSchemaProvider.hpp>
+#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
 #include <LoweringRules/AbstractLoweringRule.hpp>
 #include <Operators/LogicalOperator.hpp>
 #include <Operators/ProjectionLogicalOperator.hpp>

--- a/nes-query-compiler/src/LoweringRules/LowerToPhysical/LowerToPhysicalWindowedAggregation.cpp
+++ b/nes-query-compiler/src/LoweringRules/LowerToPhysical/LowerToPhysicalWindowedAggregation.cpp
@@ -35,7 +35,7 @@
 #include <Functions/FunctionProvider.hpp>
 #include <Functions/PhysicalFunction.hpp>
 #include <Identifiers/Identifiers.hpp>
-#include <Interface/BufferRef/LowerSchemaProvider.hpp>
+#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
 #include <Interface/Hash/MurMur3HashFunction.hpp>
 #include <Interface/HashMap/ChainedHashMap/ChainedEntryMemoryProvider.hpp>
 #include <Interface/HashMap/ChainedHashMap/ChainedHashMap.hpp>

--- a/nes-query-compiler/src/LoweringRules/LowerToPhysical/LowerToPhysicalWindowedAggregation.cpp
+++ b/nes-query-compiler/src/LoweringRules/LowerToPhysical/LowerToPhysicalWindowedAggregation.cpp
@@ -35,19 +35,19 @@
 #include <Functions/FunctionProvider.hpp>
 #include <Functions/PhysicalFunction.hpp>
 #include <Identifiers/Identifiers.hpp>
-#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
 #include <Interface/Hash/MurMur3HashFunction.hpp>
 #include <Interface/HashMap/ChainedHashMap/ChainedEntryMemoryProvider.hpp>
 #include <Interface/HashMap/ChainedHashMap/ChainedHashMap.hpp>
 #include <Interface/HashMap/HashMap.hpp>
+#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
 #include <Interface/PagedVector/PagedVectorRef.hpp>
 #include <Interface/Record.hpp>
 #include <LoweringRules/AbstractLoweringRule.hpp>
 #include <Operators/LogicalOperator.hpp>
 #include <Operators/Windows/WindowedAggregationLogicalOperator.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <SliceStore/DefaultTimeBasedSliceStore.hpp>
 #include <SliceStore/Slice.hpp>
 #include <Traits/FieldMappingTrait.hpp>
@@ -206,7 +206,7 @@ LoweringRuleResultSubgraph LowerToPhysicalWindowedAggregation::apply(LogicalOper
     auto sliceAndWindowStore = std::make_unique<DefaultTimeBasedSliceStore>(
         windowType.getSize().getTime(), windowType.getSlide().getTime(), conf.sliceCacheConfiguration);
     auto sliceStoreRef = sliceAndWindowStore->createSliceStoreRef(
-        [](Slice& slice, const WorkerThreadId workerThreadId, AbstractBufferProvider& bufferProvider) -> const TupleBuffer*
+        [](Slice& slice, const WorkerThreadId workerThreadId, AbstractBufferProvider& bufferProvider) -> const Buffer*
         {
             auto& aggregationSlice = dynamic_cast<AggregationSlice&>(slice);
             return aggregationSlice.getOrCreateHashMapBufferRefForWorker(bufferProvider, workerThreadId);

--- a/nes-query-compiler/src/Phases/PipeliningPhase.cpp
+++ b/nes-query-compiler/src/Phases/PipeliningPhase.cpp
@@ -32,8 +32,8 @@
 #include <Identifiers/Identifier.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
-#include <Interface/MemoryLayout/RowLayout.hpp>
 #include <Interface/MemoryLayout/MemoryLayout.hpp>
+#include <Interface/MemoryLayout/RowLayout.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <Util/Strings.hpp>

--- a/nes-query-compiler/src/Phases/PipeliningPhase.cpp
+++ b/nes-query-compiler/src/Phases/PipeliningPhase.cpp
@@ -31,9 +31,9 @@
 #include <DataTypes/UnboundField.hpp>
 #include <Identifiers/Identifier.hpp>
 #include <Identifiers/Identifiers.hpp>
-#include <Interface/BufferRef/LowerSchemaProvider.hpp>
-#include <Interface/BufferRef/RowTupleBufferRef.hpp>
-#include <Interface/BufferRef/TupleBufferRef.hpp>
+#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
+#include <Interface/MemoryLayout/RowLayout.hpp>
+#include <Interface/MemoryLayout/MemoryLayout.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <Util/Strings.hpp>

--- a/nes-query-compiler/tests/UnitTests/PhysicalPlanBuilderFlipTest.cpp
+++ b/nes-query-compiler/tests/UnitTests/PhysicalPlanBuilderFlipTest.cpp
@@ -32,7 +32,7 @@
 #include <DataTypes/UnboundField.hpp>
 #include <Identifiers/Identifier.hpp>
 #include <Identifiers/Identifiers.hpp>
-#include <Interface/BufferRef/LowerSchemaProvider.hpp>
+#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
 #include <Sinks/SinkCatalog.hpp>
 #include <Sources/SourceCatalog.hpp>
 #include <InputFormatterDescriptor.hpp>

--- a/nes-query-engine/Interfaces.hpp
+++ b/nes-query-engine/Interfaces.hpp
@@ -16,7 +16,7 @@
 #include <functional>
 #include <memory>
 #include <Identifiers/Identifiers.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <ErrorHandling.hpp>
 #include <PipelineExecutionContext.hpp>
 #include <QueryId.hpp>
@@ -46,7 +46,7 @@ public:
     virtual bool emitWork(
         QueryId,
         const std::shared_ptr<RunningQueryPlanNode>& target,
-        TupleBuffer,
+        Buffer,
         TaskCallback,
         PipelineExecutionContext::ContinuationPolicy continuationPolicy)
         = 0;

--- a/nes-query-engine/QueryEngine.cpp
+++ b/nes-query-engine/QueryEngine.cpp
@@ -34,9 +34,9 @@
 #include <Identifiers/NESStrongType.hpp>
 #include <Listeners/AbstractQueryStatusListener.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Runtime/QueryTerminationType.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Util/AtomicState.hpp>
 #include <fmt/format.h>
 #include <folly/MPMCQueue.h>
@@ -203,15 +203,15 @@ using Queue = folly::MPMCQueue<Task>;
 struct DefaultPEC final : PipelineExecutionContext
 {
     std::unordered_map<OperatorHandlerId, std::shared_ptr<OperatorHandler>>* operatorHandlers = nullptr;
-    std::function<bool(const TupleBuffer& tb, ContinuationPolicy)> handler;
-    std::function<void(const TupleBuffer& tb, std::chrono::milliseconds duration)> repeatHandler;
+    std::function<bool(const Buffer& tb, ContinuationPolicy)> handler;
+    std::function<void(const Buffer& tb, std::chrono::milliseconds duration)> repeatHandler;
     std::shared_ptr<AbstractBufferProvider> bm;
     size_t numberOfThreads;
     WorkerThreadId threadId;
     PipelineId pipelineId;
-    /// We want to ensure that the address of the TupleBuffer is always the same. If we would simply store the object directly in the vector,
+    /// We want to ensure that the address of the Buffer is always the same. If we would simply store the object directly in the vector,
     /// the address might change as the vector might be resized and thus, the object have a different address.
-    std::vector<std::unique_ptr<TupleBuffer>> pinnedBuffers;
+    std::vector<std::unique_ptr<Buffer>> pinnedBuffers;
 
 #ifndef NO_ASSERT
     bool wasRepeated = false;
@@ -222,8 +222,8 @@ struct DefaultPEC final : PipelineExecutionContext
         WorkerThreadId threadId,
         PipelineId pipelineId,
         std::shared_ptr<AbstractBufferProvider> bm,
-        std::function<bool(const TupleBuffer& tb, ContinuationPolicy)> handler,
-        std::function<void(const TupleBuffer& tb, std::chrono::milliseconds)> repeatHandler)
+        std::function<bool(const Buffer& tb, ContinuationPolicy)> handler,
+        std::function<void(const Buffer& tb, std::chrono::milliseconds)> repeatHandler)
         : handler(std::move(handler))
         , repeatHandler(std::move(repeatHandler))
         , bm(std::move(bm))
@@ -239,16 +239,16 @@ struct DefaultPEC final : PipelineExecutionContext
         return threadId;
     }
 
-    TupleBuffer allocateTupleBuffer() override
+    Buffer allocateTupleBuffer() override
     {
         PRECONDITION(!wasRepeated, "A task should terminate after repeating");
         return bm->getBufferBlocking();
     }
 
-    TupleBuffer& pinBuffer(TupleBuffer&& tupleBuffer) override
+    Buffer& pinBuffer(Buffer&& tupleBuffer) override
     {
         PRECONDITION(!wasRepeated, "A task should terminate after repeating");
-        pinnedBuffers.emplace_back(std::make_unique<TupleBuffer>(tupleBuffer));
+        pinnedBuffers.emplace_back(std::make_unique<Buffer>(tupleBuffer));
         return *pinnedBuffers.back();
     }
 
@@ -258,13 +258,13 @@ struct DefaultPEC final : PipelineExecutionContext
         return numberOfThreads;
     }
 
-    bool emitBuffer(const TupleBuffer& buffer, ContinuationPolicy policy) override
+    bool emitBuffer(const Buffer& buffer, ContinuationPolicy policy) override
     {
         PRECONDITION(!wasRepeated, "A task should terminate after repeating");
         return handler(buffer, policy);
     }
 
-    void repeatTask(const TupleBuffer& buffer, std::chrono::milliseconds duration) override
+    void repeatTask(const Buffer& buffer, std::chrono::milliseconds duration) override
     {
         PRECONDITION(!wasRepeated, "A task should terminate after repeating");
 #ifndef NO_ASSERT
@@ -313,7 +313,7 @@ public:
     bool emitWork(
         QueryId qid,
         const std::shared_ptr<RunningQueryPlanNode>& node,
-        TupleBuffer buffer,
+        Buffer buffer,
         TaskCallback callback,
         const PipelineExecutionContext::ContinuationPolicy continuationPolicy) override
     {
@@ -493,7 +493,7 @@ bool ThreadPool::WorkerThread::operator()(WorkTask& task) const
             WorkerThread::id,
             pipeline->id,
             pool.bufferProvider,
-            [&](const TupleBuffer& tupleBuffer, PipelineExecutionContext::ContinuationPolicy continuationPolicy)
+            [&](const Buffer& tupleBuffer, PipelineExecutionContext::ContinuationPolicy continuationPolicy)
             {
                 ENGINE_LOG_DEBUG(
                     "Task emitted tuple buffer {}-{}. Tuples: {}", task.queryId, task.pipelineId, tupleBuffer.getNumberOfTuples());
@@ -506,7 +506,7 @@ bool ThreadPool::WorkerThread::operator()(WorkTask& task) const
                         return pool.emitWork(task.queryId, successor, tupleBuffer, TaskCallback{}, continuationPolicy);
                     });
             },
-            [&](const TupleBuffer& tupleBuffer, std::chrono::milliseconds duration)
+            [&](const Buffer& tupleBuffer, std::chrono::milliseconds duration)
             {
                 if (duration.count() > 0)
                 {
@@ -550,7 +550,7 @@ bool ThreadPool::WorkerThread::operator()(StartPipelineTask& startPipeline) cons
             WorkerThread::id,
             pipeline->id,
             pool.bufferProvider,
-            [](const TupleBuffer&, PipelineExecutionContext::ContinuationPolicy)
+            [](const Buffer&, PipelineExecutionContext::ContinuationPolicy)
             {
                 /// Catch Emits, that are currently not supported during pipeline stage initialization.
                 INVARIANT(
@@ -559,7 +559,7 @@ bool ThreadPool::WorkerThread::operator()(StartPipelineTask& startPipeline) cons
                     "concurrently and there is no guarantee that the successor pipeline has been initialized");
                 return false;
             },
-            [&](const TupleBuffer&, std::chrono::milliseconds)
+            [&](const Buffer&, std::chrono::milliseconds)
             {
                 INVARIANT(
                     false,
@@ -628,7 +628,7 @@ bool ThreadPool::WorkerThread::operator()(StopPipelineTask& stopPipelineTask) co
         WorkerThread::id,
         stopPipelineTask.pipeline->id,
         pool.bufferProvider,
-        [&](const TupleBuffer& tupleBuffer, PipelineExecutionContext::ContinuationPolicy policy)
+        [&](const Buffer& tupleBuffer, PipelineExecutionContext::ContinuationPolicy policy)
         {
             if (terminating)
             {
@@ -645,7 +645,7 @@ bool ThreadPool::WorkerThread::operator()(StopPipelineTask& stopPipelineTask) co
             }
             return true;
         },
-        [&](const TupleBuffer&, std::chrono::milliseconds duration)
+        [&](const Buffer&, std::chrono::milliseconds duration)
         {
             StopPipelineTask repeatedTask(
                 stopPipelineTask.queryId, std::move(stopPipelineTask.pipeline), std::move(stopPipelineTask.callback));

--- a/nes-query-engine/Task.cpp
+++ b/nes-query-engine/Task.cpp
@@ -20,7 +20,7 @@
 #include <utility>
 #include <variant>
 #include <Identifiers/Identifiers.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <EngineLogger.hpp>
 #include <ErrorHandling.hpp>
 #include <ExecutableQueryPlan.hpp>
@@ -113,8 +113,7 @@ void BaseTask::fail(Exception exception)
     callback.callOnFailure(std::move(exception));
 }
 
-WorkTask::WorkTask(
-    QueryId queryId, PipelineId pipelineId, std::weak_ptr<RunningQueryPlanNode> pipeline, TupleBuffer buf, TaskCallback callback)
+WorkTask::WorkTask(QueryId queryId, PipelineId pipelineId, std::weak_ptr<RunningQueryPlanNode> pipeline, Buffer buf, TaskCallback callback)
     : BaseTask(queryId, std::move(callback)), pipeline(std::move(pipeline)), pipelineId(pipelineId), buf(std::move(buf))
 {
 }

--- a/nes-query-engine/Task.hpp
+++ b/nes-query-engine/Task.hpp
@@ -21,7 +21,7 @@
 #include <variant>
 #include <Identifiers/Identifiers.hpp>
 #include <Identifiers/NESStrongType.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <Util/TypeTraits.hpp>
 #include <absl/functional/any_invocable.h>
@@ -127,12 +127,12 @@ private:
 
 struct WorkTask : BaseTask
 {
-    WorkTask(QueryId queryId, PipelineId pipelineId, std::weak_ptr<RunningQueryPlanNode> pipeline, TupleBuffer buf, TaskCallback callback);
+    WorkTask(QueryId queryId, PipelineId pipelineId, std::weak_ptr<RunningQueryPlanNode> pipeline, Buffer buf, TaskCallback callback);
 
     WorkTask() = default;
     std::weak_ptr<RunningQueryPlanNode> pipeline;
     PipelineId pipelineId = INVALID<PipelineId>;
-    TupleBuffer buf;
+    Buffer buf;
 };
 
 struct StartPipelineTask : BaseTask

--- a/nes-query-engine/tests/DelayedTaskSubmitterTest.cpp
+++ b/nes-query-engine/tests/DelayedTaskSubmitterTest.cpp
@@ -126,7 +126,7 @@ TEST_F(DelayedTaskSubmitterTest, testBasicTaskSubmission)
     auto submitter = DelayedTaskSubmitter([this](Task task) noexcept { submitTask(std::move(task)); });
 
     /// Create a simple task
-    auto task = WorkTask(randomQueryId(), PipelineId(1), std::weak_ptr<RunningQueryPlanNode>(), TupleBuffer(), {});
+    auto task = WorkTask(randomQueryId(), PipelineId(1), std::weak_ptr<RunningQueryPlanNode>(), Buffer(), {});
 
     /// Submit task with immediate execution
     submitter.submitTaskIn(std::move(task), std::chrono::milliseconds(10));
@@ -159,9 +159,9 @@ TEST_F(DelayedTaskSubmitterTest, testMultipleTasksOrderedExecution)
     const auto qid1 = randomQueryId();
     const auto qid2 = randomQueryId();
     const auto qid3 = randomQueryId();
-    auto task1 = WorkTask(qid1, PipelineId(1), std::weak_ptr<RunningQueryPlanNode>(), TupleBuffer(), {});
-    auto task2 = WorkTask(qid2, PipelineId(2), std::weak_ptr<RunningQueryPlanNode>(), TupleBuffer(), {});
-    auto task3 = WorkTask(qid3, PipelineId(3), std::weak_ptr<RunningQueryPlanNode>(), TupleBuffer(), {});
+    auto task1 = WorkTask(qid1, PipelineId(1), std::weak_ptr<RunningQueryPlanNode>(), Buffer(), {});
+    auto task2 = WorkTask(qid2, PipelineId(2), std::weak_ptr<RunningQueryPlanNode>(), Buffer(), {});
+    auto task3 = WorkTask(qid3, PipelineId(3), std::weak_ptr<RunningQueryPlanNode>(), Buffer(), {});
 
     /// Submit in reverse order with increasing delays
     submitter.submitTaskIn(std::move(task3), std::chrono::milliseconds(30));
@@ -187,7 +187,7 @@ TEST_F(DelayedTaskSubmitterTest, testTaskWithZeroDelay)
 {
     auto submitter = DelayedTaskSubmitter([this](Task task) noexcept { submitTask(std::move(task)); });
 
-    auto task = WorkTask(randomQueryId(), PipelineId(1), std::weak_ptr<RunningQueryPlanNode>(), TupleBuffer(), {});
+    auto task = WorkTask(randomQueryId(), PipelineId(1), std::weak_ptr<RunningQueryPlanNode>(), Buffer(), {});
 
     /// Submit task with zero delay
     submitter.submitTaskIn(std::move(task), std::chrono::milliseconds(0));
@@ -202,9 +202,9 @@ TEST_F(DelayedTaskSubmitterTest, testDifferentDurationTypes)
 {
     auto submitter = DelayedTaskSubmitter([this](Task task) noexcept { submitTask(std::move(task)); });
 
-    auto task1 = WorkTask(randomQueryId(), PipelineId(1), std::weak_ptr<RunningQueryPlanNode>(), TupleBuffer(), {});
-    auto task2 = WorkTask(randomQueryId(), PipelineId(2), std::weak_ptr<RunningQueryPlanNode>(), TupleBuffer(), {});
-    auto task3 = WorkTask(randomQueryId(), PipelineId(3), std::weak_ptr<RunningQueryPlanNode>(), TupleBuffer(), {});
+    auto task1 = WorkTask(randomQueryId(), PipelineId(1), std::weak_ptr<RunningQueryPlanNode>(), Buffer(), {});
+    auto task2 = WorkTask(randomQueryId(), PipelineId(2), std::weak_ptr<RunningQueryPlanNode>(), Buffer(), {});
+    auto task3 = WorkTask(randomQueryId(), PipelineId(3), std::weak_ptr<RunningQueryPlanNode>(), Buffer(), {});
 
     /// Test different duration types
     submitter.submitTaskIn(std::move(task1), std::chrono::microseconds(10000)); /// 10ms
@@ -235,7 +235,7 @@ TEST_F(DelayedTaskSubmitterTest, testConcurrentTaskSubmission)
                 for (int j = 0; j < tasksPerThread; ++j)
                 {
                     auto task = WorkTask(
-                        randomQueryId(), PipelineId((i * tasksPerThread) + j), std::weak_ptr<RunningQueryPlanNode>(), TupleBuffer(), {});
+                        randomQueryId(), PipelineId((i * tasksPerThread) + j), std::weak_ptr<RunningQueryPlanNode>(), Buffer(), {});
                     if (j % 2 == 0)
                     {
                         TestClock::advance(std::chrono::milliseconds(1), false);
@@ -269,7 +269,7 @@ TEST_F(DelayedTaskSubmitterTest, testDestructorCleanup)
             randomQueryId(),
             PipelineId(1),
             std::weak_ptr<RunningQueryPlanNode>(),
-            TupleBuffer(),
+            Buffer(),
             TaskCallback(
                 TaskCallback::OnComplete([&completeCount] { ++completeCount; }),
                 TaskCallback::OnFailure([&failureCount](const Exception&) { ++failureCount; })));
@@ -309,11 +309,7 @@ TEST_F(DelayedTaskSubmitterTest, testStressRandomTasks)
                 for (int i = 0; i < tasksPerThread; ++i)
                 {
                     auto task = WorkTask(
-                        randomQueryId(),
-                        PipelineId((threadId * tasksPerThread) + i),
-                        std::weak_ptr<RunningQueryPlanNode>(),
-                        TupleBuffer(),
-                        {});
+                        randomQueryId(), PipelineId((threadId * tasksPerThread) + i), std::weak_ptr<RunningQueryPlanNode>(), Buffer(), {});
 
                     /// Random delay between 0 and maxDelayMs milliseconds
                     const int randomDelay = dis(gen);

--- a/nes-query-engine/tests/QueryPlanTest.cpp
+++ b/nes-query-engine/tests/QueryPlanTest.cpp
@@ -27,8 +27,8 @@
 #include <vector>
 #include <Identifiers/Identifiers.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Util/Logger/LogLevel.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <Util/Logger/impl/NesLogger.hpp>
@@ -145,16 +145,16 @@ concept RangeOf = std::ranges::range<R> && std::same_as<std::ranges::range_value
 
 struct TestPipelineExecutionContext : PipelineExecutionContext
 {
-    MOCK_METHOD(void, repeatTask, (const TupleBuffer&, std::chrono::milliseconds), (override));
+    MOCK_METHOD(void, repeatTask, (const Buffer&, std::chrono::milliseconds), (override));
     MOCK_METHOD(WorkerThreadId, getWorkerThreadId, (), (const, override));
-    MOCK_METHOD(TupleBuffer, allocateTupleBuffer, (), (override));
-    MOCK_METHOD(TupleBuffer&, pinBuffer, (TupleBuffer&&), (override));
+    MOCK_METHOD(Buffer, allocateTupleBuffer, (), (override));
+    MOCK_METHOD(Buffer&, pinBuffer, (Buffer&&), (override));
     MOCK_METHOD(uint64_t, getNumberOfWorkerThreads, (), (const, override));
     MOCK_METHOD(std::shared_ptr<AbstractBufferProvider>, getBufferManager, (), (const, override));
     MOCK_METHOD(PipelineId, getPipelineId, (), (const, override));
     MOCK_METHOD((std::unordered_map<OperatorHandlerId, std::shared_ptr<OperatorHandler>>&), getOperatorHandlers, (), (override));
     MOCK_METHOD(void, setOperatorHandlers, ((std::unordered_map<OperatorHandlerId, std::shared_ptr<OperatorHandler>>&)), (override));
-    MOCK_METHOD(bool, emitBuffer, (const TupleBuffer&, ContinuationPolicy), (override));
+    MOCK_METHOD(bool, emitBuffer, (const Buffer&, ContinuationPolicy), (override));
 };
 
 struct TerminatePipelineArgs

--- a/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.cpp
+++ b/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.cpp
@@ -37,9 +37,9 @@
 #include <Identifiers/Identifiers.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/Allocator/NesDefaultMemoryAllocator.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/BufferManager.hpp>
 #include <Runtime/QueryTerminationType.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Sequencing/SequenceData.hpp>
 #include <Sources/SourceHandle.hpp>
 #include <Util/Overloaded.hpp>
@@ -75,7 +75,7 @@ std::vector<std::byte> identifiableData(size_t identifier)
     return {bytes.begin(), bytes.end()};
 }
 
-bool verifyIdentifier(const TupleBuffer& buffer, size_t identifier)
+bool verifyIdentifier(const Buffer& buffer, size_t identifier)
 {
     if (buffer.getBufferSize() == 0)
     {
@@ -113,14 +113,14 @@ testing::AssertionResult TestSinkController::waitForNumberOfReceivedBuffersOrMor
                buffers->size());
 }
 
-void TestSinkController::insertBuffer(TupleBuffer&& buffer)
+void TestSinkController::insertBuffer(Buffer&& buffer)
 {
     ++invocations;
     receivedBuffers.lock()->push_back(std::move(buffer));
     receivedBufferTrigger.notify_one();
 }
 
-std::vector<TupleBuffer> TestSinkController::takeBuffers()
+std::vector<Buffer> TestSinkController::takeBuffers()
 {
     auto buffers = receivedBuffers.exchange({});
     std::ranges::sort(

--- a/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.hpp
+++ b/nes-query-engine/tests/Util/QueryEngineTestingInfrastructure.hpp
@@ -42,11 +42,11 @@
 #include <Listeners/AbstractQueryStatusListener.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/Allocator/NesDefaultMemoryAllocator.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/BufferManager.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Runtime/MemoryUtils.hpp>
 #include <Runtime/QueryTerminationType.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Sources/SourceHandle.hpp>
 #include <Util/Overloaded.hpp>
@@ -82,9 +82,9 @@ static constexpr size_t LARGE_NUMBER_OF_THREADS = 8;
 constexpr std::chrono::milliseconds DEFAULT_AWAIT_TIMEOUT = std::chrono::milliseconds(1000);
 constexpr std::chrono::milliseconds DEFAULT_LONG_AWAIT_TIMEOUT = std::chrono::milliseconds(10000);
 
-/// Creates raw TupleBuffer data based on a recognizable pattern which can later be identified using `verifyIdentifier`.
+/// Creates raw Buffer data based on a recognizable pattern which can later be identified using `verifyIdentifier`.
 std::vector<std::byte> identifiableData(size_t identifier);
-bool verifyIdentifier(const TupleBuffer& buffer, size_t identifier);
+bool verifyIdentifier(const Buffer& buffer, size_t identifier);
 
 /// Mock Implementation of the QueryEngineStatisticListener. This can be used to verify that certain
 /// statistic events have been emitted during test execution.
@@ -176,7 +176,7 @@ struct TestWorkEmitter : WorkEmitter
     MOCK_METHOD(
         bool,
         emitWork,
-        (QueryId, const std::shared_ptr<RunningQueryPlanNode>&, TupleBuffer, TaskCallback, PipelineExecutionContext::ContinuationPolicy),
+        (QueryId, const std::shared_ptr<RunningQueryPlanNode>&, Buffer, TaskCallback, PipelineExecutionContext::ContinuationPolicy),
         (override));
     MOCK_METHOD(void, emitPipelineStart, (QueryId, const std::shared_ptr<RunningQueryPlanNode>&, TaskCallback), (override));
     MOCK_METHOD(void, emitPendingPipelineStop, (QueryId, std::shared_ptr<RunningQueryPlanNode>, TaskCallback), (override));
@@ -310,11 +310,11 @@ struct TestPipeline final : ExecutablePipelineStage
         }
         else /*if (stopCalls < repeatsDuringStop)*/
         {
-            pec.repeatTask(TupleBuffer(), std::chrono::milliseconds(10));
+            pec.repeatTask(Buffer(), std::chrono::milliseconds(10));
         }
     }
 
-    void execute(const TupleBuffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext) override
+    void execute(const Buffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext) override
     {
         if (controller->invocations.fetch_add(1) + 1 == controller->throwOnNthInvocation)
         {
@@ -354,9 +354,9 @@ struct TestSinkController
     /// Waits for *at least* `numberOfExpectedBuffers`
     testing::AssertionResult waitForNumberOfReceivedBuffersOrMore(size_t numberOfExpectedBuffers);
 
-    void insertBuffer(TupleBuffer&& buffer);
+    void insertBuffer(Buffer&& buffer);
 
-    std::vector<TupleBuffer> takeBuffers();
+    std::vector<Buffer> takeBuffers();
 
     testing::AssertionResult waitForStart() const { return waitForFuture(startFuture, DEFAULT_LONG_AWAIT_TIMEOUT); }
 
@@ -382,7 +382,7 @@ struct TestSinkController
     BackpressureController backpressureController;
 
 private:
-    folly::Synchronized<std::vector<TupleBuffer>, std::mutex> receivedBuffers;
+    folly::Synchronized<std::vector<Buffer>, std::mutex> receivedBuffers;
     std::condition_variable receivedBufferTrigger;
     std::promise<void> start;
     std::promise<void> stop;
@@ -398,7 +398,7 @@ class TestSink final : public ExecutablePipelineStage
 public:
     void start(PipelineExecutionContext&) override { controller->start.set_value(); }
 
-    void execute(const TupleBuffer& inputBuffer, PipelineExecutionContext& pipelineExecutionContext) override
+    void execute(const Buffer& inputBuffer, PipelineExecutionContext& pipelineExecutionContext) override
     {
         controller->insertBuffer(deepCopyBuffer(inputBuffer, *bufferProvider));
 
@@ -433,7 +433,7 @@ public:
         }
         else /*if (stopCalls < repeatsDuringStop)*/
         {
-            pec.repeatTask(TupleBuffer(), std::chrono::milliseconds(10));
+            pec.repeatTask(Buffer(), std::chrono::milliseconds(10));
         }
     }
 

--- a/nes-query-optimizer/include/Traits/MemoryLayoutTypeTrait.hpp
+++ b/nes-query-optimizer/include/Traits/MemoryLayoutTypeTrait.hpp
@@ -18,7 +18,7 @@
 #include <string>
 #include <string_view>
 #include <typeinfo>
-#include <Interface/BufferRef/LowerSchemaProvider.hpp>
+#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
 #include <Traits/Trait.hpp>
 #include <Util/PlanRenderer.hpp>
 #include <Util/ReflectionFwd.hpp>

--- a/nes-query-optimizer/src/Rules/Static/DecideMemoryLayoutRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/DecideMemoryLayoutRule.cpp
@@ -19,7 +19,7 @@
 #include <typeindex>
 #include <typeinfo>
 
-#include <Interface/BufferRef/LowerSchemaProvider.hpp>
+#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
 #include <Operators/LogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
 #include <Rules/Barriers/FixedPlanStructureBarrier.hpp>

--- a/nes-query-optimizer/src/Traits/MemoryLayoutTypeTrait.cpp
+++ b/nes-query-optimizer/src/Traits/MemoryLayoutTypeTrait.cpp
@@ -21,7 +21,7 @@
 #include <variant>
 
 #include <Configurations/Enums/EnumWrapper.hpp>
-#include <Interface/BufferRef/LowerSchemaProvider.hpp>
+#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
 #include <Traits/Trait.hpp>
 #include <Util/PlanRenderer.hpp>
 #include <Util/Reflection.hpp>

--- a/nes-query-optimizer/tests/Rules/Static/DecideMemoryLayoutTest.cpp
+++ b/nes-query-optimizer/tests/Rules/Static/DecideMemoryLayoutTest.cpp
@@ -30,7 +30,7 @@
 #include <Functions/LogicalFunction.hpp>
 #include <Identifiers/Identifier.hpp>
 #include <Identifiers/Identifiers.hpp>
-#include <Interface/BufferRef/LowerSchemaProvider.hpp>
+#include <Interface/MemoryLayout/LowerSchemaProvider.hpp>
 #include <Iterators/BFSIterator.hpp>
 #include <Operators/LogicalOperator.hpp>
 #include <Operators/Sinks/SinkLogicalOperator.hpp>

--- a/nes-runtime/include/ExecutionContext.hpp
+++ b/nes-runtime/include/ExecutionContext.hpp
@@ -26,7 +26,7 @@
 #include <DataTypes/VariableSizedData.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Interface/NESStrongTypeRef.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Interface/TimestampRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
@@ -99,7 +99,7 @@ struct ExecutionContext final
 
 
     /// Emit a record buffer to the successor pipeline(s) or sink(s)
-    void emitBuffer(const RecordBuffer& buffer) const;
+    void emitBuffer(const TaskBufferRef& buffer) const;
 
     void setOpenReturnState(OpenReturnState openReturnState);
     [[nodiscard]] OpenReturnState getOpenReturnState() const;

--- a/nes-runtime/include/ExecutionContext.hpp
+++ b/nes-runtime/include/ExecutionContext.hpp
@@ -29,8 +29,8 @@
 #include <Interface/TaskBufferRef.hpp>
 #include <Interface/TimestampRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Time/Timestamp.hpp>
 #include <nautilus/val_concepts.hpp>
 #include <nautilus/val_ptr.hpp>
@@ -66,7 +66,7 @@ struct PipelineMemoryProvider
 
 /// Determines whether the CompiledExecutablePipelineStage continues after the open() call (with close()) or calls the 'repeatTask()' of the
 /// pipeline execution context, putting the task back into the task queue for later execution
-/// This is useful, e.g., to prevent a call to 'close()', which may emit a TupleBuffer in an unfinished state
+/// This is useful, e.g., to prevent a call to 'close()', which may emit a Buffer in an unfinished state
 enum class OpenReturnState : uint8_t
 {
     CONTINUE,
@@ -91,7 +91,7 @@ struct ExecutionContext final
     [[nodiscard]] nautilus::val<OperatorHandler*> getGlobalOperatorHandler(OperatorHandlerId handlerIndex) const;
     /// Use allocateBuffer if you want to allocate space that lives for multiple pipeline invocations, i.e., query lifetime.
     /// You must take care of the memory management yourself, i.e., when/how should the tuple buffer be returned to the buffer provider.
-    [[nodiscard]] nautilus::val<TupleBuffer*> allocateBuffer() const;
+    [[nodiscard]] nautilus::val<Buffer*> allocateBuffer() const;
 
     /// Use allocateMemory if you want to allocate memory that lives for one pipeline invocation, i.e., tuple buffer lifetime.
     /// You do not have to take care of the memory management yourself, as the memory is automatically destroyed after the pipeline invocation.

--- a/nes-runtime/include/Pipelines/CompiledExecutablePipelineStage.hpp
+++ b/nes-runtime/include/Pipelines/CompiledExecutablePipelineStage.hpp
@@ -19,8 +19,8 @@
 #include <string_view>
 #include <unordered_map>
 #include <vector>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <nautilus/Engine.hpp>
 #include <nautilus/Module.hpp>
 #include <ExecutablePipelineStage.hpp>
@@ -42,14 +42,14 @@ public:
         std::unordered_map<OperatorHandlerId, std::shared_ptr<OperatorHandler>> operatorHandler,
         nautilus::engine::Options options);
     void start(PipelineExecutionContext& pipelineExecutionContext) override;
-    void execute(const TupleBuffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext) override;
+    void execute(const Buffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext) override;
     void stop(PipelineExecutionContext& pipelineExecutionContext) override;
 
 protected:
     std::ostream& toString(std::ostream& os) const override;
 
 private:
-    using PipelineSignature = void(PipelineExecutionContext*, const TupleBuffer*, const Arena*);
+    using PipelineSignature = void(PipelineExecutionContext*, const Buffer*, const Arena*);
     static constexpr std::string_view PIPELINE_FUNCTION_NAME = "execute";
 
     /// Registers the pipeline's main traced function in the pipeline's module.

--- a/nes-runtime/src/ExecutionContext.cpp
+++ b/nes-runtime/src/ExecutionContext.cpp
@@ -24,7 +24,7 @@
 #include <Identifiers/Identifiers.hpp>
 #include <Identifiers/NESStrongType.hpp>
 #include <Interface/NESStrongTypeRef.hpp>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Runtime/TupleBuffer.hpp>
@@ -99,7 +99,7 @@ void emitBufferProxy(PipelineExecutionContext* pipelineCtx, TupleBuffer* tb)
     pipelineCtx->emitBuffer(*tb);
 }
 
-void ExecutionContext::emitBuffer(const RecordBuffer& buffer) const
+void ExecutionContext::emitBuffer(const TaskBufferRef& buffer) const
 {
     nautilus::invoke(emitBufferProxy, pipelineContext, buffer.getReference());
 }

--- a/nes-runtime/src/ExecutionContext.cpp
+++ b/nes-runtime/src/ExecutionContext.cpp
@@ -26,8 +26,8 @@
 #include <Interface/NESStrongTypeRef.hpp>
 #include <Interface/TaskBufferRef.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <nautilus/function.hpp>
 #include <ErrorHandling.hpp>
@@ -70,7 +70,7 @@ ExecutionContext::ExecutionContext(const nautilus::val<PipelineExecutionContext*
 {
 }
 
-nautilus::val<TupleBuffer*> ExecutionContext::allocateBuffer() const
+nautilus::val<Buffer*> ExecutionContext::allocateBuffer() const
 {
     auto bufferPtr = nautilus::invoke(
         +[](PipelineExecutionContext* pec)
@@ -88,7 +88,7 @@ nautilus::val<int8_t*> ExecutionContext::allocateMemory(const nautilus::val<size
     return pipelineMemoryProvider.arena.allocateMemory(sizeInBytes);
 }
 
-void emitBufferProxy(PipelineExecutionContext* pipelineCtx, TupleBuffer* tb)
+void emitBufferProxy(PipelineExecutionContext* pipelineCtx, Buffer* tb)
 {
     NES_TRACE("Emitting buffer with SequenceData = {}", tb->getSequenceDataAsString());
 

--- a/nes-runtime/src/Pipelines/CompiledExecutablePipelineStage.cpp
+++ b/nes-runtime/src/Pipelines/CompiledExecutablePipelineStage.cpp
@@ -20,7 +20,7 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
-#include <Interface/RecordBuffer.hpp>
+#include <Interface/TaskBufferRef.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
 #include <Runtime/TupleBuffer.hpp>
 #include <Util/Logger/Logger.hpp>
@@ -73,7 +73,7 @@ void CompiledExecutablePipelineStage::registerPipelineFunction(nautilus::engine:
                                nautilus::val<const Arena*> arenaRef)
     {
         auto ctx = ExecutionContext(pipelineExecutionContext, arenaRef);
-        RecordBuffer recordBuffer(recordBufferRef);
+        TaskBufferRef recordBuffer(recordBufferRef);
 
         pipeline->getRootOperator().open(ctx, recordBuffer);
         switch (ctx.getOpenReturnState())

--- a/nes-runtime/src/Pipelines/CompiledExecutablePipelineStage.cpp
+++ b/nes-runtime/src/Pipelines/CompiledExecutablePipelineStage.cpp
@@ -21,8 +21,8 @@
 #include <unordered_map>
 #include <utility>
 #include <Interface/TaskBufferRef.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Runtime/Execution/OperatorHandler.hpp>
-#include <Runtime/TupleBuffer.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <cpptrace/from_current.hpp>
 #include <cpptrace/from_current_macros.hpp>
@@ -48,7 +48,7 @@ CompiledExecutablePipelineStage::CompiledExecutablePipelineStage(
 {
 }
 
-void CompiledExecutablePipelineStage::execute(const TupleBuffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext)
+void CompiledExecutablePipelineStage::execute(const Buffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext)
 {
     INVARIANT(compiledPipelineFunction.has_value(), "execute() was called before start() compiled the pipeline");
     /// we call the compiled pipeline function with an input buffer and the execution context
@@ -66,10 +66,10 @@ void CompiledExecutablePipelineStage::registerPipelineFunction(nautilus::engine:
     /// buffers) past teardown -- which leaks buffers in the sliceCache systests.
     /// Additionally, we can NOT use const or const references for the parameters of the lambda function
     /// NOLINTBEGIN(performance-unnecessary-value-param)
-    const std::function<void(nautilus::val<PipelineExecutionContext*>, nautilus::val<const TupleBuffer*>, nautilus::val<const Arena*>)>
+    const std::function<void(nautilus::val<PipelineExecutionContext*>, nautilus::val<const Buffer*>, nautilus::val<const Arena*>)>
         compiledFunction = [this](
                                nautilus::val<PipelineExecutionContext*> pipelineExecutionContext,
-                               nautilus::val<const TupleBuffer*> recordBufferRef,
+                               nautilus::val<const Buffer*> recordBufferRef,
                                nautilus::val<const Arena*> arenaRef)
     {
         auto ctx = ExecutionContext(pipelineExecutionContext, arenaRef);
@@ -84,8 +84,7 @@ void CompiledExecutablePipelineStage::registerPipelineFunction(nautilus::engine:
             }
             case OpenReturnState::REPEAT: {
                 nautilus::invoke(
-                    +[](PipelineExecutionContext* pec, const TupleBuffer* buffer)
-                    { pec->repeatTask(*buffer, std::chrono::milliseconds(0)); },
+                    +[](PipelineExecutionContext* pec, const Buffer* buffer) { pec->repeatTask(*buffer, std::chrono::milliseconds(0)); },
                     pipelineExecutionContext,
                     recordBufferRef);
                 break;

--- a/nes-sinks/include/Sinks/BackpressureHandler.hpp
+++ b/nes-sinks/include/Sinks/BackpressureHandler.hpp
@@ -19,7 +19,7 @@
 #include <optional>
 #include <Identifiers/Identifiers.hpp>
 #include <Identifiers/NESStrongType.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <folly/Synchronized.h>
 #include <BackpressureChannel.hpp>
 
@@ -44,7 +44,7 @@ class BackpressureHandler
     struct State
     {
         bool hasBackpressure = false;
-        std::deque<TupleBuffer> buffered;
+        std::deque<Buffer> buffered;
         SequenceNumber pendingSequenceNumber = INVALID<SequenceNumber>;
         ChunkNumber pendingChunkNumber = INVALID<ChunkNumber>;
     };
@@ -58,8 +58,8 @@ public:
     /// @param lowerThreshold Number of buffered tuple buffers at which backpressure is released.
     explicit BackpressureHandler(size_t upperThreshold = 1, size_t lowerThreshold = 0); /// NOLINT(fuchsia-default-arguments-declarations)
 
-    std::optional<TupleBuffer> onFull(TupleBuffer buffer, BackpressureController& backpressureController);
-    std::optional<TupleBuffer> onSuccess(BackpressureController& backpressureController);
+    std::optional<Buffer> onFull(Buffer buffer, BackpressureController& backpressureController);
+    std::optional<Buffer> onSuccess(BackpressureController& backpressureController);
     [[nodiscard]] bool empty() const;
 };
 

--- a/nes-sinks/include/Sinks/FileSink.hpp
+++ b/nes-sinks/include/Sinks/FileSink.hpp
@@ -25,7 +25,7 @@
 #include <folly/Synchronized.h>
 
 #include <Configurations/Descriptor.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sinks/Sink.hpp>
 #include <Sinks/SinkDescriptor.hpp>
 #include <SinksParsing/SchemaFormatter.hpp>
@@ -47,7 +47,7 @@ public:
     FileSink& operator=(FileSink&&) = delete;
 
     void start(PipelineExecutionContext& pipelineExecutionContext) override;
-    void execute(const TupleBuffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext) override;
+    void execute(const Buffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext) override;
     void stop(PipelineExecutionContext& pipelineExecutionContext) override;
 
     static DescriptorConfig::Config validateAndFormat(std::unordered_map<std::string, std::string> config);

--- a/nes-sinks/include/Sinks/NetworkSink.hpp
+++ b/nes-sinks/include/Sinks/NetworkSink.hpp
@@ -23,7 +23,7 @@
 #include <unordered_map>
 #include <vector>
 #include <Configurations/Descriptor.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sinks/BackpressureHandler.hpp>
 #include <Sinks/Sink.hpp>
 #include <Sinks/SinkDescriptor.hpp>
@@ -55,7 +55,7 @@ public:
     NetworkSink& operator=(NetworkSink&&) = delete;
 
     void start(PipelineExecutionContext& pipelineExecutionContext) override;
-    void execute(const TupleBuffer& inputBuffer, PipelineExecutionContext& pec) override;
+    void execute(const Buffer& inputBuffer, PipelineExecutionContext& pec) override;
     void stop(PipelineExecutionContext& pec) override;
 
     static DescriptorConfig::Config validateAndFormat(std::unordered_map<std::string, std::string> config);
@@ -65,7 +65,7 @@ protected:
 
 private:
     size_t tupleSize;
-    folly::Synchronized<std::vector<TupleBuffer>> bufferBacklog;
+    folly::Synchronized<std::vector<Buffer>> bufferBacklog;
     BackpressureHandler backpressureHandler;
     std::optional<rust::Box<SenderNetworkService>> server;
     std::optional<rust::Box<SenderDataChannel>> channel;

--- a/nes-sinks/include/Sinks/PrintSink.hpp
+++ b/nes-sinks/include/Sinks/PrintSink.hpp
@@ -25,7 +25,7 @@
 
 #include <Configurations/Descriptor.hpp>
 #include <Identifiers/Identifiers.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sinks/Sink.hpp>
 #include <Sinks/SinkDescriptor.hpp>
 #include <BackpressureChannel.hpp>
@@ -47,7 +47,7 @@ public:
     PrintSink(PrintSink&&) = delete;
     PrintSink& operator=(PrintSink&&) = delete;
     void start(PipelineExecutionContext& pipelineExecutionContext) override;
-    void execute(const TupleBuffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext) override;
+    void execute(const Buffer& inputTupleBuffer, PipelineExecutionContext& pipelineExecutionContext) override;
     void stop(PipelineExecutionContext& pipelineExecutionContext) override;
 
     static DescriptorConfig::Config validateAndFormat(std::unordered_map<std::string, std::string> config);

--- a/nes-sinks/include/Sinks/SinkProvider.hpp
+++ b/nes-sinks/include/Sinks/SinkProvider.hpp
@@ -21,7 +21,7 @@
 namespace NES
 {
 
-/// Takes a SinkDescriptor and in exchange returns a SinkPipeline, which Tasks can process (together with a TupleBuffer).
+/// Takes a SinkDescriptor and in exchange returns a SinkPipeline, which Tasks can process (together with a Buffer).
 std::unique_ptr<Sink> lower(BackpressureController backpressureController, const SinkDescriptor& sinkDescriptor);
 
 }

--- a/nes-sinks/include/SinksParsing/BufferIterator.hpp
+++ b/nes-sinks/include/SinksParsing/BufferIterator.hpp
@@ -17,7 +17,7 @@
 #include <cstdint>
 #include <optional>
 #include <utility>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 
 namespace NES
 {
@@ -29,16 +29,16 @@ class BufferIterator
 public:
     struct BufferElement
     {
-        TupleBuffer buffer;
+        Buffer buffer;
         uint64_t contentLength;
     };
 
-    explicit BufferIterator(TupleBuffer buffer) : tupleBuffer(std::move(buffer)) { }
+    explicit BufferIterator(Buffer buffer) : tupleBuffer(std::move(buffer)) { }
 
     [[nodiscard]] std::optional<BufferElement> getNextElement();
 
 private:
-    TupleBuffer tupleBuffer;
+    Buffer tupleBuffer;
     size_t bufferIndex = 0;
 };
 }

--- a/nes-sinks/src/BackpressureHandler.cpp
+++ b/nes-sinks/src/BackpressureHandler.cpp
@@ -20,7 +20,7 @@
 #include <utility>
 #include <Identifiers/Identifiers.hpp>
 #include <Identifiers/NESStrongType.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <BackpressureChannel.hpp>
 
@@ -37,7 +37,7 @@ BackpressureHandler::BackpressureHandler(size_t upperThreshold, size_t lowerThre
     }
 }
 
-std::optional<TupleBuffer> BackpressureHandler::onFull(TupleBuffer buffer, BackpressureController& backpressureController)
+std::optional<Buffer> BackpressureHandler::onFull(Buffer buffer, BackpressureController& backpressureController)
 {
     auto rstate = stateLock.ulock();
 
@@ -71,7 +71,7 @@ std::optional<TupleBuffer> BackpressureHandler::onFull(TupleBuffer buffer, Backp
     return {};
 }
 
-std::optional<TupleBuffer> BackpressureHandler::onSuccess(BackpressureController& backpressureController)
+std::optional<Buffer> BackpressureHandler::onSuccess(BackpressureController& backpressureController)
 {
     const auto state = stateLock.wlock();
     state->pendingSequenceNumber = INVALID<SequenceNumber>;

--- a/nes-sinks/src/FileSink.cpp
+++ b/nes-sinks/src/FileSink.cpp
@@ -33,7 +33,7 @@
 #include <DataTypes/Schema.hpp>
 #include <DataTypes/SchemaFwd.hpp>
 #include <DataTypes/UnboundField.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sinks/Sink.hpp>
 #include <Sinks/SinkDescriptor.hpp>
 #include <SinksParsing/BufferIterator.hpp>
@@ -101,7 +101,7 @@ void FileSink::start(PipelineExecutionContext&)
     }
 }
 
-void FileSink::execute(const TupleBuffer& inputTupleBuffer, PipelineExecutionContext&)
+void FileSink::execute(const Buffer& inputTupleBuffer, PipelineExecutionContext&)
 {
     PRECONDITION(inputTupleBuffer, "Invalid input buffer in FileSink.");
     PRECONDITION(isOpen, "Sink was not opened");

--- a/nes-sinks/src/NetworkSink.cpp
+++ b/nes-sinks/src/NetworkSink.cpp
@@ -27,7 +27,7 @@
 
 #include <Configurations/Descriptor.hpp>
 #include <Identifiers/NESStrongType.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sinks/Sink.hpp>
 #include <Sinks/SinkDescriptor.hpp>
 #include <Util/Logger/Logger.hpp>
@@ -95,7 +95,7 @@ void NetworkSink::stop(PipelineExecutionContext& pec)
     NES_DEBUG("Sender channel {} closed", channelId);
 }
 
-void NetworkSink::execute(const TupleBuffer& inputBuffer, PipelineExecutionContext& pec)
+void NetworkSink::execute(const Buffer& inputBuffer, PipelineExecutionContext& pec)
 {
     PRECONDITION(channel, "Sender channel is not initialized");
     PRECONDITION(inputBuffer, "Invalid input buffer in NetworkSink.");

--- a/nes-sinks/src/PrintSink.cpp
+++ b/nes-sinks/src/PrintSink.cpp
@@ -25,7 +25,7 @@
 #include <utility>
 
 #include <Configurations/Descriptor.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sinks/SinkDescriptor.hpp>
 #include <SinksParsing/BufferIterator.hpp>
 #include <fmt/format.h>
@@ -54,7 +54,7 @@ void PrintSink::stop(PipelineExecutionContext&)
 {
 }
 
-void PrintSink::execute(const TupleBuffer& inputBuffer, PipelineExecutionContext&)
+void PrintSink::execute(const Buffer& inputBuffer, PipelineExecutionContext&)
 {
     PRECONDITION(inputBuffer, "Invalid input buffer in PrintSink.");
     {

--- a/nes-sinks/src/SinksParsing/BufferIterator.cpp
+++ b/nes-sinks/src/SinksParsing/BufferIterator.cpp
@@ -16,7 +16,7 @@
 
 #include <cstdint>
 #include <optional>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 
 namespace NES
 {
@@ -39,7 +39,7 @@ std::optional<BufferIterator::BufferElement> BufferIterator::getNextElement()
 
     /// Iterate through the children
     /// Child buffers store the number of written bytes in them as the number of tuples
-    const TupleBuffer childBuffer = tupleBuffer.loadChildBuffer(ChildBufferIndex(bufferIndex - 1));
+    const Buffer childBuffer = tupleBuffer.loadChildBuffer(ChildBufferIndex(bufferIndex - 1));
     ++bufferIndex;
     return std::optional<BufferElement>({.buffer = childBuffer, .contentLength = childBuffer.getNumberOfTuples()});
 }

--- a/nes-sources/include/Sources/NetworkSource.hpp
+++ b/nes-sources/include/Sources/NetworkSource.hpp
@@ -24,7 +24,7 @@
 #include <Configurations/Descriptor.hpp>
 #include <Configurations/Validation/EndpointValidation.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sources/Source.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Util/Logger/Logger.hpp>
@@ -52,7 +52,7 @@ public:
     NetworkSource(NetworkSource&&) = delete;
     NetworkSource& operator=(NetworkSource&&) = delete;
 
-    FillTupleBufferResult fillTupleBuffer(TupleBuffer& tupleBuffer, const std::stop_token& stopToken) override;
+    FillTupleBufferResult fillTupleBuffer(Buffer& tupleBuffer, const std::stop_token& stopToken) override;
     void open(std::shared_ptr<AbstractBufferProvider> provider) override;
     void close() override;
 
@@ -63,7 +63,7 @@ public:
     [[nodiscard]] std::ostream& toString(std::ostream& str) const override;
 
 private:
-    bool fillBuffer(TupleBuffer& tupleBuffer, size_t& numReceivedBytes);
+    bool fillBuffer(Buffer& tupleBuffer, size_t& numReceivedBytes);
 
     std::string channelId;
     size_t receiverQueueSize;

--- a/nes-sources/include/Sources/Source.hpp
+++ b/nes-sources/include/Sources/Source.hpp
@@ -20,7 +20,7 @@
 #include <stop_token>
 #include <variant>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Util/Logger/Formatter.hpp>
 
 namespace NES
@@ -28,7 +28,7 @@ namespace NES
 
 /// Source is the interface for all sources that read data into TupleBuffers.
 /// 'SourceThread' creates TupleBuffers and uses 'Source' to fill.
-/// When 'fillTupleBuffer()' returns successfully, 'SourceThread' creates a new Task using the filled TupleBuffer.
+/// When 'fillTupleBuffer()' returns successfully, 'SourceThread' creates a new Task using the filled Buffer.
 class Source
 {
 public:
@@ -61,9 +61,9 @@ public:
     Source() = default;
     virtual ~Source() = default;
 
-    /// Read data from a source into a TupleBuffer, until the TupleBuffer is full (or a timeout is reached).
+    /// Read data from a source into a Buffer, until the Buffer is full (or a timeout is reached).
     /// @return the number of bytes read
-    virtual FillTupleBufferResult fillTupleBuffer(TupleBuffer& tupleBuffer, const std::stop_token& stopToken) = 0;
+    virtual FillTupleBufferResult fillTupleBuffer(Buffer& tupleBuffer, const std::stop_token& stopToken) = 0;
 
     /// If applicable, opens a connection, e.g., a socket connection to get ready for data consumption.
     virtual void open(std::shared_ptr<AbstractBufferProvider> bufferProvider) = 0;

--- a/nes-sources/include/Sources/SourceProvider.hpp
+++ b/nes-sources/include/Sources/SourceProvider.hpp
@@ -27,7 +27,7 @@ namespace NES
 
 /// Takes a SourceDescriptor and in exchange returns a SourceHandle.
 /// The SourceThread spawns an independent thread for data ingestion and it manages the pipeline and task logic.
-/// The Source is owned by the SourceThread. The Source ingests bytes from an interface (TCP, CSV, ..) and writes the bytes to a TupleBuffer.
+/// The Source is owned by the SourceThread. The Source ingests bytes from an interface (TCP, CSV, ..) and writes the bytes to a Buffer.
 class SourceProvider
 {
     size_t defaultMaxInflightBuffers;

--- a/nes-sources/include/Sources/SourceReturnType.hpp
+++ b/nes-sources/include/Sources/SourceReturnType.hpp
@@ -18,7 +18,7 @@
 #include <functional>
 #include <variant>
 #include <Identifiers/Identifiers.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <ErrorHandling.hpp>
 
 namespace NES::SourceReturnType
@@ -31,7 +31,7 @@ struct Error
 
 struct Data
 {
-    TupleBuffer buffer;
+    Buffer buffer;
 };
 
 struct EoS

--- a/nes-sources/private/FileSource.hpp
+++ b/nes-sources/private/FileSource.hpp
@@ -25,7 +25,7 @@
 #include <unordered_map>
 #include <Identifiers/Identifier.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sources/Source.hpp>
 #include <Sources/SourceDescriptor.hpp>
 
@@ -47,7 +47,7 @@ public:
     FileSource(FileSource&&) = delete;
     FileSource& operator=(FileSource&&) = delete;
 
-    FillTupleBufferResult fillTupleBuffer(TupleBuffer& tupleBuffer, const std::stop_token& stopToken) override;
+    FillTupleBufferResult fillTupleBuffer(Buffer& tupleBuffer, const std::stop_token& stopToken) override;
 
     /// Open file socket.
     void open(std::shared_ptr<AbstractBufferProvider> bufferProvider) override;

--- a/nes-sources/private/SourceThread.hpp
+++ b/nes-sources/private/SourceThread.hpp
@@ -24,7 +24,7 @@
 #include <thread>
 #include <Identifiers/Identifiers.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sources/Source.hpp>
 #include <Sources/SourceReturnType.hpp>
 #include <Util/Logger/Formatter.hpp>
@@ -103,7 +103,7 @@ protected:
     /// Runs in detached thread and kills thread when finishing.
     /// while (running) { ... }: orchestrates data ingestion until end of stream or failure.
     void runningRoutine(const std::stop_token& stopToken, std::promise<SourceImplementationTermination>&);
-    void emitWork(TupleBuffer& buffer, bool addBufferMetaData = true);
+    void emitWork(Buffer& buffer, bool addBufferMetaData = true);
     friend std::ostream& operator<<(std::ostream& out, const SourceThread& sourceThread);
 };
 

--- a/nes-sources/src/FileSource.cpp
+++ b/nes-sources/src/FileSource.cpp
@@ -29,7 +29,7 @@
 #include <utility>
 #include <Configurations/Descriptor.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sources/Source.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Util/Files.hpp>
@@ -61,7 +61,7 @@ void FileSource::close()
     this->inputFile.close();
 }
 
-Source::FillTupleBufferResult FileSource::fillTupleBuffer(TupleBuffer& tupleBuffer, const std::stop_token&)
+Source::FillTupleBufferResult FileSource::fillTupleBuffer(Buffer& tupleBuffer, const std::stop_token&)
 {
     this->inputFile.read(
         tupleBuffer.getAvailableMemoryArea<std::istream::char_type>().data(), static_cast<std::streamsize>(tupleBuffer.getBufferSize()));

--- a/nes-sources/src/NetworkSource.cpp
+++ b/nes-sources/src/NetworkSource.cpp
@@ -23,7 +23,7 @@
 #include <utility>
 #include <Configurations/Descriptor.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sources/Source.hpp>
 #include <Sources/SourceDescriptor.hpp>
 #include <Util/Logger/Logger.hpp>
@@ -61,7 +61,7 @@ void NetworkSource::open(std::shared_ptr<AbstractBufferProvider> provider)
     NES_DEBUG("Receiver channel registered: {}", channelId);
 }
 
-Source::FillTupleBufferResult NetworkSource::fillTupleBuffer(TupleBuffer& tupleBuffer, const std::stop_token& stopToken)
+Source::FillTupleBufferResult NetworkSource::fillTupleBuffer(Buffer& tupleBuffer, const std::stop_token& stopToken)
 {
     PRECONDITION(channel, "Network Source was opened multiple times");
     PRECONDITION(bufferProvider, "Network Source was opened without a buffer provider");

--- a/nes-sources/src/SourceThread.cpp
+++ b/nes-sources/src/SourceThread.cpp
@@ -26,7 +26,7 @@
 #include <variant>
 #include <Identifiers/Identifiers.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sources/Source.hpp>
 #include <Sources/SourceReturnType.hpp>
 #include <Time/Timestamp.hpp>
@@ -55,7 +55,7 @@ SourceThread::SourceThread(
 
 namespace
 {
-void addBufferMetaData(OriginId originId, SequenceNumber sequenceNumber, TupleBuffer& buffer)
+void addBufferMetaData(OriginId originId, SequenceNumber sequenceNumber, Buffer& buffer)
 {
     /// set the origin id for this source
     buffer.setOriginId(originId);
@@ -76,7 +76,7 @@ void addBufferMetaData(OriginId originId, SequenceNumber sequenceNumber, TupleBu
         buffer.isLastChunk());
 }
 
-using EmitFn = std::function<void(TupleBuffer&&, bool addBufferMetadata)>;
+using EmitFn = std::function<void(Buffer&&, bool addBufferMetadata)>;
 
 SourceImplementationTermination dataSourceThreadRoutine(
     const std::stop_token& stopToken,
@@ -112,7 +112,7 @@ SourceImplementationTermination dataSourceThreadRoutine(
         /// 4. Failure. The fillTupleBuffer method will throw an exception, the exception is propagted to the SourceThread via the return promise.
         ///    The thread exists with an exception
 
-        std::optional<TupleBuffer> emptyBuffer;
+        std::optional<Buffer> emptyBuffer;
         while (!emptyBuffer && !stopToken.stop_requested())
         {
             emptyBuffer = bufferProvider->getBufferWithTimeout(std::chrono::milliseconds(25));
@@ -155,7 +155,7 @@ void dataSourceThread(
     std::shared_ptr<AbstractBufferProvider> bufferProvider)
 {
     size_t sequenceNumberGenerator = SequenceNumber::INITIAL;
-    const EmitFn dataEmit = [&](TupleBuffer&& buffer, bool shouldAddMetadata)
+    const EmitFn dataEmit = [&](Buffer&& buffer, bool shouldAddMetadata)
     {
         if (shouldAddMetadata)
         {

--- a/nes-sources/tests/Util/TestSource.cpp
+++ b/nes-sources/tests/Util/TestSource.cpp
@@ -31,7 +31,7 @@
 #include <vector>
 #include <Identifiers/Identifiers.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sources/Source.hpp>
 #include <Sources/SourceHandle.hpp>
 #include <Util/Logger/Logger.hpp>
@@ -149,7 +149,7 @@ void NES::TestSourceControl::failDuringClose(std::chrono::milliseconds blockFor)
     fail_during_close = true;
 }
 
-NES::Source::FillTupleBufferResult NES::TestSource::fillTupleBuffer(NES::TupleBuffer& tupleBuffer, const std::stop_token& stopToken)
+NES::Source::FillTupleBufferResult NES::TestSource::fillTupleBuffer(NES::Buffer& tupleBuffer, const std::stop_token& stopToken)
 {
     TestSourceControl::ControlData controlData;
     /// poll from the queue as long as stop was not requested.

--- a/nes-sources/tests/Util/TestSource.hpp
+++ b/nes-sources/tests/Util/TestSource.hpp
@@ -27,7 +27,7 @@
 #include <vector>
 #include <Identifiers/Identifiers.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
-#include <Runtime/TupleBuffer.hpp>
+#include <Runtime/Buffer.hpp>
 #include <Sources/Source.hpp>
 #include <Sources/SourceHandle.hpp>
 #include <Util/Overloaded.hpp>
@@ -95,7 +95,7 @@ private:
 class TestSource : public Source
 {
 public:
-    FillTupleBufferResult fillTupleBuffer(TupleBuffer& tupleBuffer, const std::stop_token& stopToken) override;
+    FillTupleBufferResult fillTupleBuffer(Buffer& tupleBuffer, const std::stop_token& stopToken) override;
     void open(std::shared_ptr<AbstractBufferProvider>) override;
     void close() override;
 


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR renames our buffer wrappers. See #1831 for more information. 

## Verifying this change
This change is tested by our CI test.

## Issue Closed by this pull request:

This PR closes #1831 .
