### PR TITLE
fix(join): remove invalid predicate validation

### DIFF
--- a/nes-logical-operators/src/Plans/LogicalPlanBuilder.cpp
+++ b/nes-logical-operators/src/Plans/LogicalPlanBuilder.cpp
@@ -21,7 +21,6 @@
 #include <ranges>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -30,12 +29,9 @@
 #include <DataTypes/Schema.hpp>
 #include <DataTypes/SchemaFwd.hpp>
 #include <DataTypes/UnboundField.hpp>
-#include <Functions/ConstantValueLogicalFunction.hpp>
-#include <Functions/FieldAccessLogicalFunction.hpp>
 #include <Functions/LogicalFunction.hpp>
 #include <Functions/UnboundFieldAccessLogicalFunction.hpp>
 #include <Identifiers/Identifier.hpp>
-#include <Iterators/BFSIterator.hpp>
 #include <Operators/EventTimeWatermarkAssignerLogicalOperator.hpp>
 #include <Operators/InferModelNameLogicalOperator.hpp>
 #include <Operators/IngestionTimeWatermarkAssignerLogicalOperator.hpp>
@@ -145,38 +141,6 @@ LogicalPlan LogicalPlanBuilder::addJoin(
     Windowing::TimeCharacteristic leftCharacteristic,
     Windowing::TimeCharacteristic rightCharacteristic)
 {
-    NES_TRACE("LogicalPlanBuilder: Iterate over all ExpressionNode to check join field.");
-    std::unordered_set<LogicalFunction> visitedFunctions;
-    /// We are iterating over all binary functions and check if each side's leaf is a constant value, as we are supposedly not supporting this
-    /// I am not sure why this is the case, but I will keep it for now. IMHO, the whole LogicalPlanBuilder should be refactored to be more readable and
-    /// also to be more maintainable.
-    for (const LogicalFunction& itr : BFSRange(joinFunction))
-    {
-        if (itr.getChildren().size() == 2)
-        {
-            auto leftVisitingOp = itr.getChildren()[0];
-            if (leftVisitingOp.getChildren().size() == 1)
-            {
-                if (visitedFunctions.find(leftVisitingOp) == visitedFunctions.end())
-                {
-                    visitedFunctions.insert(leftVisitingOp);
-                    auto leftChild = leftVisitingOp.getChildren().at(0);
-                    auto rightChild = leftVisitingOp.getChildren().at(1);
-                    /// ensure that the child nodes are not binary
-                    if ((leftChild.getChildren().size() == 1) && (rightChild.getChildren().size() == 1))
-                    {
-                        if (leftChild.tryGetAs<ConstantValueLogicalFunction>() || rightChild.tryGetAs<ConstantValueLogicalFunction>())
-                        {
-                            throw InvalidQuerySyntax("One of the join keys does only consist of a constant function. Use WHERE instead.");
-                        }
-                        auto leftKeyFieldAccess = leftChild.getAs<FieldAccessLogicalFunction>();
-                        auto rightKeyFieldAccess = rightChild.getAs<FieldAccessLogicalFunction>();
-                    }
-                }
-            }
-        }
-    }
-
     /// check if query contain watermark assigner, and add if missing (as default behaviour)
     leftLogicalPlan = checkAndAddWatermarkAssigner(leftLogicalPlan, leftCharacteristic);
     rightLogicalPlan = checkAndAddWatermarkAssigner(rightLogicalPlan, rightCharacteristic);


### PR DESCRIPTION
## Summary

- remove the malformed predicate traversal from `LogicalPlanBuilder::addJoin`
- remove includes that became unused with the traversal
- leave watermark setup and logical join construction unchanged

## What the removed code was intended to do

The comment and exception indicate that the traversal was intended to reject join predicates where one comparison operand consists only of a constant. For example, a predicate equivalent to `ON 1 = right_key` was meant to be rejected with guidance to express the constant condition in a `WHERE` clause instead.

To implement that rule, the code walked the predicate tree breadth-first, selected the left child of each binary function, and attempted to inspect two children below that node.

## Why the validation did not work

The tree-shape checks contradict the accesses and the intended rule:

- a direct constant is a leaf with zero children, so it never enters the `size() == 1` branch and is not rejected
- a unary expression such as `ABS(left_key)` has exactly one child, so it enters that branch and then `at(1)` throws `std::out_of_range`
- only the left child of each binary function is inspected, making the traversal asymmetric
- the later checks expect the extracted children to each have one child before casting them to field accesses, although field-access leaves have zero children
- the extracted field-access values are unused

Consequently, the block does not enforce the stated constant-only restriction. It skips the input it intends to reject and crashes on a valid unary expression instead. Removing it therefore removes an invalid failure path rather than functioning predicate validation.

## Impact

Windowed joins with unary expression operands can proceed through logical-plan construction. Existing field-to-field and binary-expression predicates retain the same construction path.

## System-test reachability

A SQL systest on current `main` cannot reach this failure: nested expression operands in join predicates are rejected earlier by the SQL parser, before `LogicalPlanBuilder::addJoin` receives the predicate tree.

Once expression operands are routed through join parsing, an end-to-end systest using a predicate such as `ON ABS(left_key) = right_key` can reproduce the failure during logical-plan creation. For this PR in isolation, a direct `LogicalPlanBuilder` unit test would be the appropriate way to exercise the malformed tree traversal; a SQL systest would require the separate parser capability first.

## Validation

- `MOLD_JOBS=1 cmake --build cmake-build-debug --target nes-unit-tests -j`
- 66 relevant `StatementBinderTest`, `JoinLogicalOperatorTest`, and `DecideJoinTypesTest` cases passed
- `git diff --check`

The isolated debug configuration used `ENABLE_LARGE_TESTS=OFF` because the host does not meet the large-systest memory requirement; unit tests remained enabled.