### PR TITLE
feat(CI): add nightly command check for docs

### DIFF
--- a/.github/workflows/nightly-quick-start.yml
+++ b/.github/workflows/nightly-quick-start.yml
@@ -1,0 +1,23 @@
+name: Nightly Quick Start Check
+
+on:
+  workflow_call:
+    inputs:
+      head_sha:
+        required: false
+        type: string
+        default: main
+
+permissions:
+  contents: read
+
+jobs:
+  quick-start:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.head_sha }}
+      - name: Run Quick Start commands
+        run: bash docs/website/scripts/test-quick-start.sh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,6 +38,12 @@ jobs:
     with:
       head_sha: ${{ needs.fetch-current-main-commit.outputs.sha }}
 
+  quick-start:
+    needs: fetch-current-main-commit
+    uses: ./.github/workflows/nightly-quick-start.yml
+    with:
+      head_sha: ${{ needs.fetch-current-main-commit.outputs.sha }}
+
   nix-build:
     name: "Run Nix Build"
     needs: [ fetch-current-main-commit ]
@@ -174,6 +180,7 @@ jobs:
       - build-and-benchmark
       - benchmark-compile-time
       - create-nightly-image
+      - quick-start
     runs-on: [ self-hosted ]
     if: ${{ failure() && !github.event.act }}
     steps:

--- a/docs/website/content/reference/GetStarted.md
+++ b/docs/website/content/reference/GetStarted.md
@@ -13,6 +13,7 @@ A basic setup consists of two components: a [**NebulaStream worker**](), which e
 
 Open a terminal and run the following Docker command to start a NebulaStream worker:
 
+<!-- quick-start-run-worker:start -->
 ```bash
 docker run -d --rm \
   --name worker \
@@ -20,6 +21,7 @@ docker run -d --rm \
   nebulastream/nes-worker \
   --grpc=0.0.0.0:8080
 ```
+<!-- quick-start-run-worker:end -->
 
 This command starts a NebulaStream worker in a Docker container and exposes its gRPC port on all network interfaces at `0.0.0.0:8080`.
 Check with `docker ps` if the worker is running.
@@ -42,6 +44,7 @@ To do this, the CLI requires a [topology file](), which defines the query config
 
 Create a file called `topology.yaml` and paste the following content:
 
+<!-- quick-start-topology:start -->
 ```yaml
 query: |
   SELECT VALUE * UINT64(2) AS SCALED_VALUE
@@ -86,6 +89,7 @@ workers:
     data_address: localhost:9090
     max_operators: 10000
 ```
+<!-- quick-start-topology:end -->
 
 ### What Does This Query Do?
 
@@ -98,6 +102,7 @@ Check the [topology file format]() for further details on how to structure a top
 
 Run the query using the following command:
 
+<!-- quick-start-submit-query:start -->
 ```bash
   docker run --rm \
     --network container:worker \
@@ -105,6 +110,7 @@ Run the query using the following command:
     nebulastream/nes-cli \
     -t /catalog/topology.yaml start
 ```
+<!-- quick-start-submit-query:end -->
 
 If query registration is successful, CLI returns the [query ID]() and stops.
 
@@ -120,9 +126,11 @@ soaring_thoroughbred_0926
 
 After a few seconds, inspect the output:
 
+<!-- quick-start-inspect-output:start -->
 ```bash
 head output/results.csv
 ```
+<!-- quick-start-inspect-output:end -->
 
 The first rows should look like this:
 
@@ -151,9 +159,11 @@ Results were outputted to a CSV file after processing.
 
 Then you can stop the worker with the following command:
 
+<!-- quick-start-stop-worker:start -->
 ```bash
 docker stop worker
 ```
+<!-- quick-start-stop-worker:end -->
 
 ## Use Docker Compose
 
@@ -161,6 +171,7 @@ You can also use [Docker Compose](https://docs.docker.com/compose/install/) to o
 
 First, create a `compose.yaml`:
 
+<!-- quick-start-compose:start -->
 ```yaml
 services:
   worker:
@@ -180,6 +191,7 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command: ["tail -f /dev/null"]
 ```
+<!-- quick-start-compose:end -->
 
 The compose file above keeps the `nes-cli` alive, so that we can check the query status, and also stop the query later.
 
@@ -188,17 +200,21 @@ The compose file above keeps the `nes-cli` alive, so that we can check the query
 Create a new topology file by using the command below.
 It uses the existing topology file to create a new one (`compose-topology.yaml`) by replacing the host address, so that the client can access the worker.
 
+<!-- quick-start-create-compose-topology:start -->
 ```bash
 sed 's/localhost/worker/g' topology.yaml > compose-topology.yaml
 ```
+<!-- quick-start-create-compose-topology:end -->
 
 ### Run the Setup
 
 Run the docker compose file using the following command:
 
+<!-- quick-start-start-compose:start -->
 ```bash
 docker compose up -d
 ```
+<!-- quick-start-start-compose:end -->
 
 This runs the worker and the nes-cli instances.
 
@@ -218,9 +234,11 @@ This runs the worker and the nes-cli instances.
 
 Check that both containers are running:
 
+<!-- quick-start-list-compose:start -->
 ```bash
 docker compose ps
 ```
+<!-- quick-start-list-compose:end -->
 
 <details>
 <summary>Expected Output</summary>
@@ -239,9 +257,11 @@ CONTAINER ID   IMAGE                       COMMAND                  CREATED     
 
 Run the following command to submit the query via `nes-cli`:
 
+<!-- quick-start-submit-compose-query:start -->
 ```bash
-docker compose exec nes-cli nes-cli -t /catalog/compose-topology.yaml start
+docker compose exec -T nes-cli nes-cli -t /catalog/compose-topology.yaml start
 ```
+<!-- quick-start-submit-compose-query:end -->
 
 The command prints a query ID.
 Seeing the query ID in the output means the query registration is successful, and the query is running.
@@ -259,9 +279,11 @@ regal_hanoverian_9516
 
 If you kept the query ID, check its status by replacing it with the `<query-id>` below:
 
+<!-- quick-start-status-compose-query:start -->
 ```bash
-docker compose exec nes-cli nes-cli -t /catalog/compose-topology.yaml status <query-id>
+docker compose exec -T nes-cli nes-cli -t /catalog/compose-topology.yaml status <query-id>
 ```
+<!-- quick-start-status-compose-query:end -->
 
 This should return the status of the registered query.
 
@@ -327,9 +349,11 @@ Each timestamp contains:
 
 Stop the query using `nes-cli`:
 
+<!-- quick-start-stop-compose-query:start -->
 ```bash
-docker compose exec nes-cli nes-cli -t /catalog/compose-topology.yaml stop <query-id>
+docker compose exec -T nes-cli nes-cli -t /catalog/compose-topology.yaml stop <query-id>
 ```
+<!-- quick-start-stop-compose-query:end -->
 
 <details>
 <summary>Example Output of a Query Stop Command</summary>
@@ -347,9 +371,11 @@ docker compose exec nes-cli nes-cli -t /catalog/compose-topology.yaml stop <quer
 
 And check the status again:
 
+<!-- quick-start-status-stopped-compose-query:start -->
 ```bash
-docker compose exec nes-cli nes-cli -t /catalog/compose-topology.yaml status <query-id>
+docker compose exec -T nes-cli nes-cli -t /catalog/compose-topology.yaml status <query-id>
 ```
+<!-- quick-start-status-stopped-compose-query:end -->
 
 This should return the status of the registered query as `Stopped`.
 
@@ -407,7 +433,9 @@ This should return the status of the registered query as `Stopped`.
 
 You can stop everything by shutting down the Compose stack.
 
+<!-- quick-start-stop-compose:start -->
 ```bash
 docker compose down
 ```
+<!-- quick-start-stop-compose:end -->
 ---

--- a/docs/website/scripts/test-quick-start.sh
+++ b/docs/website/scripts/test-quick-start.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -Eeuo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+quick_start_doc="$script_dir/../content/reference/GetStarted.md"
+
+work_dir="$(mktemp -d)"
+compose_file="$work_dir/compose.yaml"
+commands_dir="$work_dir/commands"
+
+cleanup() {
+  docker rm -f worker >/dev/null 2>&1 || true
+  if [[ -f "$compose_file" ]]; then
+    (cd "$work_dir" && docker compose down --volumes --remove-orphans) >/dev/null 2>&1 || true
+  fi
+  rm -rf "$work_dir"
+}
+trap cleanup EXIT
+
+mkdir -p "$work_dir/output" "$commands_dir"
+
+extract_code_block() {
+  local name="$1"
+  local language="$2"
+  local output="$3"
+  local start_marker="<!-- quick-start-${name}:start -->"
+  local end_marker="<!-- quick-start-${name}:end -->"
+  local opening_fence="\`\`\`$language"
+
+  if ! awk -v start_marker="$start_marker" -v end_marker="$end_marker" -v opening_fence="$opening_fence" '
+    $0 == start_marker { capture = 1; next }
+    capture && $0 == opening_fence { in_fence = 1; next }
+    in_fence && $0 == "```" { in_fence = 0; saw_fence = 1; next }
+    in_fence && $0 == end_marker { exit 1 }
+    capture && $0 == end_marker { complete = saw_fence; exit }
+    in_fence { print }
+    END { if (!complete) exit 1 }
+  ' "$quick_start_doc" >"$output"; then
+    echo "Could not extract the $name $language block from $quick_start_doc." >&2
+    return 1
+  fi
+
+  if [[ ! -s "$output" ]]; then
+    echo "The extracted $name $language block is empty." >&2
+    return 1
+  fi
+}
+
+run_documented_command() {
+  local name="$1"
+  local query_id="${2:-}"
+  local command
+
+  command="$(<"$commands_dir/$name.sh")"
+  if [[ -n "$query_id" ]]; then
+    command="${command//<query-id>/$query_id}"
+  fi
+  (cd "$work_dir" && bash -Eeuo pipefail -c "$command")
+}
+
+retry_documented_command() {
+  local name="$1"
+
+  for _ in {1..30}; do
+    if run_documented_command "$name"; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  return 1
+}
+
+extract_code_block topology yaml "$work_dir/topology.yaml"
+extract_code_block compose yaml "$compose_file"
+for command in \
+  run-worker \
+  submit-query \
+  inspect-output \
+  stop-worker \
+  create-compose-topology \
+  start-compose \
+  list-compose \
+  submit-compose-query \
+  status-compose-query \
+  stop-compose-query \
+  status-stopped-compose-query \
+  stop-compose; do
+  extract_code_block "$command" bash "$commands_dir/$command.sh"
+done
+
+wait_for_output() {
+  local results_file="$1"
+
+  for _ in {1..30}; do
+    if [[ -f "$results_file" ]] && grep -q '^498$' "$results_file"; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "Quick Start did not produce the expected CSV output." >&2
+  if [[ -f "$results_file" ]]; then
+    cat "$results_file" >&2
+  fi
+  return 1
+}
+
+echo "Checking the Docker run flow..."
+if docker container inspect worker >/dev/null 2>&1; then
+  echo "A container named worker already exists; refusing to replace it." >&2
+  exit 1
+fi
+run_documented_command run-worker
+if ! retry_documented_command submit-query; then
+  echo "Could not register the Docker run query." >&2
+  exit 1
+fi
+
+wait_for_output "$work_dir/output/results.csv"
+run_documented_command inspect-output
+run_documented_command stop-worker || true
+
+echo "Checking the Docker Compose flow..."
+run_documented_command create-compose-topology
+rm -f "$work_dir/output/results.csv"
+run_documented_command start-compose
+run_documented_command list-compose
+
+if ! compose_query_output="$(retry_documented_command submit-compose-query)"; then
+  echo "Could not register the Docker Compose query." >&2
+  exit 1
+fi
+compose_query_id="$(printf '%s\n' "$compose_query_output" | tail -n 1 | tr -d '\r')"
+if [[ ! "$compose_query_id" =~ ^[a-z0-9_]+$ ]]; then
+  echo "The Docker Compose query returned an unexpected ID: $compose_query_id" >&2
+  exit 1
+fi
+echo "$compose_query_id"
+
+run_documented_command status-compose-query "$compose_query_id"
+wait_for_output "$work_dir/output/results.csv"
+run_documented_command stop-compose-query "$compose_query_id"
+run_documented_command status-stopped-compose-query "$compose_query_id"
+run_documented_command stop-compose
+
+echo "Quick Start commands completed successfully."


### PR DESCRIPTION
 ## Summary

  Adds a nightly GitHub Actions check for the Docker commands documented in the Quick Start guide.

  The check validates both documented paths:

  - Starting a worker and submitting a query with `docker run`
  - Starting the same setup with Docker Compose
  - Waiting for `output/results.csv`
  - Verifying that the query produced scaled values

  ## Stack

  Stacked on #1876 , which adds the Quick Start documentation page.

  ## Files

  - `.github/workflows/nightly-quick-start.yml`
  - `docs/website/scripts/test-quick-start.sh`

  ## Trigger

  The workflow runs every night at `02:00 UTC` and can also be started manually through `workflow_dispatch`.

This PR closes #1887 
