### PR TITLE
Check first local development docker image

### DIFF
--- a/docker/dependency/DevelopmentLocal.dockerfile
+++ b/docker/dependency/DevelopmentLocal.dockerfile
@@ -1,4 +1,7 @@
-# syntax=docker/dockerfile:1
+# No `# syntax=` directive on purpose: this file uses only pre-18.09 Dockerfile instructions, and
+# pinning an external frontend would make every local rebuild pull docker/dockerfile:1 from Docker
+# Hub -- which breaks switching between already-downloaded dependency images while offline.
+# Re-add it if you ever need BuildKit-only syntax (--mount, --checksum, heredocs) in this file.
 # This image is build locally on a developers machine. It installs the current user into the container instead of
 # relying on the root user. Ubuntu 24 by default installs the ubuntu user which is replaced.
 ARG TAG=latest

--- a/scripts/install-local-docker-environment.sh
+++ b/scripts/install-local-docker-environment.sh
@@ -285,7 +285,12 @@ fi
 ### whether any image for the same hash exists under a different (stdlib, sanitizer)
 ### combo and let the user pick one or fall through to a local dependency rebuild.
 if [ $BUILD_LOCAL -eq 0 ]; then
-  if ! docker manifest inspect nebulastream/nes-development:${TAG} > /dev/null 2>&1 ; then
+  # Prefer an image that is already present locally over querying the registry. Tags are
+  # content-addressed (hash-arch-stdlib-sanitizer), so a local image carrying the tag is by
+  # construction the right one -- and this keeps switching between already-pulled dependency
+  # versions working without a network connection.
+  if ! docker image inspect nebulastream/nes-development:${TAG} > /dev/null 2>&1 \
+     && ! docker manifest inspect nebulastream/nes-development:${TAG} > /dev/null 2>&1 ; then
     echo -e "${RED}Remote development image nebulastream/nes-development:${TAG} does not exist.${NC}"
     ALTERNATIVE_TAGS=()
     while IFS= read -r alt_line; do


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
We now check first if a local docker image exists for the current tag before going to the docker manifest.

## Verifying this change
This change is tested by downloading two development images with different tags and then running the install local docker script.

## What components does this pull request potentially affect?
- Dependencies 
