### PR TITLE
build: register backpressure channel test with test infrastructure

### DIFF
--- a/nes-executable/tests/CMakeLists.txt
+++ b/nes-executable/tests/CMakeLists.txt
@@ -14,7 +14,6 @@ add_library(nes-executable-test-utils TestUtils/TestTaskQueue.cpp)
 target_include_directories(nes-executable-test-utils PUBLIC TestUtils)
 target_link_libraries(nes-executable-test-utils PUBLIC nes-executable nes-memory nes-runtime nes-configurations)
 
-add_executable(backpressure-channel-test BackpressureChannelTest.cpp)
+add_nes_test(backpressure-channel-test BackpressureChannelTest.cpp)
 target_include_directories(backpressure-channel-test PRIVATE ${CMAKE_SOURCE_DIR}/nes-common/tests/Util/include)
-target_link_libraries(backpressure-channel-test PRIVATE nes-executable nes-common GTest::gtest GTest::gtest_main)
-
+target_link_libraries(backpressure-channel-test nes-executable nes-common)


### PR DESCRIPTION
## Summary

- register `backpressure-channel-test` through `add_nes_test`
- keep the test's NES library dependencies on the helper-created target
- rely on the shared test helper for GoogleTest and RapidCheck dependencies

## Why

The test was created directly with `add_executable`, so it bypassed NES's split/unified test registration infrastructure. In unified mode this prevented it from being included consistently in `nes-unit-tests`.

The supplied patch referenced a `backpressure-channel-test-executable` target, but current `main` does not create that target. This version links the actual helper-created `backpressure-channel-test` target and preserves the original NES dependencies.

## Impact

The backpressure channel test now participates in the standard NES test layout in both split and unified configurations.