### PR TITLE
fix(GeneratorSource): Actually count and print generated tuples

### DIFF
--- a/nes-plugins/Sources/GeneratorSource/GeneratorSource.cpp
+++ b/nes-plugins/Sources/GeneratorSource/GeneratorSource.cpp
@@ -144,6 +144,7 @@ Source::FillTupleBufferResult GeneratorSource::fillTupleBuffer(TupleBuffer& tupl
             }
             this->generator.generateTuple(tuplesStream);
             ++curTupleCount;
+            ++generatedTuplesCounter;
             tuplesStream.seekg(0, std::ios::beg);
         }
 
@@ -179,6 +180,7 @@ std::ostream& GeneratorSource::toString(std::ostream& str) const
 {
     str << "\nGeneratorSource(";
     str << "\n\tgenerated buffers: " << this->generatedBuffers;
+    str << "\n\tgenerated tuples: " << this->generatedTuplesCounter;
     str << "\n\tschema: " << this->generatorSchemaRaw;
     str << "\n\tseed: " << this->seed;
     str << ")\n";


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
We didn't use the generatedTupleCounter field in the `GeneratorSource`, which AFAIK is an error on newer compilers.

This PR lets the source actually count the tuples, the alternative is to remove the field.
