### PR TITLE
feat(functions): Add Conditional (CASE WHEN) function

### DIFF
--- a/nes-plugins/CMakeLists.txt
+++ b/nes-plugins/CMakeLists.txt
@@ -24,6 +24,7 @@ add_plugin("Sinks/MQTTSink")
 add_plugin("InputFormatters/JSONInputFormatter")
 add_plugin("OutputFormatters/JSONOutputFormatter")
 add_plugin("Rules/RedundantUnionRemovalRule")
+add_plugin("Functions/Conditional")
 
 if (NES_ENABLES_TESTS)
   # ChecksumSink depends on Checksum.cpp from systest which is only added when tests are enabled.

--- a/nes-plugins/Functions/Conditional/CMakeLists.txt
+++ b/nes-plugins/Functions/Conditional/CMakeLists.txt
@@ -1,0 +1,45 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(${PROJECT_SOURCE_DIR}/cmake/RuntimeRegistrationUtil.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/UnreflectionRegistrationUtil.cmake)
+
+find_package(reflectcpp CONFIG REQUIRED)
+
+# Logical function: contributes to the factory and the serialized plan reconstruction registries
+# owned by nes-logical-operators.
+add_library(conditional_logical_function_plugin_library STATIC ConditionalLogicalFunction.cpp)
+target_link_libraries(conditional_logical_function_plugin_library PRIVATE nes-logical-operators reflectcpp::reflectcpp)
+target_include_directories(conditional_logical_function_plugin_library PUBLIC include PRIVATE .)
+link_plugin_library(nes-logical-operators conditional_logical_function_plugin_library)
+add_registry_entry(LogicalFunction Conditional)
+add_unreflection_entry(LogicalFunction Conditional)
+
+# Physical function: contributes to the factory registry owned by nes-physical-operators.
+add_library(conditional_physical_function_plugin_library STATIC ConditionalPhysicalFunction.cpp)
+target_link_libraries(conditional_physical_function_plugin_library PRIVATE nes-physical-operators)
+target_include_directories(conditional_physical_function_plugin_library PUBLIC include PRIVATE .)
+link_plugin_library(nes-physical-operators conditional_physical_function_plugin_library)
+add_registry_entry(PhysicalFunction Conditional)
+
+# Each generated glue translation unit includes the plugin header by basename, and the headers of
+# this plugin sit one directory deeper than the plugin root that the glue picks up by itself.
+foreach (registry IN ITEMS LogicalFunction LogicalFunctionUnreflection PhysicalFunction)
+    get_property(glue_lib GLOBAL PROPERTY "${registry}_RUNTIME_REGISTRY_GLUE_LIB")
+    target_include_directories(${glue_lib} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/Functions)
+endforeach ()
+
+if (NES_ENABLES_TESTS)
+    add_nes_unit_test(conditional-logical-function-test ConditionalLogicalFunctionTest.cpp)
+    target_link_libraries(conditional-logical-function-test conditional_logical_function_plugin_library nes-logical-operators nes-test-util reflectcpp::reflectcpp)
+    target_include_directories(conditional-logical-function-test PRIVATE include)
+endif ()

--- a/nes-plugins/Functions/Conditional/ConditionalLogicalFunction.cpp
+++ b/nes-plugins/Functions/Conditional/ConditionalLogicalFunction.cpp
@@ -1,0 +1,178 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Functions/ConditionalLogicalFunction.hpp>
+
+#include <iterator>
+#include <ranges>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/DataTypeProvider.hpp>
+#include <Functions/LogicalFunction.hpp>
+#include <Schema/Field.hpp>
+#include <Schema/Schema.hpp>
+#include <Schema/SchemaFwd.hpp>
+#include <Serialization/LogicalFunctionReflection.hpp>
+#include <Util/PlanRenderer.hpp>
+#include <Util/Reflection.hpp>
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <ErrorHandling.hpp>
+#include <LogicalFunctionRegistry.hpp>
+
+namespace NES
+{
+namespace
+{
+/// Groups the leading elements of the flat child list into (when, then) pairs, leaving out the
+/// trailing default result.
+std::vector<WhenThenLogicalFunction> groupWhenThens(const std::vector<LogicalFunction>& children)
+{
+    INVARIANT(
+        children.size() >= 3 and children.size() % 2 == 1,
+        "ConditionalLogicalFunction requires an odd number of children >= 3 (when/then pairs plus a default), but got {}",
+        children.size());
+
+    std::vector<WhenThenLogicalFunction> whenThens;
+    whenThens.reserve(children.size() / 2);
+    for (auto when = children.begin(); when != std::prev(children.end()); when += 2)
+    {
+        whenThens.push_back(WhenThenLogicalFunction{.when = *when, .then = *std::next(when)});
+    }
+    return whenThens;
+}
+}
+
+/// The result type stays untouched here; it is inferred once the input schema is known.
+ConditionalLogicalFunction::ConditionalLogicalFunction(std::vector<WhenThenLogicalFunction> whenThens, LogicalFunction elseCase)
+    : whenThens(std::move(whenThens)), elseCase(std::move(elseCase))
+{
+    INVARIANT(not this->whenThens.empty(), "ConditionalLogicalFunction requires at least one when/then pair");
+}
+
+ConditionalLogicalFunction::ConditionalLogicalFunction(const std::vector<LogicalFunction>& children)
+    : whenThens(groupWhenThens(children)), elseCase(children.back())
+{
+}
+
+DataType ConditionalLogicalFunction::getDataType() const
+{
+    return dataType;
+}
+
+std::vector<LogicalFunction> ConditionalLogicalFunction::getChildren() const
+{
+    std::vector<LogicalFunction> children;
+    children.reserve((whenThens.size() * 2) + 1);
+    for (const auto& [when, then] : whenThens)
+    {
+        children.push_back(when);
+        children.push_back(then);
+    }
+    children.push_back(elseCase);
+    return children;
+}
+
+ConditionalLogicalFunction ConditionalLogicalFunction::withChildren(const std::vector<LogicalFunction>& children) const
+{
+    auto copy = *this;
+    copy.whenThens = groupWhenThens(children);
+    copy.elseCase = children.back();
+    return copy;
+}
+
+std::string_view ConditionalLogicalFunction::getType() const
+{
+    return NAME;
+}
+
+bool ConditionalLogicalFunction::operator==(const ConditionalLogicalFunction& rhs) const
+{
+    return whenThens == rhs.whenThens and elseCase == rhs.elseCase;
+}
+
+std::string ConditionalLogicalFunction::explain(ExplainVerbosity verbosity) const
+{
+    /// Rendered in function-call form because the SQL parser does not support the CASE WHEN syntax yet.
+    const auto children = getChildren();
+    const auto explained = children | std::views::transform([verbosity](const LogicalFunction& child) { return child.explain(verbosity); })
+        | std::ranges::to<std::vector>();
+    return fmt::format("{}({})", NAME, fmt::join(explained, ", "));
+}
+
+LogicalFunction ConditionalLogicalFunction::withInferredDataType(const Schema<Field, Unordered>& schema) const
+{
+    /// The default result carries the type of the whole expression.
+    const auto inferredElseCase = elseCase.withInferredDataType(schema);
+    auto resultType = inferredElseCase.getDataType();
+
+    std::vector<WhenThenLogicalFunction> inferredWhenThens;
+    inferredWhenThens.reserve(whenThens.size());
+    for (const auto& [when, then] : whenThens)
+    {
+        auto inferredWhen = when.withInferredDataType(schema);
+        auto inferredThen = then.withInferredDataType(schema);
+        if (not inferredWhen.getDataType().isType(DataType::Type::BOOLEAN))
+        {
+            throw DifferentFieldTypeExpected("CASE WHEN condition must be BOOLEAN, but got {}", inferredWhen.getDataType());
+        }
+        if (not inferredThen.getDataType().isType(resultType.type))
+        {
+            throw DifferentFieldTypeExpected(
+                "CASE WHEN results must all share the default result's type {}, but got {}", resultType, inferredThen.getDataType());
+        }
+        /// A branch that can produce a null makes the whole expression nullable, as in SQL.
+        resultType = DataTypeProvider::provideDataType(resultType.type, resultType.joinNullable(inferredThen.getDataType()));
+        inferredWhenThens.push_back(WhenThenLogicalFunction{.when = std::move(inferredWhen), .then = std::move(inferredThen)});
+    }
+
+    auto inferred = ConditionalLogicalFunction{std::move(inferredWhenThens), inferredElseCase};
+    inferred.dataType = resultType;
+    return inferred;
+}
+
+Reflected
+Reflector<ConditionalLogicalFunction>::operator()(const ConditionalLogicalFunction& function, const ReflectionContext& context) const
+{
+    return context.reflect(detail::ReflectedConditionalLogicalFunction{.children = function.getChildren()});
+}
+
+ConditionalLogicalFunction
+Unreflector<ConditionalLogicalFunction>::operator()(const Reflected& reflected, const ReflectionContext& context) const
+{
+    const auto [children] = context.unreflect<detail::ReflectedConditionalLogicalFunction>(reflected);
+    /// The shape of a serialized plan is not trusted, so a bad child count is reported rather than asserted.
+    if (children.size() < 3 or children.size() % 2 == 0)
+    {
+        throw CannotDeserialize("ConditionalLogicalFunction requires an odd number of children >= 3, but got {}", children.size());
+    }
+    return ConditionalLogicalFunction{children};
+}
+
+LogicalFunctionRegistryReturnType ConditionalLogicalFunction::createConditional(LogicalFunctionRegistryArguments arguments)
+{
+    /// The argument count comes straight from the user's query, so a bad count is reported rather than asserted.
+    if (arguments.children.size() < 3 or arguments.children.size() % 2 == 0)
+    {
+        throw CannotDeserialize(
+            "Conditional requires an odd number of arguments >= 3 (condition/result pairs plus a default), but got {}",
+            arguments.children.size());
+    }
+    return ConditionalLogicalFunction{arguments.children};
+}
+}

--- a/nes-plugins/Functions/Conditional/ConditionalLogicalFunctionTest.cpp
+++ b/nes-plugins/Functions/Conditional/ConditionalLogicalFunctionTest.cpp
@@ -1,0 +1,92 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/// These tests cover behaviour that the end-to-end systests cannot observe: value equality (used by the
+/// optimizer), the reflection round-trip, and the textual explain() form. Execution results, type inference,
+/// and argument validation are exercised by nes-systests/function/Conditional.test instead.
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/DataTypeProvider.hpp>
+#include <Functions/ConditionalLogicalFunction.hpp>
+#include <Functions/ConstantValueLogicalFunction.hpp>
+#include <Functions/LogicalFunction.hpp>
+#include <Serialization/LogicalFunctionReflection.hpp>
+#include <Util/PlanRenderer.hpp>
+#include <Util/Reflection.hpp>
+#include <BaseUnitTest.hpp>
+
+namespace NES
+{
+namespace
+{
+LogicalFunction constant(const DataType::Type type, const std::string& value)
+{
+    return ConstantValueLogicalFunction{DataTypeProvider::provideDataType(type), value};
+}
+}
+
+/// A multi-branch function survives a reflection round-trip unchanged.
+TEST(ConditionalLogicalFunctionTest, SerializeDeserializeRoundtrip)
+{
+    const auto original = LogicalFunction{ConditionalLogicalFunction{
+        {constant(DataType::Type::BOOLEAN, "true"),
+         constant(DataType::Type::VARSIZED, "A"),
+         constant(DataType::Type::BOOLEAN, "false"),
+         constant(DataType::Type::VARSIZED, "B"),
+         constant(DataType::Type::VARSIZED, "C")}}};
+
+    const auto reflected = ReflectionContext{}.reflect(original);
+    const auto deserialized = ReflectionContext{}.unreflect<LogicalFunction>(reflected);
+    EXPECT_TRUE(original == deserialized);
+}
+
+/// Two functions built from identical children compare equal.
+TEST(ConditionalLogicalFunctionTest, EqualityIdentical)
+{
+    const auto lhs = ConditionalLogicalFunction{
+        {constant(DataType::Type::BOOLEAN, "true"), constant(DataType::Type::INT32, "1"), constant(DataType::Type::INT32, "0")}};
+    const auto rhs = ConditionalLogicalFunction{
+        {constant(DataType::Type::BOOLEAN, "true"), constant(DataType::Type::INT32, "1"), constant(DataType::Type::INT32, "0")}};
+    EXPECT_TRUE(lhs == rhs);
+}
+
+/// Functions differing in a single child do not compare equal.
+TEST(ConditionalLogicalFunctionTest, EqualityDifferent)
+{
+    const auto lhs = ConditionalLogicalFunction{
+        {constant(DataType::Type::BOOLEAN, "true"), constant(DataType::Type::INT32, "1"), constant(DataType::Type::INT32, "0")}};
+    const auto rhs = ConditionalLogicalFunction{
+        {constant(DataType::Type::BOOLEAN, "true"), constant(DataType::Type::INT32, "2"), constant(DataType::Type::INT32, "0")}};
+    EXPECT_FALSE(lhs == rhs);
+}
+
+/// explain() renders function-call syntax; the SQL parser has no CASE WHEN syntax yet, so the plan renderer
+/// (and therefore an EXPLAIN systest) never surfaces this form for the projected expression.
+TEST(ConditionalLogicalFunctionTest, ExplainUsesFunctionCallForm)
+{
+    const auto function = ConditionalLogicalFunction{
+        {constant(DataType::Type::BOOLEAN, "true"),
+         constant(DataType::Type::VARSIZED, "r1"),
+         constant(DataType::Type::VARSIZED, "fallback")}};
+    const auto explanation = function.explain(ExplainVerbosity::Short);
+    EXPECT_TRUE(explanation.starts_with("Conditional("));
+    EXPECT_EQ(explanation.find("CASE"), std::string::npos);
+    EXPECT_EQ(explanation.find("WHEN"), std::string::npos);
+}
+
+}

--- a/nes-plugins/Functions/Conditional/ConditionalPhysicalFunction.cpp
+++ b/nes-plugins/Functions/Conditional/ConditionalPhysicalFunction.cpp
@@ -1,0 +1,87 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Functions/ConditionalPhysicalFunction.hpp>
+
+#include <iterator>
+#include <utility>
+#include <vector>
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/VarVal.hpp>
+#include <Functions/PhysicalFunction.hpp>
+#include <Interface/Record.hpp>
+#include <Arena.hpp>
+#include <ErrorHandling.hpp>
+#include <PhysicalFunctionRegistry.hpp>
+#include <static.hpp>
+
+namespace NES
+{
+namespace
+{
+/// Groups the leading elements of the flat child list into (when, then) pairs, leaving out the
+/// trailing default result.
+std::vector<WhenThenPhysicalFunction> groupWhenThens(const std::vector<PhysicalFunction>& children)
+{
+    std::vector<WhenThenPhysicalFunction> whenThens;
+    whenThens.reserve(children.size() / 2);
+    for (auto when = children.begin(); when != std::prev(children.end()); when += 2)
+    {
+        whenThens.push_back(WhenThenPhysicalFunction{.when = *when, .then = *std::next(when)});
+    }
+    return whenThens;
+}
+
+/// Branches may disagree on whether they can produce a null, while the expression as a whole has
+/// one declared type. Rebuilding the result pins it to that type instead of to the branch that
+/// produced it.
+VarVal withDeclaredType(const VarVal& value, const DataType& resultType)
+{
+    return value.customVisit([&]<typename T>(const T& raw) { return VarVal{raw, resultType.nullable, value.isNull()}; });
+}
+}
+
+ConditionalPhysicalFunction::ConditionalPhysicalFunction(
+    std::vector<WhenThenPhysicalFunction> whenThens, PhysicalFunction elseCase, DataType resultType)
+    : whenThens(std::move(whenThens)), elseCase(std::move(elseCase)), resultType(std::move(resultType))
+{
+}
+
+/// Every branch returns from inside the loop, and the loop is unrolled while the query is traced, so every branch adds an exit
+/// to the trace. At 100 branches that is about 2.7 times the IR blocks of a variant with a single exit. That is fine for the
+/// branch counts that queries use in practice, but nesting multiplies them, so this may need optimizing later.
+VarVal ConditionalPhysicalFunction::execute(const Record& record, ArenaRef& arena) const
+{
+    for (const auto& [when, then] : nautilus::static_iterable(whenThens))
+    {
+        /// A condition that is null is not true, so it does not select its branch. Converting the
+        /// condition to a bool already accounts for that.
+        if (when.execute(record, arena))
+        {
+            return withDeclaredType(then.execute(record, arena), resultType);
+        }
+    }
+    return withDeclaredType(elseCase.execute(record, arena), resultType);
+}
+
+PhysicalFunctionRegistryReturnType ConditionalPhysicalFunction::createConditional(PhysicalFunctionRegistryArguments arguments)
+{
+    /// The logical function already validated the argument shape and types, so a bad shape here is a lowering bug.
+    PRECONDITION(
+        arguments.childFunctions.size() >= 3 and arguments.childFunctions.size() % 2 == 1,
+        "ConditionalPhysicalFunction requires an odd number of child functions >= 3 (when/then pairs plus a default), but got {}",
+        arguments.childFunctions.size());
+    return ConditionalPhysicalFunction{groupWhenThens(arguments.childFunctions), arguments.childFunctions.back(), arguments.outputType};
+}
+}

--- a/nes-plugins/Functions/Conditional/include/Functions/ConditionalLogicalFunction.hpp
+++ b/nes-plugins/Functions/Conditional/include/Functions/ConditionalLogicalFunction.hpp
@@ -1,0 +1,96 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+#include <DataTypes/DataType.hpp>
+#include <Functions/LogicalFunction.hpp>
+#include <Schema/Field.hpp>
+#include <Schema/Schema.hpp>
+#include <Schema/SchemaFwd.hpp>
+#include <Util/Logger/Formatter.hpp>
+#include <Util/PlanRenderer.hpp>
+#include <Util/ReflectionFwd.hpp>
+#include <LogicalFunctionRegistry.hpp>
+
+namespace NES
+{
+
+/// A single WHEN condition together with its THEN result.
+struct WhenThenLogicalFunction
+{
+    LogicalFunction when;
+    LogicalFunction then;
+
+    [[nodiscard]] bool operator==(const WhenThenLogicalFunction& rhs) const = default;
+};
+
+/// Represents a CASE WHEN expression: at least one (when, then) pair followed by the default result
+/// that applies when no condition holds. The generic child list interface flattens the pairs into
+/// [condition1, result1, ..., conditionN, resultN, default] and regroups them on the way back.
+class ConditionalLogicalFunction final
+{
+public:
+    static constexpr std::string_view NAME = "Conditional";
+
+    ConditionalLogicalFunction(std::vector<WhenThenLogicalFunction> whenThens, LogicalFunction elseCase);
+    explicit ConditionalLogicalFunction(const std::vector<LogicalFunction>& children);
+
+    [[nodiscard]] bool operator==(const ConditionalLogicalFunction& rhs) const;
+
+    [[nodiscard]] DataType getDataType() const;
+    [[nodiscard]] LogicalFunction withInferredDataType(const Schema<Field, Unordered>& schema) const;
+
+    [[nodiscard]] std::vector<LogicalFunction> getChildren() const;
+    [[nodiscard]] ConditionalLogicalFunction withChildren(const std::vector<LogicalFunction>& children) const;
+
+    [[nodiscard]] std::string_view getType() const;
+    [[nodiscard]] std::string explain(ExplainVerbosity verbosity) const;
+
+    static LogicalFunctionRegistryReturnType createConditional(LogicalFunctionRegistryArguments arguments);
+
+private:
+    DataType dataType;
+    std::vector<WhenThenLogicalFunction> whenThens;
+    LogicalFunction elseCase;
+};
+
+namespace detail
+{
+struct ReflectedConditionalLogicalFunction
+{
+    std::vector<LogicalFunction> children;
+};
+}
+
+template <>
+struct Unreflector<ConditionalLogicalFunction>
+{
+    ConditionalLogicalFunction operator()(const Reflected& reflected, const ReflectionContext& context) const;
+};
+
+template <>
+struct Reflector<ConditionalLogicalFunction>
+{
+    Reflected operator()(const ConditionalLogicalFunction& function, const ReflectionContext& context) const;
+};
+
+static_assert(LogicalFunctionConcept<ConditionalLogicalFunction>);
+
+}
+
+FMT_OSTREAM(NES::ConditionalLogicalFunction);

--- a/nes-plugins/Functions/Conditional/include/Functions/ConditionalPhysicalFunction.hpp
+++ b/nes-plugins/Functions/Conditional/include/Functions/ConditionalPhysicalFunction.hpp
@@ -1,0 +1,54 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <vector>
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/VarVal.hpp>
+#include <Functions/PhysicalFunction.hpp>
+#include <Interface/Record.hpp>
+#include <Arena.hpp>
+#include <ExecutionContext.hpp>
+#include <PhysicalFunctionRegistry.hpp>
+
+namespace NES
+{
+
+/// A single WHEN condition together with its THEN result.
+struct WhenThenPhysicalFunction
+{
+    PhysicalFunction when;
+    PhysicalFunction then;
+};
+
+/// Executes a CASE WHEN expression at runtime. Evaluates the conditions in order and returns the
+/// result of the first condition that holds, or the default result if none hold.
+class ConditionalPhysicalFunction final
+{
+public:
+    ConditionalPhysicalFunction(std::vector<WhenThenPhysicalFunction> whenThens, PhysicalFunction elseCase, DataType resultType);
+    [[nodiscard]] VarVal execute(const Record& record, ArenaRef& arena) const;
+
+    static PhysicalFunctionRegistryReturnType createConditional(PhysicalFunctionRegistryArguments arguments);
+
+private:
+    std::vector<WhenThenPhysicalFunction> whenThens;
+    PhysicalFunction elseCase;
+    DataType resultType;
+};
+
+static_assert(PhysicalFunctionConcept<ConditionalPhysicalFunction>);
+
+}

--- a/nes-systests/function/Conditional.test
+++ b/nes-systests/function/Conditional.test
@@ -1,0 +1,272 @@
+# name: function/Conditional.test
+# description: Tests for the Conditional (CASE WHEN) function
+# groups: [Function, FunctionConditional]
+
+CREATE LOGICAL SOURCE intersection(intersection_id INT32, traffic_density FLOAT32, emergency_vehicle_detected BOOLEAN, pedestrian_waiting BOOLEAN);
+CREATE PHYSICAL SOURCE FOR intersection TYPE File;
+ATTACH INLINE
+1,0.5,true,false
+2,0.1,false,true
+3,0.9,false,false
+4,0.6,false,false
+5,0.3,false,false
+6,0.1,true,true
+7,0.9,false,true
+8,0.6,false,true
+9,0.3,false,true
+10,0.95,true,false
+
+CREATE SINK simple_signal(intersection_id INT32, signal VARSIZED NOT NULL) TYPE File;
+CREATE SINK traffic_light(intersection_id INT32, signal_command VARSIZED NOT NULL) TYPE File;
+
+# Minimal conditional: single condition with default (two-way branch)
+SELECT intersection_id,
+       Conditional(emergency_vehicle_detected, VARSIZED('STOP'),
+                   VARSIZED('GO'))
+       AS signal
+FROM intersection
+INTO simple_signal;
+----
+1,STOP
+2,GO
+3,GO
+4,GO
+5,GO
+6,STOP
+7,GO
+8,GO
+9,GO
+10,STOP
+
+# All five branches are taken: emergency, pedestrian+low density, high density, medium density, and default.
+# Rows 6-10 test priority ordering when multiple conditions could match:
+#   Row 6: emergency + pedestrian both true -> first branch (emergency) wins
+#   Row 7: pedestrian=true but density too high for branch 2, falls through to branch 3
+#   Row 8: pedestrian=true but density too high for branch 2, density not > 0.8, falls to branch 4
+#   Row 9: pedestrian=true but density not < 0.2, density not > 0.5, falls to default
+#   Row 10: emergency=true with high density -> branch 1 wins over branch 3
+SELECT intersection_id,
+       Conditional(emergency_vehicle_detected, VARSIZED('ALL_RED_EMERGENCY'),
+                   pedestrian_waiting AND traffic_density < FLOAT32(0.2), VARSIZED('PEDESTRIAN_WALK'),
+                   traffic_density > FLOAT32(0.8), VARSIZED('GREEN_EXTENDED'),
+                   traffic_density > FLOAT32(0.5), VARSIZED('GREEN_STANDARD'),
+                   VARSIZED('FLASHING_YELLOW'))
+       AS signal_command
+FROM intersection
+INTO traffic_light;
+----
+1,ALL_RED_EMERGENCY
+2,PEDESTRIAN_WALK
+3,GREEN_EXTENDED
+4,GREEN_STANDARD
+5,FLASHING_YELLOW
+6,ALL_RED_EMERGENCY
+7,GREEN_EXTENDED
+8,GREEN_STANDARD
+9,FLASHING_YELLOW
+10,ALL_RED_EMERGENCY
+
+CREATE LOGICAL SOURCE scores(student_id INT32, score INT32);
+CREATE PHYSICAL SOURCE FOR scores TYPE File;
+ATTACH INLINE
+1,95
+2,82
+3,70
+4,55
+5,40
+6,100
+7,0
+
+CREATE SINK grade_points_sink(student_id INT32, grade_points INT32 NOT NULL) TYPE File;
+CREATE SINK letter_sink(student_id INT32, letter VARSIZED NOT NULL) TYPE File;
+CREATE SINK code_sink(student_id INT32, code INT32 NOT NULL) TYPE File;
+
+# Numeric (INT32) result type instead of VARSIZED, with five branches and boundary inputs.
+# Boundaries are exclusive: score 70 satisfies "> 69" and yields 2; score 0 falls through to the default.
+SELECT student_id,
+       Conditional(score > INT32(89), INT32(4),
+                   score > INT32(79), INT32(3),
+                   score > INT32(69), INT32(2),
+                   score > INT32(59), INT32(1),
+                   INT32(0))
+       AS grade_points
+FROM scores INTO grade_points_sink;
+----
+1,4
+2,3
+3,2
+4,0
+5,0
+6,4
+7,0
+
+# Nested Conditional: each default is itself a Conditional, forming a three-level chain.
+SELECT student_id,
+       Conditional(score > INT32(89), VARSIZED('A'),
+                   Conditional(score > INT32(79), VARSIZED('B'),
+                               Conditional(score > INT32(69), VARSIZED('C'),
+                                           VARSIZED('F'))))
+       AS letter
+FROM scores INTO letter_sink;
+----
+1,A
+2,B
+3,C
+4,F
+5,F
+6,A
+7,F
+
+# A nested arithmetic function (modulo) inside a condition, and a nested Conditional as a THEN result.
+# For scores above 89 the result depends on the score's parity; otherwise a coarser bucketing applies.
+SELECT student_id,
+       Conditional(score > INT32(89),
+                     Conditional((score % INT32(2)) == INT32(0), INT32(400), INT32(401)),
+                   score > INT32(59), INT32(100),
+                   INT32(0))
+       AS code
+FROM scores INTO code_sink;
+----
+1,401
+2,100
+3,100
+4,0
+5,0
+6,400
+7,0
+
+CREATE SINK guarded_division_sink(student_id INT32, code INT32) TYPE File;
+
+# The default result is only evaluated for the rows that reach it. Student 7 has a score of 0, so
+# evaluating the division for that row would divide by zero.
+SELECT student_id,
+       Conditional(score == INT32(0), INT32(0),
+                   INT32(100) / score)
+       AS code
+FROM scores INTO guarded_division_sink;
+----
+1,1
+2,1
+3,1
+4,1
+5,2
+6,1
+7,0
+
+CREATE SINK nested_condition_sink(intersection_id INT32, decision VARSIZED NOT NULL) TYPE File;
+
+# A Conditional used as the condition of another Conditional. The inner Conditional returns a BOOLEAN:
+# when an emergency is present it yields whether the density is high, otherwise whether a pedestrian waits.
+SELECT intersection_id,
+       Conditional(Conditional(emergency_vehicle_detected, traffic_density > FLOAT32(0.5), pedestrian_waiting),
+                   VARSIZED('YES'),
+                   VARSIZED('NO'))
+       AS decision
+FROM intersection INTO nested_condition_sink;
+----
+1,NO
+2,YES
+3,NO
+4,NO
+5,NO
+6,NO
+7,YES
+8,YES
+9,YES
+10,YES
+
+# ERROR CASES
+
+# Fewer than three arguments: a Conditional needs at least one WHEN/THEN pair plus a default.
+SELECT student_id, Conditional(score > INT32(50)) AS label FROM scores INTO FILE();
+----
+ERROR 2002
+
+# An even argument count means the trailing default is missing.
+SELECT student_id, Conditional(score > INT32(50), INT32(1)) AS label FROM scores INTO FILE();
+----
+ERROR 2002
+
+# A non-BOOLEAN condition is rejected during type inference.
+SELECT student_id, Conditional(score, INT32(1), INT32(0)) AS label FROM scores INTO FILE();
+----
+ERROR 2006
+
+# Every result must share the default result's type.
+SELECT student_id, Conditional(score > INT32(50), INT32(1), VARSIZED('x')) AS label FROM scores INTO FILE();
+----
+ERROR 2006
+
+# Null handling. A condition that is NULL is not true, so its branch is not taken. Results may
+# differ in nullability, in which case the whole expression becomes nullable.
+CREATE LOGICAL SOURCE nullable_input(id INT32 NOT NULL, flag BOOLEAN, value INT32);
+CREATE PHYSICAL SOURCE FOR nullable_input TYPE File;
+ATTACH INLINE
+1,true,10
+2,,10
+3,false,10
+4,true,
+
+CREATE SINK nullable_result(id INT32 NOT NULL, result INT32) TYPE File;
+
+# Row 1 takes the branch, row 2 has a NULL condition and row 3 a false one so both fall through to
+# the default, and row 4 takes the branch onto a NULL result.
+SELECT id,
+       Conditional(flag, value,
+                   INT32(-1))
+       AS result
+FROM nullable_input
+INTO nullable_result;
+----
+1,10
+2,-1
+3,-1
+4,NULL
+
+# Nullability mixed across several branches: a nullable and a non-nullable condition, a nullable and
+# a non-nullable result, and a non-nullable default. The expression is nullable because one branch is.
+CREATE LOGICAL SOURCE mixed_input(id INT32 NOT NULL, a BOOLEAN, b BOOLEAN NOT NULL, x INT32, y INT32 NOT NULL);
+CREATE PHYSICAL SOURCE FOR mixed_input TYPE File;
+ATTACH INLINE
+1,true,false,10,20
+2,,true,10,20
+3,false,false,10,20
+4,true,false,,20
+5,,false,10,20
+
+CREATE SINK mixed_result(id INT32 NOT NULL, result INT32) TYPE File;
+
+# Row 1 takes the nullable branch, row 2 has a NULL first condition and falls to the non-nullable
+# branch, row 3 matches nothing, row 4 takes the nullable branch onto a NULL, and row 5 has a NULL
+# first condition and a false second one so it reaches the default.
+SELECT id,
+       Conditional(a, x,
+                   b, y,
+                   INT32(0))
+       AS result
+FROM mixed_input
+INTO mixed_result;
+----
+1,10
+2,20
+3,0
+4,NULL
+5,0
+
+# The result of a mixed-nullability Conditional feeds an arithmetic function, which decides whether
+# to emit null handling from the nullability of its input. A NULL must survive that.
+CREATE SINK mixed_arith_result(id INT32 NOT NULL, result INT32) TYPE File;
+
+SELECT id,
+       Conditional(a, x,
+                   b, y,
+                   INT32(0)) + INT32(1)
+       AS result
+FROM mixed_input
+INTO mixed_arith_result;
+----
+1,11
+2,21
+3,1
+4,NULL
+5,1


### PR DESCRIPTION
## Summary

Implements the Conditional (CASE WHEN) function on top of current `main`, ported from the tutorial branch and adapted to how functions are written in current main.

## What's included

**Logical function** (`nes-logical-operators`)
- `ConditionalLogicalFunction` flat child list `[cond1, res1, …, condN, resN, default]`. Validates that conditions are BOOLEAN and results share the default's type.

**Physical function** (`nes-physical-operators`)
- `ConditionalPhysicalFunction` evaluates conditions in order, returns the first matching branch, else the default. Iterates `WhenThenPhysicalFunction` pairs.

## Validation

**Systests**: `nes-systests/function/Conditional.test`: priority ordering, numeric (INT32) results with boundary edges, deeply nested Conditionals, a Conditional used as another Conditional's condition, a nested arithmetic function inside a condition, and argument/type error cases (`ERROR 2002` / `ERROR 2006`).

**Unit tests**: limited to behaviour the systests cannot observe: value equality (`operator==`, used by the optimizer), reflection, and `explain()` form (EXPLAIN renders projections by field name, not by expression).

## Invoking it

The parser has **no dedicated `CASE WHEN` syntax yet**, so the function is called in function-call form:

```sql
Conditional(cond1, result1, cond2, result2, …, default)
```

`explain()` renders the same function-call form.

## Error handling

- Invalid **user input** is reported as query errors: wrong argument count → `CannotDeserialize`; non-BOOLEAN condition or mismatched result types → `DifferentFieldTypeExpected`.
- `INVARIANT` / `PRECONDITION` are used for structural/lowering bugs (they terminate), not user input.

## Follow-up work
- **Parser support for the real `CASE WHEN … THEN … ELSE … END` syntax**.