### PR TITLE
chore(schema): inline schema size calculation

### DIFF
--- a/nes-common/schema/include/Schema/Schema.hpp
+++ b/nes-common/schema/include/Schema/Schema.hpp
@@ -113,8 +113,6 @@ public:
 
     [[nodiscard]] std::unordered_set<IdList> getUniqueFieldNames() const;
 
-    [[nodiscard]] size_t getSizeInBytes() const;
-
     [[nodiscard]] auto begin() const -> decltype(std::declval<FieldContainer>().cbegin());
 
     [[nodiscard]] auto end() const -> decltype(std::declval<FieldContainer>().cend());
@@ -124,7 +122,6 @@ public:
 private:
     FieldContainer fields;
     FieldByNameType fieldsByName;
-    size_t sizeInBytes{};
 };
 
 template <typename FieldType, OrderType IsOrdered>
@@ -169,8 +166,6 @@ Schema<FieldType, IsOrdered>::Schema(FieldContainer fields) : fields(std::move(f
         NES_DEBUG("Duplicate identifiers in schema: {}", fmt::join(collisions, ", "));
     }
     this->fieldsByName = fieldsByName;
-    sizeInBytes = std::ranges::fold_left(
-        this->fields, 0, [](size_t acc, const auto& field) { return acc + field.getDataType().getSizeInBytesWithNull(); });
 }
 
 template <typename FieldType, OrderType IsOrdered>
@@ -186,8 +181,6 @@ Schema<FieldType, IsOrdered>::Schema(Range&& input) : fields{std::forward<Range>
         NES_DEBUG("Duplicate identifiers in schema: {}", fmt::join(collisions, ", "));
     }
     this->fieldsByName = std::move(calculatedFieldsByName);
-    sizeInBytes = std::ranges::fold_left(
-        this->fields, 0, [](size_t acc, const auto& field) { return acc + field.getDataType().getSizeInBytesWithNull(); });
 }
 
 template <typename FieldType, OrderType IsOrdered>
@@ -320,12 +313,6 @@ auto Schema<FieldType, IsOrdered>::getUniqueFieldNames() const -> std::unordered
 {
     auto namesView = this->fields | std::views::transform([](const FieldType& field) { return field.getFullyQualifiedName(); });
     return {namesView.begin(), namesView.end()};
-}
-
-template <typename FieldType, OrderType IsOrdered>
-size_t Schema<FieldType, IsOrdered>::getSizeInBytes() const
-{
-    return sizeInBytes;
 }
 
 template <typename FieldType, OrderType IsOrdered>

--- a/nes-data-types/include/DataTypes/UnboundSchema.hpp
+++ b/nes-data-types/include/DataTypes/UnboundSchema.hpp
@@ -13,6 +13,7 @@
 */
 
 #pragma once
+#include <cstddef>
 #include <span>
 #include <DataTypes/UnboundField.hpp>
 #include <Schema/Schema.hpp>
@@ -22,6 +23,21 @@
 
 namespace NES
 {
+
+/// Sums up the sizes of all fields, including their null bytes.
+/// These are free functions instead of members of Schema, because Schema must not require its field type
+/// to have a notion of size, only a getFullyQualifiedName() method.
+[[nodiscard]] inline size_t getSizeInBytes(const Schema<QualifiedUnboundField, Ordered>& schema)
+{
+    return std::ranges::fold_left(
+        schema, size_t{0}, [](const size_t acc, const auto& field) { return acc + field.getDataType().getSizeInBytesWithNull(); });
+}
+
+[[nodiscard]] inline size_t getSizeInBytes(const Schema<UnqualifiedUnboundField, Ordered>& schema)
+{
+    return std::ranges::fold_left(
+        schema, size_t{0}, [](const size_t acc, const auto& field) { return acc + field.getDataType().getSizeInBytesWithNull(); });
+}
 
 }
 

--- a/nes-data-types/tests/UnitTests/UnboundSchemaTest.cpp
+++ b/nes-data-types/tests/UnitTests/UnboundSchemaTest.cpp
@@ -27,6 +27,7 @@
 #include <DataTypes/DataType.hpp>
 #include <DataTypes/DataTypeProvider.hpp>
 #include <DataTypes/UnboundField.hpp>
+#include <DataTypes/UnboundSchema.hpp>
 #include <Identifiers/QualifiedIdentifier.hpp>
 #include <Schema/Schema.hpp>
 #include <Schema/SchemaFwd.hpp>
@@ -159,7 +160,7 @@ TEST_F(UnboundSchemaTest, CalcSizeInBytes)
 
     const auto expectedSize = (DataTypeProvider::provideDataType(DataType::Type::BOOLEAN).getSizeInBytesWithNull() * 2)
         + DataTypeProvider::provideDataType(DataType::Type::INT32).getSizeInBytesWithNull();
-    EXPECT_EQ(unboundSchema.getSizeInBytes(), expectedSize);
+    EXPECT_EQ(getSizeInBytes(unboundSchema), expectedSize);
 }
 
 TEST_F(UnboundSchemaTest, EqualityOrdered)

--- a/nes-input-formatters/tests/UnitTests/SmallFilesTest.cpp
+++ b/nes-input-formatters/tests/UnitTests/SmallFilesTest.cpp
@@ -31,6 +31,7 @@
 
 #include <Configuration/WorkerConfiguration.hpp>
 #include <DataTypes/UnboundField.hpp>
+#include <DataTypes/UnboundSchema.hpp>
 #include <Identifiers/Identifier.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Interface/BufferRef/LowerSchemaProvider.hpp>
@@ -216,7 +217,7 @@ public:
         }(currentTestFile, testDirPath, testConfig.fileEnding);
 
         const auto sizeOfFormattedBuffers = WorkerConfiguration().defaultQueryExecution.operatorBufferSize.getValue();
-        const auto numberOfExpectedRawBuffers = getNumberOfExpectedBuffers(testConfig, testFilePath, schema.getSizeInBytes());
+        const auto numberOfExpectedRawBuffers = getNumberOfExpectedBuffers(testConfig, testFilePath, getSizeInBytes(schema));
         rawBuffers.reserve(numberOfExpectedRawBuffers);
 
         /// Create file source, start it using the emit function, and wait for the file source to fill the result buffer vector

--- a/nes-input-formatters/tests/Util/FileUtil.hpp
+++ b/nes-input-formatters/tests/Util/FileUtil.hpp
@@ -25,6 +25,7 @@
 #include <utility>
 #include <vector>
 #include <DataTypes/UnboundField.hpp>
+#include <DataTypes/UnboundSchema.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Interface/BufferRef/TupleBufferRef.hpp>
 #include <Interface/VariableSizedAccess.hpp>
@@ -205,7 +206,7 @@ inline void writeTupleBuffersToFile(
     const std::vector<size_t>& varSizedFieldOffsets)
 {
     sortTupleBuffers(resultBufferVec);
-    const auto sizeOfSchemaInBytes = schema.getSizeInBytes();
+    const auto sizeOfSchemaInBytes = getSizeInBytes(schema);
 
     const std::vector<TupleBufferChunk> pagedSizedChunkOffsets
         = [](const std::vector<TupleBuffer>& resultBufferVec, const size_t sizeOfSchemaInBytes)
@@ -269,7 +270,7 @@ inline std::vector<TupleBuffer> loadTupleBuffersFromFile(
     const std::filesystem::path& filepath,
     const std::vector<size_t>& varSizedFieldOffsets)
 {
-    const auto sizeOfSchemaInBytes = schema.getSizeInBytes();
+    const auto sizeOfSchemaInBytes = getSizeInBytes(schema);
     if (std::ifstream file(filepath, std::ifstream::binary); file.is_open())
     {
         const auto fileHeader = [](std::ifstream& file, const std::filesystem::path& filepath)

--- a/nes-input-formatters/tests/Util/InputFormatterTestUtil.hpp
+++ b/nes-input-formatters/tests/Util/InputFormatterTestUtil.hpp
@@ -30,6 +30,7 @@
 
 #include <Configurations/Descriptor.hpp>
 #include <DataTypes/UnboundField.hpp>
+#include <DataTypes/UnboundSchema.hpp>
 #include <Identifiers/Identifier.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Interface/BufferRef/LowerSchemaProvider.hpp>
@@ -445,7 +446,7 @@ bool validateResult(TestHandle<TupleSchemaTemplate>& testHandle)
                 printTupleBuffer(" Expected result buffer:\n", testHandle.expectedResultVectors[taskIndex][bufferIndex], *tupleBufferRef);
             }
             isValid &= checkIfBuffersAreEqual(
-                actualResultBuffer, testHandle.expectedResultVectors[taskIndex][bufferIndex], testHandle.schema.getSizeInBytes());
+                actualResultBuffer, testHandle.expectedResultVectors[taskIndex][bufferIndex], getSizeInBytes(testHandle.schema));
             ++bufferIndex;
         }
         ++taskIndex;

--- a/nes-nautilus/tests/TestUtils/src/TestableChainedHashMap.cpp
+++ b/nes-nautilus/tests/TestUtils/src/TestableChainedHashMap.cpp
@@ -24,6 +24,7 @@
 #include <utility>
 #include <vector>
 #include <DataTypes/DataType.hpp>
+#include <DataTypes/UnboundSchema.hpp>
 #include <Interface/Hash/BloomFilterRef.hpp>
 #include <Interface/Hash/MurMur3HashFunction.hpp>
 #include <Interface/HashMap/ChainedHashMap/ChainedEntryMemoryProvider.hpp>
@@ -96,8 +97,8 @@ TestableChainedHashMap::TestableChainedHashMap(
     valueDataTypes
         = std::vector<DataType>(fieldTypes.begin() + numKeyFields, fieldTypes.end()); /// NOLINT(cppcoreguidelines-narrowing-conversions)
 
-    const uint64_t keySize = createSchemaFromDataTypes(keyDataTypes).getSizeInBytes();
-    const uint64_t valueSize = createSchemaFromDataTypes(valueDataTypes).getSizeInBytes();
+    const uint64_t keySize = getSizeInBytes(createSchemaFromDataTypes(keyDataTypes));
+    const uint64_t valueSize = getSizeInBytes(createSchemaFromDataTypes(valueDataTypes));
     entrySize = sizeof(ChainedHashMapEntry) + keySize + valueSize;
     const uint64_t pageSize = entrySize * numEntriesPerPage;
     /// A probe entry never stores value bytes: findEntry() only reads the key region + hash off the

--- a/nes-nautilus/tests/TestUtils/src/TestablePagedVector.cpp
+++ b/nes-nautilus/tests/TestUtils/src/TestablePagedVector.cpp
@@ -21,13 +21,13 @@
 #include <ranges>
 #include <vector>
 #include <DataTypes/DataType.hpp>
+#include <DataTypes/UnboundSchema.hpp>
 #include <Interface/NautilusBuffer.hpp>
 #include <Interface/PagedVector/PagedVector.hpp>
 #include <Interface/PagedVector/PagedVectorRef.hpp>
 #include <Interface/Record.hpp>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Schema/Schema.hpp>
 #include <nautilus/Engine.hpp>
 #include <DataStructureTestUtils.hpp>
 #include <options.hpp>
@@ -53,7 +53,7 @@ TestablePagedVector::TestablePagedVector(const std::vector<DataType>& fieldTypes
     engine = std::make_unique<nautilus::engine::NautilusEngine>(makeEngine(mode));
 
     pagedVector = bufferManager.getUnpooledBuffer(PagedVector::getMainBufferSize()).value();
-    PagedVector::init(pagedVector, bufferManager.getBufferSize(), layout->getSchema().getSizeInBytes());
+    PagedVector::init(pagedVector, bufferManager.getBufferSize(), getSizeInBytes(layout->getSchema()));
 
     pushbackFn.emplace(engine->registerFunction(std::function(
         [layout, dataTypes = dataTypes, projections = projections](

--- a/nes-nautilus/tests/UnitTests/PagedVectorTest.cpp
+++ b/nes-nautilus/tests/UnitTests/PagedVectorTest.cpp
@@ -28,6 +28,7 @@
 #include <utility>
 #include <vector>
 #include <DataTypes/DataType.hpp>
+#include <DataTypes/UnboundSchema.hpp>
 #include <DataTypes/VarVal.hpp>
 #include <DataTypes/VariableSizedData.hpp>
 #include <Interface/PagedVector/PagedVector.hpp>
@@ -36,7 +37,6 @@
 #include <Runtime/Allocator/NesDefaultMemoryAllocator.hpp>
 #include <Runtime/BufferManager.hpp>
 #include <Runtime/TupleBuffer.hpp>
-#include <Schema/Schema.hpp>
 #include <Util/Logger/LogLevel.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <Util/Logger/impl/NesLogger.hpp>
@@ -395,7 +395,7 @@ rc::Gen<TestUtils::AnyVec> genAnyVec(std::vector<DataType> types, uint64_t buffe
 
 uint64_t estimateSchemaSize(const std::vector<DataType>& types)
 {
-    return TestUtils::createSchemaFromDataTypes(types).getSizeInBytes();
+    return getSizeInBytes(TestUtils::createSchemaFromDataTypes(types));
 }
 
 /// Reads pagedVector.at(idx) for a rapidcheck-drawn set of indices and asserts each record equals the reference.

--- a/nes-physical-operators/src/Aggregation/Function/MedianAggregationPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Aggregation/Function/MedianAggregationPhysicalFunction.cpp
@@ -21,6 +21,7 @@
 
 #include <Aggregation/Function/AggregationPhysicalFunction.hpp>
 #include <DataTypes/DataType.hpp>
+#include <DataTypes/UnboundSchema.hpp>
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/NautilusBuffer.hpp>
 #include <Interface/PagedVector/PagedVector.hpp>
@@ -261,7 +262,7 @@ void MedianAggregationPhysicalFunction::reset(
     nautilus::val<TupleBuffer*> parentBuffer,
     PipelineMemoryProvider& pipelineMemoryProvider)
 {
-    const nautilus::val<uint64_t> tupleSize = tupleLayout->getSchema().getSizeInBytes();
+    const nautilus::val<uint64_t> tupleSize = getSizeInBytes(tupleLayout->getSchema());
     const nautilus::val<uint32_t> childBufferIndexVal = nautilus::invoke(
         +[](TupleBuffer* parentBuffer, AbstractBufferProvider* bufferProvider, uint64_t tupleSize)
         {

--- a/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Join/HashJoin/HJBuildPhysicalOperator.cpp
@@ -18,6 +18,7 @@
 #include <functional>
 #include <memory>
 #include <utility>
+#include <DataTypes/UnboundSchema.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Interface/BufferRef/TupleBufferRef.hpp>
 #include <Interface/HashMap/ChainedHashMap/ChainedHashMapRef.hpp>
@@ -92,7 +93,7 @@ void HJBuildPhysicalOperator::execute(ExecutionContext& ctx, Record& record) con
                 const ChainedHashMapRef::ChainedEntryRef entryRefReset{
                     entry, hashMapBuffer.asArg(), hashMapOptions.fieldKeys, hashMapOptions.fieldValues};
                 const auto state = entryRefReset.getValueMemArea();
-                const nautilus::val<uint64_t> tupleSize = tupleLayout->getSchema().getSizeInBytes();
+                const nautilus::val<uint64_t> tupleSize = getSizeInBytes(tupleLayout->getSchema());
                 nautilus::invoke(
                     +[](TupleBuffer* hashMapBuf, uint32_t* valueMemArea, AbstractBufferProvider* bufferProvider, uint64_t tupleSize) -> void
                     {

--- a/nes-query-compiler/src/LoweringRules/LowerToPhysical/LowerToPhysicalNLJoin.cpp
+++ b/nes-query-compiler/src/LoweringRules/LowerToPhysical/LowerToPhysicalNLJoin.cpp
@@ -29,6 +29,7 @@
 
 #include <DataTypes/TimeUnit.hpp>
 #include <DataTypes/UnboundField.hpp>
+#include <DataTypes/UnboundSchema.hpp>
 #include <Functions/FieldAccessLogicalFunction.hpp>
 #include <Functions/FieldAccessPhysicalFunction.hpp>
 #include <Functions/FunctionProvider.hpp>
@@ -128,8 +129,8 @@ LoweringRuleResultSubgraph LowerToPhysicalNLJoin::apply(LogicalOperator logicalO
     auto joinFunction = QueryCompilation::FunctionProvider::lowerFunction(logicalJoinFunction, combinedFieldMapping);
     auto leftTupleLayout = std::make_shared<DefaultPagedVectorTupleLayout>(leftInputSchema);
     auto rightTupleLayout = std::make_shared<DefaultPagedVectorTupleLayout>(rightInputSchema);
-    const uint64_t tupleSizeLeft = leftTupleLayout->getSchema().getSizeInBytes();
-    const uint64_t tupleSizeRight = rightTupleLayout->getSchema().getSizeInBytes();
+    const uint64_t tupleSizeLeft = getSizeInBytes(leftTupleLayout->getSchema());
+    const uint64_t tupleSizeRight = getSizeInBytes(rightTupleLayout->getSchema());
 
     const auto& joinTimeCharacteristicsVariant = join->getJoinTimeCharacteristics();
     auto characteristicsAreBound

--- a/nes-query-compiler/src/Phases/PipeliningPhase.cpp
+++ b/nes-query-compiler/src/Phases/PipeliningPhase.cpp
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include <DataTypes/UnboundField.hpp>
+#include <DataTypes/UnboundSchema.hpp>
 #include <Identifiers/Identifier.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Interface/BufferRef/LowerSchemaProvider.hpp>
@@ -98,11 +99,11 @@ PhysicalOperator createScanOperator(
 {
     INVARIANT(inputSchema.has_value(), "Wrapped operator has no input schema");
     INVARIANT(memoryLayout.has_value(), "Wrapped operator has no input memory layout type");
-    if (inputSchema.value().getSizeInBytes() > configuredBufferSize)
+    if (getSizeInBytes(inputSchema.value()) > configuredBufferSize)
     {
         throw TuplesTooLargeForPipelineBufferSize(
             "Got pipeline with an input schema size of {}, which is larger than the configured buffer size of the pipeline, which is {}",
-            inputSchema.value().getSizeInBytes(),
+            getSizeInBytes(inputSchema.value()),
             configuredBufferSize);
     }
 

--- a/nes-sinks/src/NetworkSink.cpp
+++ b/nes-sinks/src/NetworkSink.cpp
@@ -37,6 +37,7 @@
 #include <rust/cxx.h>
 
 #include <DataTypes/UnboundField.hpp>
+#include <DataTypes/UnboundSchema.hpp>
 #include <Schema/Schema.hpp>
 #include <Schema/SchemaFwd.hpp>
 #include <BackpressureChannel.hpp>
@@ -50,7 +51,7 @@ namespace NES
 
 NetworkSink::NetworkSink(BackpressureController backpressureController, const SinkDescriptor& sinkDescriptor)
     : Sink(std::move(backpressureController))
-    , tupleSize(NES::get<std::shared_ptr<const Schema<UnqualifiedUnboundField, Ordered>>>(sinkDescriptor.getSchema())->getSizeInBytes())
+    , tupleSize(getSizeInBytes(*NES::get<std::shared_ptr<const Schema<UnqualifiedUnboundField, Ordered>>>(sinkDescriptor.getSchema())))
     , backpressureHandler(
           sinkDescriptor.getFromConfig(SinkDescriptor::BACKPRESSURE_UPPER_THRESHOLD),
           sinkDescriptor.getFromConfig(SinkDescriptor::BACKPRESSURE_LOWER_THRESHOLD))


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
As I have started using the schema as a more general purpose lexical scope in my other branches, we need to remove the calculation of the schema size from the constructor of the schema, since not every type of field I am going to use it with has a notion of size.

So I added a utility function that calculates the size for a schema over unbound fields and calculate it inline wherever necessary.

