### PR TITLE
fix(worker): make termination reliable

### DIFF
--- a/nes-single-node-worker/src/SingleNodeWorkerStarter.cpp
+++ b/nes-single-node-worker/src/SingleNodeWorkerStarter.cpp
@@ -12,8 +12,9 @@
     limitations under the License.
 */
 
-#include <csignal>
-#include <semaphore>
+/// The POSIX signal APIs used below are not provided by the C++ <csignal> header.
+/// NOLINTNEXTLINE(modernize-deprecated-headers)
+#include <signal.h>
 #include <Configurations/Util.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Util/Logger/LogLevel.hpp>
@@ -32,26 +33,34 @@
 
 namespace
 {
-/// This logic is related to handling shutdown of the system when a signal is received.
-/// GRPC does not like it if it is accessed via the signal handler. Effectively, this creates a thread which waits for
-/// the shutdownBarrier to be released by the signal handler and then shuts the grpc server down, which unblocks the `Wait` call
-/// in the main function.
-/// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, cert-err58-cpp) - required for signal handler communication
-std::binary_semaphore shutdownBarrier{0};
-
-void signalHandler(int signal)
+/// Block termination signals before any worker threads are created. All subsequently created threads inherit this mask, allowing
+/// a dedicated thread to synchronously wait for the signals without doing non-async-signal-safe work in a signal handler.
+/// sigset_t is provided by <signal.h>, but clang-tidy's include-cleaner does not recognize the indirect platform typedef.
+/// NOLINTNEXTLINE(misc-include-cleaner)
+bool blockTerminationSignals(sigset_t& terminationSignals)
 {
-    NES_INFO("Received signal {}. Shutting down.", signal);
-    shutdownBarrier.release();
+    sigemptyset(&terminationSignals);
+    sigaddset(&terminationSignals, SIGINT);
+    sigaddset(&terminationSignals, SIGTERM);
+    return pthread_sigmask(SIG_BLOCK, &terminationSignals, nullptr) == 0;
 }
 
-NES::Thread shutdownHook(grpc::Server& server)
+NES::Thread shutdownHook(grpc::Server& server, const sigset_t terminationSignals)
 {
     return {
         "shutdown-hook",
-        [&]()
+        [&, terminationSignals]() mutable
         {
-            shutdownBarrier.acquire();
+            int signal{};
+            const auto error = sigwait(&terminationSignals, &signal);
+            if (error != 0)
+            {
+                NES_ERROR("Failed to wait for a termination signal: {}", error)
+            }
+            else
+            {
+                NES_INFO("Received signal {}. Shutting down.", signal);
+            }
             server.Shutdown();
         }};
 }
@@ -67,15 +76,12 @@ int main(const int argc, const char* argv[])
     CPPTRACE_TRY
     {
         NES::setupSignalHandlers();
+        sigset_t terminationSignals{};
+        if (!blockTerminationSignals(terminationSignals))
+        {
+            return 1;
+        }
         NES::Logger::setupLogging("singleNodeWorker.log", NES::LogLevel::LOG_DEBUG);
-        if (std::signal(SIGINT, signalHandler) == SIG_ERR)
-        {
-            NES_ERROR("Failed to set SIGINT signal handler")
-        }
-        if (std::signal(SIGTERM, signalHandler) == SIG_ERR)
-        {
-            NES_ERROR("Failed to set SIGTERM signal handler")
-        }
         auto configuration = NES::loadConfiguration<NES::SingleNodeWorkerConfiguration>(argc, argv);
         if (!configuration)
         {
@@ -98,7 +104,7 @@ int main(const int argc, const char* argv[])
                 return 1;
             }
 
-            const auto hook = shutdownHook(*server);
+            const auto hook = shutdownHook(*server, terminationSignals);
             NES_INFO("Server listening on {}", configuration->grpcAddressUri.getValue());
             server->Wait();
             NES_INFO("GRPC Server was shutdown. Terminating the SingleNodeWorker");

--- a/nes-single-node-worker/tests/offline.bats
+++ b/nes-single-node-worker/tests/offline.bats
@@ -64,6 +64,15 @@ teardown() {
   fi
 }
 
+# Give graceful SIGTERM shutdown a bounded amount of time. GNU timeout exits with 124 when SIGTERM works and 137 when it had to
+# escalate to SIGKILL, so tests expecting a live worker must continue to require exactly 124.
+worker_timeout() {
+  local duration="$1"
+  shift
+  run timeout --kill-after=10s "$duration" "$NES_WORKER" "$@"
+  [ "$status" -ne 137 ] # graceful termination must not require SIGKILL
+}
+
 @test "worker shows help" {
   run $NES_WORKER --help
   [ "$status" -eq 0 ]
@@ -84,17 +93,17 @@ teardown() {
 }
 
 @test "worker launches and stays alive" {
-  run timeout 5 $NES_WORKER
+  worker_timeout 5s
   [ "$status" -eq 124 ] # killed by timeout
   grep "Starting SingleNodeWorker" singleNodeWorker.log
 }
 
 @test "worker accepts grpc address" {
-  run timeout 5 $NES_WORKER --grpc=localhost:55555
+  worker_timeout 5s --grpc=localhost:55555
   [ "$status" -eq 124 ] # killed by timeout
   grep "localhost:55555" singleNodeWorker.log
 
-  run timeout 5 $NES_WORKER --grpc=0.0.0.0:55555
+  worker_timeout 5s --grpc=0.0.0.0:55555
   [ "$status" -eq 124 ] # killed by timeout
   grep "0.0.0.0:55555" singleNodeWorker.log
 }
@@ -104,24 +113,24 @@ teardown() {
   # depending on whether a DNS server is reachable (EAI_NONAME "Name or service not known")
   # or not (EAI_AGAIN "Temporary failure in name resolution"), so we only assert that the
   # worker logged a clean gRPC-startup failure rather than matching the resolver message.
-  run timeout 10 $NES_WORKER --grpc=asdf.asdf.asdf:55555
+  worker_timeout 10s --grpc=asdf.asdf.asdf:55555
 
   grep "Failed to start GRPC Server" singleNodeWorker.log
 
   # DNS Name is Invalid
-  run timeout 10 $NES_WORKER --grpc=wow!:55555
+  worker_timeout 10s --grpc=wow!:55555
   grep "Invalid hostname: 'wow!'" singleNodeWorker.log
   [ "$status" -ne 0 ]
 }
 
 @test "worker accepts valid configs" {
-  run timeout 5 $NES_WORKER --configPath=tests/good/config.yaml
+  worker_timeout 5s --configPath=tests/good/config.yaml
   [ "$status" -eq 124 ] # killed by timeout
 }
 
 @test "worker warns when CLI overrides YAML config value" {
   # The YAML config sets admission_queue_size=1024. Override it via CLI to trigger the warning.
-  run timeout 5 $NES_WORKER --configPath=tests/good/config.yaml --worker.query_engine.admission_queue_size=2048
+  worker_timeout 5s --configPath=tests/good/config.yaml --worker.query_engine.admission_queue_size=2048
   [ "$status" -eq 124 ] # killed by timeout
 
   # The log should contain the override warning
@@ -131,7 +140,7 @@ teardown() {
 
 @test "worker does not warn when CLI sets a value not in YAML" {
   # The YAML config does not set enable_event_trace. Setting it via CLI should not trigger a warning.
-  run timeout 5 $NES_WORKER --configPath=tests/good/config.yaml --enable_event_trace=true
+  worker_timeout 5s --configPath=tests/good/config.yaml --enable_event_trace=true
   [ "$status" -eq 124 ] # killed by timeout
 
   # The log should NOT contain the override warning for this key
@@ -144,17 +153,17 @@ teardown() {
 
 @test "worker rejects total_memory_in_bytes of 0" {
   # A zero budget yields zero pooled buffers, which cannot back the internal MPMC queues.
-  run timeout 5 $NES_WORKER --worker.total_memory_in_bytes=0
+  worker_timeout 5s --worker.total_memory_in_bytes=0
   grep -E "capacity 0 is impossible|Precondition violated" singleNodeWorker.log
 }
 
 @test "worker rejects unpooled_memory_fraction out of range" {
   # The fraction is validated to [0.0, 1.0] at config-parse time, so both bounds are rejected there.
-  run timeout 5 $NES_WORKER --worker.unpooled_memory_fraction=1.5
+  worker_timeout 5s --worker.unpooled_memory_fraction=1.5
   grep -E "invalid config parameter|Validator" singleNodeWorker.log
   grep "unpooled_memory_fraction" singleNodeWorker.log
 
-  run timeout 5 $NES_WORKER --worker.unpooled_memory_fraction=-0.1
+  worker_timeout 5s --worker.unpooled_memory_fraction=-0.1
   grep -E "invalid config parameter|Validator" singleNodeWorker.log
   grep "unpooled_memory_fraction" singleNodeWorker.log
 }
@@ -162,14 +171,12 @@ teardown() {
 @test "worker rejects non-power-of-two buffer_alignment_in_bytes" {
   # 48 is not a power of two. Rejected at config-parse time by PowerOfTwoValidation, so this holds on
   # every build type (a BufferManager PRECONDITION would be compiled out in the no-assert Benchmark build).
-  run timeout 5 $NES_WORKER --worker.buffer_alignment_in_bytes=48
+  worker_timeout 5s --worker.buffer_alignment_in_bytes=48
   grep -E "invalid config parameter|Validator" singleNodeWorker.log
   grep "buffer_alignment_in_bytes" singleNodeWorker.log
 }
 
 @test "worker accepts unpooled_memory_fraction of 0.0 (all pooled)" {
-  run timeout 5 $NES_WORKER --worker.unpooled_memory_fraction=0.0
+  worker_timeout 5s --worker.unpooled_memory_fraction=0.0
   [ "$status" -eq 124 ] # stays alive
 }
-
-


### PR DESCRIPTION
## Summary

- replace the worker's asynchronous SIGINT/SIGTERM handler with a dedicated `sigwait` shutdown thread
- block termination signals before worker threads are created so the shutdown thread handles them synchronously
- bound every offline worker invocation with a 10-second SIGKILL backstop
- fail the Bats test if graceful SIGTERM shutdown requires escalation to SIGKILL

## Root cause

The worker previously logged and released a `std::binary_semaphore` from its POSIX signal handler. Neither operation is guaranteed to be async-signal-safe. If SIGTERM interrupted code holding a logger, allocator, or synchronization lock, the handler could deadlock. GNU `timeout` sends SIGTERM but, without `--kill-after`, waits indefinitely when the target does not terminate.

This was observed in [the merge-queue unit-test job for PR #1728](https://github.com/nebulastream/nebulastream/actions/runs/31694641237/job/94431020071): `worker-offline-test` entered test 4 and then consumed the full 2400-second CTest timeout.

## Impact

Termination handling now runs in a regular thread, where logging and `grpc::Server::Shutdown()` are safe to call. The offline suite also has a hard upper bound: a stuck worker is killed after ten additional seconds and status 137 fails the test rather than hanging CI.
