### PR TITLE
feat(docs): How to add a function plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ For further information about our frontends, check out the [Frontend Reference](
 ## Documentation
 - Design proposals and architectural notes: [Design index](docs/design/README.md)
 - Developer workflows and environment setup: [Development environment](docs/development/development.md), [Run workflows locally](docs/development/running_workflows_locally.md), [Packaging Docker images](docs/development/packaging_docker_images.md)
-- Implementation guides: [Add a source](docs/guide/how_to_add_a_source.md), [Add a sink](docs/guide/how_to_add_a_sink.md), [Add a placement strategy](docs/guide/how_to_add_a_placement_strategy.md)
+- Implementation guides: [Add a source](docs/guide/how_to_add_a_source.md), [Add a sink](docs/guide/how_to_add_a_sink.md), [Add a function](docs/guide/how_to_add_a_function.md), [Add a placement strategy](docs/guide/how_to_add_a_placement_strategy.md)
 - Technical deep dives: [Dependency architecture](docs/technical/dependency.md), [Query engine task queue](docs/technical/QueryEngine_TaskQueue.md), [Watermarking trigger details](docs/technical/watermarking_progress_window_triggering.md)
 - Organizational guidelines and processes: [Meetings overview](docs/organizational/meetings.md), [Nightly CI process](docs/organizational/processes/nightly_ci.md)
 

--- a/docs/guide/how_to_add_a_function.md
+++ b/docs/guide/how_to_add_a_function.md
@@ -1,0 +1,253 @@
+# How to add a `Function`
+
+## 1. What is a Function
+
+A function computes a single value from a single record and has no view of the stream.
+It reads field values and constants, applies some logic, and returns one value.
+The value is a single field, but that field may be of a composite type or hold variable-sized data such as text or an image.
+Examples are `a + b`, `CHAR_LENGTH(name)`, and the CASE WHEN expression used as the example in this guide.
+
+Functions appear inside operators.
+The predicate of a Selection is a function that returns a boolean.
+Each output column of a Projection is a function.
+A join or aggregation uses functions to express keys and aggregated values.
+Without functions an operator could only pass fields through unchanged, so functions are how a query expresses computation over the data.
+
+### Function versus Operator
+
+An operator and a function work at different levels.
+
+- An operator works at the level of the stream. It decides which records pass, and how they are grouped, joined, filtered, or combined. It consumes and produces streams of records, windows, or tables.
+- A function is evaluated once per record. Its input is one or more values from that record and its output is one value. It has no view of the stream.
+
+Operators contain functions, and functions nest.
+A Selection operator holds a predicate: a tree of functions that returns a boolean, for example an AND function whose children are two comparisons.
+Each output field of a Projection is computed by such a function tree.
+When you add arithmetic, a comparison, or a string operation to the system, you add a function, not an operator.
+
+```mermaid
+graph LR
+    IN["record stream<br/>(a=1, b=9)<br/>(a=7, b=8)"] --> SEL
+    subgraph SEL["Selection operator: which records pass"]
+        FN["predicate function: one value per record<br/>a + b &gt; 10"]
+    end
+    SEL --> OUT["record stream<br/>(a=7, b=8)"]
+```
+
+The operator sees the stream, the function sees one record and produces one value.
+
+## 2. Logical and Physical Functions
+
+A function has two representations, and you implement both.
+
+The logical function is used during query planning and optimization.
+It knows its child functions and its result data type.
+Given the schema of the input, it infers the result type of the expression, which is how the enclosing operator computes its own output schema.
+The logical function answers two questions: what is the type of this expression, and is the expression valid.
+
+The physical function is used during query compilation and execution.
+It defines the execution semantics: given a record at runtime, produce the result value.
+It is lowered from the logical function and compiled by nautilus into executable code.
+The physical function answers one question: how is the value computed.
+
+Two representations exist because planning and execution need different information.
+Planning works on types and structure and never touches record values.
+Execution works on record values and never reasons about schemas.
+Keeping them apart means the optimizer stays independent of the runtime, and the runtime stays free of planning concerns.
+The two connect by name: lowering looks up the physical function using the logical function's registry key, so the names must match.
+
+## 3. Overview
+
+Function plugins are implemented in the `nes-plugins/Functions/` directory.
+For each new function, create a new directory, such as `nes-plugins/Functions/Conditional/`.
+This directory contains both the logical and the physical function.
+For our example, we use the following structure:
+
+```
+nes-plugins/
+├── Functions/
+│   ├── Conditional/
+│   │   ├── CMakeLists.txt
+│   │   ├── ConditionalLogicalFunction.cpp
+│   │   ├── ConditionalPhysicalFunction.cpp
+│   │   ├── ConditionalLogicalFunctionTest.cpp
+│   │   └── include/
+│   │       └── Functions/
+│   │           ├── ConditionalLogicalFunction.hpp
+│   │           └── ConditionalPhysicalFunction.hpp
+│   └── ...
+├── Rules/
+├── Sinks/
+├── Sources/
+└── ...
+```
+
+## 4. Plugin Registration
+
+The plugin's `CMakeLists.txt` builds one static library per function part and declares the registry entries that the plugin provides:
+1) The logical function, an entry in the `LogicalFunction` registry of nes-logical-operators
+2) The unreflection entry, which rebuilds the logical function from a serialized plan
+3) The physical function, an entry in the `PhysicalFunction` registry of nes-physical-operators
+4) The unit tests
+
+Registration happens at runtime: the build only collects the declared entries, and the host process registers them when it loads the built-in plugins.
+The plugin name is the registry key.
+A query refers to the function by that name, and lowering looks the physical function up under the same name.
+
+See `nes-plugins/Functions/Conditional/CMakeLists.txt` for the complete build setup of the example plugin.
+To activate the plugin, add the line `add_plugin("Functions/Conditional")` to `nes-plugins/CMakeLists.txt`.
+
+For a detailed explanation of the plugin system, CMake macros, and how registries work, see [guide/extensibility.md](extensibility.md).
+
+## 5. Interface
+
+A logical function can be any object that defines the following constant and methods:
+
+```cpp
+/// Name of the function, used as the registry key in a query and during lowering
+static constexpr std::string_view NAME = "NameOfFunction";
+
+/// Textual representation of the function
+std::string explain(ExplainVerbosity verbosity) const;
+
+/// Child functions of this function
+std::vector<LogicalFunction> getChildren() const;
+
+/// Result data type of the function
+DataType getDataType() const;
+
+/// New function with the given children
+T withChildren(const std::vector<LogicalFunction>& children) const;
+
+/// New function with the result type inferred from the input schema.
+/// This is the place to validate argument types and report invalid user input.
+LogicalFunction withInferredDataType(const Schema<Field, Unordered>& schema) const;
+
+/// The registry key of the function, usually NAME
+std::string_view getType() const;
+
+/// Equality operator
+bool operator==(const T& other) const;
+```
+
+To confirm the interface, add `static_assert(LogicalFunctionConcept<T>);`.
+
+The logical function also needs a `Reflector<T>` and an `Unreflector<T>` so a plan can be serialized and read back.
+See `ConditionalLogicalFunction.hpp` and `ConditionalLogicalFunction.cpp` for the reflection code.
+
+A physical function can be any object that defines the following method:
+
+```cpp
+/// Evaluate the function on a record and return the result
+VarVal execute(const Record& record, ArenaRef& arena) const;
+```
+
+To confirm the interface, add `static_assert(PhysicalFunctionConcept<T>);`.
+
+## 6. Type Inference in the Logical Function
+
+`withInferredDataType` receives the input schema, which lists the fields available to the function together with their types.
+It returns a copy of the function with a known result type, and it validates the arguments along the way.
+
+For the Conditional function it works in three steps.
+First it infers the type of the default result, which is the type of the whole expression.
+A field access child resolves its type from the schema, and a nested function infers its own type.
+Second it infers the type of every condition and every branch result the same way.
+Third it checks that every condition is BOOLEAN and every branch result has the same type as the default.
+A mismatch comes from the user's query, so it throws a query error rather than an assertion.
+
+The check compares the type only. Nullability is joined instead of compared, because a branch that can produce a null makes the whole expression nullable, as in SQL.
+
+```cpp
+LogicalFunction ConditionalLogicalFunction::withInferredDataType(const Schema<Field, Unordered>& schema) const
+{
+    /// The default result carries the type of the whole expression.
+    const auto inferredElseCase = elseCase.withInferredDataType(schema);
+    auto resultType = inferredElseCase.getDataType();
+
+    std::vector<WhenThenLogicalFunction> inferredWhenThens;
+    inferredWhenThens.reserve(whenThens.size());
+    for (const auto& [when, then] : whenThens)
+    {
+        auto inferredWhen = when.withInferredDataType(schema);
+        auto inferredThen = then.withInferredDataType(schema);
+        if (not inferredWhen.getDataType().isType(DataType::Type::BOOLEAN))
+        {
+            throw DifferentFieldTypeExpected("CASE WHEN condition must be BOOLEAN, but got {}", inferredWhen.getDataType());
+        }
+        if (not inferredThen.getDataType().isType(resultType.type))
+        {
+            throw DifferentFieldTypeExpected(
+                "CASE WHEN results must all share the default result's type {}, but got {}", resultType, inferredThen.getDataType());
+        }
+        /// A branch that can produce a null makes the whole expression nullable, as in SQL.
+        resultType = DataTypeProvider::provideDataType(resultType.type, resultType.joinNullable(inferredThen.getDataType()));
+        inferredWhenThens.push_back(WhenThenLogicalFunction{.when = std::move(inferredWhen), .then = std::move(inferredThen)});
+    }
+
+    auto inferred = ConditionalLogicalFunction{std::move(inferredWhenThens), inferredElseCase};
+    inferred.dataType = resultType;
+    return inferred;
+}
+```
+
+Type inference is the only place that assigns the result type.
+A constructor leaves it alone, because before a schema is known there is nothing to infer from, so `getDataType()` reports a usable type only after inference has run.
+The enclosing operator reads that type to build its output schema.
+For example a Projection that outputs this function as a column needs to know the column's type, and it gets it from here.
+
+## 7. Execution in the Physical Function
+
+`execute` defines the runtime semantics of the function.
+It receives one record and an arena for allocations, and returns the computed value as a `VarVal`.
+nautilus traces this method to compile it into executable code, so the control flow you write becomes the control flow of the compiled query.
+
+For the Conditional function, `execute` evaluates the conditions in order and returns the result of the first condition that holds, or the default if none hold.
+`when.execute(record, arena)` returns a `VarVal` that serves as the branch condition.
+`nautilus::static_iterable` walks the pairs at compile time, because the number of pairs is fixed once the function has been lowered, so the loop becomes a straight sequence of branches in the compiled code.
+
+```cpp
+VarVal ConditionalPhysicalFunction::execute(const Record& record, ArenaRef& arena) const
+{
+    for (const auto& [when, then] : nautilus::static_iterable(whenThens))
+    {
+        /// A condition that is null is not true, so it does not select its branch. Converting the
+        /// condition to a bool already accounts for that.
+        if (when.execute(record, arena))
+        {
+            return withDeclaredType(then.execute(record, arena), resultType);
+        }
+    }
+    return withDeclaredType(elseCase.execute(record, arena), resultType);
+}
+```
+
+The child functions are themselves physical functions, so calling `execute` on a child evaluates a nested expression.
+This is how a function such as `a + CHAR_LENGTH(name)` composes at runtime.
+
+`withDeclaredType` rebuilds the returned `VarVal` with the type that inference settled on, which is the type the enclosing operator's output schema expects.
+
+## 8. Factory Functions
+
+Each part needs a factory function that its registry calls to instantiate it.
+The factory is a static member of the function class, and the registry references it by a fixed naming pattern: `create` followed by the plugin name, so `createConditional` in the example.
+
+The logical factory receives the child functions that were parsed from the query.
+Argument count and other user input reach it directly, so report a bad count as a query error rather than an assertion.
+
+The physical factory receives the child functions and the inferred result type, which the physical function keeps so it can declare the type of whatever a branch returns.
+The plugin name must match the logical function name, because lowering looks up the physical function by the logical function's registry key.
+The logical function already validated the argument shape, so a bad shape here is a lowering bug and a precondition fits.
+
+See the factory functions in `ConditionalLogicalFunction.cpp` and `ConditionalPhysicalFunction.cpp` for the example.
+
+## 9. Example and Tests
+
+The `Conditional` function used throughout this guide implements a CASE WHEN expression.
+It evaluates condition and result pairs in order and returns the first matching result, or a trailing default.
+Both representations store the branches as (condition, result) pairs plus the default result, so the shape is correct by construction.
+The generic child list interface flattens them into `[condition1, result1, ..., default]` and regroups them on the way back, which the type inference and the execution sections above show in full.
+
+Last, it is good practice to define tests for the function.
+See `ConditionalLogicalFunctionTest.cpp` for unit tests, and `nes-systests/function/Conditional.test` for end to end tests that run queries against the function.
+Which layer a given test belongs in, and what each layer is expected to cover, is described in [standards/testing_guidelines.md](../standards/testing_guidelines.md).


### PR DESCRIPTION
Stacked on top of #1885 (base branch `ys/case-when-fn`).

Adds `docs/guide/how_to_add_a_function.md`, a guide for adding a function as an optional plugin. It covers:

- the two parts of a function: the logical function used during planning and the physical function used during execution
- plugin registration for both parts, plus unreflection for the logical function, in one `CMakeLists.txt`
- the logical and physical interfaces and the registration function naming
- the `Conditional` function as a worked example