### PR TITLE
Fix issue #1682: Accept double quotes inside quoted identifiers by escaping with double quotes

### DIFF
--- a/nes-common/src/Identifiers/Identifier.cpp
+++ b/nes-common/src/Identifiers/Identifier.cpp
@@ -42,7 +42,13 @@ std::string canonicalizeIdentifier(std::string_view identifierValue, bool quoted
     {
         identifierValue.remove_prefix(1);
         identifierValue.remove_suffix(1);
-        return std::string(identifierValue);
+        std::string result(identifierValue);
+        size_t pos = 0;
+        while ((pos = result.find("\"\"", pos)) != std::string::npos) {
+            result.replace(pos, 2, "\"");
+            pos += 1;
+        }
+        return result;
     }
     return toUpperCase(identifierValue);
 }

--- a/nes-common/tests/UnitTests/IdentifierTest.cpp
+++ b/nes-common/tests/UnitTests/IdentifierTest.cpp
@@ -72,6 +72,14 @@ TEST_F(IdentifierTest, CaseSensitiveCAPS)
     EXPECT_EQ(identifier.getOriginalString(), "\"TEST\"");
 }
 
+TEST_F(IdentifierTest, CaseSensitiveEscapedQuotes)
+{
+    const auto identifier = Identifier::parse("\"some\"\"Identifier\"");
+    EXPECT_EQ(fmt::format("{}", identifier), "some\"Identifier");
+    EXPECT_TRUE(identifier.isCaseSensitive());
+    EXPECT_EQ(identifier.getOriginalString(), "\"some\"\"Identifier\"");
+}
+
 TEST_F(IdentifierTest, Equality)
 {
     const auto identifier1 = Identifier::parse("test");

--- a/nes-sql-parser/AntlrSQL.g4
+++ b/nes-sql-parser/AntlrSQL.g4
@@ -223,7 +223,7 @@ quotedIdentifier
     ;
 
 BACKQUOTED_IDENTIFIER
-    : '"' ( ~'"' )* '"'
+    : '"' ( ~'"' | '""' )* '"'
     ;
 
 identifierChain: strictIdentifier ('.' strictIdentifier)*;


### PR DESCRIPTION
Fixes #1682.