### PR TITLE
Fix #1579: Remove passing Schema to TestTupleBuffer

### DIFF
--- a/nes-nautilus/tests/TestTupleBufferTest.cpp
+++ b/nes-nautilus/tests/TestTupleBufferTest.cpp
@@ -1,3 +1,4 @@
+#include <Interface/BufferRef/LowerSchemaProvider.hpp>
 /*
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -73,7 +74,8 @@ public:
 TEST_F(TestTupleBufferTest, AppendAndReadSingleField)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("value"), DataType::Type::INT64}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), schema, NES::MemoryLayoutType::ROW_LAYOUT);
+    Testing::TestTupleBuffer ttb(ttb_bufRef);
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -89,7 +91,8 @@ TEST_F(TestTupleBufferTest, AppendAndReadMultipleFields)
     auto schema = Testing::TestSchema{
         UnqualifiedUnboundField{Identifier::parse("a"), DataType::Type::INT64},
         UnqualifiedUnboundField{Identifier::parse("b"), DataType::Type::UINT32}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), schema, NES::MemoryLayoutType::ROW_LAYOUT);
+    Testing::TestTupleBuffer ttb(ttb_bufRef);
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -104,7 +107,8 @@ TEST_F(TestTupleBufferTest, AppendAndReadMultipleFields)
 TEST_F(TestTupleBufferTest, AppendMultipleRecords)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("x"), DataType::Type::INT32}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), schema, NES::MemoryLayoutType::ROW_LAYOUT);
+    Testing::TestTupleBuffer ttb(ttb_bufRef);
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -122,7 +126,8 @@ TEST_F(TestTupleBufferTest, AppendMultipleRecords)
 TEST_F(TestTupleBufferTest, IndexedWriteAndRead)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("val"), DataType::Type::INT64}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), schema, NES::MemoryLayoutType::ROW_LAYOUT);
+    Testing::TestTupleBuffer ttb(ttb_bufRef);
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -139,7 +144,8 @@ TEST_F(TestTupleBufferTest, IndexedWriteAndRead)
 TEST_F(TestTupleBufferTest, OutOfBoundsThrows)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("f"), DataType::Type::INT32}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), schema, NES::MemoryLayoutType::ROW_LAYOUT);
+    Testing::TestTupleBuffer ttb(ttb_bufRef);
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -154,7 +160,8 @@ TEST_F(TestTupleBufferTest, OutOfBoundsThrows)
 TEST_F(TestTupleBufferTest, UnknownFieldThrows)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("exists"), DataType::Type::INT32}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), schema, NES::MemoryLayoutType::ROW_LAYOUT);
+    Testing::TestTupleBuffer ttb(ttb_bufRef);
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -167,7 +174,8 @@ TEST_F(TestTupleBufferTest, UnknownFieldThrows)
 TEST_F(TestTupleBufferTest, TypeMismatchThrows)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("i64"), DataType::Type::INT64}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), schema, NES::MemoryLayoutType::ROW_LAYOUT);
+    Testing::TestTupleBuffer ttb(ttb_bufRef);
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -181,7 +189,8 @@ TEST_F(TestTupleBufferTest, TypeMismatchThrows)
 TEST_F(TestTupleBufferTest, DanglingFieldViewThrows)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("f"), DataType::Type::INT32}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), schema, NES::MemoryLayoutType::ROW_LAYOUT);
+    Testing::TestTupleBuffer ttb(ttb_bufRef);
 
     Testing::FieldView captured;
     {
@@ -198,7 +207,8 @@ TEST_F(TestTupleBufferTest, DanglingFieldViewThrows)
 TEST_F(TestTupleBufferTest, StringField)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("name"), DataType::Type::VARSIZED}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), schema, NES::MemoryLayoutType::ROW_LAYOUT);
+    Testing::TestTupleBuffer ttb(ttb_bufRef);
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer, bufferManager.get());
@@ -214,7 +224,8 @@ TEST_F(TestTupleBufferTest, MixedFixedAndVarSizedFields)
     auto schema = Testing::TestSchema{
         UnqualifiedUnboundField{Identifier::parse("id"), DataType::Type::INT64},
         UnqualifiedUnboundField{Identifier::parse("label"), DataType::Type::VARSIZED}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), schema, NES::MemoryLayoutType::ROW_LAYOUT);
+    Testing::TestTupleBuffer ttb(ttb_bufRef);
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer, bufferManager.get());
@@ -232,7 +243,8 @@ TEST_F(TestTupleBufferTest, MixedFixedAndVarSizedFields)
 TEST_F(TestTupleBufferTest, BooleanField)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("flag"), DataType::Type::BOOLEAN}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), schema, NES::MemoryLayoutType::ROW_LAYOUT);
+    Testing::TestTupleBuffer ttb(ttb_bufRef);
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -250,7 +262,8 @@ TEST_F(TestTupleBufferTest, FloatingPointFields)
     auto schema = Testing::TestSchema{
         UnqualifiedUnboundField{Identifier::parse("f32"), DataType::Type::FLOAT32},
         UnqualifiedUnboundField{Identifier::parse("f64"), DataType::Type::FLOAT64}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), schema, NES::MemoryLayoutType::ROW_LAYOUT);
+    Testing::TestTupleBuffer ttb(ttb_bufRef);
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -268,7 +281,8 @@ TEST_F(TestTupleBufferTest, AppendImplicitCastFromInt)
     auto schema = Testing::TestSchema{
         UnqualifiedUnboundField{Identifier::parse("a"), DataType::Type::INT64},
         UnqualifiedUnboundField{Identifier::parse("b"), DataType::Type::UINT32}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), schema, NES::MemoryLayoutType::ROW_LAYOUT);
+    Testing::TestTupleBuffer ttb(ttb_bufRef);
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -288,7 +302,8 @@ TEST_F(TestTupleBufferTest, AppendImplicitCastMultipleRecords)
         UnqualifiedUnboundField{Identifier::parse("i8"), DataType::Type::INT8},
         UnqualifiedUnboundField{Identifier::parse("u64"), DataType::Type::UINT64},
         UnqualifiedUnboundField{Identifier::parse("f32"), DataType::Type::FLOAT32}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), schema, NES::MemoryLayoutType::ROW_LAYOUT);
+    Testing::TestTupleBuffer ttb(ttb_bufRef);
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -312,7 +327,8 @@ TEST_F(TestTupleBufferTest, AppendImplicitCastStringLiteral)
     auto schema = Testing::TestSchema{
         UnqualifiedUnboundField{Identifier::parse("id"), DataType::Type::INT32},
         UnqualifiedUnboundField{Identifier::parse("name"), DataType::Type::VARSIZED}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), schema, NES::MemoryLayoutType::ROW_LAYOUT);
+    Testing::TestTupleBuffer ttb(ttb_bufRef);
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer, bufferManager.get());
@@ -329,7 +345,8 @@ TEST_F(TestTupleBufferTest, AppendImplicitCastStringLiteral)
 TEST_F(TestTupleBufferTest, AppendImplicitCastStringToNumericThrows)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("value"), DataType::Type::INT64}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), schema, NES::MemoryLayoutType::ROW_LAYOUT);
+    Testing::TestTupleBuffer ttb(ttb_bufRef);
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer);
@@ -343,7 +360,8 @@ TEST_F(TestTupleBufferTest, NullableFieldRoundTrip)
 {
     auto schema = Testing::TestSchema{
         UnqualifiedUnboundField{Identifier::parse("v"), DataType{DataType::Type::INT64, DataType::NULLABLE::IS_NULLABLE}}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), schema, NES::MemoryLayoutType::ROW_LAYOUT);
+    Testing::TestTupleBuffer ttb(ttb_bufRef);
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer, bufferManager.get());
@@ -369,7 +387,8 @@ TEST_F(TestTupleBufferTest, NullableFieldReadWithoutOptionalThrows)
 {
     auto schema = Testing::TestSchema{
         UnqualifiedUnboundField{Identifier::parse("v"), DataType{DataType::Type::INT64, DataType::NULLABLE::IS_NULLABLE}}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), schema, NES::MemoryLayoutType::ROW_LAYOUT);
+    Testing::TestTupleBuffer ttb(ttb_bufRef);
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer, bufferManager.get());
@@ -382,7 +401,8 @@ TEST_F(TestTupleBufferTest, NullableFieldReadWithoutOptionalThrows)
 TEST_F(TestTupleBufferTest, NonNullableFieldReadWithOptionalThrows)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("v"), DataType::Type::INT64}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), schema, NES::MemoryLayoutType::ROW_LAYOUT);
+    Testing::TestTupleBuffer ttb(ttb_bufRef);
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer, bufferManager.get());
@@ -395,7 +415,8 @@ TEST_F(TestTupleBufferTest, NonNullableFieldReadWithOptionalThrows)
 TEST_F(TestTupleBufferTest, NullWriteToNonNullableFieldThrows)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("v"), DataType::Type::INT64}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), schema, NES::MemoryLayoutType::ROW_LAYOUT);
+    Testing::TestTupleBuffer ttb(ttb_bufRef);
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer, bufferManager.get());
@@ -409,7 +430,8 @@ TEST_F(TestTupleBufferTest, NullWriteToNonNullableFieldThrows)
 TEST_F(TestTupleBufferTest, GetWithWrongTypeThrows)
 {
     auto schema = Testing::TestSchema{UnqualifiedUnboundField{Identifier::parse("v"), DataType::Type::INT64}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), schema, NES::MemoryLayoutType::ROW_LAYOUT);
+    Testing::TestTupleBuffer ttb(ttb_bufRef);
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer, bufferManager.get());
@@ -423,7 +445,8 @@ TEST_F(TestTupleBufferTest, NullableVarsizedRoundTrip)
 {
     auto schema = Testing::TestSchema{
         UnqualifiedUnboundField{Identifier::parse("s"), DataType{DataType::Type::VARSIZED, DataType::NULLABLE::IS_NULLABLE}}};
-    Testing::TestTupleBuffer ttb(schema);
+    auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), schema, NES::MemoryLayoutType::ROW_LAYOUT);
+    Testing::TestTupleBuffer ttb(ttb_bufRef);
 
     auto buffer = bufferManager->getBufferBlocking();
     auto view = ttb.open(buffer, bufferManager.get());

--- a/nes-nautilus/tests/TestUtils/include/TestTupleBuffer.hpp
+++ b/nes-nautilus/tests/TestUtils/include/TestTupleBuffer.hpp
@@ -107,11 +107,11 @@ class FieldView;
 
 using TestSchema = Schema<UnqualifiedUnboundField, Ordered>;
 
-/// Entry point. Holds schema config.
+/// Entry point. Holds physical layout configuration.
 class TestTupleBuffer
 {
 public:
-    explicit TestTupleBuffer(TestSchema schema);
+    explicit TestTupleBuffer(std::shared_ptr<TupleBufferRef> tupleBufferRef);
 
     /// Wraps an existing TupleBuffer for schema-aware access.
     /// bufferProvider required for VARSIZED (string) field support.
@@ -119,7 +119,7 @@ public:
     TestTupleBufferView open(TupleBuffer& buffer, AbstractBufferProvider* bufferProvider = nullptr);
 
 private:
-    TestSchema schema;
+    std::shared_ptr<TupleBufferRef> tupleBufferRef;
 };
 
 /// View over a TupleBuffer. Supports append and indexed record access.
@@ -144,7 +144,6 @@ private:
 
     struct Impl
     {
-        TestSchema schema;
         TupleBuffer&
             buffer; /// NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members) intentional reference: Impl always outlived by the TupleBuffer it wraps
         AbstractBufferProvider* bufferProvider;
@@ -290,13 +289,14 @@ template <typename... Args>
 void TestTupleBufferView::append(Args&&... values)
 {
     static_assert(sizeof...(Args) > 0, "append requires at least one argument");
-    if (sizeof...(Args) != impl->schema.size())
+    auto dataTypes = impl->bufRef->getAllDataTypes();
+    if (sizeof...(Args) != dataTypes.size())
     {
-        throw TestException("append requires exactly {} arguments, got {}", impl->schema.size(), sizeof...(Args));
+        throw TestException("append requires exactly {} arguments, got {}", dataTypes.size(), sizeof...(Args));
     }
-    auto fieldIt = impl->schema.begin();
+    auto fieldIt = dataTypes.begin();
     const std::array<std::optional<FieldValue>, sizeof...(Args)> fieldValues{
-        toFieldValue(std::forward<Args>(values), (fieldIt++)->getDataType().type)...};
+        toFieldValue(std::forward<Args>(values), (fieldIt++)->type)...};
     appendImpl(fieldValues);
 }
 

--- a/nes-nautilus/tests/TestUtils/src/TestTupleBuffer.cpp
+++ b/nes-nautilus/tests/TestUtils/src/TestTupleBuffer.cpp
@@ -223,17 +223,15 @@ std::optional<FieldValue> varValToFieldValue(const VarVal& value, const DataType
 
 /// ---- TestTupleBuffer ----
 
-TestTupleBuffer::TestTupleBuffer(TestSchema schema) : schema(std::move(schema))
+TestTupleBuffer::TestTupleBuffer(std::shared_ptr<TupleBufferRef> tupleBufferRef) : tupleBufferRef(std::move(tupleBufferRef))
 {
 }
 
 TestTupleBufferView TestTupleBuffer::open(TupleBuffer& buffer, AbstractBufferProvider* bufferProvider)
 {
-    auto bufRef = LowerSchemaProvider::lowerSchema(buffer.getBufferSize(), schema, MemoryLayoutType::ROW_LAYOUT);
-
     TestTupleBufferView view;
     view.impl = std::make_shared<TestTupleBufferView::Impl>(
-        TestTupleBufferView::Impl{.schema = schema, .buffer = buffer, .bufferProvider = bufferProvider, .bufRef = std::move(bufRef)});
+        TestTupleBufferView::Impl{.buffer = buffer, .bufferProvider = bufferProvider, .bufRef = tupleBufferRef});
     return view;
 }
 
@@ -258,9 +256,10 @@ uint64_t TestTupleBufferView::getNumberOfTuples() const
 
 void TestTupleBufferView::appendImpl(std::span<const std::optional<FieldValue>> values)
 {
-    if (values.size() != impl->schema.size())
+    auto dataTypes = impl->bufRef->getAllDataTypes();
+    if (values.size() != dataTypes.size())
     {
-        throw TestException("TestTupleBufferView: expected {} fields, got {}", impl->schema.size(), values.size());
+        throw TestException("TestTupleBufferView: expected {} fields, got {}", dataTypes.size(), values.size());
     }
 
     auto tupleIndex = nautilus::val<uint64_t>(impl->buffer.getNumberOfTuples());
@@ -269,9 +268,10 @@ void TestTupleBufferView::appendImpl(std::span<const std::optional<FieldValue>> 
     auto bufProviderVal = nautilus::val<AbstractBufferProvider*>(impl->bufferProvider);
 
     Record record;
-    for (const auto [value, field] : std::views::zip(values, impl->schema))
+    auto fieldNames = impl->bufRef->getAllFieldNames();
+    for (size_t i = 0; i < values.size(); ++i)
     {
-        record.write(field.getFullyQualifiedName(), fieldValueToVarVal(value, field.getDataType()));
+        record.write(fieldNames[i], fieldValueToVarVal(values[i], dataTypes[i]));
     }
 
     impl->bufRef->writeRecord(tupleIndex, recordBuffer, record, bufProviderVal);
@@ -282,17 +282,23 @@ void TestTupleBufferView::appendImpl(std::span<const std::optional<FieldValue>> 
 
 FieldView TestTupleBufferRecordView::operator[](const std::string& fieldName)
 {
-    const auto field = impl->schema[static_cast<QualifiedIdentifierBase<1>>(Identifier::parse(fieldName))];
-    if (!field.has_value())
+    auto fieldNames = impl->bufRef->getAllFieldNames();
+    auto dataTypes = impl->bufRef->getAllDataTypes();
+    auto qualifiedFieldName = static_cast<QualifiedIdentifierBase<1>>(Identifier::parse(fieldName));
+
+    auto it = std::find(fieldNames.begin(), fieldNames.end(), qualifiedFieldName);
+    if (it == fieldNames.end())
     {
         throw FieldNotFound("TestTupleBufferRecordView: field '{}' not found in schema", fieldName);
     }
+    
+    auto index = std::distance(fieldNames.begin(), it);
 
     FieldView fieldView;
     fieldView.implWeak = impl;
     fieldView.recordIndex = recordIndex;
     fieldView.fieldName = fieldName;
-    fieldView.dataType = field->getDataType();
+    fieldView.dataType = dataTypes[index];
     return fieldView;
 }
 

--- a/nes-physical-operators/tests/InferModelPhysicalOperatorTest.cpp
+++ b/nes-physical-operators/tests/InferModelPhysicalOperatorTest.cpp
@@ -278,7 +278,7 @@ public:
         tupleBuffer.setLastChunk(true);
         tupleBuffer.setOriginId(INITIAL<OriginId>);
 
-        auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), inputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
+        auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufMgr->getBufferSize(), inputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
         Testing::TestTupleBuffer ttb(ttb_bufRef);
         auto view = ttb.open(tupleBuffer, bufMgr.get());
         for (const auto& floats : recordFloats)
@@ -332,7 +332,7 @@ TEST_F(InferModelPhysicalOperatorTest, IdentityModelCorrectness)
         auto lockedBuffers = *emittedBuffers.rlock();
         for (auto& outBuf : lockedBuffers)
         {
-            auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), outputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
+            auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufMgr->getBufferSize(), outputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
             Testing::TestTupleBuffer ttb(ttb_bufRef);
             auto view = ttb.open(outBuf);
             for (size_t row = 0; row < view.getNumberOfTuples(); ++row)
@@ -388,7 +388,7 @@ TEST_F(InferModelPhysicalOperatorTest, ReductionModelCorrectness)
         auto lockedBuffers = *emittedBuffers.rlock();
         for (auto& outBuf : lockedBuffers)
         {
-            auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), outputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
+            auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufMgr->getBufferSize(), outputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
             Testing::TestTupleBuffer ttb(ttb_bufRef);
             auto view = ttb.open(outBuf);
             for (size_t row = 0; row < view.getNumberOfTuples(); ++row)
@@ -444,7 +444,7 @@ TEST_F(InferModelPhysicalOperatorTest, ExpansionModelCorrectness)
         auto lockedBuffers = *emittedBuffers.rlock();
         for (auto& outBuf : lockedBuffers)
         {
-            auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), outputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
+            auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufMgr->getBufferSize(), outputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
             Testing::TestTupleBuffer ttb(ttb_bufRef);
             auto view = ttb.open(outBuf);
             for (size_t row = 0; row < view.getNumberOfTuples(); ++row)
@@ -508,7 +508,7 @@ TEST_F(InferModelPhysicalOperatorTest, MultiRecordIdentity)
         auto lockedBuffers = *emittedBuffers.rlock();
         for (auto& outBuf : lockedBuffers)
         {
-            auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), outputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
+            auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufMgr->getBufferSize(), outputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
             Testing::TestTupleBuffer ttb(ttb_bufRef);
             auto view = ttb.open(outBuf);
             for (size_t row = 0; row < view.getNumberOfTuples(); ++row)
@@ -565,7 +565,7 @@ TEST_F(InferModelPhysicalOperatorTest, ZeroRecordBuffer)
         auto lockedBuffers = *emittedBuffers.rlock();
         for (auto& outBuf : lockedBuffers)
         {
-            auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), outputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
+            auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufMgr->getBufferSize(), outputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
             Testing::TestTupleBuffer ttb(ttb_bufRef);
             auto view = ttb.open(outBuf);
             totalRecords += view.getNumberOfTuples();
@@ -659,7 +659,7 @@ TEST_F(InferModelPhysicalOperatorTest, ConcurrentStressTest)
     auto outputBuffers = *emittedBuffers.rlock();
     for (auto& outBuf : outputBuffers)
     {
-        auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), outputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
+        auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufMgr->getBufferSize(), outputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
             Testing::TestTupleBuffer ttb(ttb_bufRef);
         auto view = ttb.open(outBuf);
         for (size_t row = 0; row < view.getNumberOfTuples(); ++row)
@@ -730,7 +730,7 @@ TEST_F(InferModelPhysicalOperatorTest, VarsizedOutputCorrectness)
         auto lockedBuffers = *emittedBuffers.rlock();
         for (auto& outBuf : lockedBuffers)
         {
-            auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), outputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
+            auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufMgr->getBufferSize(), outputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
             Testing::TestTupleBuffer ttb(ttb_bufRef);
             auto view = ttb.open(outBuf);
             for (size_t row = 0; row < view.getNumberOfTuples(); ++row)

--- a/nes-physical-operators/tests/InferModelPhysicalOperatorTest.cpp
+++ b/nes-physical-operators/tests/InferModelPhysicalOperatorTest.cpp
@@ -278,7 +278,8 @@ public:
         tupleBuffer.setLastChunk(true);
         tupleBuffer.setOriginId(INITIAL<OriginId>);
 
-        Testing::TestTupleBuffer ttb(inputSchema);
+        auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), inputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
+        Testing::TestTupleBuffer ttb(ttb_bufRef);
         auto view = ttb.open(tupleBuffer, bufMgr.get());
         for (const auto& floats : recordFloats)
         {
@@ -331,7 +332,8 @@ TEST_F(InferModelPhysicalOperatorTest, IdentityModelCorrectness)
         auto lockedBuffers = *emittedBuffers.rlock();
         for (auto& outBuf : lockedBuffers)
         {
-            Testing::TestTupleBuffer ttb(outputSchema);
+            auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), outputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
+            Testing::TestTupleBuffer ttb(ttb_bufRef);
             auto view = ttb.open(outBuf);
             for (size_t row = 0; row < view.getNumberOfTuples(); ++row)
             {
@@ -386,7 +388,8 @@ TEST_F(InferModelPhysicalOperatorTest, ReductionModelCorrectness)
         auto lockedBuffers = *emittedBuffers.rlock();
         for (auto& outBuf : lockedBuffers)
         {
-            Testing::TestTupleBuffer ttb(outputSchema);
+            auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), outputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
+            Testing::TestTupleBuffer ttb(ttb_bufRef);
             auto view = ttb.open(outBuf);
             for (size_t row = 0; row < view.getNumberOfTuples(); ++row)
             {
@@ -441,7 +444,8 @@ TEST_F(InferModelPhysicalOperatorTest, ExpansionModelCorrectness)
         auto lockedBuffers = *emittedBuffers.rlock();
         for (auto& outBuf : lockedBuffers)
         {
-            Testing::TestTupleBuffer ttb(outputSchema);
+            auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), outputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
+            Testing::TestTupleBuffer ttb(ttb_bufRef);
             auto view = ttb.open(outBuf);
             for (size_t row = 0; row < view.getNumberOfTuples(); ++row)
             {
@@ -504,7 +508,8 @@ TEST_F(InferModelPhysicalOperatorTest, MultiRecordIdentity)
         auto lockedBuffers = *emittedBuffers.rlock();
         for (auto& outBuf : lockedBuffers)
         {
-            Testing::TestTupleBuffer ttb(outputSchema);
+            auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), outputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
+            Testing::TestTupleBuffer ttb(ttb_bufRef);
             auto view = ttb.open(outBuf);
             for (size_t row = 0; row < view.getNumberOfTuples(); ++row)
             {
@@ -560,7 +565,8 @@ TEST_F(InferModelPhysicalOperatorTest, ZeroRecordBuffer)
         auto lockedBuffers = *emittedBuffers.rlock();
         for (auto& outBuf : lockedBuffers)
         {
-            Testing::TestTupleBuffer ttb(outputSchema);
+            auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), outputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
+            Testing::TestTupleBuffer ttb(ttb_bufRef);
             auto view = ttb.open(outBuf);
             totalRecords += view.getNumberOfTuples();
         }
@@ -653,7 +659,8 @@ TEST_F(InferModelPhysicalOperatorTest, ConcurrentStressTest)
     auto outputBuffers = *emittedBuffers.rlock();
     for (auto& outBuf : outputBuffers)
     {
-        Testing::TestTupleBuffer ttb(outputSchema);
+        auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), outputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
+            Testing::TestTupleBuffer ttb(ttb_bufRef);
         auto view = ttb.open(outBuf);
         for (size_t row = 0; row < view.getNumberOfTuples(); ++row)
         {
@@ -723,7 +730,8 @@ TEST_F(InferModelPhysicalOperatorTest, VarsizedOutputCorrectness)
         auto lockedBuffers = *emittedBuffers.rlock();
         for (auto& outBuf : lockedBuffers)
         {
-            Testing::TestTupleBuffer ttb(outputSchema);
+            auto ttb_bufRef = NES::LowerSchemaProvider::lowerSchema(bufferManager->getBufferSize(), outputSchema, NES::MemoryLayoutType::ROW_LAYOUT);
+            Testing::TestTupleBuffer ttb(ttb_bufRef);
             auto view = ttb.open(outBuf);
             for (size_t row = 0; row < view.getNumberOfTuples(); ++row)
             {


### PR DESCRIPTION
Closes #1579. Refactored TestTupleBuffer and C++ tests to use physical types instead of logical schemas.