### PR TITLE
Fix #1731: Add ByteAmount TypeValidator / ScalarOption<Byte> for size configs

### DIFF
--- a/nes-configurations/include/Configurations/ScalarOption.hpp
+++ b/nes-configurations/include/Configurations/ScalarOption.hpp
@@ -20,6 +20,7 @@
 #include <Util/URI.hpp>
 #include <yaml-cpp/yaml.h>
 #include <ErrorHandling.hpp>
+#include <Configurations/Validation/ByteAmountValidation.hpp>
 
 namespace NES
 {
@@ -83,6 +84,10 @@ private:
         {
             /// Simple boolean conversion (true for "true", false otherwise)
             return strValue == "true";
+        }
+        else if constexpr (std::is_same_v<Type, NES::Byte>)
+        {
+            return NES::parseByteAmount(strValue);
         }
         else if constexpr (NESIdentifier<Type>)
         {
@@ -184,6 +189,7 @@ using StringOption = ScalarOption<std::string>;
 using FloatOption = ScalarOption<float>;
 using UIntOption = ScalarOption<uint64_t>;
 using BoolOption = ScalarOption<bool>;
+using ByteOption = ScalarOption<Byte>;
 
 }
 

--- a/nes-configurations/include/Configurations/Validation/ByteAmountValidation.hpp
+++ b/nes-configurations/include/Configurations/Validation/ByteAmountValidation.hpp
@@ -1,0 +1,81 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <ostream>
+#include <Configurations/Validation/ConfigurationValidation.hpp>
+#include <yaml-cpp/yaml.h>
+
+namespace NES
+{
+
+/// @brief Struct representing an amount of bytes.
+struct Byte {
+    uint64_t value;
+
+    Byte() : value(0) {}
+    explicit Byte(uint64_t value) : value(value) {}
+
+    bool operator==(const Byte& other) const {
+        return value == other.value;
+    }
+
+    bool operator!=(const Byte& other) const {
+        return value != other.value;
+    }
+};
+
+inline std::ostream& operator<<(std::ostream& os, const Byte& b) {
+    os << b.value;
+    return os;
+}
+
+/// @brief Parser function to convert a resource string to Byte
+/// Supports Kubernetes' resource.Quantity grammar.
+Byte parseByteAmount(const std::string& byteAmountStr);
+
+/// @brief This class implements validation for parameters that should represent a byte amount
+class ByteAmountValidation : public ConfigurationValidation
+{
+public:
+    /// @brief Method to check the validity of a parameter as a byte amount
+    bool isValid(const std::string& parameter) const override;
+};
+}
+
+namespace YAML {
+template<>
+struct convert<NES::Byte> {
+  static Node encode(const NES::Byte& rhs) {
+    Node node;
+    node = rhs.value;
+    return node;
+  }
+
+  static bool decode(const Node& node, NES::Byte& rhs) {
+    if (!node.IsScalar()) {
+      return false;
+    }
+    try {
+        rhs = NES::parseByteAmount(node.as<std::string>());
+        return true;
+    } catch (...) {
+        return false;
+    }
+  }
+};
+}

--- a/nes-configurations/src/Configurations/Validation/ByteAmountValidation.cpp
+++ b/nes-configurations/src/Configurations/Validation/ByteAmountValidation.cpp
@@ -1,0 +1,97 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Configurations/Validation/ByteAmountValidation.hpp>
+
+#include <regex>
+#include <stdexcept>
+#include <cmath>
+
+namespace NES
+{
+
+Byte parseByteAmount(const std::string& byteAmountStr) {
+    if (byteAmountStr.empty()) {
+        throw std::invalid_argument("Empty byte amount string");
+    }
+
+    std::regex amountRegex(R"(^([0-9]+)(?:\.([0-9]+))?\s*([kKMGTPE]i?)?(b|B)?$)");
+    std::smatch match;
+
+    if (!std::regex_match(byteAmountStr, match, amountRegex)) {
+        throw std::invalid_argument("Invalid byte amount format");
+    }
+
+    std::string intPartStr = match[1];
+    std::string fracPartStr = match[2];
+    std::string suffix = match[3];
+
+    double multiplier = 1.0;
+    if (!suffix.empty()) {
+        if (suffix == "k" || suffix == "K") multiplier = 1e3;
+        else if (suffix == "M") multiplier = 1e6;
+        else if (suffix == "G") multiplier = 1e9;
+        else if (suffix == "T") multiplier = 1e12;
+        else if (suffix == "P") multiplier = 1e15;
+        else if (suffix == "E") multiplier = 1e18;
+        else if (suffix == "Ki") multiplier = 1024.0;
+        else if (suffix == "Mi") multiplier = std::pow(1024.0, 2);
+        else if (suffix == "Gi") multiplier = std::pow(1024.0, 3);
+        else if (suffix == "Ti") multiplier = std::pow(1024.0, 4);
+        else if (suffix == "Pi") multiplier = std::pow(1024.0, 5);
+        else if (suffix == "Ei") multiplier = std::pow(1024.0, 6);
+    }
+
+    if (fracPartStr.empty() && suffix.empty()) {
+        try {
+            uint64_t val = std::stoull(intPartStr);
+            return Byte(val);
+        } catch(const std::out_of_range&) {
+            throw std::overflow_error("Byte amount overflow");
+        }
+    }
+
+    std::string fullNumStr = intPartStr;
+    if (!fracPartStr.empty()) {
+        fullNumStr += "." + fracPartStr;
+    }
+    double number = std::stod(fullNumStr);
+    
+    double result = number * multiplier;
+
+    if (result < 0) {
+        throw std::invalid_argument("Negative byte amount not allowed");
+    }
+    
+    // Check against UINT64_MAX using double conversion
+    // Note: UINT64_MAX is 18446744073709551615, which as a double might be rounded up to 18446744073709551616.0
+    // So we use result > std::nextafter(18446744073709551615.0, 0.0) or simply >= 18446744073709551616.0
+    const double MAX_UINT64_AS_DOUBLE = 18446744073709551616.0; 
+    if (result >= MAX_UINT64_AS_DOUBLE) {
+        throw std::overflow_error("Byte amount overflow");
+    }
+
+    return Byte(static_cast<uint64_t>(std::round(result)));
+}
+
+bool ByteAmountValidation::isValid(const std::string& parameter) const
+{
+    try {
+        parseByteAmount(parameter);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+}

--- a/nes-configurations/src/Configurations/Validation/CMakeLists.txt
+++ b/nes-configurations/src/Configurations/Validation/CMakeLists.txt
@@ -18,4 +18,5 @@ add_source_files(nes-configurations
         FloatValidation.cpp
         BooleanValidation.cpp
         PowerOfTwoValidation.cpp
+        ByteAmountValidation.cpp
 )

--- a/nes-configurations/src/Configurations/Validation/PowerOfTwoValidation.cpp
+++ b/nes-configurations/src/Configurations/Validation/PowerOfTwoValidation.cpp
@@ -13,9 +13,9 @@
 */
 
 #include <Configurations/Validation/PowerOfTwoValidation.hpp>
+#include <Configurations/Validation/ByteAmountValidation.hpp>
 
 #include <cstdint>
-#include <regex>
 #include <string>
 
 namespace NES
@@ -23,15 +23,11 @@ namespace NES
 
 bool PowerOfTwoValidation::isValid(const std::string& parameter) const
 {
-    /// Reject anything that is not a plain integer, and cap the digit count so std::stoul cannot overflow.
-    const std::regex numberRegex("^\\d+$");
-    if (constexpr auto capDigitCount = 10; !std::regex_match(parameter, numberRegex) || parameter.length() > capDigitCount)
-    {
+    try {
+        uint64_t value = parseByteAmount(parameter).value;
+        return value > 0 && (value & (value - 1)) == 0;
+    } catch (...) {
         return false;
     }
-
-    /// A positive power of two has exactly one set bit, so n & (n - 1) clears it to zero.
-    const uint64_t value = std::stoul(parameter);
-    return value > 0 && (value & (value - 1)) == 0;
 }
 }

--- a/nes-configurations/tests/CMakeLists.txt
+++ b/nes-configurations/tests/CMakeLists.txt
@@ -14,4 +14,5 @@
 include(ExternalProject)
 ### Config Tests ###
 add_nes_unit_test(configuration-help-message-tests "UnitTests/Configurations/ConfigurationHelpMessageTests.cpp" "UnitTests/Validation/EndpointValidationTest.cpp" "UnitTests/Configurations/ExplicitlySetTrackingTests.cpp")
+add_nes_unit_test(byte-amount-validation-test "UnitTests/Configurations/ByteAmountValidationTest.cpp")
 set_tests_properties(${Tests} PROPERTIES TIMEOUT 35)

--- a/nes-configurations/tests/UnitTests/Configurations/ByteAmountValidationTest.cpp
+++ b/nes-configurations/tests/UnitTests/Configurations/ByteAmountValidationTest.cpp
@@ -1,0 +1,88 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Configurations/Validation/ByteAmountValidation.hpp>
+#include <gtest/gtest.h>
+
+namespace NES
+{
+
+class ByteAmountValidationTest : public testing::Test
+{
+};
+
+TEST_F(ByteAmountValidationTest, testValidByteAmounts)
+{
+    ByteAmountValidation validation;
+
+    EXPECT_TRUE(validation.isValid("1024"));
+    EXPECT_TRUE(validation.isValid("1024B"));
+    EXPECT_TRUE(validation.isValid("1024b"));
+    EXPECT_TRUE(validation.isValid("1KiB"));
+    EXPECT_TRUE(validation.isValid("1Ki"));
+    EXPECT_TRUE(validation.isValid("1.5Gi"));
+    EXPECT_TRUE(validation.isValid("2.5K"));
+    EXPECT_TRUE(validation.isValid("0"));
+    EXPECT_TRUE(validation.isValid("100M"));
+    EXPECT_TRUE(validation.isValid("100Mi"));
+    EXPECT_TRUE(validation.isValid("100G"));
+    EXPECT_TRUE(validation.isValid("100Gi"));
+    EXPECT_TRUE(validation.isValid("100T"));
+    EXPECT_TRUE(validation.isValid("100Ti"));
+    EXPECT_TRUE(validation.isValid("100P"));
+    EXPECT_TRUE(validation.isValid("100Pi"));
+    EXPECT_TRUE(validation.isValid("100E"));
+    EXPECT_TRUE(validation.isValid("10Ei"));
+
+    EXPECT_EQ(parseByteAmount("1024").value, 1024ULL);
+    EXPECT_EQ(parseByteAmount("1KiB").value, 1024ULL);
+    EXPECT_EQ(parseByteAmount("1Ki").value, 1024ULL);
+    EXPECT_EQ(parseByteAmount("1.5Gi").value, static_cast<uint64_t>(1.5 * 1024 * 1024 * 1024));
+    EXPECT_EQ(parseByteAmount("2.5K").value, 2500ULL);
+}
+
+TEST_F(ByteAmountValidationTest, testInvalidByteAmounts)
+{
+    ByteAmountValidation validation;
+
+    EXPECT_FALSE(validation.isValid("-1024"));
+    EXPECT_FALSE(validation.isValid("1024X"));
+    EXPECT_FALSE(validation.isValid("KiB"));
+    EXPECT_FALSE(validation.isValid("1.5.5Gi"));
+    EXPECT_FALSE(validation.isValid(""));
+    EXPECT_FALSE(validation.isValid("   "));
+
+    EXPECT_ANY_THROW(parseByteAmount("-1024"));
+    EXPECT_ANY_THROW(parseByteAmount("1024X"));
+    EXPECT_ANY_THROW(parseByteAmount("KiB"));
+}
+
+TEST_F(ByteAmountValidationTest, testOverflow)
+{
+    ByteAmountValidation validation;
+
+    // 18446744073709551615 is UINT64_MAX, which is fine
+    EXPECT_TRUE(validation.isValid("18446744073709551615"));
+    EXPECT_EQ(parseByteAmount("18446744073709551615").value, UINT64_MAX);
+
+    // One more should overflow
+    EXPECT_FALSE(validation.isValid("18446744073709551616"));
+    EXPECT_ANY_THROW(parseByteAmount("18446744073709551616"));
+
+    // Huge double value overflow
+    EXPECT_FALSE(validation.isValid("1000Ei"));
+    EXPECT_ANY_THROW(parseByteAmount("1000Ei"));
+}
+
+}

--- a/nes-query-compiler/interface/QueryExecutionConfiguration.hpp
+++ b/nes-query-compiler/interface/QueryExecutionConfiguration.hpp
@@ -24,6 +24,7 @@
 #include <Configurations/ScalarOption.hpp>
 #include <Configurations/Validation/FloatValidation.hpp>
 #include <Configurations/Validation/NumberValidation.hpp>
+#include <Configurations/Validation/ByteAmountValidation.hpp>
 #include <Util/ExecutionMode.hpp>
 #include <BloomFilterConfiguration.hpp>
 #include <SliceCacheConfiguration.hpp>
@@ -53,11 +54,11 @@ public:
            std::to_string(DEFAULT_NUMBER_OF_PARTITIONS_DATASTRUCTURES),
            "Partitions in a hash table",
            {std::make_shared<NumberValidation>()}};
-    UIntOption pageSize
+    ByteOption pageSize
         = {"page_size",
-           std::to_string(DEFAULT_PAGED_VECTOR_SIZE),
+           "1KiB",
            "Page size of any other paged data structure",
-           {std::make_shared<NumberValidation>()}};
+           {std::make_shared<ByteAmountValidation>()}};
     UIntOption numberOfRecordsPerKey
         = {"number_of_records_per_key",
            std::to_string(DEFAULT_NUMBER_OF_RECORDS_PER_KEY),
@@ -68,11 +69,11 @@ public:
         std::to_string(DEFAULT_MAX_NUMBER_OF_BUCKETS),
         "Maximal number of buckets for a hash table. If set too low or high degrades either the performance or increases the memory usage.",
         {std::make_shared<FloatValidation>()}};
-    UIntOption operatorBufferSize
+    ByteOption operatorBufferSize
         = {"operator_buffer_size",
-           std::to_string(DEFAULT_OPERATOR_BUFFER_SIZE),
+           "4KiB",
            "Buffer size of a operator e.g. during scan",
-           {std::make_shared<NumberValidation>()}};
+           {std::make_shared<ByteAmountValidation>()}};
 
     SliceCacheConfiguration sliceCacheConfiguration = {"slice_cache", "Configuration for the slice cache"};
 

--- a/nes-runtime/interface/Configuration/WorkerConfiguration.hpp
+++ b/nes-runtime/interface/Configuration/WorkerConfiguration.hpp
@@ -23,6 +23,7 @@
 #include <Configurations/ScalarOption.hpp>
 #include <Configurations/Validation/FloatValidation.hpp>
 #include <Configurations/Validation/NumberValidation.hpp>
+#include <Configurations/Validation/ByteAmountValidation.hpp>
 #include <Configurations/Validation/PowerOfTwoValidation.hpp>
 #include <Util/DumpMode.hpp>
 #include <fmt/format.h>
@@ -46,11 +47,11 @@ public:
 
     /// Total memory budget in bytes shared by the global buffer pool. The buffer manager splits it into an unpooled
     /// share (see unpooled_memory_fraction) and a pooled share; the pooled share is divided into operator buffers.
-    UIntOption totalMemoryInBytes
+    ByteOption totalMemoryInBytes
         = {"total_memory_in_bytes",
-           "268435456",
+           "256MiB",
            "Total memory budget in bytes for the global buffer pool (pooled + unpooled).",
-           {std::make_shared<NumberValidation>()}};
+           {std::make_shared<ByteAmountValidation>()}};
 
     /// Share (0.0-1.0) of total_memory_in_bytes reserved for unpooled (variable-sized) buffers, used by operator state
     /// (hash maps, paged vectors, var-sized data). On breach, the requesting query fails with CannotAllocateBuffer
@@ -63,7 +64,7 @@ public:
 
     /// Byte alignment of every pooled and unpooled buffer. Must be a power of two and at most the page size;
     /// the default is a cache line (64 B).
-    UIntOption bufferAlignmentInBytes
+    ByteOption bufferAlignmentInBytes
         = {"buffer_alignment_in_bytes",
            "64",
            "Byte alignment of every buffer (power of two, <= page size).",


### PR DESCRIPTION
Fixes #1731. This PR introduces a strong-typedef Byte and extends YAML conversion / validation. This enables configuring size options with strings like '4KiB' instead of raw numbers. Options like operator_buffer_size, page_size, total_memory_in_bytes, and buffer_alignment_in_bytes have been migrated.