### PR TITLE
chore(codeowners): cover missing components and regroup by dependency direction

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,28 +1,39 @@
-# Protecting the code owner file from any changes
-/.github/CODEOWNERS @adrianmichalke @alepping @Artraxon @keyseven123 @ls-1801 @yschroeder97
-
 # The maintainers are the default owners for everything in the repo. Unless a later match takes precedence, one of
 # the maintainers will be request review when someone opens a pull request.
 * @nebulastream/Maintainer
 
-## We set here owners for each folder that usually encapsulates one or more components.
-## We aim for having at least two persons per folder to have a little bit of a redundancy.
+## Build system, CI, packaging and dependency pinning.
+/cmake/ @nebulastream/DevOps
+/CMakeLists.txt @nebulastream/DevOps
+/codecov.yaml @nebulastream/DevOps
 /docker/ @nebulastream/DevOps
 /.github/ @nebulastream/DevOps
 /scripts/ @nebulastream/DevOps
 /vcpkg/ @nebulastream/DevOps
 
+## The nix build is maintained on its own, separately from the rest of the build system.
+/flake.lock @adrianmichalke
+/flake.nix @adrianmichalke
+/.nix/ @adrianmichalke
+
+## We set here owners for each folder that usually encapsulates one or more components.
+## We aim for having at least two persons per folder to have a little bit of a redundancy.
+
+## Linked by nearly every component, so no single team is the right reviewer.
 /nes-common/ @nebulastream/Maintainer
 /nes-configurations/ @nebulastream/Maintainer
 
-/grpc/ @nebulastream/QuerySubmission
-/nes-data-types/ @nebulastream/QuerySubmission
-/nes-frontend/ @nebulastream/QuerySubmission
-/nes-sql-parser/ @nebulastream/QuerySubmission
+/nes-frontend/ @nebulastream/Frontend
+
+## The type system and the plan representation, with the parser that builds the plan from a statement.
+/nes-data-types/ @nebulastream/IR
+/nes-logical-operators/ @nebulastream/IR
+/nes-sql-parser/ @nebulastream/IR
 
 /nes-physical-operators/ @nebulastream/Execution
 /nes-nautilus/ @nebulastream/Execution
 /nes-query-compiler/ @nebulastream/Execution
+/nes-inference/ @nebulastream/Execution @gaturchenko
 
 
 /nes-memory/ @nebulastream/Memory
@@ -30,8 +41,12 @@
 /nes-single-node-worker/ @nebulastream/Runtime
 
 
-/nes-logical-operators/ @nebulastream/QueryOptimizer
 /nes-query-optimizer/ @nebulastream/QueryOptimizer
+
+## Everything that crosses a node boundary: placement, transport, and the wire format between them.
+/grpc/ @nebulastream/Distributed
+/nes-distributed/ @nebulastream/Distributed
+/nes-network/ @nebulastream/Distributed
 
 /nes-plugins/ @nebulastream/Plugins
 
@@ -41,9 +56,25 @@
 /nes-input-formatters/ @nebulastream/InputOutput
 /nes-sinks/ @nebulastream/InputOutput
 /nes-sources/ @nebulastream/InputOutput
+/nes-output-formatters/ @nebulastream/InputOutput @LeoRaasch
 
 /nes-systests/ @nebulastream/Testing
 
 
-# We  set here the ownership specific files or folders. This will be populated in the future
+# Documentation is routed by subject to the team that owns the matching code. Where the subject is the project as
+# a whole the default maintainer rule already applies, so those documents get no entry.
+/docs/development/ @nebulastream/DevOps
+/docs/git/ @nebulastream/DevOps
+/docs/website/ @nebulastream/DevOps
+
+/docs/technical/dependency.md @nebulastream/DevOps
+/docs/technical/QueryEngine_TaskQueue.md @nebulastream/QueryEngine
+/docs/technical/ir_binding.md @nebulastream/IR
+/docs/technical/null_handling.md @nebulastream/Execution
+/docs/technical/model_inference.md @nebulastream/Execution
 /docs/technical/watermarking_progress_window_triggering.md @keyseven123 @alepping
+
+
+# Protecting the code owner file from any changes. GitHub applies the last matching pattern, so this entry has to
+# stay last in the file.
+/.github/CODEOWNERS @adrianmichalke @alepping @Artraxon @greenBene @keyseven123 @ls-1801 @oczerwia-2010 @yschroeder97


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

`.github/CODEOWNERS` no longer matches the component layout. This PR realigns it.

The assignments are suggestions and I am open to alternatives.

The change list is as follows:
**Components that had no entry and fell through to the catch-all maintainer rule:**
- Added `/nes-network/` and `/nes-distributed/` to a new `Distributed` team.
- Added `/nes-inference/` to Execution, next to the other MLIR-based compilation components, with @gaturchenko also on the path.
- Added `/nes-output-formatters/` to InputOutput, next to its `nes-input-formatters` counterpart, with @LeoRaasch on the path.
- Added `/cmake/`, `/CMakeLists.txt` and `/codecov.yaml` to DevOps, which already has `docker/`, `scripts/` and `vcpkg/`.
- Added `/flake.nix`, `/flake.lock` and `/.nix/` as their own block owned by @adrianmichalke. The nix build is maintained on its own rather than by DevOps as a whole. `/.nix/` holds the 19 per-dependency `package.nix` files and had no entry at all.

**Split of QuerySubmission**, which held four folders that are not one concern:
- `/grpc/` joins `Distributed`. The protos are the wire format between nodes: `SingleNodeWorkerRPCService.proto` is the worker control plane, and `SerializableQueryPlan.proto` is what a remote worker receives. IMO, this belongs to distributed.
- `/nes-sql-parser/`, `/nes-logical-operators/` and `/nes-data-types/` form a new `IR` team. The parser builds the plan rather than submitting it (it links `nes-logical-operators` PUBLIC and carries `StatementBinder`), and the type system is what the plan is expressed in.
- `/nes-frontend/` gets its own `Frontend` team. Today, it might not be as large, but frontends will join over time.

**Documentation**, which had no owner at all:
- Routed by subject to the team that owns the matching code: `docs/development/`, `docs/git/` and `docs/website/` to DevOps, and the technical deep dives per file (dependency to DevOps, the task queue to QueryEngine, IR binding to IR, null handling and model inference to Execution).
- Documents about the project as a whole, such as the design records and the coding standards, get no entry, because the default maintainer rule already applies.
- The watermarking doc keeps its two named owners. Its stale path was already fixed on `main`, so that part of the change dropped out in the rebase.

**Bug fix:**
- Moved the `/.github/CODEOWNERS` protection rule to the end of the file. GitHub applies the last matching pattern, so the `/.github/ @nebulastream/DevOps` entry below it was taking precedence and the listed people were never requested for review.
- Added @oczerwia-2010 and @greenBene to that rule.

Section comments record why each block groups the way it does.

## Open question

`nes-input-formatters` and `nes-output-formatters` are grouped with I/O here. Over the last months they moved more and more away from I/O towards the execution, so they could also become their own group.

## Verifying this change

- Every top-level directory on `main` now has an explicit entry. The remaining paths matching only `*` are `README.md`, `LICENSE`, `CODE_OF_CONDUCT.md` and the docs that no subject rule covers, which is intentional.
- `gh api repos/nebulastream/nebulastream/codeowners/errors` against this branch reports zero errors. Every team and every individual named on a path validates.
- No code change, nothing to build or test.

## What components does this pull request potentially affect?

Review routing only. No build or runtime effect.

## Team setup, done

`Frontend`, `IR` and `Distributed` did not exist when this was opened. All three now exist as child teams of `Maintainer`, with the rosters this PR proposed:

| Team | Members |
| --- | --- |
| `Frontend` | @ls-1801, @adrianmichalke, @yschroeder97 |
| `IR` | @greenBene, @adrianmichalke, @Artraxon, @keyseven123 |
| `Distributed` | @ls-1801, @keyseven123, @yschroeder97 |

An earlier version of this section said the teams also need explicit write access to this repository. That turned out not to be the case. Child teams inherit the parent's repository access, and every other component team here is already nested under `Maintainer` the same way, which is why they resolve without appearing in the repository's own team list. All three new teams report `admin` on this repository through that inheritance, and no separate grant was made.

`QuerySubmission` is deliberately left in place. `main` still assigns four paths to it, and CODEOWNERS matches on the current team slug, so renaming or deleting it before this merges would leave those paths unowned in the meantime. It has no paths left once this lands and can be removed in a follow-up.

## Issue Closed by this pull request:

This PR closes #1909

