### PR TITLE
refactor(worker): pass worker config options after `--`

### DIFF
--- a/.github/workflows/execute_query.yml
+++ b/.github/workflows/execute_query.yml
@@ -84,7 +84,7 @@ jobs:
           cmake -GNinja -B build -DExternalData_OBJECT_STORES=/test-file-cache -DNES_LOG_LEVEL=DEBUG
           cmake --build build -j -- -k 0
 
-          build/nes-single-node-worker/nes-single-node-worker --data_address=localhost:9090 > worker.log 2>&1 &
+          build/nes-single-node-worker/nes-single-node-worker -- --data_address=localhost:9090 > worker.log 2>&1 &
           WORKER_PID=$!
 
           sleep 5

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Build the client and worker binaries, start the worker in one terminal, register
 cmake --build cmake-build-debug -j --target nes-single-node-worker nes-repl
 
 # Terminal 1: start the worker
-cmake-build-debug/nes-single-node-worker/nes-single-node-worker --grpc=localhost:8080 --data_address=localhost:9090
+cmake-build-debug/nes-single-node-worker/nes-single-node-worker -- --grpc=localhost:8080 --data_address=localhost:9090
 
 # Terminal 2: prepare a tiny CSV and submit a query via nes-repl
 printf '1\n2\n3\n' > demo-input.csv

--- a/docs/development/systests.md
+++ b/docs/development/systests.md
@@ -375,7 +375,7 @@ To test against actual distributed workers, use the `--remote` flag. The systest
 
 ```bash
 # Terminal 1: Start a worker
-cmake-build-debug/nes-single-node-worker/nes-single-node-worker --grpc=localhost:8080 --data_address=localhost:9090
+cmake-build-debug/nes-single-node-worker/nes-single-node-worker -- --grpc=localhost:8080 --data_address=localhost:9090
 
 # Terminal 2: Run systest against the remote worker
 cmake-build-debug/nes-systests/systest/systest \

--- a/docs/guide/nebulastream-frontend.md
+++ b/docs/guide/nebulastream-frontend.md
@@ -114,7 +114,7 @@ Sources and sinks are automatically placed on the single node. No `HOST` configu
 > [!NOTE]
 > **Starting a worker:** Each worker is started with separate gRPC and data addresses:
 > ```bash
-> nes-single-node-worker --grpc=0.0.0.0:8080 --data_address=<dns-name/ip>:9090
+> nes-single-node-worker -- --grpc=0.0.0.0:8080 --data_address=<dns-name/ip>:9090
 > ```
 > The gRPC address (port 8080 by convention) is the address used to identify workers in topology files and for source/sink placement. The data address (port 9090 by convention) is used internally for data transfer between workers.
 

--- a/docs/website/content/reference/GetStarted.md
+++ b/docs/website/content/reference/GetStarted.md
@@ -18,7 +18,7 @@ docker run -d --rm \
   --name worker \
   -v "$PWD/output:/output" \
   nebulastream/nes-worker \
-  --grpc=0.0.0.0:8080
+  -- --grpc=0.0.0.0:8080
 ```
 
 This command starts a NebulaStream worker in a Docker container and exposes its gRPC port on all network interfaces at `0.0.0.0:8080`.
@@ -167,7 +167,7 @@ services:
     image: nebulastream/nes-worker
     volumes:
       - ./output:/output
-    command: ["--grpc=0.0.0.0:8080"]
+    command: ["--", "--grpc=0.0.0.0:8080"]
     tty: true
     stdin_open: true
 

--- a/nes-frontend/apps/cli/tests/util/create_compose.sh
+++ b/nes-frontend/apps/cli/tests/util/create_compose.sh
@@ -113,7 +113,7 @@ for i in $(seq 0 $((WORKER_COUNT - 1))); do
         set -e
         mkdir -p /workdir/configs
         echo '$CONFIG_B64' | base64 -d > /workdir/configs/$HOST_NAME.yaml
-        exec nes-single-node-worker --grpc=$HOST_NAME:$HOST_PORT --data_address=$DATA --worker.default_query_execution.execution_mode=INTERPRETER --worker.query_engine.number_of_worker_threads=1 --configPath=/workdir/configs/$HOST_NAME.yaml
+        exec nes-single-node-worker --workerConfig=/workdir/configs/$HOST_NAME.yaml -- --grpc=$HOST_NAME:$HOST_PORT --data_address=$DATA --worker.default_query_execution.execution_mode=INTERPRETER --worker.query_engine.number_of_worker_threads=1
     volumes:
       - $TEST_VOLUME:/workdir
 EOF
@@ -134,6 +134,7 @@ EOF
       retries: 10
       start_period: 60s
     command: [
+      "--",
       "--grpc=$HOST_NAME:$HOST_PORT",
       "--data_address=$DATA",
       "--worker.default_query_execution.execution_mode=INTERPRETER",

--- a/nes-frontend/apps/repl/tests/util/create_compose.sh
+++ b/nes-frontend/apps/repl/tests/util/create_compose.sh
@@ -95,6 +95,7 @@ for i in $(seq 0 $((WORKER_COUNT - 1))); do
       retries: 5
       start_period: 5s
     command: [
+      "--",
       "--grpc=$HOST_NAME:$HOST_PORT",
       "--data_address=$DATA",
       "--worker.default_query_execution.execution_mode=INTERPRETER",

--- a/nes-plugins/Sinks/MQTTSink/tests/util/create_compose.sh
+++ b/nes-plugins/Sinks/MQTTSink/tests/util/create_compose.sh
@@ -137,7 +137,7 @@ for i in $(seq 0 $((WORKER_COUNT - 1))); do
         set -e
         mkdir -p /workdir/configs
         echo '$CONFIG_B64' | base64 -d > /workdir/configs/$HOST_NAME.yaml
-        exec nes-single-node-worker --grpc=$HOST_NAME:$HOST_PORT --data_address=$DATA --worker.default_query_execution.execution_mode=COMPILER --worker.query_engine.number_of_worker_threads=4 --configPath=/workdir/configs/$HOST_NAME.yaml
+        exec nes-single-node-worker --workerConfig=/workdir/configs/$HOST_NAME.yaml -- --grpc=$HOST_NAME:$HOST_PORT --data_address=$DATA --worker.default_query_execution.execution_mode=COMPILER --worker.query_engine.number_of_worker_threads=4
     volumes:
       - $TEST_VOLUME:/workdir
 EOF
@@ -159,6 +159,7 @@ EOF
       retries: 10
       start_period: 60s
     command: [
+      "--",
       "--grpc=$HOST_NAME:$HOST_PORT",
       "--data_address=$DATA",
       "--worker.default_query_execution.execution_mode=COMPILER",

--- a/nes-plugins/Sources/MQTTSource/tests/util/create_compose.sh
+++ b/nes-plugins/Sources/MQTTSource/tests/util/create_compose.sh
@@ -136,7 +136,7 @@ for i in $(seq 0 $((WORKER_COUNT - 1))); do
         set -e
         mkdir -p /workdir/configs
         echo '$CONFIG_B64' | base64 -d > /workdir/configs/$HOST_NAME.yaml
-        exec nes-single-node-worker --grpc=$HOST_NAME:$HOST_PORT --data_address=$DATA --worker.default_query_execution.execution_mode=INTERPRETER --worker.query_engine.number_of_worker_threads=1 --configPath=/workdir/configs/$HOST_NAME.yaml
+        exec nes-single-node-worker --workerConfig=/workdir/configs/$HOST_NAME.yaml -- --grpc=$HOST_NAME:$HOST_PORT --data_address=$DATA --worker.default_query_execution.execution_mode=INTERPRETER --worker.query_engine.number_of_worker_threads=1
     volumes:
       - $TEST_VOLUME:/workdir
 EOF
@@ -158,6 +158,7 @@ EOF
       retries: 10
       start_period: 60s
     command: [
+      "--",
       "--grpc=$HOST_NAME:$HOST_PORT",
       "--data_address=$DATA",
       "--worker.default_query_execution.execution_mode=INTERPRETER",

--- a/nes-single-node-worker/CMakeLists.txt
+++ b/nes-single-node-worker/CMakeLists.txt
@@ -33,7 +33,8 @@ target_link_libraries(nes-single-node-worker-lib
 )
 
 add_executable(nes-single-node-worker src/SingleNodeWorkerStarter.cpp)
-target_link_libraries(nes-single-node-worker PRIVATE nes-single-node-worker-lib)
+find_package(argparse CONFIG REQUIRED)
+target_link_libraries(nes-single-node-worker PRIVATE nes-single-node-worker-lib argparse::argparse)
 if (ENABLE_BATS_TESTS)
     add_test(
             NAME worker-offline-test

--- a/nes-single-node-worker/src/SingleNodeWorkerStarter.cpp
+++ b/nes-single-node-worker/src/SingleNodeWorkerStarter.cpp
@@ -15,6 +15,11 @@
 /// The POSIX signal APIs used below are not provided by the C++ <csignal> header.
 /// NOLINTNEXTLINE(modernize-deprecated-headers)
 #include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
 #include <signal.h>
 #include <Configurations/Util.hpp>
 #include <Identifiers/Identifiers.hpp>
@@ -23,6 +28,7 @@
 #include <Util/Logger/Logger.hpp>
 #include <Util/Logger/impl/NesLogger.hpp>
 #include <Util/Signal.hpp>
+#include <argparse/argparse.hpp>
 #include <cpptrace/from_current.hpp>
 #include <grpcpp/security/server_credentials.h>
 #include <grpcpp/server_builder.h>
@@ -86,12 +92,48 @@ int main(const int argc, const char* argv[])
         NES::Logger::setupLogging("singleNodeWorker.log", NES::LogLevel::LOG_DEBUG);
         /// Register built-in plugins before any registry lookup.
         NES::loadBuiltinPlugins();
-        if (std::getenv("NES_PLUGINS") != nullptr)
+
+        argparse::ArgumentParser program("nes-single-node-worker");
+        program.add_argument("-w", "--workerConfig")
+            .help("worker config file (.yaml); options given after `--` override values from the file");
+        program.add_argument("--")
+            .help("worker config options, e.g. `-- --grpc=[::]:8080 --worker.query_engine.number_of_worker_threads=4`")
+            .default_value(std::vector<std::string>{})
+            .remaining();
         {
-            NES_ERROR("NES_PLUGINS is set, but this worker is statically linked and cannot load plugins. Unset NES_PLUGINS.");
+            std::ostringstream configOptionsHelp;
+            NES::generateHelp<NES::SingleNodeWorkerConfiguration>(configOptionsHelp);
+            program.add_epilog("worker config options (pass after --):\n" + configOptionsHelp.str());
+        }
+        try
+        {
+            program.parse_args(argc, argv);
+        }
+        catch (const std::exception& e)
+        {
+            std::cerr << e.what() << '\n' << program;
             return 1;
         }
-        auto configuration = NES::loadConfiguration<NES::SingleNodeWorkerConfiguration>(argc, argv);
+
+        /// Re-assemble an argv for the option parser from the config file given via `-w` and the
+        /// options captured after `--`.
+        /// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic) argv[0] is the program name from main's argv
+        std::vector<std::string> configArgs{argv[0]};
+        if (program.is_used("-w"))
+        {
+            configArgs.push_back("--configPath=" + program.get<std::string>("-w"));
+        }
+        const auto remainingArgs = program.get<std::vector<std::string>>("--");
+        configArgs.insert(configArgs.end(), remainingArgs.begin(), remainingArgs.end());
+        std::vector<const char*> configArgv;
+        configArgv.reserve(configArgs.size());
+        for (const auto& arg : configArgs)
+        {
+            configArgv.push_back(arg.c_str());
+        }
+
+        auto configuration
+            = NES::loadConfiguration<NES::SingleNodeWorkerConfiguration>(static_cast<int>(configArgv.size()), configArgv.data());
         if (!configuration)
         {
             return 0;

--- a/nes-single-node-worker/tests/offline.bats
+++ b/nes-single-node-worker/tests/offline.bats
@@ -99,11 +99,11 @@ worker_timeout() {
 }
 
 @test "worker accepts grpc address" {
-  worker_timeout 5s --grpc=localhost:55555
+  worker_timeout 5s -- --grpc=localhost:55555
   [ "$status" -eq 124 ] # killed by timeout
   grep "localhost:55555" singleNodeWorker.log
 
-  worker_timeout 5s --grpc=0.0.0.0:55555
+  worker_timeout 5s -- --grpc=0.0.0.0:55555
   [ "$status" -eq 124 ] # killed by timeout
   grep "0.0.0.0:55555" singleNodeWorker.log
 }
@@ -113,24 +113,24 @@ worker_timeout() {
   # depending on whether a DNS server is reachable (EAI_NONAME "Name or service not known")
   # or not (EAI_AGAIN "Temporary failure in name resolution"), so we only assert that the
   # worker logged a clean gRPC-startup failure rather than matching the resolver message.
-  worker_timeout 10s --grpc=asdf.asdf.asdf:55555
+  worker_timeout 10s -- --grpc=asdf.asdf.asdf:55555
 
   grep "Failed to start GRPC Server" singleNodeWorker.log
 
   # DNS Name is Invalid
-  worker_timeout 10s --grpc=wow!:55555
+  worker_timeout 10s -- --grpc=wow!:55555
   grep "Invalid hostname: 'wow!'" singleNodeWorker.log
   [ "$status" -ne 0 ]
 }
 
 @test "worker accepts valid configs" {
-  worker_timeout 5s --configPath=tests/good/config.yaml
+  worker_timeout 5s --workerConfig=tests/good/config.yaml
   [ "$status" -eq 124 ] # killed by timeout
 }
 
 @test "worker warns when CLI overrides YAML config value" {
   # The YAML config sets admission_queue_size=1024. Override it via CLI to trigger the warning.
-  worker_timeout 5s --configPath=tests/good/config.yaml --worker.query_engine.admission_queue_size=2048
+  worker_timeout 5s --workerConfig=tests/good/config.yaml -- --worker.query_engine.admission_queue_size=2048
   [ "$status" -eq 124 ] # killed by timeout
 
   # The log should contain the override warning
@@ -140,7 +140,7 @@ worker_timeout() {
 
 @test "worker does not warn when CLI sets a value not in YAML" {
   # The YAML config does not set enable_event_trace. Setting it via CLI should not trigger a warning.
-  worker_timeout 5s --configPath=tests/good/config.yaml --enable_event_trace=true
+  worker_timeout 5s --workerConfig=tests/good/config.yaml -- --enable_event_trace=true
   [ "$status" -eq 124 ] # killed by timeout
 
   # The log should NOT contain the override warning for this key
@@ -153,17 +153,17 @@ worker_timeout() {
 
 @test "worker rejects total_memory_in_bytes of 0" {
   # A zero budget yields zero pooled buffers, which cannot back the internal MPMC queues.
-  worker_timeout 5s --worker.total_memory_in_bytes=0
+  worker_timeout 5s -- --worker.total_memory_in_bytes=0
   grep -E "capacity 0 is impossible|Precondition violated" singleNodeWorker.log
 }
 
 @test "worker rejects unpooled_memory_fraction out of range" {
   # The fraction is validated to [0.0, 1.0] at config-parse time, so both bounds are rejected there.
-  worker_timeout 5s --worker.unpooled_memory_fraction=1.5
+  worker_timeout 5s -- --worker.unpooled_memory_fraction=1.5
   grep -E "invalid config parameter|Validator" singleNodeWorker.log
   grep "unpooled_memory_fraction" singleNodeWorker.log
 
-  worker_timeout 5s --worker.unpooled_memory_fraction=-0.1
+  worker_timeout 5s -- --worker.unpooled_memory_fraction=-0.1
   grep -E "invalid config parameter|Validator" singleNodeWorker.log
   grep "unpooled_memory_fraction" singleNodeWorker.log
 }
@@ -171,12 +171,12 @@ worker_timeout() {
 @test "worker rejects non-power-of-two buffer_alignment_in_bytes" {
   # 48 is not a power of two. Rejected at config-parse time by PowerOfTwoValidation, so this holds on
   # every build type (a BufferManager PRECONDITION would be compiled out in the no-assert Benchmark build).
-  worker_timeout 5s --worker.buffer_alignment_in_bytes=48
+  worker_timeout 5s -- --worker.buffer_alignment_in_bytes=48
   grep -E "invalid config parameter|Validator" singleNodeWorker.log
   grep "buffer_alignment_in_bytes" singleNodeWorker.log
 }
 
 @test "worker accepts unpooled_memory_fraction of 0.0 (all pooled)" {
-  worker_timeout 5s --worker.unpooled_memory_fraction=0.0
+  worker_timeout 5s -- --worker.unpooled_memory_fraction=0.0
   [ "$status" -eq 124 ] # stays alive
 }

--- a/nes-systests/systest/remote-test/create_compose.sh
+++ b/nes-systests/systest/remote-test/create_compose.sh
@@ -105,7 +105,7 @@ for i in $(seq 0 $((WORKER_COUNT - 1))); do
   HAS_CONFIG=$(yq ".workers[$i] | has(\"config\")" "$WORKERS_FILE")
   CONFIG_ARG=""
   if [ "$HAS_CONFIG" = "true" ]; then
-    CONFIG_ARG="\"--configPath=$CONTAINER_WORKDIR/configs/$HOST_NAME.yaml\","
+    CONFIG_ARG="\"--workerConfig=$CONTAINER_WORKDIR/configs/$HOST_NAME.yaml\","
   fi
 
   cat <<EOF
@@ -120,9 +120,10 @@ for i in $(seq 0 $((WORKER_COUNT - 1))); do
       retries: 3
       start_period: 0s
     command: [
+      $CONFIG_ARG
+      "--",
       "--grpc=$HOST_NAME:$GRPC_PORT",
       "--data_address=$DATA",
-      $CONFIG_ARG
     ]
     volumes:
       - $TESTDATA_VOLUME:/data


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR changes how the SingleNodeWorker takes options for the configuration, making it the same as for the other frontends.
All config options must now also be passed behind -- .
In addition, one can now pass a .yaml file with configuration with -w .
