### PR TITLE
fix(clang-tidy): skip changed headers that have no compile command

### DIFF
--- a/.github/workflows/clang_tidy_diff.yml
+++ b/.github/workflows/clang_tidy_diff.yml
@@ -91,7 +91,11 @@ jobs:
         with:
           image_name: nebulastream/nes-ci:${{ inputs.dev_image_tag }}-${{ matrix.stdlib }}-${{matrix.sanitizer}}
           run: |
-            git diff -U0 ${{ inputs.base_sha }} -- ':!*.inc' ':!*nes-rust-bindings' ':!vcpkg/**' | clang-tidy-diff-19.py -clang-tidy-binary clang-tidy-19 -p1 -path build -export-fixes clang-tidy-result/fixes.yml -j $(nproc)
+            # Same driver as the pre-check above, so both steps select the same files and skip
+            # the headers that have no compile command to reconstruct.
+            export NES_TIDY_DIFF_BASE=${{ inputs.base_sha }}
+            export NES_TIDY_EXPORT_FIXES=$(pwd)/clang-tidy-result/fixes.yml
+            cmake --build build --target tidy-diff
       # Findings are printed by clang-tidy-diff in the steps above and exported here for download.
       # A failing step means clang-tidy flagged something in .clang-tidy's WarningsAsErrors list.
       - name: Upload Clang-Tidy Results

--- a/scripts/tidy.sh
+++ b/scripts/tidy.sh
@@ -111,6 +111,7 @@ if [ "$MODE" = "full" ]; then
         -header-filter="$HEADER_FILTER" "$SOURCE_FILTER" 2>/dev/null \
         | tee >("${DECOLOR[@]}" > "$REPORT_FILE")
     STATUS=${PIPESTATUS[0]}
+    grep -q "file not found" "$REPORT_FILE" && MISSING_GENERATED_HEADERS=1
 else
     # Diff base: default to all uncommitted changes since the last commit (`git diff HEAD`).
     NES_TIDY_DIFF_BASE="${NES_TIDY_DIFF_BASE:-HEAD}"
@@ -137,20 +138,73 @@ else
     fi
     echo
 
+    # Sources and headers are analyzed in two passes, because only a source file
+    # has a compile command. For a header clang-tidy adapts the command of the
+    # nearest source file in the compilation database; a header whose directory
+    # tree holds no compiled source gets no include paths and fails on its first
+    # include. That failure describes the reconstructed flags rather than the
+    # change, so the header pass reports those headers as skipped. Every other
+    # diagnostic, in either pass, still fails the run.
+    #
     # -p1            strip the leading 'a/' 'b/' path component from the diff
     # -path          directory containing compile_commands.json
+    # -iregex        select which of the changed files this pass analyzes
+    SOURCE_PATTERN='.*\.(cpp|cc|c\+\+|cxx|c|cl|m|mm)'
+    HEADER_PATTERN='.*\.(h|hh|hpp|hxx)'
+
     git "${GIT_DIFF_SELECTOR[@]}" \
-        | python3 "$TIDY_TOOL" -p1 -path "$COMPILE_DB_DIR" "${TIDY_ARGS[@]}" \
+        | python3 "$TIDY_TOOL" -p1 -path "$COMPILE_DB_DIR" -iregex "$SOURCE_PATTERN" "${TIDY_ARGS[@]}" \
         | tee >("${DECOLOR[@]}" > "$REPORT_FILE")
     STATUS=${PIPESTATUS[1]}
+
+    # Only a source file can be missing a generated header, so the check for the
+    # hint below runs before the header pass appends to the report.
+    grep -q "file not found" "$REPORT_FILE" && MISSING_GENERATED_HEADERS=1
+
+    # The header pass records its fixes separately, so the source pass keeps the
+    # file name that CI uploads. Repeating the flag overrides the earlier one.
+    HEADER_TIDY_ARGS=("${TIDY_ARGS[@]}")
+    if [ -n "${NES_TIDY_EXPORT_FIXES:-}" ]; then
+        HEADER_TIDY_ARGS+=(-export-fixes "${NES_TIDY_EXPORT_FIXES%.*}-headers.yml")
+    fi
+
+    HEADER_REPORT_FILE="${REPORT_FILE}.headers"
+    git "${GIT_DIFF_SELECTOR[@]}" \
+        | python3 "$TIDY_TOOL" -p1 -path "$COMPILE_DB_DIR" -iregex "$HEADER_PATTERN" "${HEADER_TIDY_ARGS[@]}" \
+        | tee >("${DECOLOR[@]}" > "$HEADER_REPORT_FILE")
+    HEADER_STATUS=${PIPESTATUS[1]}
+
+    # A header pass that failed on nothing but missing includes says nothing about
+    # the change, so the skipped headers are listed and the sources decide the run.
+    ERROR_COUNT="$(grep -cE ': error: ' "$HEADER_REPORT_FILE" || true)"
+    NOT_FOUND_COUNT="$(grep -cE ': error: .*file not found' "$HEADER_REPORT_FILE" || true)"
+    if [ "$HEADER_STATUS" -ne 0 ] && [ "$NOT_FOUND_COUNT" -gt 0 ] && [ "$ERROR_COUNT" -eq "$NOT_FOUND_COUNT" ]; then
+        echo
+        echo -e "${COLOR_BOLD}Skipped ${NOT_FOUND_COUNT} changed header(s): no compile command could be reconstructed.${COLOR_RESET}"
+        grep -E ': error: .*file not found' "$HEADER_REPORT_FILE" \
+            | cut -d: -f1 | sed "s|^${REPO_ROOT}/||" | sort -u | sed 's/^/  /'
+        echo "A header has no compile command of its own, and these sit in a directory tree with no"
+        echo "compiled source to take one from. The tidy-full target analyzes them through the"
+        echo "sources that include them."
+        HEADER_STATUS=0
+    fi
+
+    cat "$HEADER_REPORT_FILE" >> "$REPORT_FILE"
+    rm -f "$HEADER_REPORT_FILE"
+
+    if [ "$STATUS" -eq 0 ]; then
+        STATUS=$HEADER_STATUS
+    fi
 fi
 set -e
 
 # Generated headers (gRPC/protobuf stubs, ANTLR, cxxbridge) only exist after the
 # nes-codegen target has run. When they're missing clang-tidy emits "'foo.h' file
-# not found" fatal errors that look like real findings but aren't -- point the
-# user at the target.
-if grep -q "file not found" "$REPORT_FILE"; then
+# not found" fatal errors on the sources that include them, which look like real
+# findings but aren't -- point the user at the target. A changed header without a
+# compile command shows the same symptom for another reason, which the header
+# pass reports as skipped.
+if [ "${MISSING_GENERATED_HEADERS:-0}" -eq 1 ]; then
     echo
     echo -e "${COLOR_BOLD}Error: clang-tidy reported missing headers ('file not found').${COLOR_RESET}"
     echo "Some headers (e.g. gRPC/protobuf stubs) are generated during the build;"


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

`clang-tidy-diff` analyzes every changed file on its own, headers included. Its
default `-iregex` covers `h` and `hpp`. Only a source file has a compile command,
so clang-tidy adapts the command of the nearest source file in the compilation
database when the input is a header. A header in a directory tree that holds no
compiled source gets no include paths at all, and it fails on its first include:

```
Model/SystestQueryId.hpp:19:10: error: 'Identifiers/NESStrongType.hpp' file not found [clang-diagnostic-error]
Model/TestCaseId.hpp:20:10:    error: 'fmt/base.h' file not found         [clang-diagnostic-error]
Model/Expectation.hpp:22:10:   error: 'ErrorHandling.hpp' file not found  [clang-diagnostic-error]
```

That is a compiler error, so the job fails. The headers are correct and the build
compiles them. clang-tidy failed to reconstruct their flags.

A shared stem with a source file is not the criterion either.
`nes-common/include/Util/Pointers.hpp` has no `Pointers.cpp` and analyzes fine,
because the same tree holds compiled sources. Header-only directories break,
which is why this surfaced now.

`scripts/tidy.sh` also misreported the failure. It read any "file not found" as a
missing codegen output and told the reader to build `nes-codegen`, which does
nothing for this case. The change list is as follows:

- Changed `scripts/tidy.sh` to analyze sources and headers in two passes over the
  same diff, selected by `-iregex`.
- Added a check on the header pass. When the pass failed on nothing but missing
  includes, the script lists the skipped headers, and the sources decide the
  status of the run. Every other diagnostic, in either pass, still fails the run.
- Changed the workflow step that runs all checks to call the `tidy-diff` target,
  like the pre-check step above it, rather than repeat the invocation inline.
- Changed the hint about generated headers to fire only for sources, where a
  missing codegen output is what the symptom means.

A header that analyzes today still analyzes, and its findings still fail the job.
A skipped header produces no findings today, only a hard error.

## Verifying this change

This change is tested by running the driver in the dev container with
`readability-duplicate-include` as the check set, over a diff that carries the
three unanalyzable headers:

| case | expected | result |
|---|---|---|
| unanalyzable headers only | pass, name them | exit 0, three headers listed |
| real finding in an analyzable header | fail | exit 1 |
| unanalyzable headers plus a real header finding | fail | exit 1 |
| missing header in a source file | fail, keep the codegen hint | exit 1, hint printed |

This pull request changes no C++, so its own clang-tidy job reports nothing to
do. #1922 is the end to end check. It fails on those three headers without this
change, and it carries this change in its history now.

## What components does this pull request potentially affect?

- CI: the `clang-tidy-diff` workflow and `scripts/tidy.sh`. Both diff targets,
  `tidy-diff` and `tidy-diff-fix`, and the local developer flow go through that
  script, so they change with it.
- No source code, no build configuration, no dependencies.

## Documentation

- The script carries the reasoning next to the two passes: why a header has no
  compile command of its own, and what a skip means.
- The header comment of the script already describes the modes and the
  environment variables, and needed no change.

## Issue Closed by this pull request:

This PR closes no issue. It came out of #1922, whose clang-tidy job failed on
the headers quoted above, and it unblocks #1577 for the same reason. #1922 has
since dropped one of those three headers as unused, so a rerun without this
change would report the two that remain.
