### PR TITLE
refactor(systest): discover test files as a list

### DIFF
--- a/nes-systests/systest/private/Config/Config.hpp
+++ b/nes-systests/systest/private/Config/Config.hpp
@@ -39,15 +39,13 @@ struct SystestClusterConfiguration
 class SystestConfiguration final : public BaseConfiguration
 {
 public:
-    SystestConfiguration()
-    {
-        /// Default discover directory; replaced when directories are passed via -t/--testLocations.
-        testDiscoverDirs.add(TEST_DISCOVER_DIR);
-    }
+    SystestConfiguration() = default;
 
     /// Note: for now we ignore/override the here specified default values with ones provided by argparse when parsing the command line
+    StringOption testDiscoverRoot
+        = {"test_discover_root", TEST_DISCOVER_DIR, "Directory that a test name is relative to. Fixed at build time: " TEST_DISCOVER_DIR};
     SequenceOption<StringOption> testDiscoverDirs
-        = {"test_discover_dirs", "Directories to discover test files in. Default: " TEST_DISCOVER_DIR};
+        = {"test_discover_dirs", "Directories to discover test files in. Default: the discovery root"};
     StringOption testDataDir
         = {"test_data_dir", SYSTEST_EXTERNAL_DATA_DIR, "Directory to lookup test data files in. Default: " SYSTEST_EXTERNAL_DATA_DIR};
     StringOption configDir

--- a/nes-systests/systest/private/Discovery/TestDiscovery.hpp
+++ b/nes-systests/systest/private/Discovery/TestDiscovery.hpp
@@ -14,16 +14,46 @@
 
 #pragma once
 
+#include <filesystem>
+#include <optional>
 #include <ostream>
-#include <Config/Config.hpp>
-#include <SystestState.hpp>
+#include <string>
+#include <unordered_set>
+#include <vector>
 
-namespace NES::Systest
+#include <Config/Config.hpp>
+#include <Identifiers/Identifiers.hpp>
+
+namespace NES
 {
 
-/// load test file map objects from files defined in systest config
-TestFileMap loadTestFileMap(const SystestConfiguration& config);
+/// A test file's name: its path relative the discovery root without extension.
+/// E.g., `operator/join/JoinNull` becomes `nes-systests/operator/join/JoinNull.test`.
+/// The name labels the file in the report and in the result file path.
+/// Strong types, so a name or a group is not confused with a path or with each other.
+using TestName = NESStrongStringType<struct TestName_, "INVALID">;
+using TestGroup = NESStrongStringType<struct TestGroup_, "INVALID">;
 
-std::ostream& operator<<(std::ostream& os, const TestFileMap& testMap);
+struct DiscoveredTestFile
+{
+    explicit DiscoveredTestFile(
+        const std::filesystem::path& file,
+        TestName testName,
+        std::optional<std::unordered_set<SystestQueryId>> enabledQueries = std::nullopt);
+    [[nodiscard]] std::string getLogFilePath() const;
+
+    [[nodiscard]] TestName name() const { return testName; }
+
+    std::filesystem::path file;
+    TestName testName;
+    /// The query numbers to run. Every query of the file runs when this is not set.
+    std::optional<std::unordered_set<SystestQueryId>> enabledQueries;
+    std::vector<TestGroup> groups;
+};
+
+std::ostream& operator<<(std::ostream& os, const std::vector<DiscoveredTestFile>& testFiles);
+
+/// Reads the configuration and searches the given directories, returning one invocation's test files.
+std::vector<DiscoveredTestFile> discoverTestFiles(const SystestConfiguration& config);
 
 }

--- a/nes-systests/systest/private/SystestBinder.hpp
+++ b/nes-systests/systest/private/SystestBinder.hpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include <Config/Config.hpp>
+#include <Discovery/TestDiscovery.hpp>
 #include <Util/Pointers.hpp>
 #include <QueryOptimizerConfiguration.hpp>
 #include <SystestState.hpp>
@@ -40,7 +41,8 @@ public:
         SystestClusterConfiguration clusterConfig);
 
     /// @return the loaded systest queries and the number of loaded files
-    [[nodiscard]] std::pair<std::vector<SystestQuery>, size_t> loadOptimizeQueries(const TestFileMap& discoveredTestFiles);
+    [[nodiscard]] std::pair<std::vector<SystestQuery>, size_t>
+    loadOptimizeQueries(const std::vector<DiscoveredTestFile>& discoveredTestFiles);
 
     ~SystestBinder();
 

--- a/nes-systests/systest/private/SystestState.hpp
+++ b/nes-systests/systest/private/SystestState.hpp
@@ -30,6 +30,7 @@
 #include <utility>
 #include <vector>
 #include <DataTypes/UnboundField.hpp>
+#include <Discovery/TestDiscovery.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Identifiers/NESStrongType.hpp>
 #include <Model/ConfigurationOverride.hpp>
@@ -50,8 +51,6 @@ namespace NES::Systest
 
 class SystestRunner;
 
-using TestName = std::string;
-using TestGroup = std::string;
 
 static constexpr SystestQueryId INVALID_SYSTEST_QUERY_ID = INVALID<SystestQueryId>;
 static constexpr SystestQueryId INITIAL_SYSTEST_QUERY_ID = INITIAL<SystestQueryId>;
@@ -166,42 +165,6 @@ struct RunningQuery
     std::chrono::duration<double> getElapsedTime() const;
     [[nodiscard]] std::string getThroughput() const;
 };
-
-struct TestFile
-{
-    explicit TestFile(
-        const std::filesystem::path& file, std::shared_ptr<SourceCatalog> sourceCatalog, std::shared_ptr<SinkCatalog> sinkCatalog);
-    explicit TestFile(
-        const std::filesystem::path& file,
-        TestName testName,
-        std::shared_ptr<SourceCatalog> sourceCatalog,
-        std::shared_ptr<SinkCatalog> sinkCatalog);
-    explicit TestFile(
-        const std::filesystem::path& file,
-        std::unordered_set<SystestQueryId> onlyEnableQueriesWithTestQueryNumber,
-        std::shared_ptr<SourceCatalog> sourceCatalog,
-        std::shared_ptr<SinkCatalog> sinkCatalog);
-    explicit TestFile(
-        const std::filesystem::path& file,
-        std::unordered_set<SystestQueryId> onlyEnableQueriesWithTestQueryNumber,
-        TestName testName,
-        std::shared_ptr<SourceCatalog> sourceCatalog,
-        std::shared_ptr<SinkCatalog> sinkCatalog);
-    [[nodiscard]] std::string getLogFilePath() const;
-
-    [[nodiscard]] TestName name() const { return testName; }
-
-    std::filesystem::path file;
-    TestName testName;
-    std::unordered_set<SystestQueryId> onlyEnableQueriesWithTestQueryNumber;
-    std::vector<TestGroup> groups;
-    std::vector<SystestQuery> queries;
-    std::shared_ptr<SourceCatalog> sourceCatalog;
-    std::shared_ptr<SinkCatalog> sinkCatalog;
-};
-
-/// intermediate representation storing all considered test files
-using TestFileMap = std::unordered_map<std::filesystem::path, TestFile>;
 
 }
 

--- a/nes-systests/systest/src/Config/Config.cpp
+++ b/nes-systests/systest/src/Config/Config.cpp
@@ -22,6 +22,7 @@ namespace NES
 std::vector<BaseOption*> SystestConfiguration::getOptions()
 {
     return {
+        &testDiscoverRoot,
         &testDiscoverDirs,
         &directlySpecifiedTestFiles,
         &testFileExtension,

--- a/nes-systests/systest/src/Config/ConfigParser.cpp
+++ b/nes-systests/systest/src/Config/ConfigParser.cpp
@@ -14,6 +14,7 @@
 
 #include <Config/ConfigParser.hpp>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdlib>
 #include <exception>
@@ -24,6 +25,7 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 #include <Config/Config.hpp>
 #include <Configurations/Util.hpp>
@@ -217,16 +219,16 @@ void addTestQueryNumbers(NES::SystestConfiguration& config, const std::string& t
     }
 }
 
-std::filesystem::path parseTestLocationPath(const std::string& testFileDefinition, NES::SystestConfiguration& config)
+/// Splits `path` or `path:test_numbers` into the two.
+std::pair<std::filesystem::path, std::string> splitTestLocation(const std::string& testFileDefinition)
 {
     const size_t delimiterPos = testFileDefinition.find(':');
     if (delimiterPos == std::string::npos)
     {
-        return {testFileDefinition};
+        return {std::filesystem::path{testFileDefinition}, std::string{}};
     }
 
-    addTestQueryNumbers(config, testFileDefinition.substr(delimiterPos + 1));
-    return {testFileDefinition.substr(0, delimiterPos)};
+    return {std::filesystem::path{testFileDefinition.substr(0, delimiterPos)}, testFileDefinition.substr(delimiterPos + 1)};
 }
 
 std::vector<std::filesystem::path> findAllInTree(const std::filesystem::path& wanted, const std::filesystem::path& root)
@@ -243,15 +245,19 @@ std::vector<std::filesystem::path> findAllInTree(const std::filesystem::path& wa
     return hits;
 }
 
-void applyDiscoveredTestLocation(const std::filesystem::path& testFilePath, NES::SystestConfiguration& config)
+void applyDiscoveredTestLocation(
+    const std::filesystem::path& testFilePath, const std::vector<std::filesystem::path>& searchDirs, NES::SystestConfiguration& config)
 {
-    /// Search all discover directories for a matching file name
+    /// A bare file name is looked up in every directory that the run searches, so a test can be given without its folder.
     std::vector<std::filesystem::path> allMatches;
-    for (const auto& dir : config.testDiscoverDirs.getValues())
+    for (const auto& searchDir : searchDirs)
     {
-        auto matches = findAllInTree(testFilePath.filename(), dir.getValue());
+        auto matches = findAllInTree(testFilePath.filename(), searchDir);
         allMatches.insert(allMatches.end(), matches.begin(), matches.end());
     }
+    std::ranges::sort(allMatches);
+    const auto duplicates = std::ranges::unique(allMatches);
+    allMatches.erase(duplicates.begin(), duplicates.end());
 
     if (allMatches.empty())
     {
@@ -280,32 +286,51 @@ void applyTestLocations(const ArgumentParser& program, NES::SystestConfiguration
         return;
     }
 
-    /// Directories given on the command line replace the default discover directory rather than extending it,
-    /// so `-t dirA dirB` discovers in dirA and dirB only. The default is dropped on the first directory seen.
-    bool defaultDiscoverDirReplaced = false;
-
-    const auto testLocations = program.get<std::vector<std::string>>("--testLocations");
-    for (const auto& location : testLocations)
+    std::vector<std::filesystem::path> directories;
+    std::vector<std::pair<std::filesystem::path, std::string>> files;
+    for (const auto& location : program.get<std::vector<std::string>>("--testLocations"))
     {
-        const auto testFilePath = parseTestLocationPath(location, config);
-        if (std::filesystem::is_directory(testFilePath))
+        if (auto split = splitTestLocation(location); std::filesystem::is_directory(split.first))
         {
-            if (not defaultDiscoverDirReplaced)
-            {
-                config.testDiscoverDirs.clear();
-                defaultDiscoverDirReplaced = true;
-            }
-            config.testDiscoverDirs.add(testFilePath.string());
-            continue;
+            directories.push_back(std::move(split.first));
+        }
+        else
+        {
+            files.push_back(std::move(split));
+        }
+    }
+
+    /// A bare file name is looked up in the search directories, which are fixed before any lookup. Collecting them
+    /// first keeps the result independent of argument order, which matters when a directory lies outside the root or
+    /// resolves a name that is ambiguous under it.
+    for (const auto& directory : directories)
+    {
+        config.testDiscoverDirs.add(directory.string());
+    }
+
+    auto searchDirs = config.testDiscoverDirs.getValues()
+        | std::views::transform([](const auto& option) { return std::filesystem::path{option.getValue()}; })
+        | std::ranges::to<std::vector<std::filesystem::path>>();
+    if (searchDirs.empty())
+    {
+        searchDirs.emplace_back(config.testDiscoverRoot.getValue());
+    }
+
+    for (const auto& [testFilePath, testNumbers] : files)
+    {
+        if (not testNumbers.empty())
+        {
+            addTestQueryNumbers(config, testNumbers);
         }
 
         if (std::filesystem::is_regular_file(testFilePath))
         {
             config.directlySpecifiedTestFiles = testFilePath;
-            continue;
         }
-
-        applyDiscoveredTestLocation(testFilePath, config);
+        else
+        {
+            applyDiscoveredTestLocation(testFilePath, searchDirs, config);
+        }
     }
 }
 
@@ -472,7 +497,7 @@ void handleMetaCommands(const ArgumentParser& program, const NES::SystestConfigu
 {
     if (program.is_used("--list"))
     {
-        std::cout << NES::Systest::loadTestFileMap(config);
+        std::cout << NES::discoverTestFiles(config);
         std::exit(0); ///NOLINT(concurrency-mt-unsafe)
     }
 

--- a/nes-systests/systest/src/Discovery/TestDiscovery.cpp
+++ b/nes-systests/systest/src/Discovery/TestDiscovery.cpp
@@ -16,27 +16,29 @@
 
 #include <algorithm>
 #include <cctype>
-#include <cstddef>
+#include <cstdlib>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
-#include <memory>
+#include <iterator>
 #include <optional>
 #include <ostream>
 #include <ranges>
+#include <span>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
 
-#include <Config/Config.hpp>
-#include <Identifiers/Identifiers.hpp>
-#include <Sinks/SinkCatalog.hpp>
-#include <Sources/SourceCatalog.hpp>
-#include <Util/Strings.hpp>
 #include <fmt/format.h>
 #include <fmt/ranges.h> ///NOLINT: required by fmt
-#include <SystestState.hpp>
+
+#include <Config/Config.hpp>
+#include <Identifiers/Identifiers.hpp>
+#include <Util/Strings.hpp>
+#include <ErrorHandling.hpp>
 
 namespace
 {
@@ -74,12 +76,12 @@ DiscoveryFilters createDiscoveryFilters(const NES::SystestConfiguration& config)
         .disabledTestFiles = toLowerSet(config.disabledTestFiles.getValues(), [](const auto& option) { return option.getValue(); })};
 }
 
-bool hasMatchingGroup(const NES::Systest::TestFile& testFile, const std::unordered_set<std::string>& groups)
+bool hasMatchingGroup(const NES::DiscoveredTestFile& testFile, const std::unordered_set<std::string>& groups)
 {
-    return std::ranges::any_of(testFile.groups, [&](const auto& group) { return groups.contains(NES::toLowerCase(group)); });
+    return std::ranges::any_of(testFile.groups, [&](const auto& group) { return groups.contains(NES::toLowerCase(group.getRawValue())); });
 }
 
-bool matchesDisabledTestFile(const NES::Systest::TestFile& testFile, const std::unordered_set<std::string>& disabledTestFiles)
+bool matchesDisabledTestFile(const NES::DiscoveredTestFile& testFile, const std::unordered_set<std::string>& disabledTestFiles)
 {
     const auto lowerPath = NES::toLowerCase(testFile.file.string());
     const auto lowerFileName = NES::toLowerCase(testFile.file.filename().string());
@@ -96,7 +98,7 @@ bool matchesDisabledTestFile(const NES::Systest::TestFile& testFile, const std::
         });
 }
 
-std::optional<std::string> getIncludedGroupSkipReason(const NES::Systest::TestFile& testFile, const DiscoveryFilters& filters)
+std::optional<std::string> getIncludedGroupSkipReason(const NES::DiscoveredTestFile& testFile, const DiscoveryFilters& filters)
 {
     if (filters.includedGroups.empty() || hasMatchingGroup(testFile, filters.includedGroups))
     {
@@ -105,7 +107,7 @@ std::optional<std::string> getIncludedGroupSkipReason(const NES::Systest::TestFi
     return fmt::format("Skipping file://{} because it is not part of the {:} groups\n", testFile.getLogFilePath(), filters.includedGroups);
 }
 
-std::optional<std::string> getExcludedGroupSkipReason(const NES::Systest::TestFile& testFile, const DiscoveryFilters& filters)
+std::optional<std::string> getExcludedGroupSkipReason(const NES::DiscoveredTestFile& testFile, const DiscoveryFilters& filters)
 {
     if (!hasMatchingGroup(testFile, filters.excludedGroups))
     {
@@ -121,7 +123,7 @@ std::optional<std::string> getExcludedGroupSkipReason(const NES::Systest::TestFi
         sourceSuffix);
 }
 
-std::optional<std::string> getDisabledTestFileSkipReason(const NES::Systest::TestFile& testFile, const DiscoveryFilters& filters)
+std::optional<std::string> getDisabledTestFileSkipReason(const NES::DiscoveredTestFile& testFile, const DiscoveryFilters& filters)
 {
     if (!matchesDisabledTestFile(testFile, filters.disabledTestFiles))
     {
@@ -131,7 +133,7 @@ std::optional<std::string> getDisabledTestFileSkipReason(const NES::Systest::Tes
         "Skipping file://{} because it is configured in disabled_test_files in the disable config file\n", testFile.getLogFilePath());
 }
 
-std::optional<std::string> getSkipReason(const NES::Systest::TestFile& testFile, const DiscoveryFilters& filters)
+std::optional<std::string> getSkipReason(const NES::DiscoveredTestFile& testFile, const DiscoveryFilters& filters)
 {
     if (const auto skipReason = getIncludedGroupSkipReason(testFile, filters))
     {
@@ -148,45 +150,36 @@ std::optional<std::string> getSkipReason(const NES::Systest::TestFile& testFile,
     return std::nullopt;
 }
 
-NES::Systest::TestName testNameFromRelativePath(std::filesystem::path relativePath)
+/// Whether `path` is located at or below `root`.
+bool isBelow(const std::filesystem::path& path, const std::filesystem::path& root)
+{
+    const auto relative = std::filesystem::weakly_canonical(path).lexically_relative(std::filesystem::weakly_canonical(root));
+    return not relative.empty() && *relative.begin() != "..";
+}
+
+std::filesystem::path normalizedDirectory(const std::filesystem::path& directory)
+{
+    auto normalized = std::filesystem::weakly_canonical(directory);
+    return normalized.has_filename() ? normalized : normalized.parent_path();
+}
+
+NES::TestName testNameFromRelativePath(std::filesystem::path relativePath)
 {
     relativePath.replace_extension();
-    return relativePath.generic_string();
+    return NES::TestName{relativePath.generic_string()};
 }
 
-NES::Systest::TestName testNameStem(const NES::Systest::TestFile& testFile)
+}
+
+namespace NES
 {
-    return std::filesystem::path(testFile.name()).filename().string();
-}
 
-/// Use the filename stem when it is unique, retaining the relative path to disambiguate duplicate stems.
-void shortenUniqueTestNames(NES::Systest::TestFileMap& testFiles)
-{
-    std::unordered_map<NES::Systest::TestName, size_t> testNameCounts;
-    for (const auto& testFile : testFiles | std::views::values)
-    {
-        ++testNameCounts[testNameStem(testFile)];
-    }
-
-    for (auto& testFile : testFiles | std::views::values)
-    {
-        auto stem = testNameStem(testFile);
-        if (testNameCounts.at(stem) == 1)
-        {
-            testFile.testName = std::move(stem);
-        }
-    }
-}
-}
-
-namespace NES::Systest
-{
 namespace
 {
-
-TestFileMap discoverTestsRecursively(const std::filesystem::path& path, const std::optional<std::string>& fileExtension)
+std::vector<std::filesystem::path>
+findTestFilesBelow(const std::filesystem::path& searchRoot, const std::optional<std::string>& fileExtension)
 {
-    TestFileMap testFiles;
+    std::vector<std::filesystem::path> files;
 
     auto toLowerCopy = [](const std::string& str)
     {
@@ -197,22 +190,87 @@ TestFileMap discoverTestsRecursively(const std::filesystem::path& path, const st
 
     const auto desiredExtension = fileExtension.has_value() ? toLowerCopy(*fileExtension) : "";
 
-    for (const auto& entry : std::filesystem::recursive_directory_iterator(path, std::filesystem::directory_options::skip_permission_denied)
-             | std::views::filter([](const auto& entry) { return entry.is_regular_file(); }))
+    for (const auto& entry :
+         std::filesystem::recursive_directory_iterator(searchRoot, std::filesystem::directory_options::skip_permission_denied)
+             | std::views::filter([](const auto& path_) { return path_.is_regular_file(); }))
     {
-        const std::string entryExt = toLowerCopy(entry.path().extension().string());
-        if (!fileExtension || entryExt == desiredExtension)
+        if (const std::string entryExt = toLowerCopy(entry.path().extension().string()); !fileExtension || entryExt == desiredExtension)
         {
-            const TestFile testfile(
-                entry.path(),
-                testNameFromRelativePath(entry.path().lexically_relative(path)),
-                std::make_shared<SourceCatalog>(),
-                std::make_shared<SinkCatalog>());
-            testFiles.insert({testfile.file, testfile});
+            files.push_back(std::filesystem::weakly_canonical(entry.path()));
         }
     }
-    return testFiles;
+    return files;
 }
+
+TestName
+nameFor(const std::filesystem::path& file, const std::filesystem::path& discoverRoot, std::span<const std::filesystem::path> searchRoots)
+{
+    if (isBelow(file, discoverRoot))
+    {
+        return testNameFromRelativePath(file.lexically_relative(discoverRoot));
+    }
+    auto namingRoot = file.parent_path();
+    for (const auto& searchRoot : searchRoots)
+    {
+        if (isBelow(file, searchRoot) and isBelow(namingRoot, searchRoot))
+        {
+            namingRoot = searchRoot;
+        }
+    }
+    return testNameFromRelativePath(file.lexically_relative(namingRoot.parent_path()));
+}
+
+std::vector<TestGroup> readGroups(const DiscoveredTestFile& testfile)
+{
+    constexpr auto groupsPrefix = std::string_view{"# groups:"};
+
+    std::vector<TestGroup> groups;
+    if (std::ifstream ifstream(testfile.file); ifstream.is_open())
+    {
+        std::string line;
+        while (std::getline(ifstream, line))
+        {
+            if (line.starts_with(groupsPrefix))
+            {
+                const auto content = std::string_view(line).substr(groupsPrefix.size());
+                const auto open = content.find('[');
+                const auto close = content.find(']');
+                /// A wrong header group declaration is an error, as the file is otherwise excluded from runs without noticing.
+                /// Text after the closing bracket is allowed, as some files put an issue reference there.
+                if (open == std::string_view::npos || close == std::string_view::npos || close < open)
+                {
+                    throw TestException(
+                        "malformed groups line in file://{}: '{}', expected '# groups: [a, b]'", testfile.file.string(), line);
+                }
+                for (auto inner = content.substr(open + 1, close - open - 1);
+                     auto part : inner | std::views::split(',') | std::views::transform([](auto group) { return std::string_view(group); })
+                         | std::views::transform(
+                                     [](auto group)
+                                     { return group | std::views::filter([](char character) { return !std::isspace(character); }); }))
+                {
+                    auto group = std::ranges::to<std::string>(part);
+                    if (group.empty())
+                    {
+                        throw TestException("empty group name in file://{}: '{}'", testfile.file.string(), line);
+                    }
+                    groups.emplace_back(std::move(group));
+                }
+                break;
+            }
+        }
+        ifstream.close();
+    }
+    return groups;
+}
+
+}
+
+DiscoveredTestFile::DiscoveredTestFile(
+    const std::filesystem::path& file, TestName testName, std::optional<std::unordered_set<SystestQueryId>> enabledQueries)
+    : file(weakly_canonical(file)), testName(std::move(testName)), enabledQueries(std::move(enabledQueries)), groups(readGroups(*this)) { };
+
+namespace
+{
 
 struct TestGroupFiles
 {
@@ -220,15 +278,15 @@ struct TestGroupFiles
     std::vector<std::filesystem::path> files;
 };
 
-std::vector<TestGroupFiles> collectTestGroups(const TestFileMap& testMap)
+std::vector<TestGroupFiles> collectTestGroups(const std::vector<DiscoveredTestFile>& testFiles)
 {
     std::unordered_map<std::string, std::vector<std::filesystem::path>> groupFilesMap;
 
-    for (const auto& [testName, testFile] : testMap)
+    for (const auto& testFile : testFiles)
     {
         for (const auto& groupName : testFile.groups)
         {
-            groupFilesMap[groupName].push_back(testFile.file);
+            groupFilesMap[groupName.getRawValue()].push_back(testFile.file);
         }
     }
 
@@ -243,52 +301,63 @@ std::vector<TestGroupFiles> collectTestGroups(const TestFileMap& testMap)
 
 }
 
-TestFileMap loadTestFileMap(const SystestConfiguration& config)
+std::vector<DiscoveredTestFile> discoverTestFiles(const SystestConfiguration& config)
 {
     const auto filters = createDiscoveryFilters(config);
+    const auto discoverRoot = normalizedDirectory(config.testDiscoverRoot.getValue());
 
     if (not config.directlySpecifiedTestFiles.getValue().empty())
     {
-        const auto directlySpecifiedTestFiles = config.directlySpecifiedTestFiles.getValue();
-
-        if (config.testQueryNumbers.empty())
+        std::optional<std::unordered_set<SystestQueryId>> enabledQueries;
+        if (not config.testQueryNumbers.empty())
         {
-            const auto testfile = TestFile(directlySpecifiedTestFiles, std::make_shared<SourceCatalog>(), std::make_shared<SinkCatalog>());
-            if (matchesDisabledTestFile(testfile, filters.disabledTestFiles))
-            {
-                std::cout << fmt::format(
-                    "Including file://{} because it was explicitly selected via --testLocations, overriding disabled_test_files\n",
-                    testfile.getLogFilePath());
-            }
-            return TestFileMap{{testfile.file, testfile}};
+            enabledQueries = std::ranges::to<std::unordered_set<SystestQueryId>>(
+                config.testQueryNumbers.getValues()
+                | std::views::transform([](const auto& option) { return SystestQueryId(option.getValue()); }));
         }
-
-        const auto testNumbers = std::ranges::to<std::unordered_set<SystestQueryId>>(
-            config.testQueryNumbers.getValues()
-            | std::views::transform([](const auto& option) { return SystestQueryId(option.getValue()); }));
-        const auto testfile
-            = TestFile(directlySpecifiedTestFiles, testNumbers, std::make_shared<SourceCatalog>(), std::make_shared<SinkCatalog>());
+        const auto file = std::filesystem::weakly_canonical(config.directlySpecifiedTestFiles.getValue());
+        const DiscoveredTestFile testfile{file, nameFor(file, discoverRoot, {}), std::move(enabledQueries)};
         if (matchesDisabledTestFile(testfile, filters.disabledTestFiles))
         {
             std::cout << fmt::format(
                 "Including file://{} because it was explicitly selected via --testLocations, overriding disabled_test_files\n",
                 testfile.getLogFilePath());
         }
-        return TestFileMap{{testfile.file, testfile}};
+        return {testfile};
     }
 
-    TestFileMap testMap;
-    for (const auto& discoverDir : config.testDiscoverDirs.getValues())
+    /// A relative directory would not match the absolute root, and a trailing separator would make its parent the
+    /// directory itself, so both are normalised away first.
+    auto searchRoots = config.testDiscoverDirs.getValues()
+        | std::views::transform([](const auto& option) { return normalizedDirectory(option.getValue()); })
+        | std::ranges::to<std::vector<std::filesystem::path>>();
+    if (searchRoots.empty())
     {
-        auto tests = discoverTestsRecursively(discoverDir.getValue(), config.testFileExtension.getValue());
-        testMap.merge(tests);
+        searchRoots.push_back(discoverRoot);
     }
-
-    std::erase_if(
-        testMap,
-        [&](const auto& nameAndFile)
+    std::vector<std::filesystem::path> files;
+    /// Two search directories may nest, and a file below both would otherwise be discovered and run twice.
+    std::unordered_set<std::string> seen;
+    for (const auto& searchRoot : searchRoots)
+    {
+        for (auto& file : findTestFilesBelow(searchRoot, config.testFileExtension.getValue()))
         {
-            const auto& [name, testFile] = nameAndFile;
+            if (seen.insert(file.string()).second)
+            {
+                files.push_back(std::move(file));
+            }
+        }
+    }
+    std::vector<DiscoveredTestFile> testFiles;
+    testFiles.reserve(files.size());
+    for (const auto& file : files)
+    {
+        testFiles.emplace_back(file, nameFor(file, discoverRoot, searchRoots));
+    }
+    std::erase_if(
+        testFiles,
+        [&](const DiscoveredTestFile& testFile)
+        {
             if (const auto skipReason = getSkipReason(testFile, filters))
             {
                 std::cout << *skipReason;
@@ -296,27 +365,40 @@ TestFileMap loadTestFileMap(const SystestConfiguration& config)
             }
             return false;
         });
-    shortenUniqueTestNames(testMap);
+    /// Names below the root are distinct by construction. Two directories outside the root can still yield one name, and
+    /// two files under one name would share a result file, so the run stops here with both paths rather than later with
+    /// a registration error.
+    std::unordered_map<TestName, std::filesystem::path> fileByName;
+    for (const auto& testFile : testFiles)
+    {
+        if (const auto [existing, inserted] = fileByName.emplace(testFile.testName, testFile.file); not inserted)
+        {
+            throw TestException(
+                "the test files file://{} and file://{} would both run under the name '{}'; pass a discovery root that contains both",
+                existing->second.string(),
+                testFile.file.string(),
+                testFile.testName);
+        }
+    }
 
-    return testMap;
+    return testFiles;
 }
 
-std::ostream& operator<<(std::ostream& os, const TestFileMap& testMap)
+std::ostream& operator<<(std::ostream& os, const std::vector<DiscoveredTestFile>& testFiles)
 {
-    if (testMap.empty())
+    if (testFiles.empty())
     {
         os << "No matching test files found\n";
     }
     else
     {
         os << "Discovered Test Files:\n";
-        for (const auto& testFile : testMap)
+        for (const auto& testFile : testFiles)
         {
-            os << "\t" << testFile.first << "\tfile://" << testFile.second.file.c_str() << "\n";
+            os << "\tfile://" << testFile.file.c_str() << "\n";
         }
 
-        auto testGroups = collectTestGroups(testMap);
-        if (not testGroups.empty())
+        if (auto testGroups = collectTestGroups(testFiles); not testGroups.empty())
         {
             os << "\nDiscovered Test Groups:\n";
             for (const auto& [name, files] : testGroups)
@@ -332,4 +414,28 @@ std::ostream& operator<<(std::ostream& os, const TestFileMap& testMap)
     return os;
 }
 
+std::string DiscoveredTestFile::getLogFilePath() const
+{
+    /// NOLINTNEXTLINE(concurrency-mt-unsafe) The environment is read while the run is still single threaded.
+    if (const char* hostNebulaStreamRoot = std::getenv("HOST_NEBULASTREAM_ROOT"))
+    {
+        const auto commonFolder = std::filesystem::path(hostNebulaStreamRoot).filename();
+
+        auto filePathIter = file.begin();
+        if (const auto it = std::ranges::find(file, commonFolder); it != file.end())
+        {
+            filePathIter = std::next(it);
+        }
+
+        std::filesystem::path resultPath(hostNebulaStreamRoot);
+        for (; filePathIter != file.end(); ++filePathIter)
+        {
+            resultPath /= *filePathIter;
+        }
+
+        return resultPath.string();
+    }
+
+    return std::filesystem::path(file);
+}
 }

--- a/nes-systests/systest/src/Runner/SystestRunner.cpp
+++ b/nes-systests/systest/src/Runner/SystestRunner.cpp
@@ -444,7 +444,7 @@ void printQueryResultToStdOut(
     SystestProgressTracker& progressTracker,
     const std::string_view queryPerformanceMessage)
 {
-    const auto queryNameLength = runningQuery.systestQuery.testName.size();
+    const auto queryNameLength = runningQuery.systestQuery.testName.view().size();
     const auto queryNumberAsString = runningQuery.systestQuery.queryIdInFile.toString();
     const auto queryNumberLength = queryNumberAsString.size();
     const auto queryCounterAsString = std::to_string(progressTracker.getQueryCounter());
@@ -546,7 +546,7 @@ std::vector<RunningQuery> runQueriesAndBenchmark(
         recordProcessedInput(runningQuery);
         const auto executionTimeInSeconds = runningQuery.getElapsedTime().count();
         benchmarkResults.push_back(
-            {.queryName = runningQuery.systestQuery.testName,
+            {.queryName = runningQuery.systestQuery.testName.getRawValue(),
              .time = executionTimeInSeconds,
              .bytesPerSecond = static_cast<double>(runningQuery.bytesProcessed.value_or(NAN)) / executionTimeInSeconds,
              .tuplesPerSecond = static_cast<double>(runningQuery.tuplesProcessed.value_or(NAN)) / executionTimeInSeconds});

--- a/nes-systests/systest/src/SystestBinder.cpp
+++ b/nes-systests/systest/src/SystestBinder.cpp
@@ -41,6 +41,7 @@
 #include <DataTypes/DataType.hpp>
 #include <DataTypes/DataTypeProvider.hpp>
 #include <DataTypes/UnboundField.hpp>
+#include <Discovery/TestDiscovery.hpp>
 #include <Discovery/TestFileReader.hpp>
 #include <Identifiers/Identifier.hpp>
 #include <Identifiers/Identifiers.hpp>
@@ -476,13 +477,13 @@ struct SystestBinder::Impl
         }
     }
 
-    std::pair<std::vector<SystestQuery>, size_t> loadOptimizeQueries(const TestFileMap& discoveredTestFiles)
+    std::pair<std::vector<SystestQuery>, size_t> loadOptimizeQueries(const std::vector<DiscoveredTestFile>& discoveredTestFiles)
     {
         /// This method could also be removed with the checks and loop put in the SystestExecutor, but it's an aesthetic choice.
         std::vector<SystestQuery> queries;
         uint64_t loadedFiles = 0;
 
-        for (const auto& testfile : discoveredTestFiles | std::views::values)
+        for (const auto& testfile : discoveredTestFiles)
         {
             std::cout << "Loading queries from test file: file://" << testfile.getLogFilePath() << '\n' << std::flush;
             try
@@ -505,21 +506,24 @@ struct SystestBinder::Impl
         return std::make_pair(queries, loadedFiles);
     }
 
-    std::vector<SystestQuery> loadOptimizeQueriesFromTestFile(const Systest::TestFile& testfile)
+    std::vector<SystestQuery> loadOptimizeQueriesFromTestFile(const DiscoveredTestFile& testfile)
     {
-        SLTSinkFactory sinkProvider{testfile.sinkCatalog, clusterConfiguration.allowSinkPlacement};
+        /// Each test file declares its sources and sinks in its own terms, so each one binds against its own catalogs.
+        const auto sourceCatalog = std::make_shared<SourceCatalog>();
+        const auto sinkCatalog = std::make_shared<SinkCatalog>();
+
+        SLTSinkFactory sinkProvider{sinkCatalog, clusterConfiguration.allowSinkPlacement};
         auto modelCatalog = std::make_shared<ModelCatalog>();
-        auto loadedSystests = loadFromSLTFile(testfile.file, testfile.name(), testfile.sourceCatalog, modelCatalog, sinkProvider);
+        auto loadedSystests = loadFromSLTFile(testfile.file, testfile.name().view(), sourceCatalog, modelCatalog, sinkProvider);
         std::unordered_set<SystestQueryId> foundQueries;
 
-        const QueryOptimizer queryOptimizer{
-            queryOptimizerConfiguration, testfile.sourceCatalog, testfile.sinkCatalog, copyPtr(workerCatalog), modelCatalog};
+        const QueryOptimizer queryOptimizer{queryOptimizerConfiguration, sourceCatalog, sinkCatalog, copyPtr(workerCatalog), modelCatalog};
 
         std::vector<SystestQuery> buildSystests;
         for (auto& builder : loadedSystests)
         {
-            const bool includeBuilder = testfile.onlyEnableQueriesWithTestQueryNumber.empty()
-                || testfile.onlyEnableQueriesWithTestQueryNumber.contains(builder.getSystemTestQueryId());
+            const bool includeBuilder
+                = not testfile.enabledQueries.has_value() || testfile.enabledQueries->contains(builder.getSystemTestQueryId());
             if (!includeBuilder)
             {
                 continue;
@@ -534,16 +538,20 @@ struct SystestBinder::Impl
         }
 
         /// Warn about queries specified via the command line that were not found in the test file
-        std::ranges::for_each(
-            testfile.onlyEnableQueriesWithTestQueryNumber
-                | std::views::filter([&foundQueries](const SystestQueryId testNumber) { return not foundQueries.contains(testNumber); }),
-            [&testfile](const auto badTestNumber)
-            {
-                std::cerr << fmt::format(
-                    "Warning: Query number {} specified via command line argument but not found in file://{}",
-                    badTestNumber,
-                    testfile.file.string());
-            });
+        if (testfile.enabledQueries.has_value())
+        {
+            std::ranges::for_each(
+                *testfile.enabledQueries
+                    | std::views::filter([&foundQueries](const SystestQueryId testNumber)
+                                         { return not foundQueries.contains(testNumber); }),
+                [&testfile](const auto badTestNumber)
+                {
+                    std::cerr << fmt::format(
+                        "Warning: Query number {} specified via command line argument but not found in file://{}",
+                        badTestNumber,
+                        testfile.file.string());
+                });
+        }
 
         return buildSystests;
     }
@@ -1057,7 +1065,7 @@ struct SystestBinder::Impl
         for (auto& builder : builders)
         {
             builder.setPaths(testFilePath, workingDir);
-            builder.setName(std::string{testFileName});
+            builder.setName(TestName{std::string{testFileName}});
             builder.setAdditionalSourceThreads(sourceThreads);
         }
         return builders;
@@ -1083,7 +1091,7 @@ SystestBinder::SystestBinder(
 {
 }
 
-std::pair<std::vector<SystestQuery>, size_t> SystestBinder::loadOptimizeQueries(const TestFileMap& discoveredTestFiles)
+std::pair<std::vector<SystestQuery>, size_t> SystestBinder::loadOptimizeQueries(const std::vector<DiscoveredTestFile>& discoveredTestFiles)
 {
     return impl->loadOptimizeQueries(discoveredTestFiles);
 }

--- a/nes-systests/systest/src/SystestExecutor.cpp
+++ b/nes-systests/systest/src/SystestExecutor.cpp
@@ -209,7 +209,7 @@ SystestExecutorResult SystestExecutor::executeSystests()
         std::filesystem::remove_all(config.workingDir.getValue());
         std::filesystem::create_directory(config.workingDir.getValue());
 
-        auto discoveredTestFiles = Systest::loadTestFileMap(config);
+        auto discoveredTestFiles = discoverTestFiles(config);
         Systest::SystestBinder binder{
             config.workingDir.getValue(),
             config.testDataDir.getValue(),

--- a/nes-systests/systest/src/SystestState.cpp
+++ b/nes-systests/systest/src/SystestState.cpp
@@ -80,80 +80,13 @@ std::filesystem::path SystestQuery::sourceFile(const std::filesystem::path& work
 
 std::filesystem::path SystestQuery::resultFile() const
 {
-    return resultFile(workingDir, testName, queryIdInFile);
+    return resultFile(workingDir, testName.view(), queryIdInFile);
 }
 
 std::filesystem::path SystestQuery::resultFileForDifferentialQuery() const
 {
-    return resultFile(workingDir, testName + "differential", queryIdInFile);
+    return resultFile(workingDir, testName.getRawValue() + "differential", queryIdInFile);
 }
-
-std::vector<TestGroup> readGroups(const TestFile& testfile)
-{
-    std::vector<TestGroup> groups;
-    if (std::ifstream ifstream(testfile.file); ifstream.is_open())
-    {
-        std::string line;
-        while (std::getline(ifstream, line))
-        {
-            if (line.starts_with("# groups:"))
-            {
-                auto content = std::string_view(line).substr(9);
-                auto open = content.find('[');
-                auto close = content.find(']');
-                auto inner = content.substr(open + 1, close - open - 1);
-                for (auto part : inner | std::views::split(',') | std::views::transform([](auto r) { return std::string_view(r); })
-                         | std::views::transform([](auto sv) { return sv | std::views::filter([](char c) { return !std::isspace(c); }); }))
-                {
-                    groups.emplace_back(std::ranges::to<std::string>(part));
-                }
-                break;
-            }
-        }
-        ifstream.close();
-    }
-    return groups;
-}
-
-TestFile::TestFile(
-    const std::filesystem::path& file, std::shared_ptr<SourceCatalog> sourceCatalog, std::shared_ptr<SinkCatalog> sinkCatalog)
-    : TestFile(file, file.stem().string(), std::move(sourceCatalog), std::move(sinkCatalog))
-{
-}
-
-TestFile::TestFile(
-    const std::filesystem::path& file,
-    TestName testName,
-    std::shared_ptr<SourceCatalog> sourceCatalog,
-    std::shared_ptr<SinkCatalog> sinkCatalog)
-    : file(weakly_canonical(file))
-    , testName(std::move(testName))
-    , groups(readGroups(*this))
-    , sourceCatalog(std::move(sourceCatalog))
-    , sinkCatalog(std::move(sinkCatalog)) { };
-
-TestFile::TestFile(
-    const std::filesystem::path& file,
-    std::unordered_set<SystestQueryId> onlyEnableQueriesWithTestQueryNumber,
-    std::shared_ptr<SourceCatalog> sourceCatalog,
-    std::shared_ptr<SinkCatalog> sinkCatalog)
-    : TestFile(
-          file, std::move(onlyEnableQueriesWithTestQueryNumber), file.stem().string(), std::move(sourceCatalog), std::move(sinkCatalog))
-{
-}
-
-TestFile::TestFile(
-    const std::filesystem::path& file,
-    std::unordered_set<SystestQueryId> onlyEnableQueriesWithTestQueryNumber,
-    TestName testName,
-    std::shared_ptr<SourceCatalog> sourceCatalog,
-    std::shared_ptr<SinkCatalog> sinkCatalog)
-    : file(weakly_canonical(file))
-    , testName(std::move(testName))
-    , onlyEnableQueriesWithTestQueryNumber(std::move(onlyEnableQueriesWithTestQueryNumber))
-    , groups(readGroups(*this))
-    , sourceCatalog(std::move(sourceCatalog))
-    , sinkCatalog(std::move(sinkCatalog)) { };
 
 std::chrono::duration<double> RunningQuery::getElapsedTime() const
 {
@@ -204,27 +137,4 @@ std::string RunningQuery::getThroughput() const
     return fmt::format("{}B/s / {}Tup/s", formatUnits(bytesPerSecond), formatUnits(tuplesPerSecond));
 }
 
-std::string TestFile::getLogFilePath() const
-{
-    if (const char* hostNebulaStreamRoot = std::getenv("HOST_NEBULASTREAM_ROOT"))
-    {
-        auto commonFolder = std::filesystem::path(hostNebulaStreamRoot).filename();
-
-        auto filePathIter = file.begin();
-        if (const auto it = std::ranges::find(file, commonFolder); it != file.end())
-        {
-            filePathIter = std::next(it);
-        }
-
-        std::filesystem::path resultPath(hostNebulaStreamRoot);
-        for (; filePathIter != file.end(); ++filePathIter)
-        {
-            resultPath /= *filePathIter;
-        }
-
-        return resultPath.string();
-    }
-
-    return std::filesystem::path(file);
-}
 }

--- a/nes-systests/systest/tests/CMakeLists.txt
+++ b/nes-systests/systest/tests/CMakeLists.txt
@@ -15,9 +15,13 @@ function(add_nes_test_systest)
     set(TARGET_NAME ${ARGV0})
     target_link_libraries(${TARGET_NAME} nes-systest-lib)
     target_include_directories(${TARGET_NAME}
-            PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../private>)
+            PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../private>
+            PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
     target_compile_definitions(${TARGET_NAME} PRIVATE SYSTEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/testdata/")
 endfunction()
+
+add_nes_test_systest(systest-test-discovery-test
+        "Discovery/TestDiscoveryTests.cpp")
 
 add_nes_test_systest(slt-parser-test
         "Parser/SystestParserTests.cpp"

--- a/nes-systests/systest/tests/Discovery/TestDiscoveryTests.cpp
+++ b/nes-systests/systest/tests/Discovery/TestDiscoveryTests.cpp
@@ -1,0 +1,397 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <Config/Config.hpp>
+#include <Discovery/TestDiscovery.hpp>
+#include <Util/Logger/LogLevel.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <Util/Logger/impl/NesLogger.hpp>
+#include <BaseUnitTest.hpp>
+#include <ErrorHandling.hpp>
+#include <TemporaryDirectory.hpp>
+
+namespace
+{
+void writeTextFile(const std::filesystem::path& path, const std::string& content)
+{
+    std::filesystem::create_directories(path.parent_path());
+    std::ofstream out(path);
+    ASSERT_TRUE(out.is_open()) << "Failed to open file " << path;
+    out << content;
+    out.close();
+}
+}
+
+namespace NES
+{
+namespace
+{
+/// This file's discovered name, so a test can refer to the file directly (instead of its position in the result).
+std::string nameOf(const std::vector<DiscoveredTestFile>& discovered, const std::filesystem::path& file)
+{
+    const auto canonical = std::filesystem::weakly_canonical(file);
+    const auto found = std::ranges::find(discovered, canonical, &DiscoveredTestFile::file);
+    return found == discovered.end() ? std::string{"<not discovered>"} : found->name().getRawValue();
+}
+}
+
+class TestDiscoveryTest : public Testing::BaseUnitTest
+{
+public:
+    static void SetUpTestSuite()
+    {
+        Logger::setupLogging("TestDiscoveryTest.log", LogLevel::LOG_DEBUG);
+        NES_DEBUG("Setup TestDiscoveryTest test class.");
+    }
+
+    static void TearDownTestSuite() { NES_DEBUG("Tear down TestDiscoveryTest test class."); }
+};
+
+/// A name is counted from the root, not from the directory that the run searched, so a result file path does not move
+/// when a run is narrowed. A run of the whole root reports `benchmark/a/DEBS`, and searching only `benchmark` reports
+/// the same.
+TEST_F(TestDiscoveryTest, NarrowingTheSearchKeepsTheNamesOfAFullRun)
+{
+    const Testing::TemporaryDirectory tempDir;
+    writeTextFile(tempDir.get() / "benchmark" / "a" / "DEBS.test", "# groups:[x]\n");
+    writeTextFile(tempDir.get() / "benchmark" / "b" / "DEBS.test", "# groups:[x]\n");
+
+    SystestConfiguration config;
+    config.testDiscoverRoot = tempDir.get().string();
+    config.testFileExtension = ".test";
+    config.testDiscoverDirs.add((tempDir.get() / "benchmark").string());
+
+    const auto discovered = discoverTestFiles(config);
+
+    ASSERT_EQ(discovered.size(), 2);
+    EXPECT_EQ(nameOf(discovered, tempDir.get() / "benchmark" / "a" / "DEBS.test"), "benchmark/a/DEBS");
+    EXPECT_EQ(nameOf(discovered, tempDir.get() / "benchmark" / "b" / "DEBS.test"), "benchmark/b/DEBS");
+}
+
+/// A relative search directory selects the same files under the same test names as its absolute form.
+/// Discovery resolves it to an absolute path first, because a relative path would match neither the root nor the discovered files.
+TEST_F(TestDiscoveryTest, RelativeSearchDirectoriesResolveAgainstTheWorkingDirectory)
+{
+    const Testing::TemporaryDirectory tempDir;
+    writeTextFile(tempDir.get() / "benchmark" / "a" / "DEBS.test", "# groups:[x]\n");
+    const auto relativeDir = std::filesystem::proximate(tempDir.get() / "benchmark");
+    ASSERT_TRUE(relativeDir.is_relative());
+
+    SystestConfiguration config;
+    config.testDiscoverRoot = tempDir.get().string();
+    config.testFileExtension = ".test";
+    config.testDiscoverDirs.add(relativeDir.string());
+
+    const auto discovered = discoverTestFiles(config);
+
+    ASSERT_EQ(discovered.size(), 1);
+    EXPECT_EQ(nameOf(discovered, tempDir.get() / "benchmark" / "a" / "DEBS.test"), "benchmark/a/DEBS");
+}
+
+/// A run without -t has no search directory, and every file below the root is a candidate.
+TEST_F(TestDiscoveryTest, SearchesTheWholeRootWhenNoDirectoryWasNamed)
+{
+    const Testing::TemporaryDirectory tempDir;
+    writeTextFile(tempDir.get() / "wanted" / "a.test", "# groups:[x]\n");
+    writeTextFile(tempDir.get() / "other" / "b.test", "# groups:[x]\n");
+
+    SystestConfiguration config;
+    config.testDiscoverRoot = tempDir.get().string();
+    config.testFileExtension = ".test";
+
+    EXPECT_EQ(discoverTestFiles(config).size(), 2);
+}
+
+TEST_F(TestDiscoveryTest, ExplicitlyIncludedGroupOverridesMatchingDisableConfigExclusion)
+{
+    const Testing::TemporaryDirectory tempDir;
+    const auto largeFile = tempDir.get() / "large.test";
+    const auto otherFile = tempDir.get() / "other.test";
+    writeTextFile(largeFile, "# groups:[large]\n");
+    writeTextFile(otherFile, "# groups:[other]\n");
+
+    SystestConfiguration config;
+    config.testDiscoverRoot = tempDir.get().string();
+    config.testFileExtension = ".test";
+    config.globalExcludedGroups = {"large"};
+    config.testGroups.add("large");
+
+    const auto discovered = discoverTestFiles(config);
+
+    ASSERT_EQ(discovered.size(), 1);
+    EXPECT_EQ(discovered.front().file, std::filesystem::weakly_canonical(largeFile));
+}
+
+TEST_F(TestDiscoveryTest, ExplicitCommandLineExclusionOverridesExplicitInclusion)
+{
+    const Testing::TemporaryDirectory tempDir;
+    const auto joinFile = tempDir.get() / "join.test";
+    writeTextFile(joinFile, "# groups:[Join]\n");
+
+    SystestConfiguration config;
+    config.testDiscoverRoot = tempDir.get().string();
+    config.testFileExtension = ".test";
+    config.testGroups.add("Join");
+    config.excludeGroups.add("Join");
+
+    const auto testMap = discoverTestFiles(config);
+
+    EXPECT_TRUE(testMap.empty());
+}
+
+TEST_F(TestDiscoveryTest, DirectlySpecifiedTestFileOverridesDisabledTestFiles)
+{
+    const Testing::TemporaryDirectory tempDir;
+    const auto joinFile = tempDir.get() / "join.test";
+    writeTextFile(joinFile, "# groups:[Join]\n");
+
+    SystestConfiguration config;
+    config.directlySpecifiedTestFiles = joinFile.string();
+    config.disabledTestFiles.add("join.test");
+
+    const auto discovered = discoverTestFiles(config);
+
+    ASSERT_EQ(discovered.size(), 1);
+    EXPECT_EQ(discovered.front().file, std::filesystem::weakly_canonical(joinFile));
+}
+
+/// A name is the path below the root whether or not another file shares the file name, so the name says where the
+/// file is.
+TEST_F(TestDiscoveryTest, NamesAreThePathBelowTheRoot)
+{
+    const Testing::TemporaryDirectory tempDir;
+    writeTextFile(tempDir.get() / "left" / "same.test", "# groups:[Join]\n");
+    writeTextFile(tempDir.get() / "right" / "same.test", "# groups:[Join]\n");
+    writeTextFile(tempDir.get() / "right" / "unique.test", "# groups:[Join]\n");
+
+    SystestConfiguration config;
+    config.testDiscoverRoot = tempDir.get().string();
+    config.testFileExtension = ".test";
+
+    const auto discovered = discoverTestFiles(config);
+
+    ASSERT_EQ(discovered.size(), 3);
+    EXPECT_EQ(nameOf(discovered, tempDir.get() / "left" / "same.test"), "left/same");
+    EXPECT_EQ(nameOf(discovered, tempDir.get() / "right" / "same.test"), "right/same");
+    EXPECT_EQ(nameOf(discovered, tempDir.get() / "right" / "unique.test"), "right/unique");
+}
+
+TEST_F(TestDiscoveryTest, DirectlySpecifiedTestFilesKeepTheNamesOfAFullRun)
+{
+    const Testing::TemporaryDirectory tempDir;
+    const auto testFile = tempDir.get() / "left" / "same.test";
+    writeTextFile(testFile, "# groups:[Join]\n");
+
+    SystestConfiguration config;
+    config.testDiscoverRoot = tempDir.get().string();
+    config.directlySpecifiedTestFiles = testFile.string();
+
+    const auto directlySpecified = discoverTestFiles(config);
+    config.testQueryNumbers.add(1);
+    const auto queryFiltered = discoverTestFiles(config);
+
+    ASSERT_EQ(directlySpecified.size(), 1);
+    ASSERT_EQ(queryFiltered.size(), 1);
+    EXPECT_EQ(directlySpecified.front().name().getRawValue(), "left/same");
+    EXPECT_EQ(queryFiltered.front().name().getRawValue(), "left/same");
+    /// Without numbers every query runs, which is a missing filter rather than an empty one.
+    EXPECT_FALSE(directlySpecified.front().enabledQueries.has_value());
+    EXPECT_EQ(queryFiltered.front().enabledQueries, std::optional{std::unordered_set<SystestQueryId>{SystestQueryId(1)}});
+}
+
+/// The command line can give a directly specified file as a relative path.
+/// Discovery resolves it against the working directory, so the file keeps the test name of a full run.
+TEST_F(TestDiscoveryTest, RelativeDirectlySpecifiedTestFilesResolveAgainstTheWorkingDirectory)
+{
+    const Testing::TemporaryDirectory tempDir;
+    const auto testFile = tempDir.get() / "left" / "same.test";
+    writeTextFile(testFile, "# groups:[Join]\n");
+    const auto relativeFile = std::filesystem::proximate(testFile);
+    ASSERT_TRUE(relativeFile.is_relative());
+
+    SystestConfiguration config;
+    config.testDiscoverRoot = tempDir.get().string();
+    config.directlySpecifiedTestFiles = relativeFile.string();
+
+    const auto discovered = discoverTestFiles(config);
+
+    ASSERT_EQ(discovered.size(), 1);
+    EXPECT_EQ(discovered.front().file, std::filesystem::weakly_canonical(testFile));
+    EXPECT_EQ(discovered.front().name().getRawValue(), "left/same");
+}
+
+TEST_F(TestDiscoveryTest, DirectlySpecifiedTestFilesOutsideTheRootAreNamedFromTheirDirectory)
+{
+    const Testing::TemporaryDirectory root;
+    const Testing::TemporaryDirectory outside;
+    const auto testFile = outside.get() / "sub" / "Alpha.test";
+    writeTextFile(testFile, "# groups:[x]\n");
+
+    SystestConfiguration config;
+    config.testDiscoverRoot = root.get().string();
+    config.directlySpecifiedTestFiles = testFile.string();
+
+    const auto discovered = discoverTestFiles(config);
+
+    ASSERT_EQ(discovered.size(), 1);
+    EXPECT_EQ(discovered.front().name().getRawValue(), "sub/Alpha");
+}
+
+/// A directory outside the root has no path below the root, so its files are named from the directory's parent: the
+/// directory's own name is part of the test name, and no name contains `..`, which would put a result file outside
+/// 'results/'.
+TEST_F(TestDiscoveryTest, FilesOutsideTheRootAreNamedFromTheirDirectory)
+{
+    const Testing::TemporaryDirectory root;
+    const Testing::TemporaryDirectory outside;
+    writeTextFile(outside.get() / "sub" / "Alpha.test", "# groups:[x]\n");
+    writeTextFile(outside.get() / "other" / "Alpha.test", "# groups:[x]\n");
+
+    SystestConfiguration config;
+    config.testDiscoverRoot = root.get().string();
+    config.testFileExtension = ".test";
+    config.testDiscoverDirs.add(outside.get().string());
+
+    const auto discovered = discoverTestFiles(config);
+
+    ASSERT_EQ(discovered.size(), 2);
+    const auto outsideName = outside.get().filename().string();
+    EXPECT_EQ(nameOf(discovered, outside.get() / "sub" / "Alpha.test"), outsideName + "/sub/Alpha");
+    EXPECT_EQ(nameOf(discovered, outside.get() / "other" / "Alpha.test"), outsideName + "/other/Alpha");
+}
+
+/// Two directories outside the root can each hold a file of the same name. Each name starts with the directory that
+/// holds the file, so the run reports them apart and their result files stay apart.
+TEST_F(TestDiscoveryTest, FilesOfTheSameNameInSeparateSearchDirectoriesStayApart)
+{
+    const Testing::TemporaryDirectory root;
+    const Testing::TemporaryDirectory outside;
+    writeTextFile(outside.get() / "a" / "Dup.test", "# groups:[x]\n");
+    writeTextFile(outside.get() / "b" / "Dup.test", "# groups:[x]\n");
+
+    SystestConfiguration config;
+    config.testDiscoverRoot = root.get().string();
+    config.testFileExtension = ".test";
+    config.testDiscoverDirs.add((outside.get() / "a").string());
+    config.testDiscoverDirs.add((outside.get() / "b").string());
+
+    const auto discovered = discoverTestFiles(config);
+
+    ASSERT_EQ(discovered.size(), 2);
+    EXPECT_EQ(nameOf(discovered, outside.get() / "a" / "Dup.test"), "a/Dup");
+    EXPECT_EQ(nameOf(discovered, outside.get() / "b" / "Dup.test"), "b/Dup");
+}
+
+TEST_F(TestDiscoveryTest, OverlappingSearchDirectoriesNameFromTheOutermostInAnyOrder)
+{
+    const Testing::TemporaryDirectory root;
+    const Testing::TemporaryDirectory outside;
+    writeTextFile(outside.get() / "a" / "nested" / "F.test", "# groups:[x]\n");
+
+    SystestConfiguration nestedFirst;
+    nestedFirst.testDiscoverRoot = root.get().string();
+    nestedFirst.testFileExtension = ".test";
+    nestedFirst.testDiscoverDirs.add((outside.get() / "a" / "nested").string());
+    nestedFirst.testDiscoverDirs.add((outside.get() / "a").string());
+
+    SystestConfiguration outerFirst;
+    outerFirst.testDiscoverRoot = root.get().string();
+    outerFirst.testFileExtension = ".test";
+    outerFirst.testDiscoverDirs.add((outside.get() / "a").string());
+    outerFirst.testDiscoverDirs.add((outside.get() / "a" / "nested").string());
+
+    const auto nestedFirstDiscovered = discoverTestFiles(nestedFirst);
+    const auto outerFirstDiscovered = discoverTestFiles(outerFirst);
+
+    ASSERT_EQ(nestedFirstDiscovered.size(), 1);
+    ASSERT_EQ(outerFirstDiscovered.size(), 1);
+    EXPECT_EQ(nestedFirstDiscovered.front().name().getRawValue(), "a/nested/F");
+    EXPECT_EQ(outerFirstDiscovered.front().name().getRawValue(), "a/nested/F");
+}
+
+/// Two directories outside the root can share their own name as well, and then two files would run under one name and
+/// write one result file. Discovery rejects that instead of the run failing later.
+TEST_F(TestDiscoveryTest, RejectsTwoFilesThatWouldShareAName)
+{
+    const Testing::TemporaryDirectory root;
+    const Testing::TemporaryDirectory left;
+    const Testing::TemporaryDirectory right;
+    writeTextFile(left.get() / "a" / "Dup.test", "# groups:[x]\n");
+    writeTextFile(right.get() / "a" / "Dup.test", "# groups:[x]\n");
+
+    SystestConfiguration config;
+    config.testDiscoverRoot = root.get().string();
+    config.testFileExtension = ".test";
+    config.testDiscoverDirs.add((left.get() / "a").string());
+    config.testDiscoverDirs.add((right.get() / "a").string());
+
+    EXPECT_THROW(discoverTestFiles(config), Exception);
+}
+
+/// A groups header that does not parse would drop the file from every group lane without a word, so discovery rejects it.
+TEST_F(TestDiscoveryTest, RejectsAGroupsLineWithoutBrackets)
+{
+    const Testing::TemporaryDirectory tempDir;
+    writeTextFile(tempDir.get() / "a.test", "# groups: Join, Aggregation\n");
+
+    SystestConfiguration config;
+    config.testDiscoverRoot = tempDir.get().string();
+    config.testFileExtension = ".test";
+
+    EXPECT_THROW(discoverTestFiles(config), Exception);
+}
+
+TEST_F(TestDiscoveryTest, RejectsAnEmptyGroupName)
+{
+    const Testing::TemporaryDirectory tempDir;
+    writeTextFile(tempDir.get() / "a.test", "# groups: [Join,]\n");
+
+    SystestConfiguration config;
+    config.testDiscoverRoot = tempDir.get().string();
+    config.testFileExtension = ".test";
+
+    EXPECT_THROW(discoverTestFiles(config), Exception);
+}
+
+/// Several directories narrow to their union, and a file below two of them is discovered once.
+TEST_F(TestDiscoveryTest, SeveralSearchDirectoriesNarrowToTheirUnionWithoutRepeating)
+{
+    const Testing::TemporaryDirectory tempDir;
+    writeTextFile(tempDir.get() / "wanted" / "a.test", "# groups:[x]\n");
+    writeTextFile(tempDir.get() / "wanted" / "nested" / "b.test", "# groups:[x]\n");
+    writeTextFile(tempDir.get() / "other" / "c.test", "# groups:[x]\n");
+
+    SystestConfiguration config;
+    config.testDiscoverRoot = tempDir.get().string();
+    config.testFileExtension = ".test";
+    config.testDiscoverDirs.add((tempDir.get() / "wanted").string());
+    config.testDiscoverDirs.add((tempDir.get() / "wanted" / "nested").string());
+
+    const auto discovered = discoverTestFiles(config);
+
+    ASSERT_EQ(discovered.size(), 2);
+    EXPECT_EQ(nameOf(discovered, tempDir.get() / "wanted" / "a.test"), "wanted/a");
+    EXPECT_EQ(nameOf(discovered, tempDir.get() / "wanted" / "nested" / "b.test"), "wanted/nested/b");
+}
+}

--- a/nes-systests/systest/tests/Parser/SystestParserValidTestFilesTests.cpp
+++ b/nes-systests/systest/tests/Parser/SystestParserValidTestFilesTests.cpp
@@ -521,10 +521,11 @@ TEST_F(SystestParserValidTestFileTest, TextAfterClosingBracketOfGroups)
     SystestConfiguration config{};
     const auto testFileName = fmt::format("comment_text_bracket{}", ".dummy");
     config.directlySpecifiedTestFiles.setValue(fmt::format("{}/{}", SYSTEST_DATA_DIR, testFileName));
-    const auto testMap = Systest::loadTestFileMap(config);
-    ASSERT_EQ(testMap.size(), 1);
-    const auto& testFile = testMap.begin()->second;
-    const std::vector<std::string> expectedGroups = {"Aggregation", "WindowOperators", "CompilationIntensive"};
+    const auto discovered = discoverTestFiles(config);
+    ASSERT_EQ(discovered.size(), 1);
+    const auto& testFile = discovered.front();
+    const std::vector<TestGroup> expectedGroups
+        = {TestGroup{"Aggregation"}, TestGroup{"WindowOperators"}, TestGroup{"CompilationIntensive"}};
     ASSERT_EQ(testFile.groups, expectedGroups);
 }
 

--- a/nes-systests/systest/tests/ResultChecker/SystestResultCheckTests.cpp
+++ b/nes-systests/systest/tests/ResultChecker/SystestResultCheckTests.cpp
@@ -40,7 +40,7 @@ namespace
 NES::Systest::RunningQuery makeExplainRunningQuery(std::vector<std::string> expectedResultLines, std::string actualExplainOutput)
 {
     NES::Systest::SystestQuery query{
-        .testName = "regex_explain",
+        .testName = NES::TestName{"regex_explain"},
         .queryIdInFile = NES::SystestQueryId(1),
         .testFilePath = SYSTEST_DATA_DIR "regex_explain.dummy",
         .workingDir = {},

--- a/nes-systests/systest/tests/Runner/SystestRunnerTest.cpp
+++ b/nes-systests/systest/tests/Runner/SystestRunnerTest.cpp
@@ -92,11 +92,11 @@ makeSummary(const NES::QueryId& id, const NES::QueryStatus currState, const std:
 NES::Systest::SystestQuery makeQuery(
     const std::expected<NES::Systest::SystestQuery::PlanInfo, NES::Exception> planInfoOrException,
     NES::Expectation expected,
-    std::optional<std::pair<NES::Systest::TestName, NES::SystestQueryId>> runAfter,
+    std::optional<std::pair<NES::TestName, NES::SystestQueryId>> runAfter,
     NES::SystestQueryId queryId)
 {
     return NES::Systest::SystestQuery{
-        .testName = "test_query",
+        .testName = NES::TestName{"test_query"},
         .queryIdInFile = queryId,
         .testFilePath = SYSTEST_DATA_DIR "filter.dummy",
         .workingDir = NES::SystestConfiguration{}.workingDir.getValue(),
@@ -281,7 +281,7 @@ TEST_F(SystestRunnerTest, SequentialExecutionThrowOnNonExistentDependency)
     const LogicalPlan plan{INVALID_QUERY_ID, {SinkLogicalOperator::create(sourceOperator, dummySinkDescriptor)}};
     const DistributedLogicalPlan distributedPlan{{{Host("localhost:8080"), std::vector{plan}}}, plan};
 
-    auto runAfter = std::make_pair(std::string{"test_query"}, SystestQueryId(std::numeric_limits<uint64_t>::max()));
+    auto runAfter = std::make_pair(TestName{"test_query"}, SystestQueryId(std::numeric_limits<uint64_t>::max()));
 
     EXPECT_ANY_THROW(
         const auto result = runQueries(
@@ -347,13 +347,13 @@ TEST_F(SystestRunnerTest, SequentialExecutionOrderTest)
     auto query2 = makeQuery(
         SystestQuery::PlanInfo{distributedPlan, Schema<UnqualifiedUnboundField, Ordered>{}},
         ExpectedRows{},
-        std::make_pair(std::string{"test_query"}, SystestQueryId(1)),
+        std::make_pair(TestName{"test_query"}, SystestQueryId(1)),
         SystestQueryId(2));
 
     auto query3 = makeQuery(
         SystestQuery::PlanInfo{distributedPlan, Schema<UnqualifiedUnboundField, Ordered>{}},
         ExpectedRows{},
-        std::make_pair(std::string{"test_query"}, SystestQueryId(2)),
+        std::make_pair(TestName{"test_query"}, SystestQueryId(2)),
         SystestQueryId(3));
 
     std::ofstream(query1.resultFile()) << "\n";

--- a/nes-systests/systest/tests/SystestE2ETests.cpp
+++ b/nes-systests/systest/tests/SystestE2ETests.cpp
@@ -68,7 +68,7 @@ public:
 TEST_F(SystestE2ETest, CheckThatOnlyWrongQueriesFailInFileWithManyQueries)
 {
     SystestConfiguration config{};
-    config.testDiscoverDirs.add(SYSTEST_DATA_DIR);
+    config.testDiscoverRoot = SYSTEST_DATA_DIR;
     const auto testFileName = fmt::format("MultipleCorrectAndIncorrect{}", EXTENSION);
     config.directlySpecifiedTestFiles.setValue(fmt::format("{}/errors/{}", SYSTEST_DATA_DIR, testFileName));
     config.workingDir.setValue(fmt::format("{}/nes-systests/systest/MultipleCorrectAndIncorrect", PATH_TO_BINARY_DIR));
@@ -103,7 +103,7 @@ TEST_P(SystestE2ETest, correctAndIncorrectSchemaTestFile)
     const auto& [directory, testFile] = GetParam();
     const auto testFileName = testFile + std::string(".dummy");
     SystestConfiguration config{};
-    config.testDiscoverDirs.add(SYSTEST_DATA_DIR);
+    config.testDiscoverRoot = SYSTEST_DATA_DIR;
     config.directlySpecifiedTestFiles.setValue(fmt::format("{}/errors/{}/{}", SYSTEST_DATA_DIR, directory, testFileName));
     config.testFileExtension.setValue(std::string(EXTENSION));
     config.workingDir.setValue(fmt::format("{}/nes-systests/systest/{}", PATH_TO_BINARY_DIR, testFile));

--- a/nes-systests/systest/tests/SystestStateTests.cpp
+++ b/nes-systests/systest/tests/SystestStateTests.cpp
@@ -12,64 +12,17 @@
     limitations under the License.
 */
 
-#include <atomic>
-#include <chrono>
 #include <filesystem>
-#include <fstream>
 #include <string>
-#include <vector>
-#include <Config/Config.hpp>
-#include <Discovery/TestDiscovery.hpp>
+
+#include <Identifiers/Identifiers.hpp>
 #include <Util/Logger/LogLevel.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <Util/Logger/impl/NesLogger.hpp>
 #include <gtest/gtest.h>
 #include <BaseUnitTest.hpp>
 #include <SystestState.hpp>
-
-namespace
-{
-std::filesystem::path createUniqueTempDirectory()
-{
-    static std::atomic_uint64_t counter = 0;
-    const auto uniqueId = std::chrono::steady_clock::now().time_since_epoch().count();
-    const auto path = std::filesystem::temp_directory_path()
-        / ("nes-systest-state-" + std::to_string(uniqueId) + "-" + std::to_string(counter.fetch_add(1)));
-    std::filesystem::create_directories(path);
-    return path;
-}
-
-class TemporaryDirectory
-{
-public:
-    TemporaryDirectory() : path(createUniqueTempDirectory()) { }
-
-    ~TemporaryDirectory()
-    {
-        std::error_code errorCode;
-        std::filesystem::remove_all(path, errorCode);
-    }
-
-    TemporaryDirectory(const TemporaryDirectory&) = delete;
-    TemporaryDirectory& operator=(const TemporaryDirectory&) = delete;
-    TemporaryDirectory(TemporaryDirectory&&) = delete;
-    TemporaryDirectory& operator=(TemporaryDirectory&&) = delete;
-
-    [[nodiscard]] const std::filesystem::path& get() const { return path; }
-
-private:
-    std::filesystem::path path;
-};
-
-void writeTextFile(const std::filesystem::path& path, const std::string& content)
-{
-    std::filesystem::create_directories(path.parent_path());
-    std::ofstream out(path);
-    ASSERT_TRUE(out.is_open()) << "Failed to open file " << path;
-    out << content;
-    out.close();
-}
-}
+#include <TemporaryDirectory.hpp>
 
 namespace NES::Systest
 {
@@ -85,134 +38,9 @@ public:
     static void TearDownTestSuite() { NES_DEBUG("Tear down SystestStateTest test class."); }
 };
 
-TEST_F(SystestStateTest, ExplicitlyIncludedGroupOverridesMatchingDisableConfigExclusion)
-{
-    const TemporaryDirectory tempDir;
-    const auto largeFile = tempDir.get() / "large.test";
-    const auto otherFile = tempDir.get() / "other.test";
-    writeTextFile(largeFile, "# groups:[large]\n");
-    writeTextFile(otherFile, "# groups:[other]\n");
-
-    SystestConfiguration config;
-    /// Drop the default TEST_DISCOVER_DIR so discovery is limited to the temporary directory of this test.
-    config.testDiscoverDirs.clear();
-    config.testDiscoverDirs.add(tempDir.get().string());
-    config.testFileExtension = ".test";
-    config.globalExcludedGroups = {"large"};
-    config.testGroups.add("large");
-
-    const auto testMap = loadTestFileMap(config);
-
-    ASSERT_EQ(testMap.size(), 1);
-    EXPECT_TRUE(testMap.contains(std::filesystem::weakly_canonical(largeFile)));
-}
-
-TEST_F(SystestStateTest, ExplicitCommandLineExclusionOverridesExplicitInclusion)
-{
-    const TemporaryDirectory tempDir;
-    const auto joinFile = tempDir.get() / "join.test";
-    writeTextFile(joinFile, "# groups:[Join]\n");
-
-    SystestConfiguration config;
-    /// Drop the default TEST_DISCOVER_DIR so discovery is limited to the temporary directory of this test.
-    config.testDiscoverDirs.clear();
-    config.testDiscoverDirs.add(tempDir.get().string());
-    config.testFileExtension = ".test";
-    config.testGroups.add("Join");
-    config.excludeGroups.add("Join");
-
-    const auto testMap = loadTestFileMap(config);
-
-    EXPECT_TRUE(testMap.empty());
-}
-
-TEST_F(SystestStateTest, DirectlySpecifiedTestFileOverridesDisabledTestFiles)
-{
-    const TemporaryDirectory tempDir;
-    const auto joinFile = tempDir.get() / "join.test";
-    writeTextFile(joinFile, "# groups:[Join]\n");
-
-    SystestConfiguration config;
-    config.directlySpecifiedTestFiles = joinFile.string();
-    config.disabledTestFiles.add("join.test");
-
-    const auto testMap = loadTestFileMap(config);
-
-    ASSERT_EQ(testMap.size(), 1);
-    EXPECT_TRUE(testMap.contains(std::filesystem::weakly_canonical(joinFile)));
-}
-
-TEST_F(SystestStateTest, OnlyDuplicateDiscoveredTestNamesIncludeRelativeDirectory)
-{
-    const TemporaryDirectory tempDir;
-    const auto leftFile = tempDir.get() / "left" / "same.test";
-    const auto rightFile = tempDir.get() / "right" / "same.test";
-    const auto uniqueFile = tempDir.get() / "right" / "unique.test";
-    writeTextFile(leftFile, "# groups:[Join]\n");
-    writeTextFile(rightFile, "# groups:[Join]\n");
-    writeTextFile(uniqueFile, "# groups:[Join]\n");
-
-    SystestConfiguration config;
-    /// Drop the default TEST_DISCOVER_DIR so discovery is limited to the temporary directory of this test.
-    config.testDiscoverDirs.clear();
-    config.testDiscoverDirs.add(tempDir.get().string());
-    config.testFileExtension = ".test";
-
-    const auto testMap = loadTestFileMap(config);
-
-    ASSERT_EQ(testMap.size(), 3);
-    EXPECT_EQ(testMap.at(std::filesystem::weakly_canonical(leftFile)).name(), "left/same");
-    EXPECT_EQ(testMap.at(std::filesystem::weakly_canonical(rightFile)).name(), "right/same");
-    EXPECT_EQ(testMap.at(std::filesystem::weakly_canonical(uniqueFile)).name(), "unique");
-}
-
-TEST_F(SystestStateTest, FilteredDuplicateTestNameUsesStem)
-{
-    const TemporaryDirectory tempDir;
-    const auto includedFile = tempDir.get() / "included" / "same.test";
-    const auto filteredFile = tempDir.get() / "filtered" / "same.test";
-    writeTextFile(includedFile, "# groups:[Included]\n");
-    writeTextFile(filteredFile, "# groups:[Filtered]\n");
-
-    SystestConfiguration config;
-    /// Drop the default TEST_DISCOVER_DIR so discovery is limited to the temporary directory of this test.
-    config.testDiscoverDirs.clear();
-    config.testDiscoverDirs.add(tempDir.get().string());
-    config.testFileExtension = ".test";
-    config.testGroups.add("Included");
-
-    const auto testMap = loadTestFileMap(config);
-
-    ASSERT_EQ(testMap.size(), 1);
-    EXPECT_EQ(testMap.at(std::filesystem::weakly_canonical(includedFile)).name(), "same");
-}
-
-TEST_F(SystestStateTest, DirectlySpecifiedTestNamesUseStem)
-{
-    const TemporaryDirectory tempDir;
-    const auto testFile = tempDir.get() / "left" / "same.test";
-    writeTextFile(testFile, "# groups:[Join]\n");
-
-    SystestConfiguration config;
-    /// Drop the default TEST_DISCOVER_DIR so discovery is limited to the temporary directory of this test.
-    config.testDiscoverDirs.clear();
-    config.testDiscoverDirs.add(tempDir.get().string());
-    config.directlySpecifiedTestFiles = testFile.string();
-
-    const auto directlySpecifiedTestMap = loadTestFileMap(config);
-    config.testQueryNumbers.add(1);
-    const auto queryFilteredTestMap = loadTestFileMap(config);
-
-    const auto canonicalTestFile = std::filesystem::weakly_canonical(testFile);
-    ASSERT_EQ(directlySpecifiedTestMap.size(), 1);
-    ASSERT_EQ(queryFilteredTestMap.size(), 1);
-    EXPECT_EQ(directlySpecifiedTestMap.at(canonicalTestFile).name(), "same");
-    EXPECT_EQ(queryFilteredTestMap.at(canonicalTestFile).name(), "same");
-}
-
 TEST_F(SystestStateTest, ResultFilesCreateDirectoriesForNestedTestNames)
 {
-    const TemporaryDirectory tempDir;
+    const Testing::TemporaryDirectory tempDir;
 
     const auto resultFile = SystestQuery::resultFile(tempDir.get(), "left/same", SystestQueryId(1));
 

--- a/nes-systests/systest/tests/TemporaryDirectory.hpp
+++ b/nes-systests/systest/tests/TemporaryDirectory.hpp
@@ -1,0 +1,60 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <string>
+#include <system_error>
+
+#include <unistd.h>
+
+namespace NES::Testing
+{
+
+/// A fresh directory under the system temp directory for one test, removed when the test is done.
+/// The name holds the process id, the time and a counter, so tests in one process and in processes that ctest runs side
+/// by side never share a directory.
+class TemporaryDirectory
+{
+public:
+    TemporaryDirectory()
+    {
+        static std::atomic_uint64_t counter = 0;
+        const auto uniqueId = std::chrono::steady_clock::now().time_since_epoch().count();
+        path = std::filesystem::temp_directory_path()
+            / ("nes-systest-" + std::to_string(::getpid()) + "-" + std::to_string(uniqueId) + "-" + std::to_string(counter.fetch_add(1)));
+        std::filesystem::create_directories(path);
+    }
+
+    ~TemporaryDirectory()
+    {
+        std::error_code errorCode;
+        std::filesystem::remove_all(path, errorCode);
+    }
+
+    TemporaryDirectory(const TemporaryDirectory&) = delete;
+    TemporaryDirectory& operator=(const TemporaryDirectory&) = delete;
+    TemporaryDirectory(TemporaryDirectory&&) = delete;
+    TemporaryDirectory& operator=(TemporaryDirectory&&) = delete;
+
+    [[nodiscard]] const std::filesystem::path& get() const { return path; }
+
+private:
+    std::filesystem::path path;
+};
+
+}


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

Part of #1920. Stacked on #1922.

A test file's name is its path below `nes-systests/`, always: `operator/join/JoinNull`. The name is the report label and the result file path, so it says where the file is, and two files with the same file name cannot collide. Before, a file was keyed against whichever `-t` directory found it and shortened to its file name when unique, so `-t dirA dirB` with two `Dup.test` files failed with `query already registered`, and a report line did not say which directory a file was in.

- Discovery returns `std::vector<DiscoveredTestFile>` instead of `TestFileMap`, an `unordered_map<path, TestFile>`. No consumer looked a file up by its path: the binder, the group listing and the printer all iterated the values, so the key bought nothing and the unordered map dropped the discovery order. `TestFile` also carried a source and a sink catalog per file that only the binder read; the binder creates them itself now, and a discovered file holds only what discovery knows: path, name, groups, and the query filter from the command line.
- `TestName` and `TestGroup` are strong types instead of `std::string` aliases, so a name is not mistaken for a path or a group where it serves as a map key or a report label.
- `test_discover_root` is the directory that names are relative to (default `nes-systests/`); `-t` narrows the search below it and may be relative. A `-t` directory outside the root is named from its parent; if two files would still share a name, discovery stops with both paths.
- A malformed `# groups:` header is an error instead of being read best-effort.
- Behaviour change relative to main: names are no longer shortened to the bare file name. Benchmark metrics tagged by query name change once (`Nexmark` becomes `benchmark/Nexmark`).

## Verifying this change

This change is tested by
- 13 discovery unit tests in the new target `systest-test-discovery-test`: naming below the root, narrowing, directories outside the root, name collisions, command-line files with and without a query filter, malformed group headers
- `slt-parser-test` and `testfile-builder-test`
- by hand: `-t dirA dirB` with two same-named files, `-t nes-systests/explain` (relative path), `-t .../EXPLAIN.test:03`

## What components does this pull request potentially affect?

- `nes-systests` only: discovery, the catalog construction in the binder, the test locations in the config parser.
- Configuration: `test_discover_root` is new; `test_discover_dirs` keeps its name and meaning.
- No dependency changes.

## Issue Closed by this pull request:

This PR closes #1914. Follow-up on the discovery root: #1969.
