### PR TITLE
feat(systest): lock the working directory of a run

### DIFF
--- a/nes-systests/systest/private/WorkingDirectoryGuard.hpp
+++ b/nes-systests/systest/private/WorkingDirectoryGuard.hpp
@@ -1,0 +1,55 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <filesystem>
+
+namespace NES
+{
+
+/// RAII guard that owns the working directory for one systest invocation and empties it on construction.
+/// This guarantees that no concurrent runs make conflicting updates or remove result files that another run reads.
+/// Implemented as a lock on the directory that makes a second run report the conflict.
+class WorkingDirectoryGuard
+{
+public:
+    /// Constructing acquires the lock, then empties the directory, and throws on error.
+    explicit WorkingDirectoryGuard(const std::filesystem::path& directory);
+
+    WorkingDirectoryGuard(const WorkingDirectoryGuard&) = delete;
+    WorkingDirectoryGuard& operator=(const WorkingDirectoryGuard&) = delete;
+    WorkingDirectoryGuard(WorkingDirectoryGuard&&) = delete;
+    WorkingDirectoryGuard& operator=(WorkingDirectoryGuard&&) = delete;
+
+    ~WorkingDirectoryGuard() = default;
+
+private:
+    /// Owns the descriptor of the locked directory. Closing it releases the lock, which happens when the guard goes out
+    /// of scope. It is also closed when the constructor throws after opening it, which a bare descriptor would not,
+    /// because a constructor that throws runs no destructor.
+    struct LockedDirectory
+    {
+        LockedDirectory() = default;
+        LockedDirectory(const LockedDirectory&) = delete;
+        LockedDirectory& operator=(const LockedDirectory&) = delete;
+        LockedDirectory(LockedDirectory&&) = delete;
+        LockedDirectory& operator=(LockedDirectory&&) = delete;
+        ~LockedDirectory();
+
+        int descriptor = -1;
+    } lockedDirectory;
+};
+
+}

--- a/nes-systests/systest/src/CMakeLists.txt
+++ b/nes-systests/systest/src/CMakeLists.txt
@@ -25,4 +25,5 @@ add_source_files(nes-systest-lib
         Progress.cpp
         SystestState.cpp
         SystestBinder.cpp
+        WorkingDirectoryGuard.cpp
 )

--- a/nes-systests/systest/src/SystestExecutor.cpp
+++ b/nes-systests/systest/src/SystestExecutor.cpp
@@ -58,6 +58,7 @@
 #include <SystestBinder.hpp>
 #include <SystestState.hpp>
 #include <WorkerCatalog.hpp>
+#include <WorkingDirectoryGuard.hpp>
 
 /// Rust FFI function that enables in-memory communication channels for embedded multi-worker mode.
 /// Configures the network layer to use shared memory instead of real network sockets
@@ -206,8 +207,7 @@ SystestExecutorResult SystestExecutor::executeSystests()
     CPPTRACE_TRY
     {
         /// Read the configuration
-        std::filesystem::remove_all(config.workingDir.getValue());
-        std::filesystem::create_directory(config.workingDir.getValue());
+        const WorkingDirectoryGuard workingDirectoryGuard{config.workingDir.getValue()};
 
         auto discoveredTestFiles = discoverTestFiles(config);
         Systest::SystestBinder binder{

--- a/nes-systests/systest/src/WorkingDirectoryGuard.cpp
+++ b/nes-systests/systest/src/WorkingDirectoryGuard.cpp
@@ -1,0 +1,89 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <WorkingDirectoryGuard.hpp>
+
+#include <filesystem>
+#include <system_error>
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/file.h>
+
+#include <Util/Files.hpp>
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+namespace
+{
+
+/// Empties the working directory of one systest invocation.
+/// Data and result file names are derived from test file names, so they repeat across invocations.
+/// For example, the result checker could read a leftover file as the result of a query that wrote nothing.
+void clearWorkingDirectory(const std::filesystem::path& workingDir)
+{
+    std::error_code errorCode;
+    for (const auto& entry : std::filesystem::directory_iterator{workingDir, errorCode})
+    {
+        std::filesystem::remove_all(entry.path(), errorCode);
+        if (errorCode)
+        {
+            break;
+        }
+    }
+    if (errorCode)
+    {
+        throw TestException("could not clear the working directory {}: {}", workingDir.string(), errorCode.message());
+    }
+}
+
+}
+
+WorkingDirectoryGuard::WorkingDirectoryGuard(const std::filesystem::path& directory)
+{
+    std::error_code errorCode;
+    std::filesystem::create_directories(directory, errorCode);
+    if (errorCode)
+    {
+        throw TestException("could not create the working directory {}: {}", directory.string(), errorCode.message());
+    }
+
+    /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) - POSIX API requires varargs
+    lockedDirectory.descriptor = ::open(directory.c_str(), O_DIRECTORY | O_RDONLY | O_CLOEXEC);
+    if (lockedDirectory.descriptor < 0)
+    {
+        throw TestException("could not open the working directory {}: {}", directory.string(), getErrorMessageFromERRNO());
+    }
+    /// The kernel releases a flock however the process ends, so a crashed run leaves no lock to remove by hand.
+    /// An flock also works across containers.
+    if (::flock(lockedDirectory.descriptor, LOCK_EX | LOCK_NB) != 0)
+    {
+        throw TestException(
+            "another run holds the working directory {}, and each would clear it under the other. "
+            "Wait for that run, or pass --workingDir to use a different working directory",
+            directory.string());
+    }
+    clearWorkingDirectory(directory);
+}
+
+WorkingDirectoryGuard::LockedDirectory::~LockedDirectory()
+{
+    if (descriptor >= 0)
+    {
+        ::close(descriptor);
+    }
+}
+
+}

--- a/nes-systests/systest/tests/CMakeLists.txt
+++ b/nes-systests/systest/tests/CMakeLists.txt
@@ -29,7 +29,8 @@ add_nes_test_systest(slt-parser-test
         "Parser/SystestParserValidTestFilesTests.cpp"
         "ResultChecker/SystestResultCheckTests.cpp"
         "Runner/SystestRunnerTest.cpp"
-        "SystestStateTests.cpp")
+        "SystestStateTests.cpp"
+        "WorkingDirectoryGuardTests.cpp")
 
 add_nes_test_systest(testfile-builder-test
         "Parser/TestFileBuilderTests.cpp")

--- a/nes-systests/systest/tests/WorkingDirectoryGuardTests.cpp
+++ b/nes-systests/systest/tests/WorkingDirectoryGuardTests.cpp
@@ -1,0 +1,105 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <cstddef>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include <Util/Logger/LogLevel.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <Util/Logger/impl/NesLogger.hpp>
+#include <BaseUnitTest.hpp>
+#include <ErrorHandling.hpp>
+#include <TemporaryDirectory.hpp>
+#include <WorkingDirectoryGuard.hpp>
+
+namespace
+{
+
+/// The number of descriptors this process holds, so a test can show that a failed guard left none behind.
+std::size_t openDescriptors()
+{
+    return static_cast<std::size_t>(
+        std::distance(std::filesystem::directory_iterator{"/proc/self/fd"}, std::filesystem::directory_iterator{}));
+}
+
+}
+
+namespace NES
+{
+
+class WorkingDirectoryGuardTest : public Testing::BaseUnitTest
+{
+public:
+    static void SetUpTestSuite() { Logger::setupLogging("WorkingDirectoryGuardTest.log", LogLevel::LOG_DEBUG); }
+};
+
+TEST_F(WorkingDirectoryGuardTest, EmptiesTheDirectoryAndLeavesNoArtifacts)
+{
+    const Testing::TemporaryDirectory tempDir;
+    const auto workingDir = tempDir.get() / "work";
+    std::filesystem::create_directories(workingDir / "stale");
+    std::ofstream{workingDir / "stale.csv"};
+
+    const WorkingDirectoryGuard guard{workingDir.string() + "/"};
+
+    EXPECT_TRUE(std::filesystem::is_directory(workingDir));
+    EXPECT_TRUE(std::filesystem::is_empty(workingDir));
+    EXPECT_EQ(std::distance(std::filesystem::directory_iterator{tempDir.get()}, std::filesystem::directory_iterator{}), 1);
+}
+
+/// Two runs on one directory would each clear it under the other, so the second one is refused. The directory is the
+/// same with or without the trailing separator.
+TEST_F(WorkingDirectoryGuardTest, RefusesASecondGuardOnTheSameDirectory)
+{
+    const Testing::TemporaryDirectory tempDir;
+    const auto workingDir = tempDir.get() / "work";
+
+    const WorkingDirectoryGuard guard{workingDir};
+
+    EXPECT_THROW(WorkingDirectoryGuard{workingDir}, Exception);
+    EXPECT_THROW(WorkingDirectoryGuard{workingDir.string() + "/"}, Exception);
+}
+
+TEST_F(WorkingDirectoryGuardTest, ReleasesTheDirectoryWhenTheGuardGoesOutOfScope)
+{
+    const Testing::TemporaryDirectory tempDir;
+    const auto workingDir = tempDir.get() / "work";
+
+    {
+        const WorkingDirectoryGuard guard{workingDir};
+    }
+
+    EXPECT_NO_THROW(WorkingDirectoryGuard{workingDir});
+}
+
+/// A guard that fails to take the lock has opened the directory already, and a constructor that throws runs no destructor,
+/// so the descriptor has to be owned by a member to be closed.
+TEST_F(WorkingDirectoryGuardTest, ClosesTheDirectoryWhenTheLockIsTaken)
+{
+    const Testing::TemporaryDirectory tempDir;
+    const auto workingDir = tempDir.get() / "work";
+    const WorkingDirectoryGuard guard{workingDir};
+
+    const auto before = openDescriptors();
+    EXPECT_THROW(WorkingDirectoryGuard{workingDir}, Exception);
+
+    EXPECT_EQ(openDescriptors(), before);
+}
+
+}

--- a/nes-systests/systest/tests/WorkingDirectoryGuardTests.cpp
+++ b/nes-systests/systest/tests/WorkingDirectoryGuardTests.cpp
@@ -20,11 +20,10 @@
 
 #include <gtest/gtest.h>
 
-#include <Util/Logger/LogLevel.hpp>
-#include <Util/Logger/Logger.hpp>
-#include <Util/Logger/impl/NesLogger.hpp>
+#include <Config/Config.hpp>
 #include <BaseUnitTest.hpp>
 #include <ErrorHandling.hpp>
+#include <Logging.hpp>
 #include <TemporaryDirectory.hpp>
 #include <WorkingDirectoryGuard.hpp>
 
@@ -46,7 +45,7 @@ namespace NES
 class WorkingDirectoryGuardTest : public Testing::BaseUnitTest
 {
 public:
-    static void SetUpTestSuite() { Logger::setupLogging("WorkingDirectoryGuardTest.log", LogLevel::LOG_DEBUG); }
+    static void SetUpTestSuite() { setupLogging(SystestConfiguration{}); }
 };
 
 TEST_F(WorkingDirectoryGuardTest, EmptiesTheDirectoryAndLeavesNoArtifacts)
@@ -54,7 +53,7 @@ TEST_F(WorkingDirectoryGuardTest, EmptiesTheDirectoryAndLeavesNoArtifacts)
     const Testing::TemporaryDirectory tempDir;
     const auto workingDir = tempDir.get() / "work";
     std::filesystem::create_directories(workingDir / "stale");
-    std::ofstream{workingDir / "stale.csv"};
+    const std::ofstream staleFile{workingDir / "stale.csv"};
 
     const WorkingDirectoryGuard guard{workingDir.string() + "/"};
 


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

Every systest invocation defaults to the same working directory,
`<build>/nes-systests/working-dir`, and clears it at startup. The directory
holds the data and result files, and both are tagged from the test file's name/path and the query number, so they repeat across invocations. 
A second run, therefore, could delete the files the first run was still reading, and the first run failed due to a missing or empty result file. 

The change list is as follows:

- Added `WorkingDirectoryGuard`. It creates the working directory, opens it
  with `O_DIRECTORY`, takes an exclusive `flock` on the directory itself, and
  empties it afterward.
- Changed `SystestExecutor` to build the guard where it used to remove and
  recreate the directory.
- Added the `private/` include directory to the systest library, for headers
  that the library uses but does not publish.

The lock lives on the directory's inode, so there is no lock file anywhere.
Emptying keeps the directory and removes every direct child, which preserves
the locked inode for the whole run. The kernel releases a `flock` however the
process ends, so a crashed run leaves nothing to remove by hand, and the lock
also holds across containers, which matters because each CI run is its own
container. Two containers that mount the same host directory open the same
inode, so the conflict is detected across mounts as well, and nothing is
written outside the working directory.

The guard reports a filesystem error with the path in the message, and it
creates nested working directories, which the previous single-level call did
not.

Two details from review:

- An earlier revision locked a sibling file, `<workingDir>.lock`, because a
  lock file inside the directory would be deleted when the guard empties it.
  The sibling left an artifact next to the directory, required write permission
  outside it, and needed the trailing separator of `--workingDir=/dir/` to be
  normalized away so that `/dir/` and `/dir` shared one lock. Locking the
  directory itself removes all three concerns, since `open` resolves both
  spellings to the same inode.
- The descriptor of the locked directory is owned by a member, not a bare
  `int`. A constructor that throws runs no destructor of its own, so a failure
  after the directory was opened (lock taken by another run, directory not
  clearable) would have leaked the descriptor and, with it, kept the lock for
  the rest of the process.

## Verifying this change

This change is tested by
- four unit tests in `slt-parser-test`: the guard empties a prepopulated
  directory and leaves no artifact inside or next to it, a second guard on the
  same directory is refused with or without a trailing separator, the lock is
  released when the guard goes out of scope, and a refused guard leaves no
  open descriptor behind
- starting a run against a working directory that another run holds. The second
  run stops with `another run holds the working directory <path>, and each would
  clear it under the other. Wait for that run, or pass --workingDir to use a
  different working directory`.
- the full corpus in the dev container, which passes with the guard in place
- a single test file run, which clears and repopulates its working directory as
  before

## What components does this pull request potentially affect?

- nes-systests.
- No dependency changes, and no test target changes.

## Issue Closed by this pull request:

This PR closes #1928.
