### PR TITLE
refactor(systest): interpret the run-related options into a run policy

### DIFF
--- a/nes-systests/systest/private/Config/Config.hpp
+++ b/nes-systests/systest/private/Config/Config.hpp
@@ -70,7 +70,7 @@ public:
     BoolOption remoteWorker = {"remote_worker", "false", "use remote worker"};
     StringOption clusterConfigPath = {"cluster_config", TEST_CONFIGURATION_DIR "/topologies/two-node.yaml", "cluster configuration"};
     BoolOption showQueryPerformance = {"show_query_performance", "false", "print per-query performance timing in the console output"};
-    BoolOption endlessMode = {"query_compiler_config", "false", "continuously issue queries to the worker"};
+    BoolOption endlessMode = {"endless_mode", "false", "continuously issue queries to the worker"};
 
     bool excludeGroupsConfiguredInDisableConfig = false;
     bool excludedGroupsProvidedOnCommandLine = false;

--- a/nes-systests/systest/private/Config/RunPolicy.hpp
+++ b/nes-systests/systest/private/Config/RunPolicy.hpp
@@ -1,0 +1,71 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <cstddef>
+#include <filesystem>
+#include <optional>
+#include <variant>
+
+namespace NES
+{
+
+/// Runs the queries in file order (default).
+struct RunInFileOrder
+{
+};
+
+/// Runs the queries in a random order, which is how tests that depend on each other are found.
+/// Every query in a run is submitted to the same worker, so a test can pass on state that an earlier query left behind.
+struct RunInShuffledOrder
+{
+};
+
+using OrderingPolicy = std::variant<RunInFileOrder, RunInShuffledOrder>;
+
+/// Submits every query once (default).
+struct SubmitOnce
+{
+};
+
+/// Submits the queries round after round, until something outside the run stops it.
+struct SubmitUntilStopped
+{
+};
+
+using RepetitionPolicy = std::variant<SubmitOnce, SubmitUntilStopped>;
+
+class SystestConfiguration;
+
+/// One invocation's policy, read once from the systest config.
+struct RunPolicy
+{
+    RunPolicy() = delete;
+
+    /// Reads the options into the policy that the run follows.
+    [[nodiscard]] static RunPolicy create(const SystestConfiguration& config);
+
+    OrderingPolicy ordering;
+    /// How many queries the run submits at once.
+    size_t concurrency;
+    RepetitionPolicy repetition;
+    /// `std::nullopt` means the run measures nothing.
+    std::optional<std::filesystem::path> measureReport;
+
+private:
+    RunPolicy(OrderingPolicy ordering, size_t concurrency, RepetitionPolicy repetition, std::optional<std::filesystem::path> measureReport);
+};
+
+}

--- a/nes-systests/systest/private/SystestExecutor.hpp
+++ b/nes-systests/systest/private/SystestExecutor.hpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <Config/Config.hpp>
+#include <Config/RunPolicy.hpp>
 #include <Runner/SystestRunner.hpp>
 #include <ErrorHandling.hpp>
 #include <Progress.hpp>
@@ -48,7 +49,7 @@ public:
     SystestExecutorResult executeSystests();
 
 private:
-    void runEndlessMode(const std::vector<Systest::SystestQuery>& queries);
+    void runEndlessMode(const std::vector<Systest::SystestQuery>& queries, const RunPolicy& policy);
 
     SystestConfiguration config;
     Systest::SystestProgressTracker progressTracker;

--- a/nes-systests/systest/src/Config/CMakeLists.txt
+++ b/nes-systests/systest/src/Config/CMakeLists.txt
@@ -13,4 +13,5 @@
 add_source_files(nes-systest-lib
         Config.cpp
         ConfigParser.cpp
+        RunPolicy.cpp
 )

--- a/nes-systests/systest/src/Config/ConfigParser.cpp
+++ b/nes-systests/systest/src/Config/ConfigParser.cpp
@@ -159,16 +159,19 @@ void applyBenchmarkMode(const ArgumentParser& program, NES::SystestConfiguration
     }
 
     config.benchmark = true;
+    /// A measuring run is limited to one query at a time, so -b and -n above 1 contradict each other.
     if ((program.is_used("-n") || program.is_used("--numberConcurrentQueries")) && program.get<int>("--numberConcurrentQueries") > 1)
     {
-        NES_ERROR("Cannot run systest in Benchmarking mode with concurrency enabled!");
-        std::cout << "Cannot run systest in benchmarking mode with concurrency enabled!\n";
+        const auto message = fmt::format(
+            "Cannot combine -b with -n {}: a measuring run submits one query at a time. Drop one of the two.",
+            program.get<int>("--numberConcurrentQueries"));
+        NES_ERROR("{}", message);
+        std::cout << message << '\n';
         std::exit(-1); ///NOLINT(concurrency-mt-unsafe)
     }
 
     std::cout << "Running systests in benchmarking mode. Only one query is run at a time!\n";
     std::cout << "Any included differential queries and queries expecting an error will be skipped.\n";
-    config.numberConcurrentQueries = 1;
 }
 
 void applyDebugMode(const ArgumentParser& program)

--- a/nes-systests/systest/src/Config/RunPolicy.cpp
+++ b/nes-systests/systest/src/Config/RunPolicy.cpp
@@ -1,0 +1,52 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Config/RunPolicy.hpp>
+
+#include <cstddef>
+#include <filesystem>
+#include <optional>
+#include <utility>
+
+#include <Config/Config.hpp>
+
+namespace NES
+{
+
+RunPolicy::RunPolicy(
+    const OrderingPolicy ordering,
+    const size_t concurrency,
+    const RepetitionPolicy repetition,
+    std::optional<std::filesystem::path> measureReport)
+    : ordering(ordering), concurrency(concurrency), repetition(repetition), measureReport(std::move(measureReport))
+{
+}
+
+RunPolicy RunPolicy::create(const SystestConfiguration& config)
+{
+    const auto measuring = config.benchmark.getValue();
+    /// A measuring run submits one query at a time, because queries that run together share the worker and their timings
+    /// would depend on each other.
+    const auto concurrency = measuring ? 1 : config.numberConcurrentQueries.getValue();
+    const auto measureReport
+        = measuring ? std::optional{std::filesystem::path{config.workingDir.getValue()} / "BenchmarkResults.json"} : std::nullopt;
+
+    return RunPolicy{
+        config.randomQueryOrder.getValue() ? OrderingPolicy{RunInShuffledOrder{}} : OrderingPolicy{RunInFileOrder{}},
+        concurrency,
+        config.endlessMode.getValue() ? RepetitionPolicy{SubmitUntilStopped{}} : RepetitionPolicy{SubmitOnce{}},
+        measureReport};
+}
+
+}

--- a/nes-systests/systest/src/SystestExecutor.cpp
+++ b/nes-systests/systest/src/SystestExecutor.cpp
@@ -35,6 +35,7 @@
 #include <variant>
 #include <vector>
 #include <Config/Config.hpp>
+#include <Config/RunPolicy.hpp>
 #include <Discovery/TestDiscovery.hpp>
 #include <Identifiers/NESStrongTypeYaml.hpp> ///NOLINT(misc-include-cleaner)
 #include <Model/ConfigurationOverride.hpp>
@@ -166,11 +167,11 @@ SystestExecutor::SystestExecutor(SystestConfiguration config) : config(std::move
 {
 }
 
-void SystestExecutor::runEndlessMode(const std::vector<Systest::SystestQuery>& queries)
+void SystestExecutor::runEndlessMode(const std::vector<Systest::SystestQuery>& queries, const RunPolicy& policy)
 {
     std::cout << std::format("Running endlessly over a total of {} queries (across all configuration overrides).", queries.size()) << '\n';
 
-    const auto numberConcurrentQueries = config.numberConcurrentQueries.getValue();
+    const auto numberConcurrentQueries = policy.concurrency;
     auto singleNodeWorkerConfiguration = config.singleNodeWorkerConfig.value_or(SingleNodeWorkerConfiguration{});
     if (not config.workerConfig.getValue().empty())
     {
@@ -203,6 +204,7 @@ void SystestExecutor::runEndlessMode(const std::vector<Systest::SystestQuery>& q
 SystestExecutorResult SystestExecutor::executeSystests()
 {
     setupLogging(config);
+    const auto policy = RunPolicy::create(config);
 
     CPPTRACE_TRY
     {
@@ -241,21 +243,21 @@ SystestExecutorResult SystestExecutor::executeSystests()
 
         progressTracker.reset();
 
-        if (config.endlessMode)
+        if (std::holds_alternative<SubmitUntilStopped>(policy.repetition))
         {
-            runEndlessMode(queries);
+            runEndlessMode(queries, policy);
             return {
                 .returnType = SystestExecutorResult::ReturnType::FAILED,
                 .outputMessage = "Endless mode should not stop.",
                 .errorCode = ErrorCode::TestException};
         }
 
-        if (config.randomQueryOrder)
+        if (std::holds_alternative<RunInShuffledOrder>(policy.ordering))
         {
             std::mt19937 rng(std::random_device{}());
             std::ranges::shuffle(queries, rng);
         }
-        const auto numberConcurrentQueries = config.numberConcurrentQueries.getValue();
+        const auto numberConcurrentQueries = policy.concurrency;
         std::vector<Systest::RunningQuery> failedQueries;
         if (config.remoteWorker.getValue())
         {
@@ -280,7 +282,7 @@ SystestExecutorResult SystestExecutor::executeSystests()
             {
                 singleNodeWorkerConfiguration = config.singleNodeWorkerConfig.value();
             }
-            if (config.benchmark)
+            if (policy.measureReport.has_value())
             {
                 std::vector<Systest::BenchmarkResult> benchmarkResults;
                 std::vector<Systest::SystestQuery> benchmarkQueries;
@@ -328,7 +330,7 @@ SystestExecutorResult SystestExecutor::executeSystests()
                 }
                 const auto serializedResults = rfl::json::write(benchmarkResults, rfl::json::pretty);
                 std::cout << serializedResults;
-                const auto outputPath = std::filesystem::path(config.workingDir.getValue()) / "BenchmarkResults.json";
+                const auto& outputPath = *policy.measureReport;
                 std::ofstream outputFile(outputPath);
                 outputFile << serializedResults;
                 outputFile.close();

--- a/nes-systests/systest/tests/CMakeLists.txt
+++ b/nes-systests/systest/tests/CMakeLists.txt
@@ -23,6 +23,9 @@ endfunction()
 add_nes_test_systest(systest-test-discovery-test
         "Discovery/TestDiscoveryTests.cpp")
 
+add_nes_test_systest(systest-run-policy-test
+        "Config/RunPolicyTests.cpp")
+
 add_nes_test_systest(slt-parser-test
         "Parser/SystestParserTests.cpp"
         "Parser/SystestParserInvalidTestFilesTests.cpp"

--- a/nes-systests/systest/tests/Config/RunPolicyTests.cpp
+++ b/nes-systests/systest/tests/Config/RunPolicyTests.cpp
@@ -1,0 +1,59 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Config/Config.hpp>
+#include <Config/RunPolicy.hpp>
+#include <Util/Logger/LogLevel.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <Util/Logger/impl/NesLogger.hpp>
+#include <gtest/gtest.h>
+#include <BaseUnitTest.hpp>
+
+namespace NES
+{
+
+class RunPolicyTest : public Testing::BaseUnitTest
+{
+public:
+    static void SetUpTestSuite()
+    {
+        Logger::setupLogging("RunPolicyTest.log", LogLevel::LOG_DEBUG);
+        NES_DEBUG("Setup RunPolicyTest test class.");
+    }
+
+    static void TearDownTestSuite() { NES_DEBUG("Tear down RunPolicyTest test class."); }
+};
+
+TEST_F(RunPolicyTest, AMeasuringRunNamesItsReportUnderTheWorkingDirectory)
+{
+    SystestConfiguration config;
+    config.benchmark = true;
+    config.workingDir = "/tmp/systest-run-policy-test";
+
+    const auto policy = RunPolicy::create(config);
+
+    ASSERT_TRUE(policy.measureReport.has_value());
+    EXPECT_EQ(policy.measureReport.value(), "/tmp/systest-run-policy-test/BenchmarkResults.json");
+}
+
+TEST_F(RunPolicyTest, AMeasuringRunSubmitsOneQueryAtATime)
+{
+    SystestConfiguration config;
+    config.benchmark = true;
+    config.numberConcurrentQueries = 4;
+
+    EXPECT_EQ(RunPolicy::create(config).concurrency, 1);
+}
+
+}


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

Stacked on #1929.

The executor decided what a run does from individual options of `SystestConfiguration`: whether to
shuffle the queries, how many to submit at once, whether to keep issuing them,
and whether to record timings.
These options are logically related and belong together, since they define how to run a test battery.

The change list is as follows:

- Added `Config/RunPolicy`, holding an ordering (`RunInFileOrder` or
  `RunInShuffledOrder`), a concurrency, a repetition (`SubmitOnce` or
  `SubmitUntilStopped`) and, for a measuring run, the report that it writes.
  `RunPolicy::create` is the only way to build one (private constructor), so a
  measuring run cannot be handed more than one query at a time.
- Changed `SystestExecutor` to follow the policy rather than the options.
- Bugfix: gave the endless mode option the correct key. It had
  `query_compiler_config`, the key of the query compiler config option, so a
  config file could set neither of the two on its own.

## Verifying this change

This change is tested by
- two unit tests in `systest-run-policy-test`: a measuring run submits one
  query at a time (the rule the parser's `-b`/`-n` check and the executor rely
  on), and its report is `<workingDir>/BenchmarkResults.json` (the name
  `scripts/benchmarking/benchmark.py` reads)
- format and clang-tidy on the changed lines

## What components does this pull request potentially affect?

- nes-systests only: the run options, and how the executor reads them.
- Configuration: the endless mode option answers to `endless_mode` rather than
  to the key of another option.
- One new test target, `systest-run-policy-test`. No dependency changes.

## Documentation

- `RunPolicy` has in-code documentation for each policy, and for what a
  measuring run does.

## Issue Closed by this pull request:

This PR closes #1927.


