### PR TITLE
fix(config): Fix scalar SequenceOption CLI parsing

### DIFF
--- a/nes-configurations/include/Configurations/ScalarOption.hpp
+++ b/nes-configurations/include/Configurations/ScalarOption.hpp
@@ -159,11 +159,11 @@ void ScalarOption<T>::parseFromYAMLNode(YAML::Node node)
 template <class T>
 void ScalarOption<T>::parseFromString(std::string identifier, std::unordered_map<std::string, std::string>& inputParams)
 {
-    if (!inputParams.contains(this->getName()))
+    if (!inputParams.contains(identifier))
     {
         throw InvalidConfigParameter("Identifier {} is not known.", identifier);
     }
-    std::string value = inputParams[this->getName()];
+    std::string value = inputParams[identifier];
     if (value.empty())
     {
         throw InvalidConfigParameter("Identifier {} is not known.", identifier);

--- a/nes-configurations/tests/CMakeLists.txt
+++ b/nes-configurations/tests/CMakeLists.txt
@@ -13,5 +13,10 @@
 # Google Testing Framework ----------------------------------------------------
 include(ExternalProject)
 ### Config Tests ###
-add_nes_unit_test(configuration-help-message-tests "UnitTests/Configurations/ConfigurationHelpMessageTests.cpp" "UnitTests/Validation/EndpointValidationTest.cpp" "UnitTests/Configurations/ExplicitlySetTrackingTests.cpp")
+add_nes_unit_test(
+    configuration-help-message-tests
+    "UnitTests/Configurations/ConfigurationHelpMessageTests.cpp"
+    "UnitTests/Configurations/ExplicitlySetTrackingTests.cpp"
+    "UnitTests/Configurations/SequenceOptionTests.cpp"
+    "UnitTests/Validation/EndpointValidationTest.cpp")
 set_tests_properties(${Tests} PROPERTIES TIMEOUT 35)

--- a/nes-configurations/tests/UnitTests/Configurations/SequenceOptionTests.cpp
+++ b/nes-configurations/tests/UnitTests/Configurations/SequenceOptionTests.cpp
@@ -1,0 +1,133 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <cstddef>
+#include <string>
+#include <vector>
+#include <Configurations/BaseConfiguration.hpp>
+#include <Configurations/BaseOption.hpp>
+#include <Configurations/ScalarOption.hpp>
+#include <Configurations/SequenceOption.hpp>
+#include <Util/Logger/LogLevel.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <gtest/gtest.h>
+#include <yaml-cpp/yaml.h>
+#include <BaseIntegrationTest.hpp>
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+
+class ScalarSequenceConfiguration final : public BaseConfiguration
+{
+public:
+    SequenceOption<StringOption> testGroups{"test_groups", "Test groups to run"};
+    SequenceOption<UIntOption> testQueryNumbers{"test_query_numbers", "Test query numbers to run"};
+
+protected:
+    std::vector<BaseOption*> getOptions() override { return {&testGroups, &testQueryNumbers}; }
+};
+
+class SequenceOptionCliParsingTest : public Testing::BaseIntegrationTest
+{
+public:
+    static void SetUpTestSuite() { Logger::setupLogging("SequenceOptionCliParsingTest.log", LogLevel::LOG_DEBUG); }
+};
+
+TEST_F(SequenceOptionCliParsingTest, ParsesStringValueFromNormalKey)
+{
+    ScalarSequenceConfiguration config;
+
+    EXPECT_NO_THROW(config.overwriteConfigWithCommandLineInput({{"--test_groups", "Join"}}));
+
+    ASSERT_EQ(config.testGroups.size(), 1U);
+    EXPECT_EQ(config.testGroups[0].getValue(), "Join");
+}
+
+TEST_F(SequenceOptionCliParsingTest, ParsesUnsignedIntegerValueFromNormalKey)
+{
+    ScalarSequenceConfiguration config;
+
+    EXPECT_NO_THROW(config.overwriteConfigWithCommandLineInput({{"--test_query_numbers", "42"}}));
+
+    ASSERT_EQ(config.testQueryNumbers.size(), 1U);
+    EXPECT_EQ(config.testQueryNumbers[0].getValue(), 42U);
+}
+
+TEST_F(SequenceOptionCliParsingTest, RejectsTrailingDotKey)
+{
+    ScalarSequenceConfiguration config;
+
+    EXPECT_THROW(config.overwriteConfigWithCommandLineInput({{"--test_groups.", "Join"}}), Exception);
+    EXPECT_TRUE(config.testGroups.empty());
+}
+
+TEST_F(SequenceOptionCliParsingTest, RejectsEmptyValue)
+{
+    ScalarSequenceConfiguration config;
+
+    EXPECT_THROW(config.overwriteConfigWithCommandLineInput({{"--test_groups", ""}}), Exception);
+    EXPECT_TRUE(config.testGroups.empty());
+}
+
+TEST_F(SequenceOptionCliParsingTest, DoesNotSplitCommaSeparatedStringValue)
+{
+    ScalarSequenceConfiguration config;
+
+    EXPECT_NO_THROW(config.overwriteConfigWithCommandLineInput({{"--test_groups", "Join,Aggregation"}}));
+
+    ASSERT_EQ(config.testGroups.size(), 1U);
+    EXPECT_EQ(config.testGroups[0].getValue(), "Join,Aggregation");
+}
+
+TEST_F(SequenceOptionCliParsingTest, PreservesYamlSequenceParsing)
+{
+    ScalarSequenceConfiguration config;
+    const auto yaml = YAML::Load(R"(
+test_groups:
+  - Join
+  - Aggregation
+test_query_numbers:
+  - 3
+  - 7
+)");
+
+    EXPECT_NO_THROW(config.overwriteConfigWithYAMLNode(yaml));
+
+    ASSERT_EQ(config.testGroups.size(), 2U);
+    EXPECT_EQ(config.testGroups[0].getValue(), "Join");
+    EXPECT_EQ(config.testGroups[1].getValue(), "Aggregation");
+    ASSERT_EQ(config.testQueryNumbers.size(), 2U);
+    EXPECT_EQ(config.testQueryNumbers[0].getValue(), 3U);
+    EXPECT_EQ(config.testQueryNumbers[1].getValue(), 7U);
+}
+
+TEST_F(SequenceOptionCliParsingTest, PreservesProgrammaticAdd)
+{
+    ScalarSequenceConfiguration config;
+
+    config.testGroups.add("Join");
+    config.testGroups.add("Aggregation");
+    config.testQueryNumbers.add(3U);
+    config.testQueryNumbers.add(7U);
+
+    ASSERT_EQ(config.testGroups.size(), 2U);
+    EXPECT_EQ(config.testGroups[0].getValue(), "Join");
+    EXPECT_EQ(config.testGroups[1].getValue(), "Aggregation");
+    ASSERT_EQ(config.testQueryNumbers.size(), 2U);
+    EXPECT_EQ(config.testQueryNumbers[0].getValue(), 3U);
+    EXPECT_EQ(config.testQueryNumbers[1].getValue(), 7U);
+}
+
+}


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

Fix scalar `SequenceOption` command-line parsing.

`SequenceOption` passes the option identifier to `ScalarOption::parseFromString()`, but the parser previously looked up `this->getName()`, which is empty for the temporary scalar option. As a result, valid arguments such as `--test_groups=Join` failed to parse.

This change makes `ScalarOption::parseFromString()` use the supplied identifier and adds regression coverage.

## Verifying this change

- Added string `SequenceOption` CLI parsing coverage.
- Added unsigned-integer `SequenceOption` CLI parsing coverage.
- Verified malformed trailing-dot keys are rejected.
- Verified comma-separated scalar values are not split.
- Verified YAML sequence parsing remains unchanged.
- Verified programmatic `.add()` behavior remains unchanged.
- Full Debug build passed.
- Formatting check passed.
- All 921 enabled tests passed.
- One existing test remains intentionally disabled.

## What components does this pull request potentially affect?

- `nes-configurations`
- Scalar and sequence configuration option parsing

## Documentation

No documentation changes are required.

The configuration rework may replace this implementation later, but the regression tests should preserve the expected behavior.

## Issue Closed by this pull request

This PR closes #1908