### PR TITLE
feat(systest): SQL rewriter

### DIFF
--- a/nes-systests/systest/CMakeLists.txt
+++ b/nes-systests/systest/CMakeLists.txt
@@ -95,7 +95,7 @@ find_package(reflectcpp CONFIG REQUIRED)
 find_package(argparse CONFIG REQUIRED)
 
 add_library(nes-systest-lib STATIC ${SLT_SOURCE_FILES})
-target_link_libraries(nes-systest-lib PUBLIC nes-schema nes-frontend-embedded-lib nes-single-node-worker-lib nes-sql-parser nes-query-optimizer reflectcpp::reflectcpp PRIVATE nes-input-formatters argparse::argparse)
+target_link_libraries(nes-systest-lib PUBLIC nes-schema nes-frontend-embedded-lib nes-single-node-worker-lib nes-sql-parser nes-query-optimizer reflectcpp::reflectcpp PRIVATE nes-input-formatters argparse::argparse tcp_source_plugin_library)
 target_include_directories(nes-systest-lib PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/private>)
 target_compile_definitions(nes-systest-lib PUBLIC
         PATH_TO_BINARY_DIR="${CMAKE_BINARY_DIR}"

--- a/nes-systests/systest/private/Model/RewrittenTest.hpp
+++ b/nes-systests/systest/private/Model/RewrittenTest.hpp
@@ -1,0 +1,150 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include <Identifiers/Identifiers.hpp>
+#include <Model/Expectation.hpp>
+
+namespace NES
+{
+
+/// The rewriter decides the path and the contents, and the runner writes the file before submitting the statement.
+struct InlineData
+{
+    /// The CSV file that will store the rows declared under `ATTACH INLINE`
+    std::filesystem::path path;
+    /// Holds the actual input tuples declared under `ATTACH INLINE`
+    std::vector<std::string> rows;
+    bool operator==(const InlineData& other) const = default;
+};
+
+/// The data for a TCP source, send by an in-process TCP server.
+/// The runner learns the port only once that server binds, so it adds the endpoint to the statement afterwards.
+struct ServedData
+{
+    /// Either inline rows, or read from a file.
+    std::variant<std::vector<std::string>, std::filesystem::path> content;
+};
+
+/// A setup statement the runner submits as is: sink, model and logical source DDL, and a physical source with no data to stage.
+struct PlainStatement
+{
+    std::string sql;
+};
+
+/// A physical source whose inline rows the runner writes to a CSV before submitting.
+struct StatementWithInlineData
+{
+    std::string sql;
+    InlineData data;
+};
+
+/// A TCP source whose data a server sends.
+/// The runner starts the server and merges its endpoint into this statement's sql before submitting.
+struct StatementWithServedData
+{
+    std::string sql;
+    ServedData data;
+};
+
+/// One statement to submit before the queries, as the action the runner takes for it.
+using SetupStatement = std::variant<PlainStatement, StatementWithInlineData, StatementWithServedData>;
+
+/// The statement text of any setup alternative.
+inline const std::string& sqlOf(const SetupStatement& statement)
+{
+    return std::visit([](const auto& alternative) -> const std::string& { return alternative.sql; }, statement);
+}
+
+/// One query to submit.
+struct RewrittenQuery
+{
+    std::string sql;
+    /// The query's number in the test file, so a reported result points back at it.
+    SystestQueryId id;
+    /// Absent when there is nothing to compare: the sink discards its input (e.g., `VoidSink`), or the statement does not
+    /// parse and never runs.
+    std::optional<std::filesystem::path> resultFile;
+
+    Expectation expectation;
+};
+
+/// Both halves of a differential block, which asserts only that the two results agree.
+/// Each half writes a result file of its own, because one shared file would compare a result against itself.
+struct RewrittenDifferential
+{
+    std::string firstSql;
+    SystestQueryId firstId;
+    std::filesystem::path firstResultFile;
+    std::string secondSql;
+    SystestQueryId secondId;
+    std::filesystem::path secondResultFile;
+};
+
+/// One EXPLAIN to submit: it starts no query and writes no file, and the plan it prints is the answer.
+struct RewrittenExplain
+{
+    std::string sql;
+    SystestQueryId id;
+    ExpectedPlan expected;
+};
+
+/// One test case in a test file.
+/// A case is the unit that gets a verdict (i.e., PASSED || FAILED).
+struct RewrittenCase
+{
+    std::variant<RewrittenQuery, RewrittenDifferential, RewrittenExplain> action;
+    /// The data files of this case's sources, once per reference, so a query that joins a source with itself counts
+    /// it twice, and a differential block counts both halves.
+    /// A measurement derives throughput from their size, and a source that generates its own rows contributes none.
+    std::vector<std::filesystem::path> inputFiles;
+    /// Whether the case before this one has to reach a terminal state before this one is submitted.
+    /// A file marked `SEQUENTIAL_EXECUTION` sets this on every case.
+    bool runsAfterPrevious = false;
+};
+
+inline SystestQueryId caseNumber(const RewrittenCase& testCase)
+{
+    if (const auto* query = std::get_if<RewrittenQuery>(&testCase.action))
+    {
+        return query->id;
+    }
+    if (const auto* explain = std::get_if<RewrittenExplain>(&testCase.action))
+    {
+        return explain->id;
+    }
+    return std::get<RewrittenDifferential>(testCase.action).firstId;
+}
+
+/// One runnable test file.
+/// The rewriter produces this and the runner consumes it.
+struct RewrittenTest
+{
+    /// Name for reporting failure/progress.
+    std::string name;
+    /// The prefix that qualifying put in front of every catalog-visible name, so a consumer comparing printed
+    /// plans can strip it and read the names the test wrote originally.
+    std::string qualifyingPrefix;
+    std::vector<SetupStatement> setupStatements;
+    std::vector<RewrittenCase> cases;
+};
+
+}

--- a/nes-systests/systest/private/Rewriter/ClassifiedStatement.hpp
+++ b/nes-systests/systest/private/Rewriter/ClassifiedStatement.hpp
@@ -1,0 +1,80 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <memory>
+#include <variant>
+#include <vector>
+
+#include <AntlrSQLParser.h>
+
+#include <Model/ParsedTestFile.hpp>
+#include <Rewriter/SqlParse.hpp>
+
+namespace NES
+{
+
+struct LogicalSourceDeclaration
+{
+    AntlrSQLParser::CreateLogicalSourceDefinitionContext* definition;
+};
+
+struct PhysicalSourceDeclaration
+{
+    AntlrSQLParser::CreatePhysicalSourceDefinitionContext* definition;
+    /// Null when the source produces its own rows (e.g., `GeneratorSource`) instead of reading attached data.
+    /// A pointer into the test file's statement, which outlives one rewrite.
+    const AttachedData* attached = nullptr;
+};
+
+struct SinkDeclaration
+{
+    AntlrSQLParser::CreateSinkDefinitionContext* definition;
+};
+
+struct ModelDeclaration
+{
+    AntlrSQLParser::CreateModelDefinitionContext* definition;
+};
+
+using CreateDeclaration = std::variant<LogicalSourceDeclaration, PhysicalSourceDeclaration, SinkDeclaration, ModelDeclaration>;
+
+/// A pointer holds the parse, because a parse refers to its own members and cannot be moved.
+/// The declaration points into that parse and the statement into the caller's test file, so both outlive one rewrite.
+struct ClassifiedCreate
+{
+    const CreateStatement* create;
+    std::unique_ptr<SqlParse> parse;
+    CreateDeclaration declaration;
+};
+
+/// A CREATE is parsed and classified, because both later phases need that.
+/// The other statements pass through classification as bare pointers,
+/// because rewriting them needs the qualified names, which do not exist after classification.
+/// The test file owning them outlives every phase of one rewrite, so this is safe.
+using ClassifiedStatement = std::variant<ClassifiedCreate, const SelectStatement*, const DifferentialStatement*, const ExplainStatement*>;
+
+struct ClassifiedTest
+{
+    std::vector<ClassifiedStatement> statements;
+    /// A file containing an EXPLAIN submits its sink declarations (they can't be turned to anonymous sinks),
+    /// because the test author needs to match the expectation on the declared names.
+    bool containsExplain = false;
+};
+
+/// Parses and classifies every CREATE statement of the file, in the order the test wrote them.
+[[nodiscard]] ClassifiedTest classifyStatements(const ParsedTestFile& testFile);
+
+}

--- a/nes-systests/systest/private/Rewriter/Constants.hpp
+++ b/nes-systests/systest/private/Rewriter/Constants.hpp
@@ -1,0 +1,112 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
+#include <Identifiers/Identifier.hpp>
+#include <Util/Strings.hpp>
+
+/// SQL building blocks the rewriter emits.
+/// These names are identifiers the binder interprets rather than grammar tokens, so ANTLR cannot supply them.
+namespace NES::Sql
+{
+
+/// Config groups
+/// The rewriter quotes them, so the parser treats a group whose name is also a keyword as an identifier.
+constexpr auto Source = "SOURCE";
+constexpr auto Sink = "SINK";
+constexpr auto InputFormatter = "INPUT_FORMATTER";
+constexpr auto OutputFormatter = "OUTPUT_FORMATTER";
+
+/// Config keys within the groups.
+constexpr auto FilePath = "FILE_PATH";
+constexpr auto Host = "HOST";
+constexpr auto OutputFormat = "OUTPUT_FORMAT";
+constexpr auto Type = "TYPE";
+constexpr auto Schema = "SCHEMA";
+constexpr auto QuoteStrings = "QUOTE_STRINGS";
+
+/// Default format
+constexpr auto Csv = "CSV";
+
+/// Sink type that discards its input.
+/// The rewriter recognizes it because it takes no arguments and produces no result.
+constexpr auto Void = "Void";
+
+/// Sink type that writes a checksum over its rows instead of the rows.
+/// The rewriter recognizes it because the expected checksums were computed over quoted strings, so it quotes them
+/// unless the test chose otherwise.
+constexpr auto Checksum = "CHECKSUM";
+
+/// The rewriter recognizes it because a server sends its attached data, and the port is known only once the server binds.
+constexpr auto Tcp = "TCP";
+/// Config keys for a TCP source.
+constexpr auto SocketHost = "SOCKET_HOST";
+constexpr auto SocketPort = "SOCKET_PORT";
+constexpr auto FlushIntervalMs = "FLUSH_INTERVAL_MS";
+
+/// Returns whether two spellings resolve to the same name under the binder's case rules.
+/// A quoted and an unquoted spelling of one name match, and two unquoted spellings differing only in case match.
+inline bool sameName(const std::string_view left, const std::string_view right)
+{
+    return Identifier::parse(std::string{left}) == Identifier::parse(std::string{right});
+}
+
+/// Returns the value as a SQL string literal.
+/// A quote inside the value is doubled, so a path or a pattern holding one cannot end the literal early.
+inline std::string stringLiteral(const std::string_view value)
+{
+    return fmt::format("'{}'", replaceAll(value, "'", "''"));
+}
+
+/// Returns one config option, `'value' AS "group"."key"`.
+/// Both names are quoted, so the parser treats a name that is or becomes a keyword as an identifier and no caller has to distinguish.
+inline std::string option(const std::string_view group, const std::string_view key, const std::string_view value)
+{
+    return fmt::format(R"({} AS "{}"."{}")", stringLiteral(value), group, key);
+}
+
+/// Returns a config option whose value is a schema literal rather than a quoted string, `SCHEMA<body> AS "group"."SCHEMA"`.
+/// The leading `SCHEMA` is the schema-literal keyword, and the trailing quoted `SCHEMA` is the config key.
+inline std::string schemaOption(const std::string_view group, const std::string_view schemaBody)
+{
+    return fmt::format(R"({}{} AS "{}"."{}")", Schema, schemaBody, group, Schema);
+}
+
+/// Joins config options into the body of a `SET` clause or a parameter list.
+inline std::string optionList(const std::vector<std::string>& options)
+{
+    return fmt::to_string(fmt::join(options, ", "));
+}
+
+/// Wraps an option body in the `SET` clause that holds a statement's config.
+inline std::string setClause(const std::string_view body)
+{
+    return fmt::format("SET ({})", body);
+}
+
+/// Wraps an option body in an anonymous sink of the given type, such as File or Checksum.
+inline std::string sink(const std::string_view type, const std::string_view body)
+{
+    return fmt::format("{}({})", type, body);
+}
+
+}

--- a/nes-systests/systest/private/Rewriter/Declarations.hpp
+++ b/nes-systests/systest/private/Rewriter/Declarations.hpp
@@ -1,0 +1,38 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <string>
+
+#include <Rewriter/ClassifiedStatement.hpp>
+#include <Rewriter/NameQualifier.hpp>
+#include <Rewriter/SinkRewriting.hpp>
+
+namespace NES
+{
+
+/// What is catalog-visible for one test file: each name's qualified spelling, and each declared sink's definition.
+/// The declaring phase produces this, and the emitting phase rewrites every statement against it.
+struct Declarations
+{
+    QualifiedNames names;
+    SinkByName sinkByName;
+};
+
+/// Registers every catalog-visible name of the file before the emitting phase rewrites any statement against it.
+/// Rewriting substitutes only registered names, so declaring everything first lets a statement refer to a name declared further down.
+Declarations declareAll(ClassifiedTest& classified, const std::string& testFileKey);
+
+}

--- a/nes-systests/systest/private/Rewriter/Emitter.hpp
+++ b/nes-systests/systest/private/Rewriter/Emitter.hpp
@@ -1,0 +1,84 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include <Identifiers/Identifier.hpp>
+#include <Identifiers/Identifiers.hpp>
+#include <Model/RewrittenTest.hpp>
+#include <Rewriter/ClassifiedStatement.hpp>
+#include <Rewriter/Declarations.hpp>
+#include <Rewriter/RewriteTarget.hpp>
+#include <Rewriter/SinkRewriting.hpp>
+#include <Rewriter/SourceRewriting.hpp>
+#include <Rewriter/SqlParse.hpp>
+
+namespace NES
+{
+
+/// The emitting phase of one rewrite.
+/// An instance emits exactly one test file, so no state reaches the next rewrite.
+/// The declaring phase's declarations come in through the constructor and stays constant while emitting.
+class Emitter
+{
+public:
+    Emitter(const RewriteTarget& target, Declarations declarations);
+
+    /// Emits the setup statements, then the cases, and returns the assembled test.
+    [[nodiscard]] RewrittenTest emit(ClassifiedTest& classified) &&;
+
+private:
+    /// One statement's SQL after the full query rewrite, and what the rewrite learned about it.
+    /// The query, differential and EXPLAIN paths each wrap this into their own case.
+    struct RewrittenSql
+    {
+        std::string sql;
+        std::optional<std::filesystem::path> resultFile;
+        std::vector<std::filesystem::path> inputFiles;
+    };
+
+    /// The first pass: rewrites every CREATE into a setup statement, which also records the data file of each source,
+    /// so a query emitted by the second pass can resolve its input files wherever its ATTACH stands in the file.
+    void emitSetup(std::vector<ClassifiedStatement>& statements, bool submitsDeclaredSinks);
+    /// The second pass: rewrites everything that is not a CREATE into a case, in file order.
+    void emitCases(std::vector<ClassifiedStatement>& statements);
+
+    [[nodiscard]] RewrittenSql rewriteSql(const std::string& sql, SystestQueryId id, std::string_view resultDiscriminator);
+    void emitCreate(ClassifiedCreate& create, bool submitsDeclaredSinks);
+    void emitExplain(const ExplainStatement& explain);
+    void emitDifferential(const DifferentialStatement& block);
+
+    /// Builds the model statement to submit, pointing at the file that holds the model.
+    /// A test gives that path relative to the test data directory, but the worker loading it resolves a relative path against its own
+    /// working directory, so the path has to be absolute.
+    [[nodiscard]] PlainStatement modelStatement(SqlParse& parse, const ModelDeclaration& declaration) const;
+
+    const RewriteTarget& target;
+    Declarations declarations;
+    SourceRewriter sourceRewriter;
+    SinkRewriter sinkRewriter;
+
+    /// The data files that each logical source reads, filled by the setup pass and read by the case pass.
+    std::unordered_map<Identifier, std::vector<std::filesystem::path>> inputFilesBySource;
+    RewrittenTest runnable;
+};
+
+}

--- a/nes-systests/systest/private/Rewriter/NameQualifier.hpp
+++ b/nes-systests/systest/private/Rewriter/NameQualifier.hpp
@@ -1,0 +1,95 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <Identifiers/Identifier.hpp>
+
+namespace NES
+{
+
+/// Derives a catalog-legal key for a test file from its location under the discovery root.
+/// The directory is part of the key, so two files sharing a stem in different directories get distinct keys.
+/// The derivation is injective up to case, so no two files of one run share a key and collide in the shared catalog.
+std::string getTestFileKey(const std::filesystem::path& testFile, const std::filesystem::path& discoveryRoot);
+
+/// Derives the key of one part of a test file, when a file yields one runnable test per configuration combination.
+/// All parts declare the same names into the shared catalog, so each needs a key of its own or their entries would collide.
+/// A file with a single part keeps its own key, so the SQL that it emits does not change.
+std::string getTestFilePartKey(const std::string& testFileKey, size_t part, size_t parts);
+
+/// Maps a canonical name to its qualified spelling.
+/// The key type compares and hashes by canonical form, so two unquoted spellings differing only in case share an entry.
+using QualifiedByName = std::unordered_map<Identifier, std::string>;
+
+/// The catalog-visible names of one test file and each name's spelling, fixed once the registry has seen every name.
+/// The rewriter takes this rather than the registry that built it, so it cannot rewrite a statement while names are still missing.
+class QualifiedNames
+{
+public:
+    /// Returns the qualified spelling of a registered name, and nullopt for any other name.
+    /// The rewriter substitutes catalog-visible names and leaves column names and aliases untouched.
+    [[nodiscard]] std::optional<std::string> qualified(std::string_view name) const;
+
+    /// The prefix qualifying puts in front of every name, so a consumer can strip it from a text again.
+    [[nodiscard]] const std::string& qualifyingPrefix() const { return prefix; }
+
+private:
+    friend class NameRegistry;
+    QualifiedNames(QualifiedByName qualifiedByName, std::string prefix);
+
+    QualifiedByName qualifiedByName;
+    std::string prefix;
+};
+
+/// Collects the catalog-visible names of one test file, prefixing each with that file's key.
+/// Every test file of one invocation can then share a single catalog.
+/// Sealing hands the finished names to the rewriter and consumes the registry,
+/// so no caller can add a name once the rewriting phase started.
+class NameRegistry
+{
+public:
+    explicit NameRegistry(std::string testFileKey);
+
+    /// Returns the qualified spelling of a name, registering it on the first encounter.
+    /// Two spellings with the same canonical form map to one qualified name, so declaring a name twice changes nothing.
+    std::string declare(std::string_view name);
+
+    /// Hands the registered names to the rewriting that follows.
+    /// Rvalue-qualified, so the call site shows that sealing consumes the registry.
+    [[nodiscard]] QualifiedNames seal() &&;
+
+private:
+    std::string key;
+    QualifiedByName qualifiedByName;
+    /// Every spelling handed out so far, so the registry rejects two distinct names that qualify to one spelling.
+    std::unordered_set<std::string> takenSpellings;
+};
+
+/// Removes the qualifying prefix wherever it occurs in a text, so a plan reads as the test wrote it.
+/// A plain text scan rather than a lookup, because a printed plan is not a statement and has no tokens to read.
+std::string unqualified(std::string_view text, std::string_view qualifyingPrefix);
+
+/// Rewrites the identifiers of a SQL statement to their qualified spellings and copies every other token unchanged.
+/// Only registered names change, so column names, aliases, keywords and string literals stay as the test wrote them.
+std::string rewriteIdentifiers(std::string_view sql, const QualifiedNames& names);
+
+}

--- a/nes-systests/systest/private/Rewriter/RewriteTarget.hpp
+++ b/nes-systests/systest/private/Rewriter/RewriteTarget.hpp
@@ -1,0 +1,62 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <cstddef>
+#include <filesystem>
+#include <string>
+#include <string_view>
+
+#include <fmt/format.h>
+
+#include <Identifiers/Identifiers.hpp>
+
+namespace NES
+{
+
+/// Context of one test file's rewrite.
+/// The key qualifies the catalog-visible names, the working directory takes the generated data and result files, and the
+/// test data directory holds the files that the test refers to.
+/// Both directories are absolute paths on the host running this process, and a worker resolves them on its own, so a run
+/// reaching workers in other processes needs those paths to reach the same files there.
+/// The source host and the sink host are separate fields, because a run on a cluster may place sources and sinks
+/// on different workers, respectively.
+struct RewriteTarget
+{
+    std::string testFileKey;
+    /// This file's display name in failures and progress lines, which discovery chose so that two files that
+    /// share a stem in different folders do not report the same.
+    std::string displayName;
+    std::filesystem::path workingDir;
+    std::filesystem::path testDataDir;
+    Host sourceHost;
+    Host sinkHost;
+
+    /// The file that one case's sink writes.
+    /// The suffix keeps the files of one test file apart, so no two queries write the same one.
+    [[nodiscard]] std::filesystem::path resultFile(const std::string_view suffix) const
+    {
+        return workingDir / fmt::format("{}_{}.csv", testFileKey, suffix);
+    }
+
+    /// The CSV that the rewriter plans for a source whose rows the test declared inline.
+    /// The ordinal keeps the generated file names unique within the test file.
+    [[nodiscard]] std::filesystem::path sourceDataFile(const size_t ordinal) const
+    {
+        return workingDir / "sources" / fmt::format("{}_{}.csv", testFileKey, ordinal);
+    }
+};
+
+}

--- a/nes-systests/systest/private/Rewriter/SinkRewriting.hpp
+++ b/nes-systests/systest/private/Rewriter/SinkRewriting.hpp
@@ -1,0 +1,90 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#include <AntlrSQLParser.h>
+
+#include <Identifiers/Identifier.hpp>
+#include <Rewriter/NameQualifier.hpp>
+#include <Rewriter/RewriteTarget.hpp>
+#include <Rewriter/SqlParse.hpp>
+
+namespace NES
+{
+
+/// A sink declaration that is stored for inlining.
+struct SinkDefinition
+{
+    std::string type;
+    std::string schema;
+};
+
+using SinkByName = std::unordered_map<Identifier, SinkDefinition>;
+
+/// A sink after its lowering into the query that writes to it.
+/// The result file is absent when the sink writes none.
+struct RewrittenSink
+{
+    std::string sql;
+    std::optional<std::filesystem::path> resultFile;
+};
+
+/// Returns the sink that a query writes into, and rejects a query that writes into none or more than one.
+/// A query needs exactly one, because the runner reads back a single result file per query.
+AntlrSQLParser::SinkContext* requireSingleSink(const SqlParse& parse, const std::string& sql);
+
+/// The sink side of one rewrite: inlines a sink into the query that writes to it, and builds the declarations that a
+/// test file with an EXPLAIN submits.
+class SinkRewriter
+{
+public:
+    SinkRewriter(const RewriteTarget& target, const QualifiedNames& names, const SinkByName& sinkByName);
+
+    /// Lowers the sink that a query writes into, whether the test declared it above or wrote it into the query.
+    /// Both forms become an anonymous sink of the declared type.
+    /// A declared sink contributes its schema, because it sets the output field names and the casts to their types, and always writes CSV.
+    /// A sink written into the query keeps its options as the test wrote them.
+    /// A sink that writes a result file takes the candidate file, so two queries never write the same one.
+    /// A sink that states its own `SINK`.`FILE_PATH` is rejected, because the checker reads the file the rewriter chose.
+    [[nodiscard]] RewrittenSink
+    inlineSink(SqlParse& parse, AntlrSQLParser::SinkContext* sink, const std::filesystem::path& candidateResultFile) const;
+
+    /// Builds the declaration to submit for a declared sink of a test file that contains an EXPLAIN.
+    /// The coordinator validates a sink as it is declared, so a File sink needs its mandatory options even though an EXPLAIN writes no row.
+    [[nodiscard]] std::string declaredSinkStatement(SqlParse& parse, const AntlrSQLParser::CreateSinkDefinitionContext* definition) const;
+
+private:
+    /// Builds the anonymous sink replacing either form: the run's sink worker unless the sink chose its own host, then
+    /// the result file and a CSV default when the sink writes a file and chose no format, then quoted strings for a
+    /// checksum sink that did not choose, then the form's own trailing options.
+    [[nodiscard]] RewrittenSink inlined(
+        const std::string& type,
+        const std::optional<std::string>& declaredFormat,
+        bool hostAlreadySet,
+        bool quoteStringsAlreadySet,
+        const std::string& trailingOptions,
+        const std::filesystem::path& candidateResultFile) const;
+
+    const RewriteTarget& target;
+    const QualifiedNames& names;
+    const SinkByName& sinkByName;
+};
+
+}

--- a/nes-systests/systest/private/Rewriter/SourceRewriting.hpp
+++ b/nes-systests/systest/private/Rewriter/SourceRewriting.hpp
@@ -1,0 +1,86 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <cstddef>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <AntlrSQLParser.h>
+#include <TokenStreamRewriter.h>
+
+#include <Identifiers/Identifiers.hpp>
+#include <Model/RewrittenTest.hpp>
+#include <Rewriter/ClassifiedStatement.hpp>
+#include <Rewriter/NameQualifier.hpp>
+#include <Rewriter/RewriteTarget.hpp>
+#include <Rewriter/SqlParse.hpp>
+
+namespace NES
+{
+
+/// One physical source after rewriting: the statement to submit, and the file that the source's bytes come from, when they come from one.
+struct RewrittenSource
+{
+    SetupStatement statement;
+    std::optional<std::filesystem::path> inputFile;
+};
+
+/// Rewrites the physical source declarations of one test file.
+/// It counts them, so each generated data file gets a unique name.
+class SourceRewriter
+{
+public:
+    SourceRewriter(const RewriteTarget& target, const QualifiedNames& names);
+
+    /// Builds the physical source statement to submit, plus the CSV to write when the test declared its rows inline.
+    [[nodiscard]] RewrittenSource rewrite(SqlParse& parse, const PhysicalSourceDeclaration& declaration);
+
+private:
+    /// Builds the SET clause of a physical source.
+    /// The clause pins the source to one worker unless the test chose one, so the coordinator can place it.
+    /// It points at the file with the attached data when there is one, and defaults to a CSV input format unless the test chose one.
+    /// The options that the test wrote come last, unchanged.
+    [[nodiscard]] std::string setClauseFor(
+        SqlParse& parse,
+        AntlrSQLParser::NamedConfigExpressionSeqContext* declared,
+        const std::optional<std::filesystem::path>& dataFile) const;
+
+    const RewriteTarget& target;
+    const QualifiedNames& names;
+    size_t ordinal = 0;
+};
+
+/// Rewrites the data file path of a source written into a query to an absolute path under the test data directory.
+/// A test gives that path relative to the test data directory, as it does everywhere else.
+/// The worker resolves a relative path against its own working directory, so only an absolute path reaches the same file.
+void makeAnonymousSourcePathsAbsolute(
+    const SqlParse& parse, antlr4::TokenStreamRewriter& rewriter, const std::filesystem::path& testDataDir);
+
+/// Completes a source that is written into a query with the options that every runnable source needs.
+/// It pins the source to the run's source worker, because the coordinator resolves an omitted host to the worker that
+/// answers, and a run placed on a topology answers none, so such a source would have nowhere to run.
+/// It defaults the input format to CSV, because creating the source's descriptor rejects a source without one.
+/// An option that the test wrote itself stays as written.
+void completeAnonymousSources(const SqlParse& parse, antlr4::TokenStreamRewriter& rewriter, const Host& host);
+
+/// Adds config options to a physical source statement the rewriter already emitted.
+/// The new options merge into the statement's single `SET` clause, keeping the options already there.
+/// The runner needs this for a value that is known only once the run started, such as the port that a data server bound.
+std::string addSourceOptions(const std::string& sql, const std::vector<std::string>& options);
+
+}

--- a/nes-systests/systest/private/Rewriter/SqlParse.hpp
+++ b/nes-systests/systest/private/Rewriter/SqlParse.hpp
@@ -1,0 +1,201 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <exception>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <ANTLRInputStream.h>
+#include <AntlrSQLLexer.h>
+#include <AntlrSQLParser.h>
+#include <BaseErrorListener.h>
+#include <CommonTokenStream.h>
+#include <Recognizer.h>
+#include <tree/ParseTree.h>
+
+#include <Rewriter/Constants.hpp>
+#include <ErrorHandling.hpp>
+
+/// One SQL parse of a statement, and the queries the rewriter runs against it.
+/// Everything here reads the statement that the test file wrote.
+/// The rewriter decides what to emit in its place.
+namespace NES
+{
+
+/// Throws on a parse error instead of recovering, so a malformed statement fails at once.
+class ThrowingErrorListener final : public antlr4::BaseErrorListener
+{
+public:
+    explicit ThrowingErrorListener(std::string statement) : statement{std::move(statement)} { }
+
+private:
+    void
+    syntaxError(antlr4::Recognizer*, antlr4::Token*, const size_t line, const size_t column, const std::string& message, std::exception_ptr)
+        override
+    {
+        throw TestException("Could not parse a statement at {}:{}: {} in {}", line, column, message, statement);
+    }
+
+    std::string statement;
+};
+
+/// Owns one parse of a statement and keeps its token stream alive, so a rewriter can edit it and render the text again.
+/// The lexer puts whitespace on a hidden channel, so rendering preserves every part that the rewriter did not touch.
+class SqlParse
+{
+public:
+    explicit SqlParse(const std::string& statement)
+        : listener{statement}, input{statement}, lexer{&input}, tokens{&lexer}, parser{&tokens}, root{parse()}
+    {
+    }
+
+    [[nodiscard]] antlr4::tree::ParseTree* tree() const { return root; }
+
+    [[nodiscard]] antlr4::CommonTokenStream& tokenStream() { return tokens; }
+
+    /// Returns a subtree exactly as the statement wrote it, whitespace and quoting included.
+    [[nodiscard]] std::string textOf(antlr4::ParserRuleContext* node) { return node != nullptr ? tokens.getText(node) : std::string{}; }
+
+private:
+    /// Installs the throwing listener on the lexer and the parser, then parses the whole statement.
+    /// The default error strategy reports the first syntax error to that listener, which throws before attempting recovery.
+    /// A bail-out strategy would instead raise a parser exception with no message, losing the location and the offending token.
+    AntlrSQLParser::SingleStatementContext* parse()
+    {
+        lexer.removeErrorListeners();
+        parser.removeErrorListeners();
+        lexer.addErrorListener(&listener);
+        parser.addErrorListener(&listener);
+        return parser.singleStatement();
+    }
+
+    ThrowingErrorListener listener;
+    antlr4::ANTLRInputStream input;
+    AntlrSQLLexer lexer;
+    antlr4::CommonTokenStream tokens;
+    AntlrSQLParser parser;
+    AntlrSQLParser::SingleStatementContext* root;
+};
+
+/// Returns the first node of the given rule type anywhere under the tree, or null when the statement has none.
+template <typename Context>
+Context* findFirst(antlr4::tree::ParseTree* node)
+{
+    if (node == nullptr)
+    {
+        return nullptr;
+    }
+    if (auto* typed = dynamic_cast<Context*>(node))
+    {
+        return typed;
+    }
+    for (auto* child : node->children)
+    {
+        if (auto* found = findFirst<Context>(child))
+        {
+            return found;
+        }
+    }
+    return nullptr;
+}
+
+namespace detail
+{
+template <typename Context>
+void findAll(antlr4::tree::ParseTree* node, std::vector<Context*>& found)
+{
+    if (node == nullptr)
+    {
+        return;
+    }
+    if (auto* typed = dynamic_cast<Context*>(node))
+    {
+        found.push_back(typed);
+    }
+    for (auto* child : node->children)
+    {
+        findAll<Context>(child, found);
+    }
+}
+}
+
+/// Returns every node of the given rule type anywhere under the tree, in the order they occur in the statement.
+template <typename Context>
+std::vector<Context*> findAll(antlr4::tree::ParseTree* node)
+{
+    std::vector<Context*> found;
+    detail::findAll<Context>(node, found);
+    return found;
+}
+
+/// Returns whether a config option has exactly the given qualified name.
+/// The comparison canonicalizes both names the way the binder does, so a quoted and an unquoted spelling of one name match.
+/// Comparing the parsed name rather than the statement text also stops a value that reads like the name from matching.
+inline bool namesOption(AntlrSQLParser::NamedConfigExpressionContext* option, const std::string_view group, const std::string_view key)
+{
+    const auto& parts = option->name->strictIdentifier();
+    return parts.size() == 2 and Sql::sameName(parts.at(0)->getText(), group) and Sql::sameName(parts.at(1)->getText(), key);
+}
+
+/// Returns whether an option list sets the given name.
+/// The rewriter keeps a value that the test chose instead of writing its own default.
+/// A statement without an option list sets nothing.
+inline bool
+declaresOption(AntlrSQLParser::NamedConfigExpressionSeqContext* options, const std::string_view group, const std::string_view key)
+{
+    return options != nullptr
+        and std::ranges::any_of(options->namedConfigExpression(), [&](auto* option) { return namesOption(option, group, key); });
+}
+
+/// Returns the node holding a config option's value when that value is a string literal, and null for a number or a schema.
+/// The node rather than the text, so the caller can replace the value in place.
+inline AntlrSQLParser::StringLiteralContext* stringValueOf(AntlrSQLParser::NamedConfigExpressionContext* option)
+{
+    return dynamic_cast<AntlrSQLParser::StringLiteralContext*>(option->constant());
+}
+
+/// Returns the content of a string literal, without the quotes around it.
+inline std::string unquote(const std::string& literal)
+{
+    return literal.substr(1, literal.size() - 2);
+}
+
+/// Returns a config option's value as a string, or nullopt when the list does not set the option or sets it to something
+/// other than a string literal.
+/// The caller needs the value that the test chose, not only whether it chose one.
+inline std::optional<std::string>
+declaredOptionValue(AntlrSQLParser::NamedConfigExpressionSeqContext* options, const std::string_view group, const std::string_view key)
+{
+    if (options == nullptr)
+    {
+        return std::nullopt;
+    }
+    for (auto* option : options->namedConfigExpression())
+    {
+        if (auto* value = stringValueOf(option); value != nullptr and namesOption(option, group, key))
+        {
+            return unquote(value->getText());
+        }
+    }
+    return std::nullopt;
+}
+
+}

--- a/nes-systests/systest/private/Rewriter/SqlRewriter.hpp
+++ b/nes-systests/systest/private/Rewriter/SqlRewriter.hpp
@@ -1,0 +1,38 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <Model/ParsedTestFile.hpp>
+#include <Model/RewrittenTest.hpp>
+#include <Rewriter/RewriteTarget.hpp>
+
+namespace NES
+{
+
+/// Rewrites the statements of one test file.
+/// Creates a `RewrittenTest`, consisting of rewritten setup statements and rewritten cases (i.e., queries)
+/// Because every test of one invocation shares the catalog, we need to disambiguate the names defined in the tests.
+/// This disambiguation and the insertion of the correct file path for the result file is the goal of the rewriter.
+/// To do this, it applies the following steps:
+/// - Prefixing every logical source name with the test file key (to avoid collisions among files).
+/// - Inlining each declared sink into its query with a dedicated result file path.
+/// - Deriving each query's name from its location.
+///
+/// The first phase parses and classifies every CREATE statement.
+/// The second declares every name (by prefixing it with the test file key) that becomes catalog-visible.
+/// The third emits the setup DDL and rewrites the queries, in file order.
+[[nodiscard]] RewrittenTest rewriteTestFile(const ParsedTestFile& testFile, const RewriteTarget& target);
+
+}

--- a/nes-systests/systest/private/Runner/DataStaging.hpp
+++ b/nes-systests/systest/private/Runner/DataStaging.hpp
@@ -1,0 +1,43 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <Model/RewrittenTest.hpp>
+
+namespace NES
+{
+
+/// Writes the rewriter's planned rows to the file that the physical source reads, creating the parent directory first.
+void writeInlineData(const InlineData& data);
+
+/// A data server for one source, and the source options for the endpoint that it bound.
+/// The server sends its data once and then closes the connection, which ends the stream.
+/// Stopping the thread earlier leaves the source without its data, so the thread has to outlive the queries reading from it.
+struct RunningServer
+{
+    std::jthread thread;
+    std::vector<std::string> options;
+};
+
+/// Starts a server on an ephemeral port that sends the given data.
+/// The port is known only once the server binds, so the options come from here rather than from the rewriter.
+/// Takes the data by value, because the server owns it for as long as it sends.
+[[nodiscard]] RunningServer serve(ServedData data);
+
+}

--- a/nes-systests/systest/src/Rewriter/CMakeLists.txt
+++ b/nes-systests/systest/src/Rewriter/CMakeLists.txt
@@ -10,21 +10,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The stages of the systest pipeline, in the order they run:
-# configure, discover test files, read one, parse it, rewrite its statements, run it and check the results.
-add_subdirectory(Config)
-add_subdirectory(Discovery)
-add_subdirectory(Model)
-add_subdirectory(Parser)
-add_subdirectory(Rewriter)
-add_subdirectory(Runner)
-add_subdirectory(ResultChecker)
-
 add_source_files(nes-systest-lib
-        SystestExecutor.cpp
-        Logging.cpp
-        Progress.cpp
-        SystestState.cpp
-        SystestBinder.cpp
-        WorkingDirectoryGuard.cpp
+        ClassifiedStatement.cpp
+        Emitter.cpp
+        NameQualifier.cpp
+        SinkRewriting.cpp
+        SourceRewriting.cpp
+        SqlRewriter.cpp
+        Declarations.cpp
 )

--- a/nes-systests/systest/src/Rewriter/ClassifiedStatement.cpp
+++ b/nes-systests/systest/src/Rewriter/ClassifiedStatement.cpp
@@ -1,0 +1,88 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Rewriter/ClassifiedStatement.hpp>
+
+#include <memory>
+#include <utility>
+#include <variant>
+
+#include <Model/ParsedTestFile.hpp>
+#include <Rewriter/SqlParse.hpp>
+#include <Util/Overloaded.hpp>
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+namespace
+{
+
+/// Reads what a CREATE declares from its parse tree, and binds attached data only to a physical source.
+/// The test file format allows an ATTACH after any CREATE, because the parser matches line prefixes and never reads the statement.
+/// This rejects a misplaced ATTACH.
+CreateDeclaration classify(const SqlParse& parse, const CreateStatement& create)
+{
+    if (auto* physicalSource = findFirst<AntlrSQLParser::CreatePhysicalSourceDefinitionContext>(parse.tree()))
+    {
+        return PhysicalSourceDeclaration{.definition = physicalSource, .attached = create.attach.has_value() ? &*create.attach : nullptr};
+    }
+    if (create.attach.has_value())
+    {
+        throw TestException("ATTACH supplies the data of a physical source, but this statement declares something else: {}", create.sql);
+    }
+
+    if (auto* logicalSource = findFirst<AntlrSQLParser::CreateLogicalSourceDefinitionContext>(parse.tree()))
+    {
+        return LogicalSourceDeclaration{.definition = logicalSource};
+    }
+    if (auto* sink = findFirst<AntlrSQLParser::CreateSinkDefinitionContext>(parse.tree()))
+    {
+        return SinkDeclaration{.definition = sink};
+    }
+    if (auto* model = findFirst<AntlrSQLParser::CreateModelDefinitionContext>(parse.tree()))
+    {
+        return ModelDeclaration{.definition = model};
+    }
+    throw TestException("Unsupported CREATE statement: {}", create.sql);
+}
+
+}
+
+ClassifiedTest classifyStatements(const ParsedTestFile& testFile)
+{
+    ClassifiedTest classified;
+    classified.statements.reserve(testFile.statements.size());
+    for (const auto& statement : testFile.statements)
+    {
+        classified.statements.push_back(std::visit(
+            Overloaded{
+                [](const CreateStatement& create) -> ClassifiedStatement
+                {
+                    auto parse = std::make_unique<SqlParse>(create.sql);
+                    auto declaration = classify(*parse, create);
+                    return ClassifiedCreate{.create = &create, .parse = std::move(parse), .declaration = std::move(declaration)};
+                },
+                [](const SelectStatement& query) -> ClassifiedStatement { return &query; },
+                [](const DifferentialStatement& block) -> ClassifiedStatement { return &block; },
+                [&](const ExplainStatement& explain) -> ClassifiedStatement
+                {
+                    classified.containsExplain = true;
+                    return &explain;
+                }},
+            statement));
+    }
+    return classified;
+}
+
+}

--- a/nes-systests/systest/src/Rewriter/Declarations.cpp
+++ b/nes-systests/systest/src/Rewriter/Declarations.cpp
@@ -1,0 +1,89 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Rewriter/Declarations.hpp>
+
+#include <string>
+#include <utility>
+#include <variant>
+
+#include <Identifiers/Identifier.hpp>
+#include <Rewriter/ClassifiedStatement.hpp>
+#include <Rewriter/NameQualifier.hpp>
+#include <Rewriter/SinkRewriting.hpp>
+#include <Util/Overloaded.hpp>
+
+namespace NES
+{
+namespace
+{
+
+void declareNames(ClassifiedCreate& create, NameRegistry& registry, SinkByName& sinkByName, const bool submitsDeclaredSinks)
+{
+    std::visit(
+        Overloaded{
+            [&](const LogicalSourceDeclaration& declaration)
+            {
+                /// Qualifying the logical source name keeps it apart from the names of other test files.
+                registry.declare(declaration.definition->sourceName->getText());
+            },
+            /// A physical source declares no name of its own.
+            /// It references a logical source that another statement declares.
+            [](const PhysicalSourceDeclaration&) {},
+            [&](const ModelDeclaration& declaration)
+            {
+                /// A query that infers with a model refers to it, so a model qualifies like a source.
+                registry.declare(declaration.definition->modelName->getText());
+            },
+            [&](const SinkDeclaration& declaration)
+            {
+                /// A test file that contains an EXPLAIN submits its sink declarations, so a plan that refers to a declared sink
+                /// prints the name that the test gave it.
+                /// An inlined sink prints as its type instead.
+                /// A declared sink name qualifies like any other name.
+                if (submitsDeclaredSinks)
+                {
+                    registry.declare(declaration.definition->sinkName->getText());
+                }
+                /// The rewriter inlines a sink into the query that writes to it, so this holds its type and schema and emits nothing.
+                sinkByName.emplace(
+                    Identifier::parse(declaration.definition->sinkName->getText()),
+                    SinkDefinition{
+                        .type = declaration.definition->type->getText(),
+                        .schema = create.parse->textOf(declaration.definition->schemaDefinition())});
+            }},
+        create.declaration);
+}
+
+}
+
+Declarations declareAll(ClassifiedTest& classified, const std::string& testFileKey)
+{
+    /// The query of an EXPLAIN can refer to a declared sink, and the plan prints that sink's name only when the sink exists in
+    /// the catalog, so a file that contains an EXPLAIN registers its sink names and submits their declarations.
+    /// An EXPLAIN whose query writes its sink inline needs no declaration, and an EXPLAIN runs nothing, so the
+    /// declared sinks are never written.
+    NameRegistry registry{testFileKey};
+    SinkByName sinkByName;
+    for (auto& statement : classified.statements)
+    {
+        if (auto* create = std::get_if<ClassifiedCreate>(&statement))
+        {
+            declareNames(*create, registry, sinkByName, classified.containsExplain);
+        }
+    }
+    return Declarations{.names = std::move(registry).seal(), .sinkByName = std::move(sinkByName)};
+}
+
+}

--- a/nes-systests/systest/src/Rewriter/Emitter.cpp
+++ b/nes-systests/systest/src/Rewriter/Emitter.cpp
@@ -1,0 +1,243 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Rewriter/Emitter.hpp>
+
+#include <algorithm>
+#include <filesystem>
+#include <iterator>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include <AntlrSQLParser.h>
+#include <TokenStreamRewriter.h>
+
+#include <Identifiers/Identifier.hpp>
+#include <Identifiers/Identifiers.hpp>
+#include <Model/RewrittenTest.hpp>
+#include <Rewriter/Constants.hpp>
+#include <Rewriter/NameQualifier.hpp>
+#include <Rewriter/SinkRewriting.hpp>
+#include <Rewriter/SourceRewriting.hpp>
+#include <Rewriter/SqlParse.hpp>
+#include <Util/Overloaded.hpp>
+#include <fmt/format.h>
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+
+Emitter::Emitter(const RewriteTarget& target, Declarations declarations)
+    : target{target}
+    , declarations{std::move(declarations)}
+    , sourceRewriter{target, this->declarations.names}
+    , sinkRewriter{target, this->declarations.names, this->declarations.sinkByName}
+{
+    runnable.name = target.displayName;
+    runnable.qualifyingPrefix = this->declarations.names.qualifyingPrefix();
+}
+
+RewrittenTest Emitter::emit(ClassifiedTest& classified) &&
+{
+    emitSetup(classified.statements, classified.containsExplain);
+    emitCases(classified.statements);
+    return std::move(runnable);
+}
+
+void Emitter::emitSetup(std::vector<ClassifiedStatement>& statements, const bool submitsDeclaredSinks)
+{
+    for (auto& statement : statements)
+    {
+        if (auto* create = std::get_if<ClassifiedCreate>(&statement))
+        {
+            emitCreate(*create, submitsDeclaredSinks);
+        }
+    }
+}
+
+void Emitter::emitCases(std::vector<ClassifiedStatement>& statements)
+{
+    for (auto& statement : statements)
+    {
+        std::visit(
+            Overloaded{/// The setup pass already emitted every CREATE.
+                       [](const ClassifiedCreate&) {},
+                       [this](const SelectStatement* query)
+                       {
+                           auto rewritten = rewriteSql(query->sql, query->id, {});
+                           runnable.cases.push_back(RewrittenCase{
+                        .action = RewrittenQuery{
+                            .sql = std::move(rewritten.sql),
+                            .id = query->id,
+                            .resultFile = std::move(rewritten.resultFile),
+                            .expectation = query->expected},
+                        .inputFiles = std::move(rewritten.inputFiles),
+                        .runsAfterPrevious = query->sequential});
+                       },
+                       [this](const DifferentialStatement* block) { emitDifferential(*block); },
+                       [this](const ExplainStatement* explain) { emitExplain(*explain); }},
+            statement);
+    }
+}
+
+void Emitter::emitCreate(ClassifiedCreate& create, const bool submitsDeclaredSinks)
+{
+    std::visit(
+        Overloaded{
+            [&](const LogicalSourceDeclaration&)
+            {
+                /// A logical source needs only its identifiers qualified.
+                runnable.setupStatements.push_back(PlainStatement{.sql = rewriteIdentifiers(create.create->sql, declarations.names)});
+            },
+            [&](const PhysicalSourceDeclaration& declaration)
+            {
+                auto [statement, inputFile] = sourceRewriter.rewrite(*create.parse, declaration);
+                runnable.setupStatements.push_back(std::move(statement));
+                if (inputFile.has_value())
+                {
+                    /// Keyed by the qualified name, because a query is parsed after its identifiers were substituted and
+                    /// refers to the source by the spelling that the catalog sees.
+                    const auto logical = declaration.definition->logicalSource->getText();
+                    inputFilesBySource[Identifier::parse(declarations.names.qualified(logical).value_or(logical))].push_back(*inputFile);
+                }
+            },
+            [&](const ModelDeclaration& declaration) { runnable.setupStatements.push_back(modelStatement(*create.parse, declaration)); },
+            [&](const SinkDeclaration& declaration)
+            {
+                /// A test file that inlines its sinks emits nothing here, because the declaring phase already stored this one.
+                /// An EXPLAIN needs the declared sink in the catalog, so a plan that refers to it can print its name.
+                if (submitsDeclaredSinks)
+                {
+                    runnable.setupStatements.push_back(
+                        PlainStatement{.sql = sinkRewriter.declaredSinkStatement(*create.parse, declaration.definition)});
+                }
+            }},
+        create.declaration);
+}
+
+PlainStatement Emitter::modelStatement(SqlParse& parse, const ModelDeclaration& declaration) const
+{
+    antlr4::TokenStreamRewriter rewriter{&parse.tokenStream()};
+    if (const std::filesystem::path declared{unquote(declaration.definition->modelPath->getText())}; declared.is_relative())
+    {
+        rewriter.replace(declaration.definition->modelPath, Sql::stringLiteral((target.testDataDir / declared).string()));
+    }
+    return PlainStatement{.sql = rewriteIdentifiers(rewriter.getText(), declarations.names)};
+}
+
+Emitter::RewrittenSql Emitter::rewriteSql(const std::string& sql, const SystestQueryId id, const std::string_view resultDiscriminator)
+{
+    /// Qualifying the source references comes first, because everything below locates and replaces text in the qualified statement.
+    /// Substituting names reads tokens rather than a parse tree, so it also works on a statement that does not parse.
+    auto qualified = rewriteIdentifiers(sql, declarations.names);
+
+    /// A statement that the parser rejects goes to the coordinator unchanged, which reports the syntax error against this one query.
+    /// Several tests assert exactly that error, and a statement without a parse tree has nothing to inline into.
+    /// Such a query never runs, so it writes no result file.
+    std::unique_ptr<SqlParse> parse;
+    try
+    {
+        parse = std::make_unique<SqlParse>(qualified);
+    }
+    catch (const Exception&)
+    {
+        return RewrittenSql{.sql = std::move(qualified), .resultFile = std::nullopt, .inputFiles = {}};
+    }
+
+    antlr4::TokenStreamRewriter rewriter{&parse->tokenStream()};
+
+    makeAnonymousSourcePathsAbsolute(*parse, rewriter, target.testDataDir);
+    completeAnonymousSources(*parse, rewriter, target.sourceHost);
+
+    const auto queryNumber = id.getRawValue();
+    const auto suffix
+        = resultDiscriminator.empty() ? fmt::format("{}", queryNumber) : fmt::format("{}_{}", resultDiscriminator, queryNumber);
+
+    auto* sink = requireSingleSink(*parse, sql);
+    auto [inlinedSink, resultFile] = sinkRewriter.inlineSink(*parse, sink, target.resultFile(suffix));
+    rewriter.replace(sink->getStart(), sink->getStop(), inlinedSink);
+
+    std::vector<std::filesystem::path> inputFiles;
+    for (auto* reference : findAll<AntlrSQLParser::NamedSourceContext>(parse->tree()))
+    {
+        if (const auto files = inputFilesBySource.find(Identifier::parse(reference->multipartIdentifier()->getText()));
+            files != inputFilesBySource.end())
+        {
+            std::ranges::copy(files->second, std::back_inserter(inputFiles));
+        }
+    }
+
+    return RewrittenSql{.sql = rewriter.getText(), .resultFile = std::move(resultFile), .inputFiles = std::move(inputFiles)};
+}
+
+void Emitter::emitExplain(const ExplainStatement& explain)
+{
+    auto qualified = rewriteIdentifiers(explain.sql, declarations.names);
+    SqlParse parse{qualified};
+    antlr4::TokenStreamRewriter rewriter{&parse.tokenStream()};
+
+    /// The explained query binds and optimizes as a regular query does, so its sources need the same completion.
+    makeAnonymousSourcePathsAbsolute(parse, rewriter, target.testDataDir);
+    completeAnonymousSources(parse, rewriter, target.sourceHost);
+
+    /// A sink that the test declared keeps its name, because the expected plan prints that name and the emitted
+    /// declaration makes it resolve.
+    /// The rewriter inlines a sink written into the statement as it does for a query, and the plan prints it as the operator that the
+    /// optimizer has not bound yet.
+    if (auto* sink = requireSingleSink(parse, explain.sql); sink->identifier() == nullptr)
+    {
+        const auto candidate = target.resultFile(fmt::format("{}", explain.id.getRawValue()));
+        rewriter.replace(sink->getStart(), sink->getStop(), sinkRewriter.inlineSink(parse, sink, candidate).sql);
+    }
+
+    runnable.cases.push_back(RewrittenCase{
+        .action = RewrittenExplain{.sql = rewriter.getText(), .id = explain.id, .expected = explain.expected},
+        .inputFiles = {},
+        .runsAfterPrevious = false});
+}
+
+void Emitter::emitDifferential(const DifferentialStatement& block)
+{
+    /// The second half needs its own result file name, because the halves share one query number.
+    static constexpr auto SecondHalf = "DIFFERENTIAL";
+
+    auto first = rewriteSql(block.firstSql, block.firstId, {});
+    auto second = rewriteSql(block.secondSql, block.secondId, SecondHalf);
+    if (not first.resultFile.has_value() or not second.resultFile.has_value())
+    {
+        throw TestException("a differential query has to write a result to compare: {}", block.firstSql);
+    }
+
+    /// The block is one case, so the input files of both halves combine.
+    auto inputFiles = std::move(first.inputFiles);
+    std::ranges::move(second.inputFiles, std::back_inserter(inputFiles));
+
+    runnable.cases.push_back(RewrittenCase{
+        .action = RewrittenDifferential{
+            .firstSql = std::move(first.sql),
+            .firstId = block.firstId,
+            .firstResultFile = std::move(*first.resultFile),
+            .secondSql = std::move(second.sql),
+            .secondId = block.secondId,
+            .secondResultFile = std::move(*second.resultFile)},
+        .inputFiles = std::move(inputFiles),
+        .runsAfterPrevious = block.sequential});
+}
+
+}

--- a/nes-systests/systest/src/Rewriter/NameQualifier.cpp
+++ b/nes-systests/systest/src/Rewriter/NameQualifier.cpp
@@ -1,0 +1,170 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Rewriter/NameQualifier.hpp>
+
+#include <cctype>
+#include <cstddef>
+#include <filesystem>
+#include <optional>
+#include <ranges>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include <ANTLRInputStream.h>
+#include <AntlrSQLLexer.h>
+#include <fmt/format.h>
+
+#include <Identifiers/Identifier.hpp>
+#include <Util/Strings.hpp>
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+namespace
+{
+
+/// One character of a test file key.
+/// A letter or a digit passes through, and everything else becomes a token between underscores: `__` an underscore,
+/// `_D_` a directory separator, and `_<hex>_` any other byte.
+/// A token cannot be mistaken for passed-through text, so decoding is unambiguous.
+std::string encodeKeyCharacter(const char character)
+{
+    if (std::isalnum(static_cast<unsigned char>(character)) != 0)
+    {
+        return std::string{character};
+    }
+    if (character == '_')
+    {
+        return "__";
+    }
+    if (character == '/')
+    {
+        return "_D_";
+    }
+    return fmt::format("_{:02X}_", static_cast<unsigned char>(character));
+}
+
+}
+
+std::string getTestFileKey(const std::filesystem::path& testFile, const std::filesystem::path& discoveryRoot)
+{
+    /// Both paths take the same normal form before one is subtracted from the other.
+    /// Relating an absolute path to a relative one gives an empty result rather than an error, and every file of the run would then
+    /// key the same and collide in the shared catalog.
+    /// The command line decides the discovery root, while a discovered test file is always absolute.
+    const auto canonicalRoot = std::filesystem::weakly_canonical(discoveryRoot);
+    auto relative = std::filesystem::weakly_canonical(testFile).lexically_relative(canonicalRoot);
+    /// A file above the root, or unrelated to it, has no position under the root and therefore no key.
+    if (relative.empty() or *relative.begin() == std::filesystem::path{".."})
+    {
+        throw TestException("test file {} is not located under the discovery root {}", testFile.string(), discoveryRoot.string());
+    }
+    relative.replace_extension();
+
+    /// The relative path without its extension is the raw key, so the directory keeps files sharing a stem apart.
+    /// The per-character encoding is reversible, so no two paths share a key.
+    /// Two paths differing only in case share a key, because an unquoted identifier folds case anyway.
+    const auto folded = toUpperCase(relative.generic_string());
+    auto key = folded | std::views::transform(encodeKeyCharacter) | std::views::join | std::ranges::to<std::string>();
+    /// An unquoted identifier may not start with a digit, so a leading digit is encoded like a special character.
+    /// No path encodes to a leading token on its own, because a relative path does not start with a separator.
+    if (std::isdigit(static_cast<unsigned char>(key.front())) != 0)
+    {
+        key = fmt::format("_{:02X}_{}", static_cast<unsigned char>(key.front()), key.substr(1));
+    }
+    return key;
+}
+
+std::string getTestFilePartKey(const std::string& testFileKey, const size_t part, const size_t parts)
+{
+    return parts == 1 ? testFileKey : fmt::format("{}_C{}", testFileKey, part);
+}
+
+std::string unqualified(const std::string_view text, const std::string_view qualifyingPrefix)
+{
+    return replaceAll(text, qualifyingPrefix, "");
+}
+
+NameRegistry::NameRegistry(std::string testFileKey) : key{std::move(testFileKey)}
+{
+}
+
+std::string NameRegistry::declare(const std::string_view name)
+{
+    auto identifier = Identifier::parse(std::string{name});
+    if (const auto existing = qualifiedByName.find(identifier); existing != qualifiedByName.end())
+    {
+        return existing->second;
+    }
+
+    /// A quoted name keeps the case and punctuation the test wrote, and only quotes preserve that through the catalog.
+    /// An unquoted `A_INPUT STREAM` for a source declared as `"INPUT STREAM"` produces a statement that does not parse.
+    auto qualified = identifier.isCaseSensitive() ? fmt::format(R"("{}_{}")", key, identifier.asCanonicalString())
+                                                  : fmt::format("{}_{}", key, identifier.asCanonicalString());
+    /// A spelling already taken means two distinct canonical names collided, which the prefix cannot represent reversibly.
+    /// Rejecting it is better than overwriting the earlier name.
+    INVARIANT(!takenSpellings.contains(qualified), "two names in this test file qualify to the same spelling '{}'", qualified);
+
+    takenSpellings.emplace(qualified);
+    qualifiedByName.emplace(std::move(identifier), qualified);
+    return qualified;
+}
+
+QualifiedNames NameRegistry::seal() &&
+{
+    return QualifiedNames{std::move(qualifiedByName), fmt::format("{}_", key)};
+}
+
+QualifiedNames::QualifiedNames(QualifiedByName qualifiedByName, std::string prefix)
+    : qualifiedByName{std::move(qualifiedByName)}, prefix{std::move(prefix)}
+{
+}
+
+std::optional<std::string> QualifiedNames::qualified(const std::string_view name) const
+{
+    if (const auto found = qualifiedByName.find(Identifier::parse(std::string{name})); found != qualifiedByName.end())
+    {
+        return found->second;
+    }
+    return std::nullopt;
+}
+
+std::string rewriteIdentifiers(const std::string_view sql, const QualifiedNames& names)
+{
+    antlr4::ANTLRInputStream input{sql.data(), sql.length()};
+    AntlrSQLLexer lexer{&input};
+
+    /// Copies the original text and replaces each registered identifier token with its qualified spelling.
+    /// Token positions are character offsets, so untouched runs including whitespace and comments are copied rather than relexed.
+    std::string rewritten;
+    size_t cursor = 0;
+    for (const auto& token : lexer.getAllTokens())
+    {
+        if (const auto type = token->getType(); type == AntlrSQLLexer::IDENTIFIER || type == AntlrSQLLexer::BACKQUOTED_IDENTIFIER)
+        {
+            if (const auto qualified = names.qualified(token->getText()))
+            {
+                rewritten.append(sql.substr(cursor, token->getStartIndex() - cursor));
+                rewritten.append(*qualified);
+                cursor = token->getStopIndex() + 1;
+            }
+        }
+    }
+    rewritten.append(sql.substr(cursor));
+    return rewritten;
+}
+
+}

--- a/nes-systests/systest/src/Rewriter/SinkRewriting.cpp
+++ b/nes-systests/systest/src/Rewriter/SinkRewriting.cpp
@@ -1,0 +1,157 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Rewriter/SinkRewriting.hpp>
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <AntlrSQLParser.h>
+#include <TokenStreamRewriter.h>
+#include <fmt/format.h>
+
+#include <Identifiers/Identifier.hpp>
+#include <Rewriter/Constants.hpp>
+#include <Rewriter/NameQualifier.hpp>
+#include <Rewriter/SqlParse.hpp>
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+namespace
+{
+
+/// Returns whether a sink of this type writes a result file.
+/// The File and Checksum sinks do, and they take a path and an output format.
+/// The sink that discards its input takes neither and leaves the query with nothing to check.
+bool writesResultFile(const std::string_view sinkType)
+{
+    return not Sql::sameName(sinkType, Sql::Void);
+}
+
+/// Returns whether a sink of this type writes a checksum instead of the rows.
+/// Such a sink quotes its strings, because the expected checksums were computed over quoted strings.
+bool writesChecksum(const std::string_view sinkType)
+{
+    return Sql::sameName(sinkType, Sql::Checksum);
+}
+
+}
+
+AntlrSQLParser::SinkContext* requireSingleSink(const SqlParse& parse, const std::string& sql)
+{
+    auto* sinkClause = findFirst<AntlrSQLParser::SinkClauseContext>(parse.tree());
+    if (sinkClause == nullptr or sinkClause->sink().empty())
+    {
+        throw TestException("A systest query must write into a sink: {}", sql);
+    }
+    if (sinkClause->sink().size() > 1)
+    {
+        throw TestException("A query writing into more than one sink is not supported yet: {}", sql);
+    }
+    return sinkClause->sink().front();
+}
+
+SinkRewriter::SinkRewriter(const RewriteTarget& target, const QualifiedNames& names, const SinkByName& sinkByName)
+    : target{target}, names{names}, sinkByName{sinkByName}
+{
+}
+
+RewrittenSink SinkRewriter::inlined(
+    const std::string& type,
+    const std::optional<std::string>& declaredFormat,
+    const bool hostAlreadySet,
+    const bool quoteStringsAlreadySet,
+    const std::string& trailingOptions,
+    const std::filesystem::path& candidateResultFile) const
+{
+    std::vector<std::string> options;
+    if (not hostAlreadySet)
+    {
+        options.push_back(Sql::option(Sql::Sink, Sql::Host, target.sinkHost.view()));
+    }
+    std::optional<std::filesystem::path> resultFile;
+    if (writesResultFile(type))
+    {
+        resultFile = candidateResultFile;
+        options.push_back(Sql::option(Sql::Sink, Sql::FilePath, resultFile->string()));
+        if (not declaredFormat.has_value())
+        {
+            options.push_back(Sql::option(Sql::Sink, Sql::OutputFormat, Sql::Csv));
+        }
+    }
+    if (writesChecksum(type) and not quoteStringsAlreadySet)
+    {
+        options.push_back(Sql::option(Sql::OutputFormatter, Sql::QuoteStrings, "true"));
+    }
+    if (not trailingOptions.empty())
+    {
+        options.push_back(trailingOptions);
+    }
+    return {.sql = Sql::sink(type, Sql::optionList(options)), .resultFile = std::move(resultFile)};
+}
+
+RewrittenSink
+SinkRewriter::inlineSink(SqlParse& parse, AntlrSQLParser::SinkContext* sink, const std::filesystem::path& candidateResultFile) const
+{
+    if (auto* sinkName = sink->identifier(); sinkName != nullptr)
+    {
+        const auto declaration = sinkByName.find(Identifier::parse(sinkName->getText()));
+        if (declaration == sinkByName.end())
+        {
+            throw TestException("Query writes to sink '{}' that no sink declaration in this file names", sinkName->getText());
+        }
+        return inlined(
+            declaration->second.type,
+            std::nullopt,
+            false,
+            false,
+            Sql::schemaOption(Sql::Sink, declaration->second.schema),
+            candidateResultFile);
+    }
+    if (const auto* anonymous = sink->anonymousSink(); anonymous != nullptr)
+    {
+        if (declaresOption(anonymous->parameters, Sql::Sink, Sql::FilePath))
+        {
+            throw TestException(
+                "A sink written into a query must not choose its result file, because the checker reads the file the rewriter chose: {}",
+                sink->getText());
+        }
+        const auto declaredFormat = declaredOptionValue(anonymous->parameters, Sql::Sink, Sql::OutputFormat);
+        const bool hostSet = declaresOption(anonymous->parameters, Sql::Sink, Sql::Host);
+        const bool quoteStringsSet = declaresOption(anonymous->parameters, Sql::OutputFormatter, Sql::QuoteStrings);
+        return inlined(
+            anonymous->type->getText(), declaredFormat, hostSet, quoteStringsSet, parse.textOf(anonymous->parameters), candidateResultFile);
+    }
+    throw TestException(
+        "A query sink that is neither a declared sink nor one written into the query is not supported: {}", sink->getText());
+}
+
+std::string SinkRewriter::declaredSinkStatement(SqlParse& parse, const AntlrSQLParser::CreateSinkDefinitionContext* definition) const
+{
+    const std::vector options{
+        Sql::option(Sql::Sink, Sql::Host, target.sinkHost.view()),
+        Sql::option(Sql::Sink, Sql::FilePath, target.resultFile(definition->sinkName->getText()).string()),
+        Sql::option(Sql::Sink, Sql::OutputFormat, Sql::Csv)};
+
+    antlr4::TokenStreamRewriter rewriter{&parse.tokenStream()};
+    rewriter.insertAfter(definition->getStop(), fmt::format(" {}", Sql::setClause(Sql::optionList(options))));
+    return rewriteIdentifiers(rewriter.getText(), names);
+}
+
+}

--- a/nes-systests/systest/src/Rewriter/SourceRewriting.cpp
+++ b/nes-systests/systest/src/Rewriter/SourceRewriting.cpp
@@ -1,0 +1,221 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Rewriter/SourceRewriting.hpp>
+
+#include <algorithm>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include <AntlrSQLParser.h>
+#include <TokenStreamRewriter.h>
+
+#include <Model/ParsedTestFile.hpp>
+#include <Model/RewrittenTest.hpp>
+#include <Rewriter/Constants.hpp>
+#include <Rewriter/NameQualifier.hpp>
+#include <Rewriter/SqlParse.hpp>
+#include <Util/Overloaded.hpp>
+#include <fmt/format.h>
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+namespace
+{
+
+/// Returns whether a source of this type reads over a connection instead of from a file.
+/// Such a source takes an endpoint instead of a path, and needs a server sending its data while it reads.
+bool readsFromSocket(const std::string_view sourceType)
+{
+    return Sql::sameName(sourceType, Sql::Tcp);
+}
+
+/// Returns the options that the test wrote on a physical source, or null when it wrote none.
+AntlrSQLParser::NamedConfigExpressionSeqContext* declaredOptions(AntlrSQLParser::CreatePhysicalSourceDefinitionContext* definition)
+{
+    const auto* clause = definition->optionsClause();
+    return clause != nullptr ? clause->options : nullptr;
+}
+
+/// Replaces a physical source's SET clause with the given options, or adds the clause when the source has none.
+/// The grammar allows only one SET clause per physical source, so appending a second one is not an option.
+std::string
+spliceSetClause(SqlParse& parse, AntlrSQLParser::CreatePhysicalSourceDefinitionContext* definition, const std::string_view setClause)
+{
+    antlr4::TokenStreamRewriter rewriter{&parse.tokenStream()};
+    if (const auto* clause = definition->optionsClause(); clause != nullptr)
+    {
+        rewriter.replace(clause->getStart(), clause->getStop(), std::string{setClause});
+    }
+    else
+    {
+        rewriter.insertAfter(definition->getStop(), fmt::format(" {}", setClause));
+    }
+    return rewriter.getText();
+}
+
+}
+
+SourceRewriter::SourceRewriter(const RewriteTarget& target, const QualifiedNames& names) : target{target}, names{names}
+{
+}
+
+RewrittenSource SourceRewriter::rewrite(SqlParse& parse, const PhysicalSourceDeclaration& declaration)
+{
+    const auto sourceNumber = ordinal++;
+
+    /// The file that the source itself opens, which goes into its options.
+    std::optional<std::filesystem::path> dataFile;
+    /// The file whose bytes feed the source, whether it opens the file or a server sends the content.
+    /// A measurement counts what a source reads, and it reads the same bytes either way.
+    std::optional<std::filesystem::path> inputFile;
+    std::optional<InlineData> inlineData;
+    std::optional<ServedData> servedData;
+    /// A source that produces its own data (e.g., Generator) takes neither.
+    if (declaration.attached != nullptr)
+    {
+        if (readsFromSocket(declaration.definition->type->getText()))
+        {
+            /// A server sends the source its data, so no file goes into the options.
+            std::visit(
+                Overloaded{
+                    [&](const InlineRows& inlined) { servedData = ServedData{.content = inlined.rows}; },
+                    [&](const AttachedFile& attachedFile)
+                    {
+                        auto file = target.testDataDir / attachedFile.path;
+                        inputFile = file;
+                        servedData = ServedData{.content = std::move(file)};
+                    }},
+                *declaration.attached);
+        }
+        else
+        {
+            /// The source opens the attached file itself, or the CSV that the rewriter plans for the inline rows.
+            std::visit(
+                Overloaded{
+                    [&](const InlineRows& inlined)
+                    {
+                        auto file = target.sourceDataFile(sourceNumber);
+                        inlineData = InlineData{.path = file, .rows = inlined.rows};
+                        dataFile = std::move(file);
+                    },
+                    [&](const AttachedFile& attachedFile) { dataFile = target.testDataDir / attachedFile.path; }},
+                *declaration.attached);
+            inputFile = dataFile;
+        }
+    }
+
+    const auto setClause = setClauseFor(parse, declaredOptions(declaration.definition), dataFile);
+    auto sql = rewriteIdentifiers(spliceSetClause(parse, declaration.definition, setClause), names);
+    auto statement = [&]() -> SetupStatement
+    {
+        if (inlineData.has_value())
+        {
+            return StatementWithInlineData{.sql = std::move(sql), .data = std::move(*inlineData)};
+        }
+        if (servedData.has_value())
+        {
+            return StatementWithServedData{.sql = std::move(sql), .data = std::move(*servedData)};
+        }
+        return PlainStatement{.sql = std::move(sql)};
+    }();
+    return RewrittenSource{.statement = std::move(statement), .inputFile = std::move(inputFile)};
+}
+
+std::string SourceRewriter::setClauseFor(
+    SqlParse& parse, AntlrSQLParser::NamedConfigExpressionSeqContext* declared, const std::optional<std::filesystem::path>& dataFile) const
+{
+    std::vector<std::string> options;
+    if (dataFile.has_value())
+    {
+        options.push_back(Sql::option(Sql::Source, Sql::FilePath, dataFile->string()));
+    }
+    if (not declaresOption(declared, Sql::Source, Sql::Host))
+    {
+        options.push_back(Sql::option(Sql::Source, Sql::Host, target.sourceHost.view()));
+    }
+    if (not declaresOption(declared, Sql::InputFormatter, Sql::Type))
+    {
+        options.push_back(Sql::option(Sql::InputFormatter, Sql::Type, Sql::Csv));
+    }
+    if (const auto declaredText = parse.textOf(declared); not declaredText.empty())
+    {
+        options.push_back(declaredText);
+    }
+    return Sql::setClause(Sql::optionList(options));
+}
+
+void makeAnonymousSourcePathsAbsolute(
+    const SqlParse& parse, antlr4::TokenStreamRewriter& rewriter, const std::filesystem::path& testDataDir)
+{
+    for (const auto* source : findAll<AntlrSQLParser::AnonymousSourceContext>(parse.tree()))
+    {
+        for (auto* option : source->parameters->namedConfigExpression())
+        {
+            if (auto* value = stringValueOf(option); value != nullptr and namesOption(option, Sql::Source, Sql::FilePath))
+            {
+                if (const std::filesystem::path declared{unquote(value->getText())}; declared.is_relative())
+                {
+                    rewriter.replace(value->getStart(), value->getStop(), Sql::stringLiteral((testDataDir / declared).string()));
+                }
+            }
+        }
+    }
+}
+
+void completeAnonymousSources(const SqlParse& parse, antlr4::TokenStreamRewriter& rewriter, const Host& host)
+{
+    for (const auto* source : findAll<AntlrSQLParser::AnonymousSourceContext>(parse.tree()))
+    {
+        const auto declared = source->parameters->namedConfigExpression();
+        std::vector<std::string> missing;
+        if (not std::ranges::any_of(declared, [](auto* option) { return namesOption(option, Sql::Source, Sql::Host); }))
+        {
+            missing.push_back(Sql::option(Sql::Source, Sql::Host, host.view()));
+        }
+        if (not std::ranges::any_of(declared, [](auto* option) { return namesOption(option, Sql::InputFormatter, Sql::Type); }))
+        {
+            missing.push_back(Sql::option(Sql::InputFormatter, Sql::Type, Sql::Csv));
+        }
+        if (not missing.empty())
+        {
+            rewriter.insertAfter(source->parameters->getStop(), fmt::format(", {}", Sql::optionList(missing)));
+        }
+    }
+}
+
+std::string addSourceOptions(const std::string& sql, const std::vector<std::string>& options)
+{
+    SqlParse parse{sql};
+    auto* definition = findFirst<AntlrSQLParser::CreatePhysicalSourceDefinitionContext>(parse.tree());
+    if (definition == nullptr)
+    {
+        throw TestException("Only a physical source takes source options, but this statement declares something else: {}", sql);
+    }
+
+    auto merged = options;
+    if (const auto declaredText = parse.textOf(declaredOptions(definition)); not declaredText.empty())
+    {
+        merged.push_back(declaredText);
+    }
+    return spliceSetClause(parse, definition, Sql::setClause(Sql::optionList(merged)));
+}
+
+}

--- a/nes-systests/systest/src/Rewriter/SqlRewriter.cpp
+++ b/nes-systests/systest/src/Rewriter/SqlRewriter.cpp
@@ -1,0 +1,35 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Rewriter/SqlRewriter.hpp>
+
+#include <utility>
+
+#include <Model/ParsedTestFile.hpp>
+#include <Model/RewrittenTest.hpp>
+#include <Rewriter/ClassifiedStatement.hpp>
+#include <Rewriter/Declarations.hpp>
+#include <Rewriter/Emitter.hpp>
+
+namespace NES
+{
+
+RewrittenTest rewriteTestFile(const ParsedTestFile& testFile, const RewriteTarget& target)
+{
+    auto classified = classifyStatements(testFile);
+    auto declarations = declareAll(classified, target.testFileKey);
+    return Emitter{target, std::move(declarations)}.emit(classified);
+}
+
+}

--- a/nes-systests/systest/src/Runner/CMakeLists.txt
+++ b/nes-systests/systest/src/Runner/CMakeLists.txt
@@ -13,4 +13,5 @@
 add_source_files(nes-systest-lib
         SystestRunner.cpp
         QuerySubmitter.cpp
+        DataStaging.cpp
 )

--- a/nes-systests/systest/src/Runner/DataStaging.cpp
+++ b/nes-systests/systest/src/Runner/DataStaging.cpp
@@ -1,0 +1,68 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Runner/DataStaging.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <stop_token>
+#include <string>
+#include <thread>
+#include <utility>
+#include <variant>
+
+#include <Model/RewrittenTest.hpp>
+#include <Rewriter/Constants.hpp>
+#include <Util/Files.hpp>
+#include <ErrorHandling.hpp>
+#include <TCPDataServer.hpp>
+
+namespace NES
+{
+
+void writeInlineData(const InlineData& data)
+{
+    std::filesystem::create_directories(data.path.parent_path());
+    std::ofstream file{data.path};
+    for (const auto& row : data.rows)
+    {
+        file << row << '\n';
+    }
+    /// A source that cannot open this file reports only that the path does not resolve.
+    /// Failing here reports the write that did not happen.
+    file.flush();
+    if (not file)
+    {
+        throw TestException("could not write the inline data of a source to {}: {}", data.path.string(), getErrorMessageFromERRNO());
+    }
+}
+
+RunningServer serve(ServedData data)
+{
+    /// The server binds in its constructor, so the port in the options is the one that the source connects to.
+    auto server = std::visit(
+        [](auto&& content) { return std::make_unique<TCPDataServer>(std::forward<decltype(content)>(content)); }, std::move(data.content));
+    const auto port = server->getPort();
+
+    return {
+        .thread = std::jthread{[owned = std::move(server)](const std::stop_token& stopToken) { owned->run(stopToken); }},
+        .options
+        = {Sql::option(Sql::Source, Sql::SocketHost, "localhost"),
+           Sql::option(Sql::Source, Sql::SocketPort, std::to_string(port)),
+           /// The test data sets are small, so a source would otherwise wait on a partial buffer for rows that never come.
+           Sql::option(Sql::Source, Sql::FlushIntervalMs, "100")}};
+}
+
+}

--- a/nes-systests/systest/tests/CMakeLists.txt
+++ b/nes-systests/systest/tests/CMakeLists.txt
@@ -39,5 +39,11 @@ add_nes_test_systest(slt-parser-test
 add_nes_test_systest(testfile-builder-test
         "Parser/TestFileBuilderTests.cpp")
 
+add_nes_test_systest(systest-name-qualifier-test
+        "Rewriter/NameQualifierTests.cpp")
+
+add_nes_test_systest(systest-sql-rewriter-test
+        "Rewriter/SqlRewriterTests.cpp")
+
 add_nes_test_systest(slt-e2e-test
         "SystestE2ETests.cpp")

--- a/nes-systests/systest/tests/Rewriter/NameQualifierTests.cpp
+++ b/nes-systests/systest/tests/Rewriter/NameQualifierTests.cpp
@@ -1,0 +1,209 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <array>
+#include <cctype>
+#include <filesystem>
+#include <string>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include <Rewriter/NameQualifier.hpp>
+#include <Util/Logger/LogLevel.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <Util/Logger/impl/NesLogger.hpp>
+#include <BaseUnitTest.hpp>
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+
+class NameQualifierTest : public Testing::BaseUnitTest
+{
+public:
+    static void SetUpTestSuite()
+    {
+        Logger::setupLogging("NameQualifier.log", LogLevel::LOG_DEBUG);
+        NES_INFO("Setup NameQualifier test class.");
+    }
+
+    static void TearDownTestSuite() { NES_INFO("Tear down NameQualifier test class."); }
+
+    static std::string keyOf(const std::string& relativePath) { return getTestFileKey(root / relativePath, root); }
+
+    static inline const std::filesystem::path root{"/discovery"};
+};
+
+/// The nine stems that appear in more than one directory must key differently, or their catalog entries overwrite each other in the
+/// shared catalog.
+
+/// A printed plan holds what the test wrote, so comparing it needs the qualifying prefix taken back off.
+TEST(UnqualifiedTest, RemovesEveryOccurrenceOfThePrefix)
+{
+    EXPECT_EQ(unqualified("SINK(TESTKEY_SINKONETUPLE) <- SOURCE(TESTKEY_ONETUPLE)", "TESTKEY_"), "SINK(SINKONETUPLE) <- SOURCE(ONETUPLE)");
+}
+
+/// A plan holding nothing this file qualified comes back word for word.
+TEST(UnqualifiedTest, LeavesTextWithoutThePrefixAlone)
+{
+    EXPECT_EQ(unqualified("SINK(SINKONETUPLE)", "TESTKEY_"), "SINK(SINKONETUPLE)");
+}
+
+/// Two prefixes in a row are two occurrences, and both go.
+TEST(UnqualifiedTest, RemovesAdjacentOccurrences)
+{
+    EXPECT_EQ(unqualified("A_A_NAME", "A_"), "NAME");
+}
+
+/// An empty text has nothing to take off it.
+TEST(UnqualifiedTest, HandlesAnEmptyText)
+{
+    EXPECT_EQ(unqualified("", "TESTKEY_"), "");
+}
+
+/// The directory prefix separates them.
+TEST_F(NameQualifierTest, DuplicateStemsKeyApartByDirectory)
+{
+    static constexpr std::array duplicatedStems
+        = {"Nexmark",
+           "DEBS",
+           "YahooStreamingBenchmark",
+           "LinearRoadBenchmark",
+           "LinearRoadBenchmarkTCP",
+           "ClusterMonitoring",
+           "Manufacturing",
+           "Nexmark_with_varsized",
+           "YahooStreamingBenchmark_with_varsized"};
+
+    for (const auto* stem : duplicatedStems)
+    {
+        const auto inBenchmark = keyOf(std::string{"benchmark/"} + stem + ".test");
+        const auto inBenchmarkSmall = keyOf(std::string{"benchmark_small/"} + stem + ".test");
+        EXPECT_NE(inBenchmark, inBenchmarkSmall) << "stem '" << stem << "' collides across directories";
+    }
+}
+
+/// A plain stem and its `_with_varsized` variant share one directory, so the suffix has to separate them on its own.
+TEST_F(NameQualifierTest, VariantSuffixKeepsKeysApart)
+{
+    EXPECT_NE(keyOf("benchmark/Nexmark.test"), keyOf("benchmark/Nexmark_with_varsized.test"));
+}
+
+/// Two corpus stems are not legal unquoted identifiers: a leading digit and hyphens.
+/// The key has to come back legal and stable.
+TEST_F(NameQualifierTest, IllegalStemsSanitizedToLegalIdentifiers)
+{
+    EXPECT_EQ(keyOf("regression/2025-09-10_BrokenNotFieldAccInJoin.test"), "REGRESSION_D_2025_2D_09_2D_10__BROKENNOTFIELDACCINJOIN");
+    EXPECT_EQ(
+        keyOf("regression/2026-06-15_RedundantProjectionDropsSwap.test"), "REGRESSION_D_2026_2D_06_2D_15__REDUNDANTPROJECTIONDROPSSWAP");
+}
+
+/// A stem that starts with a digit at the discovery root has no directory in front of it, so it gets a legal leading character.
+TEST_F(NameQualifierTest, LeadingDigitStemGetsLegalLeadingCharacter)
+{
+    const auto key = keyOf("2025-09-10_BrokenNotFieldAccInJoin.test");
+    ASSERT_FALSE(key.empty());
+    EXPECT_FALSE(std::isdigit(static_cast<unsigned char>(key.front())));
+}
+
+/// The encoding keeps distinct paths apart even when they differ only in characters that an identifier cannot hold.
+/// A run whose catalog these files share would otherwise reject one of them for the other's names.
+TEST_F(NameQualifierTest, KeysStayApartForPathsThatSanitizeAlike)
+{
+    EXPECT_EQ(keyOf("benchmark/Nexmark.test"), "BENCHMARK_D_NEXMARK");
+    EXPECT_NE(keyOf("foo-bar.test"), keyOf("foo_bar.test"));
+    EXPECT_NE(keyOf("foo-bar.test"), keyOf("foo/bar.test"));
+    EXPECT_NE(keyOf("foo_bar.test"), keyOf("foo/bar.test"));
+    EXPECT_NE(keyOf("a_/b.test"), keyOf("a/_b.test"));
+}
+
+/// A file with a single part keeps its own key, and every further part gets a suffix of its own, so the parts of one
+/// file do not collide in the shared catalog.
+TEST_F(NameQualifierTest, PartKeysStayDistinct)
+{
+    EXPECT_EQ(getTestFilePartKey("BENCHMARK_NEXMARK", 0, 1), "BENCHMARK_NEXMARK");
+    EXPECT_EQ(getTestFilePartKey("BENCHMARK_NEXMARK", 0, 2), "BENCHMARK_NEXMARK_C0");
+    EXPECT_EQ(getTestFilePartKey("BENCHMARK_NEXMARK", 1, 2), "BENCHMARK_NEXMARK_C1");
+}
+
+/// No encoded path ends in a bare part suffix, because a lone underscore only occurs inside a token.
+/// A file named like another file's part therefore cannot take that part's key.
+TEST_F(NameQualifierTest, PartKeysCannotCollideWithFileKeys)
+{
+    EXPECT_NE(keyOf("x_c0.test"), getTestFilePartKey(keyOf("x.test"), 0, 2));
+}
+
+/// A discovery root given as a relative path addresses the same files as the absolute path to it, and a discovered test file is
+/// always absolute.
+/// Both have to produce the same key, or the key of every file in the run depends on how the run was invoked.
+///
+/// A relative path only resolves while the process runs where that directory exists, so the test moves there
+/// rather than assuming the directory that the run happened to start in.
+TEST_F(NameQualifierTest, RelativeDiscoveryRootKeysLikeTheAbsoluteOne)
+{
+    const std::filesystem::path relativeRoot{"nes-systests"};
+    const auto previous = std::filesystem::current_path();
+    const auto sandbox = std::filesystem::temp_directory_path() / "nes-name-qualifier-relative-root";
+    std::filesystem::create_directories(sandbox / relativeRoot / "benchmark");
+    std::filesystem::current_path(sandbox);
+
+    const auto absoluteRoot = std::filesystem::current_path() / relativeRoot;
+    const auto testFile = absoluteRoot / "benchmark" / "Nexmark.test";
+
+    EXPECT_EQ(getTestFileKey(testFile, relativeRoot), "BENCHMARK_D_NEXMARK");
+    EXPECT_EQ(getTestFileKey(testFile, relativeRoot), getTestFileKey(testFile, absoluteRoot));
+
+    std::filesystem::current_path(previous);
+    std::error_code errorCode;
+    std::filesystem::remove_all(sandbox, errorCode);
+}
+
+/// A file that is not under the discovery root has no key, and an unqualified name from one test file collides in the shared
+/// catalog with the same name from the next.
+/// Report it rather than return a key that qualifies nothing.
+TEST_F(NameQualifierTest, RejectsATestFileOutsideTheDiscoveryRoot)
+{
+    EXPECT_THROW(getTestFileKey("/elsewhere/benchmark/Nexmark.test", root), Exception);
+}
+
+/// An unquoted name qualifies the same however it is cased, because the catalog compares it case-insensitively.
+/// A repeat returns the same spelling rather than registering a second entry.
+TEST_F(NameQualifierTest, DeclareIsCaseInsensitiveAndIdempotent)
+{
+    NameRegistry registry{"BENCHMARK_NEXMARK"};
+    const auto lower = registry.declare("bid");
+    EXPECT_EQ(lower, "BENCHMARK_NEXMARK_BID");
+    EXPECT_EQ(registry.declare("BID"), lower);
+    EXPECT_EQ(registry.declare("bid"), lower);
+}
+
+/// A name that the test quoted keeps its case and punctuation, and only quotes preserve that in a statement.
+/// Prefixing such a name and emitting it bare produces a statement that does not parse, when the name holds a space.
+TEST_F(NameQualifierTest, QuotesAQualifiedNameThatWasQuoted)
+{
+    NameRegistry registry{"BENCHMARK_NEXMARK"};
+    EXPECT_EQ(registry.declare(R"("INPUT STREAM")"), R"("BENCHMARK_NEXMARK_INPUT STREAM")");
+    EXPECT_EQ(registry.declare("bid"), "BENCHMARK_NEXMARK_BID");
+}
+
+/// The sealed names hold the prefix that qualifying used, so a consumer can strip it from a printed plan again.
+TEST_F(NameQualifierTest, SealCarriesTheQualifyingPrefix)
+{
+    NameRegistry registry{"BENCHMARK_NEXMARK"};
+    registry.declare("bid");
+    EXPECT_EQ(std::move(registry).seal().qualifyingPrefix(), "BENCHMARK_NEXMARK_");
+}
+
+}

--- a/nes-systests/systest/tests/Rewriter/SqlRewriterTests.cpp
+++ b/nes-systests/systest/tests/Rewriter/SqlRewriterTests.cpp
@@ -1,0 +1,686 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <filesystem>
+#include <initializer_list>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <Identifiers/Identifiers.hpp>
+#include <Model/Expectation.hpp>
+#include <Model/RewrittenTest.hpp>
+#include <Parser/SystestParser.hpp>
+#include <Parser/TestFileBuilder.hpp>
+#include <Rewriter/NameQualifier.hpp>
+#include <Rewriter/SourceRewriting.hpp>
+#include <Rewriter/SqlRewriter.hpp>
+#include <Util/Logger/LogLevel.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <Util/Logger/impl/NesLogger.hpp>
+#include <BaseUnitTest.hpp>
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+
+class RewriteIdentifiersTest : public Testing::BaseUnitTest
+{
+public:
+    static void SetUpTestSuite()
+    {
+        Logger::setupLogging("RewriteIdentifiers.log", LogLevel::LOG_DEBUG);
+        NES_INFO("Setup RewriteIdentifiers test class.");
+    }
+
+    static void TearDownTestSuite() { NES_INFO("Tear down RewriteIdentifiers test class."); }
+
+    /// Registers the given catalog names under one key and seals them, mirroring the declaring pass that precedes a rewrite.
+    static QualifiedNames namesWith(const std::initializer_list<std::string_view> declared)
+    {
+        NameRegistry registry{"BENCHMARK_NEXMARK"};
+        for (const auto name : declared)
+        {
+            registry.declare(name);
+        }
+        return std::move(registry).seal();
+    }
+};
+
+/// The rewrite substitutes a registered name and preserves the surrounding keywords, punctuation and whitespace exactly.
+TEST_F(RewriteIdentifiersTest, SubstitutesRegisteredNames)
+{
+    const auto names = namesWith({"stream", "bid"});
+    EXPECT_EQ(rewriteIdentifiers("SELECT bid FROM stream", names), "SELECT BENCHMARK_NEXMARK_BID FROM BENCHMARK_NEXMARK_STREAM");
+}
+
+/// The catalog compares an unquoted name case-insensitively, so the token matches its registration however it is cased.
+TEST_F(RewriteIdentifiersTest, MatchesRegisteredNameRegardlessOfCase)
+{
+    const auto names = namesWith({"stream"});
+    EXPECT_EQ(rewriteIdentifiers("SELECT x FROM STREAM", names), "SELECT x FROM BENCHMARK_NEXMARK_STREAM");
+}
+
+/// The rewrite leaves an identifier that the qualifier never registered unchanged, so column names and aliases pass through.
+TEST_F(RewriteIdentifiersTest, LeavesUnregisteredIdentifiersAlone)
+{
+    const auto names = namesWith({"stream"});
+    EXPECT_EQ(rewriteIdentifiers("SELECT unknown FROM stream", names), "SELECT unknown FROM BENCHMARK_NEXMARK_STREAM");
+}
+
+/// An identifier that merely contains a registered name is a distinct token, and the rewrite leaves it unchanged.
+TEST_F(RewriteIdentifiersTest, DoesNotRewriteIdentifierContainingRegisteredName)
+{
+    const auto names = namesWith({"stream"});
+    EXPECT_EQ(rewriteIdentifiers("SELECT x FROM streamSink", names), "SELECT x FROM streamSink");
+    EXPECT_EQ(rewriteIdentifiers("SELECT x FROM sinkStream", names), "SELECT x FROM sinkStream");
+}
+
+/// A registered name that appears inside a string literal is not an identifier token, so the literal stays byte for byte.
+TEST_F(RewriteIdentifiersTest, DoesNotRewriteInsideStringLiterals)
+{
+    const auto names = namesWith({"stream"});
+    EXPECT_EQ(rewriteIdentifiers("INTO File(file_path='/data/stream/x.csv')", names), "INTO File(file_path='/data/stream/x.csv')");
+}
+
+/// Rewriting is a fixed point: the qualified spelling is not itself registered, so a second pass changes nothing.
+TEST_F(RewriteIdentifiersTest, IsIdempotent)
+{
+    const auto names = namesWith({"stream", "bid"});
+    const auto once = rewriteIdentifiers("SELECT bid FROM stream", names);
+    EXPECT_EQ(rewriteIdentifiers(once, names), once);
+}
+
+class SqlRewriterTest : public Testing::BaseUnitTest
+{
+public:
+    static void SetUpTestSuite()
+    {
+        Logger::setupLogging("SqlRewriter.log", LogLevel::LOG_DEBUG);
+        NES_INFO("Setup SqlRewriter test class.");
+    }
+
+    static void TearDownTestSuite() { NES_INFO("Tear down SqlRewriter test class."); }
+
+    static RewrittenTest rewriteSlt(const std::string& slt)
+    {
+        SystestParser parser;
+        parser.loadString(slt);
+        const auto testFile = buildTestFile(parser, "/tests/OneTuple.test");
+        return rewriteTestFile(
+            testFile,
+            RewriteTarget{
+                .testFileKey = "TESTKEY",
+                .displayName = "testkey",
+                .workingDir = "/work",
+                .testDataDir = "/data",
+                .sourceHost = Host{"localhost:8080"},
+                .sinkHost = Host{"localhost:8080"}});
+    }
+
+    /// Unwraps the single-query action of a case, throwing when the case holds a differential block instead.
+    static const RewrittenQuery& queryOf(const RewrittenCase& testCase) { return std::get<RewrittenQuery>(testCase.action); }
+};
+
+/// A file marked `SEQUENTIAL_EXECUTION` runs its queries in order, so every query of it waits for the one above.
+/// The first query has nothing above it, and the runner starts it whatever the flag says.
+TEST_F(SqlRewriterTest, MarksEveryQueryOfASequentialFileAsFollowingTheOneAbove)
+{
+    const auto [name, qualifyingPrefix, setup, queries] = rewriteSlt("SEQUENTIAL_EXECUTION\n"
+                                                                     "CREATE LOGICAL SOURCE oneTuple(field_1 UINT64 NOT NULL);\n"
+                                                                     "CREATE SINK sinkOneTuple(field_1 UINT64 NOT NULL) TYPE File;\n"
+                                                                     "\n"
+                                                                     "SELECT field_1 FROM oneTuple INTO sinkOneTuple;\n"
+                                                                     "----\n"
+                                                                     "1\n"
+                                                                     "\n"
+                                                                     "SELECT field_1 FROM oneTuple INTO sinkOneTuple;\n"
+                                                                     "----\n"
+                                                                     "1\n");
+
+    ASSERT_EQ(queries.size(), 2U);
+    EXPECT_TRUE(queries.at(0).runsAfterPrevious);
+    EXPECT_TRUE(queries.at(1).runsAfterPrevious);
+}
+
+/// A differential block asserts one thing, that its two queries agree, so it becomes one case with one verdict.
+/// The runner submits the halves back to back itself, so the case does not wait for anything in a file without order.
+TEST_F(SqlRewriterTest, MergesADifferentialBlockIntoOneCase)
+{
+    const auto [name, qualifyingPrefix, setup, queries] = rewriteSlt("CREATE LOGICAL SOURCE oneTuple(field_1 UINT64 NOT NULL);\n"
+                                                                     "CREATE SINK sinkOneTuple(field_1 UINT64 NOT NULL) TYPE File;\n"
+                                                                     "\n"
+                                                                     "SELECT field_1 FROM oneTuple INTO sinkOneTuple;\n"
+                                                                     "====\n"
+                                                                     "SELECT field_1 FROM oneTuple INTO sinkOneTuple;\n");
+
+    ASSERT_EQ(queries.size(), 1U);
+    EXPECT_FALSE(queries.at(0).runsAfterPrevious);
+    EXPECT_TRUE(std::holds_alternative<RewrittenDifferential>(queries.at(0).action));
+}
+
+/// The plain path: an inline source, a declared File sink, and one query rewrite to qualified DDL, a configured physical source, and an
+/// inlined per-query sink.
+TEST_F(SqlRewriterTest, RewritesInlineSourceNamedSinkAndQuery)
+{
+    const auto [name, qualifyingPrefix, setup, queries] = rewriteSlt("CREATE LOGICAL SOURCE oneTuple(field_1 UINT64 NOT NULL);\n"
+                                                                     "CREATE PHYSICAL SOURCE FOR oneTuple TYPE File;\n"
+                                                                     "ATTACH INLINE\n"
+                                                                     "1\n"
+                                                                     "\n"
+                                                                     "CREATE SINK sinkOneTuple(field_1 UINT64 NOT NULL) TYPE File;\n"
+                                                                     "\n"
+                                                                     "SELECT field_1 FROM oneTuple INTO sinkOneTuple;\n"
+                                                                     "----\n"
+                                                                     "1\n");
+
+    ASSERT_EQ(setup.size(), 2U);
+    EXPECT_EQ(sqlOf(setup.at(0)), "CREATE LOGICAL SOURCE TESTKEY_ONETUPLE(field_1 UINT64 NOT NULL);");
+    EXPECT_TRUE(std::holds_alternative<PlainStatement>(setup.at(0)));
+
+    EXPECT_EQ(
+        sqlOf(setup.at(1)),
+        R"(CREATE PHYSICAL SOURCE FOR TESTKEY_ONETUPLE TYPE File SET ('/work/sources/TESTKEY_0.csv' AS "SOURCE"."FILE_PATH", )"
+        R"('localhost:8080' AS "SOURCE"."HOST", 'CSV' AS "INPUT_FORMATTER"."TYPE");)");
+    const auto* withInline = std::get_if<StatementWithInlineData>(&setup.at(1));
+    ASSERT_NE(withInline, nullptr);
+    EXPECT_EQ(withInline->data.path, "/work/sources/TESTKEY_0.csv");
+    EXPECT_EQ(withInline->data.rows, (std::vector<std::string>{"1"}));
+
+    ASSERT_EQ(queries.size(), 1U);
+    EXPECT_EQ(
+        queryOf(queries.at(0)).sql,
+        R"(SELECT field_1 FROM TESTKEY_ONETUPLE INTO File('localhost:8080' AS "SINK"."HOST", '/work/TESTKEY_1.csv' AS "SINK"."FILE_PATH", )"
+        R"('CSV' AS "SINK"."OUTPUT_FORMAT", SCHEMA(field_1 UINT64 NOT NULL) AS "SINK"."SCHEMA");)");
+    EXPECT_EQ(queryOf(queries.at(0)).resultFile, "/work/TESTKEY_1.csv");
+    const auto* expectedRows = std::get_if<ExpectedRows>(&queryOf(queries.at(0)).expectation);
+    ASSERT_NE(expectedRows, nullptr);
+    EXPECT_EQ(expectedRows->rows, (std::vector<std::string>{"1"}));
+}
+
+/// The two halves of a differential block share one query number, and one result file between them would compare a
+/// result against itself and pass whatever either query returned.
+TEST_F(SqlRewriterTest, GivesEachHalfOfADifferentialBlockItsOwnResultFile)
+{
+    const auto [name, qualifyingPrefix, setup, queries] = rewriteSlt("CREATE LOGICAL SOURCE oneTuple(field_1 UINT64 NOT NULL);\n"
+                                                                     "CREATE SINK sinkOneTuple(field_1 UINT64 NOT NULL) TYPE File;\n"
+                                                                     "\n"
+                                                                     "SELECT field_1 FROM oneTuple INTO sinkOneTuple;\n"
+                                                                     "====\n"
+                                                                     "SELECT field_1 FROM oneTuple WHERE field_1 > 0 INTO sinkOneTuple;\n");
+
+    ASSERT_EQ(queries.size(), 1U);
+    const auto* differential = std::get_if<RewrittenDifferential>(&queries.at(0).action);
+    ASSERT_NE(differential, nullptr);
+    EXPECT_NE(differential->firstResultFile, differential->secondResultFile);
+    EXPECT_NE(differential->firstSql, differential->secondSql);
+}
+
+/// Every name is registered before any statement is rewritten, so a source declared below the query that reads it still qualifies.
+/// Registering as each statement was rewritten would leave this reference raw and the query would bind against nothing.
+TEST_F(SqlRewriterTest, QualifiesSourceDeclaredBelowTheQuery)
+{
+    const auto [name, qualifyingPrefix, setup, queries] = rewriteSlt("CREATE SINK sinkOneTuple(field_1 UINT64 NOT NULL) TYPE File;\n"
+                                                                     "\n"
+                                                                     "SELECT field_1 FROM oneTuple INTO sinkOneTuple;\n"
+                                                                     "----\n"
+                                                                     "1\n"
+                                                                     "\n"
+                                                                     "CREATE LOGICAL SOURCE oneTuple(field_1 UINT64 NOT NULL);\n");
+
+    ASSERT_EQ(setup.size(), 1U);
+    EXPECT_EQ(sqlOf(setup.at(0)), "CREATE LOGICAL SOURCE TESTKEY_ONETUPLE(field_1 UINT64 NOT NULL);");
+
+    ASSERT_EQ(queries.size(), 1U);
+    EXPECT_EQ(
+        queryOf(queries.at(0)).sql,
+        R"(SELECT field_1 FROM TESTKEY_ONETUPLE INTO File('localhost:8080' AS "SINK"."HOST", '/work/TESTKEY_1.csv' AS "SINK"."FILE_PATH", )"
+        R"('CSV' AS "SINK"."OUTPUT_FORMAT", SCHEMA(field_1 UINT64 NOT NULL) AS "SINK"."SCHEMA");)");
+}
+
+/// The declaring pass stores sinks alongside the names it registers, so a sink declared below the query that writes to it is still
+/// inlined with the schema that it declares.
+TEST_F(SqlRewriterTest, InlinesSinkDeclaredBelowTheQuery)
+{
+    const auto [name, qualifyingPrefix, setup, queries] = rewriteSlt("CREATE LOGICAL SOURCE oneTuple(field_1 UINT64 NOT NULL);\n"
+                                                                     "\n"
+                                                                     "SELECT field_1 FROM oneTuple INTO sinkOneTuple;\n"
+                                                                     "----\n"
+                                                                     "1\n"
+                                                                     "\n"
+                                                                     "CREATE SINK sinkOneTuple(field_1 UINT64 NOT NULL) TYPE File;\n");
+
+    ASSERT_EQ(setup.size(), 1U);
+    ASSERT_EQ(queries.size(), 1U);
+    EXPECT_EQ(
+        queryOf(queries.at(0)).sql,
+        R"(SELECT field_1 FROM TESTKEY_ONETUPLE INTO File('localhost:8080' AS "SINK"."HOST", '/work/TESTKEY_1.csv' AS "SINK"."FILE_PATH", )"
+        R"('CSV' AS "SINK"."OUTPUT_FORMAT", SCHEMA(field_1 UINT64 NOT NULL) AS "SINK"."SCHEMA");)");
+    EXPECT_EQ(queryOf(queries.at(0)).resultFile, "/work/TESTKEY_1.csv");
+}
+
+/// A test that asserts a syntax error writes a query the parser rejects, and nothing can be inlined into a statement with no parse tree.
+/// It goes to the coordinator as it stands, so the coordinator reports the error against that query rather than the rewrite failing
+/// every query of the file.
+/// The rewrite still qualifies its source references, because substituting names reads tokens.
+TEST_F(SqlRewriterTest, PassesAQueryThatDoesNotParseThrough)
+{
+    const auto [name, qualifyingPrefix, setup, queries]
+        = rewriteSlt("CREATE LOGICAL SOURCE oneTuple(field_1 UINT64 NOT NULL);\n"
+                     "CREATE PHYSICAL SOURCE FOR oneTuple TYPE File;\n"
+                     "ATTACH INLINE\n"
+                     "1\n"
+                     "\n"
+                     "CREATE SINK sinkOneTuple(field_1 UINT64 NOT NULL) TYPE File;\n"
+                     "\n"
+                     "SELECT field_1 FROM oneTuple GROUP BY field_1 WHERE field_1 > UINT64(1) INTO sinkOneTuple;\n"
+                     "----\n"
+                     "ERROR 2000\n");
+
+    ASSERT_EQ(queries.size(), 1U);
+    /// The sink keeps the name that the test wrote, because the declaring pass stores a declared sink for inlining rather than
+    /// registering it as a name.
+    /// It resolves to nothing in the catalog, which does not matter: the statement fails to parse before any name lookup.
+    EXPECT_EQ(
+        queryOf(queries.at(0)).sql, "SELECT field_1 FROM TESTKEY_ONETUPLE GROUP BY field_1 WHERE field_1 > UINT64(1) INTO sinkOneTuple;");
+    EXPECT_FALSE(queryOf(queries.at(0)).resultFile.has_value());
+}
+
+/// A query that infers with a model refers to it, so a model qualifies like a source.
+/// The path to that file is relative to the test-data directory, and the worker loading it resolves a relative path against
+/// its own working directory instead.
+TEST_F(SqlRewriterTest, RewritesModelAndTheQueryThatInfersWithIt)
+{
+    const auto [name, qualifyingPrefix, setup, queries]
+        = rewriteSlt("CREATE LOGICAL SOURCE stream(p1 FLOAT32 NOT NULL);\n"
+                     "CREATE PHYSICAL SOURCE FOR stream TYPE File;\n"
+                     "ATTACH FILE small/iris.csv\n"
+                     "\n"
+                     "CREATE MODEL iris ('model/iris.onnx')\n"
+                     "INPUT (p1 FLOAT32)\n"
+                     "OUTPUT (setosa FLOAT32);\n"
+                     "\n"
+                     "CREATE SINK result(p1 FLOAT32 NOT NULL, setosa FLOAT32 NOT NULL) TYPE File;\n"
+                     "\n"
+                     "SELECT * FROM MODEL_INFERENCE(iris, stream) INTO result;\n"
+                     "----\n"
+                     "1,1\n");
+
+    ASSERT_EQ(setup.size(), 3U);
+    EXPECT_EQ(
+        sqlOf(setup.at(2)),
+        "CREATE MODEL TESTKEY_IRIS ('/data/model/iris.onnx')\n"
+        "INPUT (p1 FLOAT32)\n"
+        "OUTPUT (setosa FLOAT32);");
+    EXPECT_TRUE(std::holds_alternative<PlainStatement>(setup.at(2)));
+
+    ASSERT_EQ(queries.size(), 1U);
+    EXPECT_TRUE(queryOf(queries.at(0)).sql.contains("MODEL_INFERENCE(TESTKEY_IRIS, TESTKEY_STREAM)"));
+}
+
+/// An ATTACH FILE source references an existing file under the test-data directory rather than materializing a new one.
+TEST_F(SqlRewriterTest, RewritesFileSourceWithoutMaterializing)
+{
+    const auto [name, qualifyingPrefix, setup, queries] = rewriteSlt("CREATE LOGICAL SOURCE stream(id UINT64 NOT NULL);\n"
+                                                                     "CREATE PHYSICAL SOURCE FOR stream TYPE File;\n"
+                                                                     "ATTACH FILE small/stream8.csv\n"
+                                                                     "\n"
+                                                                     "CREATE SINK out(id UINT64 NOT NULL) TYPE File;\n"
+                                                                     "\n"
+                                                                     "SELECT id FROM stream INTO out;\n"
+                                                                     "----\n"
+                                                                     "1\n");
+
+    ASSERT_EQ(setup.size(), 2U);
+    EXPECT_EQ(
+        sqlOf(setup.at(1)),
+        R"(CREATE PHYSICAL SOURCE FOR TESTKEY_STREAM TYPE File SET ('/data/small/stream8.csv' AS "SOURCE"."FILE_PATH", )"
+        R"('localhost:8080' AS "SOURCE"."HOST", 'CSV' AS "INPUT_FORMATTER"."TYPE");)");
+    /// An ATTACH FILE source points at an existing file, so no statement holds inline data to write.
+    EXPECT_TRUE(std::holds_alternative<PlainStatement>(setup.at(1)));
+}
+
+/// A source that reads from a socket gets no file path: a server sends it the attached data, and the endpoint is known only once that
+/// server binds, so the rewriter leaves the statement without one and stages the rows for a server instead.
+/// The options that the test set stay as the test wrote them.
+TEST_F(SqlRewriterTest, StagesTheDataOfASourceThatReadsFromASocket)
+{
+    const auto [name, qualifyingPrefix, setup, queries]
+        = rewriteSlt("CREATE LOGICAL SOURCE stream(id UINT64 NOT NULL);\n"
+                     R"(CREATE PHYSICAL SOURCE FOR stream TYPE TCP SET('|' AS INPUT_FORMATTER.FIELD_DELIMITER);)"
+                     "\n"
+                     "ATTACH INLINE\n"
+                     "1|19\n"
+                     "\n"
+                     "CREATE SINK out(id UINT64 NOT NULL) TYPE File;\n"
+                     "\n"
+                     "SELECT id FROM stream INTO out;\n"
+                     "----\n"
+                     "1\n");
+
+    ASSERT_EQ(setup.size(), 2U);
+    EXPECT_EQ(
+        sqlOf(setup.at(1)),
+        R"(CREATE PHYSICAL SOURCE FOR TESTKEY_STREAM TYPE TCP SET ('localhost:8080' AS "SOURCE"."HOST", )"
+        R"('CSV' AS "INPUT_FORMATTER"."TYPE", '|' AS INPUT_FORMATTER.FIELD_DELIMITER);)");
+    const auto* served = std::get_if<StatementWithServedData>(&setup.at(1));
+    ASSERT_NE(served, nullptr);
+    EXPECT_EQ(std::get<std::vector<std::string>>(served->data.content), (std::vector<std::string>{"1|19"}));
+}
+
+/// A source that reads from a socket pointed at a file rather than declaring rows, so the server sends that file.
+TEST_F(SqlRewriterTest, ServesTheFileOfASourceThatReadsFromASocket)
+{
+    const auto [name, qualifyingPrefix, setup, queries] = rewriteSlt("CREATE LOGICAL SOURCE stream(id UINT64 NOT NULL);\n"
+                                                                     "CREATE PHYSICAL SOURCE FOR stream TYPE TCP;\n"
+                                                                     "ATTACH FILE small/stream8.csv\n"
+                                                                     "\n"
+                                                                     "CREATE SINK out(id UINT64 NOT NULL) TYPE File;\n"
+                                                                     "\n"
+                                                                     "SELECT id FROM stream INTO out;\n"
+                                                                     "----\n"
+                                                                     "1\n");
+
+    ASSERT_EQ(setup.size(), 2U);
+    const auto* served = std::get_if<StatementWithServedData>(&setup.at(1));
+    ASSERT_NE(served, nullptr);
+    EXPECT_EQ(std::get<std::filesystem::path>(served->data.content), "/data/small/stream8.csv");
+}
+
+/// The endpoint that a data server bound is known only once the run is under way, so the runner merges it into the statement then,
+/// alongside whatever the rewriter already put there.
+TEST_F(SqlRewriterTest, AddsSourceOptionsToAnAlreadyRewrittenStatement)
+{
+    EXPECT_EQ(
+        addSourceOptions(
+            R"(CREATE PHYSICAL SOURCE FOR TESTKEY_STREAM TYPE TCP SET ('localhost:8080' AS "SOURCE"."HOST");)",
+            {R"('4242' AS "SOURCE"."SOCKET_PORT")"}),
+        R"(CREATE PHYSICAL SOURCE FOR TESTKEY_STREAM TYPE TCP SET ('4242' AS "SOURCE"."SOCKET_PORT", 'localhost:8080' AS "SOURCE"."HOST");)");
+}
+
+/// A sink that discards its input writes no file, so it gets neither a path nor an output format, and the query has no result file
+/// to read back.
+/// The rewrite lowers both sink forms that way.
+TEST_F(SqlRewriterTest, GivesASinkThatDiscardsItsInputNoResultFile)
+{
+    const auto declared = rewriteSlt("CREATE SINK discard(id UINT64 NOT NULL) TYPE Void;\n"
+                                     "\n"
+                                     R"(SELECT id FROM File('small/stream8.csv' AS "SOURCE".FILE_PATH) INTO discard;)"
+                                     "\n----\n");
+    ASSERT_EQ(declared.cases.size(), 1U);
+    EXPECT_FALSE(queryOf(declared.cases.at(0)).resultFile.has_value());
+    EXPECT_TRUE(queryOf(declared.cases.at(0))
+                    .sql.contains(R"(INTO Void('localhost:8080' AS "SINK"."HOST", SCHEMA(id UINT64 NOT NULL) AS "SINK"."SCHEMA"))"));
+
+    const auto written = rewriteSlt(R"(SELECT id FROM File('small/stream8.csv' AS "SOURCE".FILE_PATH) INTO Void();)"
+                                    "\n----\n");
+    ASSERT_EQ(written.cases.size(), 1U);
+    EXPECT_FALSE(queryOf(written.cases.at(0)).resultFile.has_value());
+    EXPECT_TRUE(queryOf(written.cases.at(0)).sql.contains(R"(INTO Void('localhost:8080' AS "SINK"."HOST"))"));
+}
+
+/// Only a physical source reads attached data.
+/// The test file format admits an ATTACH after any CREATE, since it matches on line prefixes, so one placed elsewhere is a mistake to
+/// report rather than something to drop.
+TEST_F(SqlRewriterTest, RejectsDataAttachedToAnythingButAPhysicalSource)
+{
+    EXPECT_THROW(
+        rewriteSlt("CREATE LOGICAL SOURCE stream(id UINT64 NOT NULL);\n"
+                   "ATTACH FILE small/stream8.csv\n"
+                   "\n"
+                   "CREATE SINK out(id UINT64 NOT NULL) TYPE File;\n"
+                   "\n"
+                   "SELECT id FROM stream INTO out;\n"
+                   "----\n"
+                   "1\n"),
+        Exception);
+}
+
+/// A source written into the query gives its path relative to the test-data directory, so the rewrite resolves the path against it
+/// and handles the rest of the source options and the sink as usual.
+TEST_F(SqlRewriterTest, ResolvesTheFileOfASourceWrittenIntoTheQuery)
+{
+    const auto [name, qualifyingPrefix, setup, queries]
+        = rewriteSlt("CREATE SINK out(id UINT64 NOT NULL) TYPE File;\n"
+                     "\n"
+                     R"(SELECT id FROM File('small/stream8.csv' AS "SOURCE".FILE_PATH, 'CSV' AS INPUT_FORMATTER."TYPE") INTO out;)"
+                     "\n----\n"
+                     "1\n");
+
+    ASSERT_EQ(queries.size(), 1U);
+    EXPECT_EQ(
+        queryOf(queries.at(0)).sql,
+        R"(SELECT id FROM File('/data/small/stream8.csv' AS "SOURCE".FILE_PATH, 'CSV' AS INPUT_FORMATTER."TYPE", )"
+        R"('localhost:8080' AS "SOURCE"."HOST") )"
+        R"(INTO File('localhost:8080' AS "SINK"."HOST", '/work/TESTKEY_1.csv' AS "SINK"."FILE_PATH", 'CSV' AS "SINK"."OUTPUT_FORMAT", )"
+        R"(SCHEMA(id UINT64 NOT NULL) AS "SINK"."SCHEMA");)");
+}
+
+/// A source that is written into the query and holds its own data has no file to resolve, so it keeps the options that the test wrote.
+/// It still gets the host, because the coordinator has to place it like any other source.
+TEST_F(SqlRewriterTest, KeepsTheOptionsOfASelfContainedSourceWrittenIntoTheQuery)
+{
+    const auto [name, qualifyingPrefix, setup, queries]
+        = rewriteSlt("CREATE SINK out(id UINT64 NOT NULL) TYPE File;\n"
+                     "\n"
+                     R"(SELECT id FROM Generator('SEQUENCE UINT64 0 10 1' AS "SOURCE".GENERATOR_SCHEMA) INTO out;)"
+                     "\n----\n"
+                     "1\n");
+
+    ASSERT_EQ(queries.size(), 1U);
+    EXPECT_TRUE(queryOf(queries.at(0))
+                    .sql.starts_with(R"(SELECT id FROM Generator('SEQUENCE UINT64 0 10 1' AS "SOURCE".GENERATOR_SCHEMA, )"
+                                     R"('localhost:8080' AS "SOURCE"."HOST", 'CSV' AS "INPUT_FORMATTER"."TYPE") INTO )"));
+}
+
+/// An absolute path already resolves the same way wherever it is read, so the rewrite leaves it unchanged.
+TEST_F(SqlRewriterTest, KeepsAnAbsoluteFileOfASourceWrittenIntoTheQuery)
+{
+    const auto [name, qualifyingPrefix, setup, queries]
+        = rewriteSlt("CREATE SINK out(id UINT64 NOT NULL) TYPE File;\n"
+                     "\n"
+                     R"(SELECT id FROM File('/elsewhere/stream8.csv' AS "SOURCE".FILE_PATH) INTO out;)"
+                     "\n----\n"
+                     "1\n");
+
+    ASSERT_EQ(queries.size(), 1U);
+    EXPECT_TRUE(queryOf(queries.at(0))
+                    .sql.starts_with(R"(SELECT id FROM File('/elsewhere/stream8.csv' AS "SOURCE".FILE_PATH, )"
+                                     R"('localhost:8080' AS "SOURCE"."HOST", 'CSV' AS "INPUT_FORMATTER"."TYPE") INTO )"));
+}
+
+/// A self-contained physical source draws its data from its own options rather than an attached data set.
+/// The rewrite pins it to the worker, keeps its options as the test wrote them, and stages no inline data to write.
+TEST_F(SqlRewriterTest, RewritesSelfContainedSourceKeepingItsOptions)
+{
+    const auto [name, qualifyingPrefix, setup, queries]
+        = rewriteSlt("CREATE LOGICAL SOURCE gen(id UINT64 NOT NULL);\n"
+                     R"(CREATE PHYSICAL SOURCE FOR gen TYPE Generator SET('SEQUENCE UINT64 0 10 1' AS "SOURCE".GENERATOR_SCHEMA);)"
+                     "\n\n"
+                     "CREATE SINK out(id UINT64 NOT NULL) TYPE File;\n"
+                     "\n"
+                     "SELECT id FROM gen INTO out;\n"
+                     "----\n"
+                     "1\n");
+
+    ASSERT_EQ(setup.size(), 2U);
+    EXPECT_EQ(
+        sqlOf(setup.at(1)),
+        R"(CREATE PHYSICAL SOURCE FOR TESTKEY_GEN TYPE Generator SET ('localhost:8080' AS "SOURCE"."HOST", )"
+        R"('CSV' AS "INPUT_FORMATTER"."TYPE", 'SEQUENCE UINT64 0 10 1' AS "SOURCE".GENERATOR_SCHEMA);)");
+    EXPECT_TRUE(std::holds_alternative<PlainStatement>(setup.at(1)));
+}
+
+/// A physical source that chose its own host keeps it, and the rewriter injects no second one.
+TEST_F(SqlRewriterTest, KeepsTheHostAPhysicalSourceChose)
+{
+    const auto [name, qualifyingPrefix, setup, queries]
+        = rewriteSlt("CREATE LOGICAL SOURCE gen(id UINT64 NOT NULL);\n"
+                     R"(CREATE PHYSICAL SOURCE FOR gen TYPE Generator SET('SEQUENCE UINT64 0 10 1' AS "SOURCE".GENERATOR_SCHEMA, )"
+                     R"('elsewhere:9999' AS "SOURCE"."HOST");)"
+                     "\n\n"
+                     "CREATE SINK out(id UINT64 NOT NULL) TYPE File;\n"
+                     "\n"
+                     "SELECT id FROM gen INTO out;\n"
+                     "----\n"
+                     "1\n");
+
+    ASSERT_EQ(setup.size(), 2U);
+    EXPECT_TRUE(sqlOf(setup.at(1)).contains(R"('elsewhere:9999' AS "SOURCE"."HOST")"));
+    EXPECT_FALSE(sqlOf(setup.at(1)).contains(R"('localhost:8080' AS "SOURCE"."HOST")"));
+}
+
+/// A sink written into the query that chose its own host keeps it, and the rewriter injects no second one.
+TEST_F(SqlRewriterTest, KeepsTheHostASinkWrittenIntoTheQueryChose)
+{
+    const auto [name, qualifyingPrefix, setup, queries]
+        = rewriteSlt("CREATE LOGICAL SOURCE stream(id UINT64 NOT NULL);\n"
+                     "\n"
+                     R"(SELECT id FROM stream INTO Void('elsewhere:9999' AS "SINK"."HOST");)"
+                     "\n----\n"
+                     "1\n");
+
+    ASSERT_EQ(queries.size(), 1U);
+    EXPECT_TRUE(queryOf(queries.at(0)).sql.contains(R"('elsewhere:9999' AS "SINK"."HOST")"));
+    EXPECT_FALSE(queryOf(queries.at(0)).sql.contains(R"('localhost:8080' AS "SINK"."HOST")"));
+}
+
+/// The checker reads the result file the rewriter chose, so a sink picking its own would succeed or fail against a file nobody reads.
+TEST_F(SqlRewriterTest, RejectsASinkThatChoosesItsResultFile)
+{
+    EXPECT_THROW(
+        rewriteSlt("CREATE LOGICAL SOURCE stream(id UINT64 NOT NULL);\n"
+                   "\n"
+                   R"(SELECT id FROM stream INTO File('/elsewhere/out.csv' AS "SINK"."FILE_PATH");)"
+                   "\n----\n"
+                   "1\n"),
+        Exception);
+}
+
+/// A checksum sink quotes its strings, because the expected checksums were computed over quoted strings.
+TEST_F(SqlRewriterTest, ChecksumSinkGetsQuotedStrings)
+{
+    const auto [name, qualifyingPrefix, setup, queries] = rewriteSlt("CREATE LOGICAL SOURCE stream(id UINT64 NOT NULL);\n"
+                                                                     "\n"
+                                                                     "SELECT id FROM stream INTO Checksum();\n"
+                                                                     "----\n"
+                                                                     "1\n");
+
+    ASSERT_EQ(queries.size(), 1U);
+    EXPECT_TRUE(queryOf(queries.at(0)).sql.contains(R"('true' AS "OUTPUT_FORMATTER"."QUOTE_STRINGS")"));
+}
+
+/// A checksum sink that chose its own quoting keeps it, so the rewriter injects no second value.
+TEST_F(SqlRewriterTest, ChecksumSinkKeepsItsOwnQuotingChoice)
+{
+    const auto [name, qualifyingPrefix, setup, queries]
+        = rewriteSlt("CREATE LOGICAL SOURCE stream(id UINT64 NOT NULL);\n"
+                     "\n"
+                     "SELECT id FROM stream INTO Checksum('false' AS \"OUTPUT_FORMATTER\".\"QUOTE_STRINGS\");\n"
+                     "----\n"
+                     "1\n");
+
+    ASSERT_EQ(queries.size(), 1U);
+    EXPECT_TRUE(queryOf(queries.at(0)).sql.contains(R"('false' AS "OUTPUT_FORMATTER"."QUOTE_STRINGS")"));
+    EXPECT_FALSE(queryOf(queries.at(0)).sql.contains(R"('true' AS "OUTPUT_FORMATTER"."QUOTE_STRINGS")"));
+}
+
+/// The explained query binds and optimizes as a regular query does, so a source written into it gets the same completion:
+/// an absolute data path, the run's source worker, and the CSV input format default.
+TEST_F(SqlRewriterTest, ExplainCompletesASourceWrittenIntoTheQuery)
+{
+    const auto [name, qualifyingPrefix, setup, queries]
+        = rewriteSlt("EXPLAIN (OPTIMIZED) SELECT id FROM File('small/stream8.csv' AS \"SOURCE\".FILE_PATH) "
+                     "INTO Void('true' AS \"SINK\".\"NOOP\");\n"
+                     "----\n"
+                     "== Optimized Plan ==\n");
+
+    ASSERT_EQ(queries.size(), 1U);
+    const auto* explain = std::get_if<RewrittenExplain>(&queries.at(0).action);
+    ASSERT_NE(explain, nullptr);
+    EXPECT_TRUE(explain->sql.contains(R"('/data/small/stream8.csv' AS "SOURCE".FILE_PATH)"));
+    EXPECT_TRUE(explain->sql.contains(R"('localhost:8080' AS "SOURCE"."HOST")"));
+    EXPECT_TRUE(explain->sql.contains(R"('CSV' AS "INPUT_FORMATTER"."TYPE")"));
+}
+
+/// The query of an EXPLAIN can refer to a declared sink, and the plan prints that sink's name, so the sink has to exist in the catalog.
+/// The rewriter submits the declaration with its mandatory options spliced in, and the reference keeps the qualified name rather
+/// than an inlined sink.
+TEST_F(SqlRewriterTest, ExplainKeepsTheDeclaredSinkAndSubmitsItsDeclaration)
+{
+    const auto [name, qualifyingPrefix, setup, queries] = rewriteSlt("CREATE LOGICAL SOURCE stream(id UINT64 NOT NULL);\n"
+                                                                     "CREATE SINK out(id UINT64 NOT NULL) TYPE File;\n"
+                                                                     "\n"
+                                                                     "EXPLAIN (OPTIMIZED) SELECT id FROM stream INTO out;\n"
+                                                                     "----\n"
+                                                                     "== Optimized Plan ==\n");
+
+    ASSERT_EQ(setup.size(), 2U);
+    EXPECT_EQ(
+        sqlOf(setup.at(1)),
+        R"(CREATE SINK TESTKEY_OUT(id UINT64 NOT NULL) TYPE File )"
+        R"(SET ('localhost:8080' AS "SINK"."HOST", '/work/TESTKEY_out.csv' AS "SINK"."FILE_PATH", 'CSV' AS "SINK"."OUTPUT_FORMAT");)");
+
+    ASSERT_EQ(queries.size(), 1U);
+    const auto* explain = std::get_if<RewrittenExplain>(&queries.at(0).action);
+    ASSERT_NE(explain, nullptr);
+    EXPECT_EQ(explain->sql, "EXPLAIN (OPTIMIZED) SELECT id FROM TESTKEY_STREAM INTO TESTKEY_OUT;");
+    EXPECT_EQ(qualifyingPrefix, "TESTKEY_");
+}
+
+/// An EXPLAIN whose query writes its sink inline needs no declaration: the rewriter inlines the sink as it does for a query
+/// and submits nothing for it.
+TEST_F(SqlRewriterTest, ExplainInlinesTheSinkThatItsQueryWrites)
+{
+    const auto [name, qualifyingPrefix, setup, queries] = rewriteSlt("CREATE LOGICAL SOURCE stream(id UINT64 NOT NULL);\n"
+                                                                     "\n"
+                                                                     "EXPLAIN (OPTIMIZED) SELECT id FROM stream "
+                                                                     "INTO Void('true' AS \"SINK\".\"NOOP\");\n"
+                                                                     "----\n"
+                                                                     "== Optimized Plan ==\n");
+
+    ASSERT_EQ(setup.size(), 1U);
+    ASSERT_EQ(queries.size(), 1U);
+    const auto* explain = std::get_if<RewrittenExplain>(&queries.at(0).action);
+    ASSERT_NE(explain, nullptr);
+    EXPECT_TRUE(explain->sql.contains("INTO Void("));
+    EXPECT_TRUE(explain->sql.contains(R"('localhost:8080' AS "SINK"."HOST")"));
+}
+
+/// Pins a limitation of the file-global sink mode: an EXPLAIN registers the declared sink names, so the rewrite qualifies the
+/// reference in an executed query before the sink lookup, whose key is the written name.
+/// The rewriter rejects such a file rather than rewriting it wrongly.
+/// Lifting this needs the lookup to resolve the qualified spelling back to the written one.
+TEST_F(SqlRewriterTest, RejectsAFileThatMixesAnExplainWithAQueryIntoADeclaredSink)
+{
+    EXPECT_THROW(
+        rewriteSlt("CREATE LOGICAL SOURCE stream(id UINT64 NOT NULL);\n"
+                   "CREATE SINK out(id UINT64 NOT NULL) TYPE File;\n"
+                   "\n"
+                   "EXPLAIN (OPTIMIZED) SELECT id FROM stream INTO out;\n"
+                   "----\n"
+                   "== Optimized Plan ==\n"
+                   "==END==\n"
+                   "\n"
+                   "SELECT id FROM stream INTO out;\n"
+                   "----\n"
+                   "1\n"),
+        Exception);
+}
+
+}


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

Stacked on #1936.

The rewriter turns a parsed test file into statements that we can then submit unchanged, so any mid-pipeline plan patching of the binder can be deleted in the next step. 
Nothing calls it yet, except its unit tests. 

The change list is as follows:

- Added `Model/RunnableTest.hpp`, the rewriter's output and the runner's future input: `RunnableTest` holds the setup DDL, the cases to run and check, and the data to stage (`InlineData` for a planned CSV, `ServedData` for a TCP source).
- Added the rewriter as three phases behind one umbrella class,`SqlRewriter::rewrite(const TestFile&) const`, each phase a file pair in `Rewriter/`:
  - `PreparedStatement`: parses and classifies every CREATE statement.
  - `Declarations`: registers every catalog-visible name and captures the declared sinks, sealed (i.e., consumed) before any rewriting.
  - `Emitter`: emits the setup DDL and rewrites the queries, in file order.
    An instance exists for a single test file, so no state carries over.
- Qualification prefixes every catalog-visible name with the test file key,
  token by token through the lexer (`NameQualifier`), so literals and
  whitespace stay as the test wrote them, and every test file of one
  invocation can share a single catalog.
- Physical sources get their file path, host and input formatter injected;
  inline data becomes a planned CSV file and socket data a served payload
  (`SourceRewriting`, `DataStaging`).
- The sink of each query is inlined with its schema and a result file of its
  own (`SinkRewriting`), and a `SET` clause puts the query name as the
  correlation key. A statement that does not parse is still qualified,
  so a syntax error test will still be caught later.

## Verifying this change

This change is tested by
- two new unit test targets: `systest-sql-rewriter-test`
  (24 tests: qualification, source splicing, sink inlining, EXPLAIN,
  differential blocks, staged data) and `systest-name-qualifier-test`
  (14 tests: key derivation, sealing, unqualification)
- the parser and runner suites, unchanged: `testfile-parser-test` (9) and
  `slt-parser-test` (40)
- the full corpus in the dev container

## What components does this pull request potentially affect?

- nes-systests only. The library now has a `Rewriter/` stage and links
  `tcp_source_plugin_library`; no other dependency changes.
- Two new test targets.

## Documentation

- Every phase type and every rewriting rule has extensive in-code docs.

## Issue Closed by this pull request:

This PR closes #1916, part of the systest refactoring epic #1920.
