### PR TITLE
build(Docker): Reduce development docker image

### DIFF
--- a/cmake/RuntimeRegistrationUtil.cmake
+++ b/cmake/RuntimeRegistrationUtil.cmake
@@ -103,7 +103,19 @@ function(create_runtime_registry name target)
                 $<LINK_LIBRARY:WHOLE_ARCHIVE,${glue_lib}>
         )
     else()
-        target_link_libraries(${glue_lib} PRIVATE ${target})
+        # COMPILE_ONLY for the same reason as the executable branch above: a real link edge here
+        # would form a glue <-> owner cycle. CMake tolerates cycles among static libraries by
+        # repeating the whole cyclic group on the link line (LINK_INTERFACE_MULTIPLICITY), which is
+        # harmless for a plain archive but makes WHOLE_ARCHIVE instantiate every collector TU twice
+        # and the PluginLoader then rejects the build with "duplicate registration". The glue only
+        # needs the owner's usage requirements to compile; the final consumer links the owner.
+        target_link_libraries(${glue_lib} PRIVATE $<COMPILE_ONLY:${target}>)
+        # COMPILE_ONLY carries the owner's usage requirements but creates no dependency edge, so it
+        # does not order the glue TUs after the owner's generated sources (cxxbridge, gRPC, ANTLR).
+        # Without this the glue can be compiled before those headers exist. add_dependencies chains
+        # the glue's object-order phony to the owner's, which is not a link edge and so does not
+        # reintroduce the cycle.
+        add_dependencies(${glue_lib} ${target})
         target_link_libraries(${target} INTERFACE
                 $<LINK_LIBRARY:WHOLE_ARCHIVE,${glue_lib}>
         )

--- a/docker/dependency/Base.dockerfile
+++ b/docker/dependency/Base.dockerfile
@@ -27,14 +27,16 @@ RUN apt update -y && apt install \
     ccache \
     ninja-build \
     pkg-config \
-    -y
+    -y \
+    && apt clean && rm -rf /var/lib/apt/lists/*
 
 # install llvm based toolchain
 RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/keyrings/llvm-snapshot.gpg \
     && chmod a+r /etc/apt/keyrings/llvm-snapshot.gpg \
     && echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/"$(. /etc/os-release && echo "$VERSION_CODENAME")"/ llvm-toolchain-"$(. /etc/os-release && echo "$VERSION_CODENAME")"-${LLVM_TOOLCHAIN_VERSION} main" > /etc/apt/sources.list.d/llvm-snapshot.list \
     && echo "deb-src [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/"$(. /etc/os-release && echo "$VERSION_CODENAME")"/ llvm-toolchain-"$(. /etc/os-release && echo "$VERSION_CODENAME")"-${LLVM_TOOLCHAIN_VERSION} main" >> /etc/apt/sources.list.d/llvm-snapshot.list \
-    && apt update -y && apt install clang-${LLVM_TOOLCHAIN_VERSION} libc++-${LLVM_TOOLCHAIN_VERSION}-dev libc++abi-${LLVM_TOOLCHAIN_VERSION}-dev libclang-rt-${LLVM_TOOLCHAIN_VERSION}-dev -y
+    && apt update -y && apt install clang-${LLVM_TOOLCHAIN_VERSION} libc++-${LLVM_TOOLCHAIN_VERSION}-dev libc++abi-${LLVM_TOOLCHAIN_VERSION}-dev libclang-rt-${LLVM_TOOLCHAIN_VERSION}-dev -y \
+    && apt clean && rm -rf /var/lib/apt/lists/*
 
 # install recent version of the mold linker
 RUN wget https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-$(uname -m)-linux.tar.gz \
@@ -49,7 +51,8 @@ RUN curl -fsSL https://apt.kitware.com/keys/kitware-archive-latest.asc | gpg --d
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $(. /etc/os-release && echo "$VERSION_CODENAME") main" > /etc/apt/sources.list.d/kitware.list \
     && apt update -y \
     && apt install cmake=${CMAKE_VERSION} cmake-data=${CMAKE_VERSION} -y \
-    && cmake --version
+    && cmake --version \
+    && apt clean && rm -rf /var/lib/apt/lists/*
 
 # default cmake generator is ninja
 ENV CMAKE_GENERATOR=Ninja

--- a/docker/dependency/Development.dockerfile
+++ b/docker/dependency/Development.dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update -y && apt-get install -y \
         bats-support \
         bats-assert \
         bats-file \
-        openjdk-21-jre-headless
+        openjdk-21-jre-headless \
+    && apt clean && rm -rf /var/lib/apt/lists/*
 
 # Additional testing libraries for bats are discovered via the BATS_LIB_PATH environemnt
 ENV BATS_LIB_PATH=/usr/lib/bats
@@ -106,13 +107,16 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 # Install IREE compiler tools for ML inference (ONNX → IREE compilation)
 ARG IREE_COMPILER_VERSION=3.11.0
 RUN python3 -m venv /opt/iree && \
-    /opt/iree/bin/pip install --no-cache-dir \
+    /opt/iree/bin/pip install --no-cache-dir --no-compile \
         iree-base-compiler==${IREE_COMPILER_VERSION} \
-        iree-turbine \
         onnx && \
+    rm -rf /opt/iree/bin/pip* /opt/iree/lib/python*/site-packages/pip \
+           /opt/iree/lib/python*/site-packages/pip-*.dist-info && \
+    find /opt/iree -name '__pycache__' -type d -prune -exec rm -rf {} + && \
     ln -s /opt/iree/bin/iree-compile /usr/local/bin/iree-compile && \
     ln -s /opt/iree/bin/iree-import-onnx /usr/local/bin/iree-import-onnx && \
-    iree-compile --version
+    iree-compile --version && \
+    iree-import-onnx --help > /dev/null
 
 # Pre-clone Corrosion at the exact ref CMake will request, so offline configures inside the
 # container can fall back to it when GitHub is unreachable. EnableRust.cmake probes GitHub

--- a/docker/dependency/DevelopmentLocal.dockerfile
+++ b/docker/dependency/DevelopmentLocal.dockerfile
@@ -13,12 +13,16 @@ ARG GID=1000
 ARG USERNAME=ubuntu
 ARG ROOTLESS=false
 
+# The vcpkg root is made world-writable rather than chown -R'd: the export is ~2.8GB across ~16k
+# files, and rewriting every inode would store the whole tree a second time (~2.9GB of image).
+# Dependency.dockerfile already ran `chmod -R g=u,o=u` on it, so every file below is world-readable
+# and world-writable; only the /vcpkg root itself was 0755, which this single-inode chmod fixes.
 RUN (${ROOTLESS} || (echo "uid: ${UID} gid ${GID} username ${USERNAME}" && \
     (delgroup ubuntu || true) && \
     (deluser ubuntu || true) && \
     addgroup --gid ${GID} ${USERNAME} && \
     adduser --uid ${UID} --gid ${GID} ${USERNAME} && \
-    chown -R ${UID}:${GID} ${NES_PREBUILT_VCPKG_ROOT}))
+    chmod 0777 ${NES_PREBUILT_VCPKG_ROOT}))
 
 # Create containerd socket directory with appropriate permissions
 RUN mkdir -p /run/containerd && \


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This PR reduces the size of the development Docker image chain by three changes:
1. Replacign the recursive ownership change
2. Trimming the IREE virtual environment
3. Cleaning APT metadata in the layers that create it

## Verifying this change
This change is tested by pulling the new docker image via `scripts/install-local-docker-environment.sh`and then runnign all tests.

## What components does this pull request potentially affect?
- Docker Images
