### PR TITLE
fix(nautilus): Missing llvm flag for lowering bools in nautilus causes miscompilation

### DIFF
--- a/vcpkg/vcpkg-registry/ports/nautilus/0002-bool-return-zeroext.patch
+++ b/vcpkg/vcpkg-registry/ports/nautilus/0002-bool-return-zeroext.patch
@@ -1,0 +1,17 @@
+diff --git a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
+--- a/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
++++ b/nautilus/src/nautilus/compiler/backends/mlir/MLIRLoweringProvider.cpp
+@@ -608,7 +608,12 @@ void MLIRLoweringProvider::visitAnd(ir::AndOperation* andOperation, ValueFrame&
+ 
+ 	// Only set result attributes if the function returns a value
+ 	if (functionOp.getOutputArg() != Type::v) {
+-		if (isUnsignedInteger(functionOp.getStamp())) {
++		// A bool (Type::b) is semantically an unsigned 1-bit integer and must be
++		// zero-extended so its i1 result has defined (0/1) upper bits at the ABI
++		// boundary. Without zeroext the x86 i1 return has undefined upper bits;
++		// the AVX-512 mask->bool lowering (kmovd) leaves them non-zero, so a
++		// `false` result is read as `true` by the C++ FFI that consumes it.
++		if (isUnsignedInteger(functionOp.getStamp()) || functionOp.getStamp() == Type::b) {
+ 			mlirFunction.setResultAttr(0, "llvm.zeroext", mlir::UnitAttr::get(context));
+ 		} else if (isSignedInteger(functionOp.getStamp())) {
+ 			mlirFunction.setResultAttr(0, "llvm.signext", mlir::UnitAttr::get(context));

--- a/vcpkg/vcpkg-registry/ports/nautilus/portfile.cmake
+++ b/vcpkg/vcpkg-registry/ports/nautilus/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_from_github(
         SHA512 6c36e2aefeb2780672da4c7f7c12ac15ae41c7e5803d7fcddc43905ac1b482cd760dbf9a82b1ede6594ed79ff63a7440488351b0ad48a45259a004ac4bbf1d61
 		PATCHES
 		0001-disable-ubsan-function-call-check.patch
+		0002-bool-return-zeroext.patch
 )
 
 set(ADDITIONAL_CMAKE_OPTIONS "")


### PR DESCRIPTION
We caught a miscompilation in https://github.com/nebulastream/nebulastream/issues/1952 , where the apparent reason is that nautilus forgets to set the zeroext flag for bools, causing miscompilation on AVX512 , where a false value is misinterpreted as true because the upper bits are garbage.

I will try to upstream this fix as well.
