### PR TITLE
fix(SingleNodeWorker): terminate correctly during startup, even when exceptions or invariants are triggered

### DIFF
--- a/nes-common/include/ErrorHandling.hpp
+++ b/nes-common/include/ErrorHandling.hpp
@@ -130,13 +130,15 @@ inline std::string formatStacktrace(const cpptrace::stacktrace& stacktrace, cons
     /// This documents (and checks) requirements for calling a function. If violated, the function was called incorrectly.
     /// @param condition must be true to correctly call function guarded by precondition
     /// @param formatString can contain `{}` to reference varargs. Must not contain positional reference like `{0}`.
+    /// Log the marker before generating the (potentially slow) symbolized stacktrace so it reaches
+    /// the log even if the process is killed mid-symbolization (e.g. a `timeout` SIGKILL at startup).
     #define PRECONDITION(condition, formatString, ...) \
         do \
         { \
             if (!(condition)) \
             { \
-                auto trace = NES::formatStacktrace(cpptrace::generate_trace(), true); \
-                NES_ERROR("Precondition violated: ({}): " formatString "\u001B[0m\n\n{}", #condition __VA_OPT__(, ) __VA_ARGS__, trace); \
+                NES_ERROR("Precondition violated: ({}): " formatString, #condition __VA_OPT__(, ) __VA_ARGS__); \
+                NES_ERROR("\u001B[0m\n\n{}", NES::formatStacktrace(cpptrace::generate_trace(), true)); \
                 if (auto logger = ::NES::Logger::getInstance()) \
                 { \
                     if (!logger->isConsoleLoggingEnabled()) \
@@ -152,13 +154,15 @@ inline std::string formatStacktrace(const cpptrace::stacktrace& stacktrace, cons
     /// This documents what is assumed to be true at this particular point in a program. If violated, there is a misunderstanding and maybe a bug.
     /// @param condition is assumed to be true
     /// @param formatString can contain `{}` to reference varargs. Must not contain positional referencen like `{0}`.
+    /// Log the marker before generating the (potentially slow) symbolized stacktrace so it reaches
+    /// the log even if the process is killed mid-symbolization (e.g. a `timeout` SIGKILL at startup)
     #define INVARIANT(condition, formatString, ...) \
         do \
         { \
             if (!(condition)) \
             { \
-                auto trace = NES::formatStacktrace(cpptrace::generate_trace(), true); \
-                NES_ERROR("Invariant violated: ({}): " formatString "\u001B[0m\n\n{}", #condition __VA_OPT__(, ) __VA_ARGS__, trace); \
+                NES_ERROR("Invariant violated: ({}): " formatString, #condition __VA_OPT__(, ) __VA_ARGS__); \
+                NES_ERROR("\u001B[0m\n\n{}", NES::formatStacktrace(cpptrace::generate_trace(), true)); \
                 if (auto logger = ::NES::Logger::getInstance()) \
                 { \
                     if (!logger->isConsoleLoggingEnabled()) \

--- a/nes-common/src/ErrorHandling.cpp
+++ b/nes-common/src/ErrorHandling.cpp
@@ -135,26 +135,37 @@ std::string formatLogMessage(const std::exception& e)
 
 void tryLogCurrentException()
 {
+    /// Log the concise error headline (code + message) BEFORE resolving the stacktrace. Symbolizing a trace against a
+    /// large, statically linked binary can take many seconds; emitting the headline first guarantees the error marker
+    /// reaches the log even if the process is terminated (e.g. a `timeout` SIGKILL) part-way through symbolization.
     try
     {
         throw;
     }
     catch (const Exception& e)
     {
-        auto msg = formatLogMessage(e);
-        NES_ERROR("{}", msg)
+        const auto headline = fmt::format("failed to process with error code ({}) : {}", e.code(), e.what());
+        NES_ERROR("{}", headline)
         if (auto logger = Logger::getInstance(); logger && !logger->isConsoleLoggingEnabled())
         {
-            fmt::print(stderr, "{}\n", msg);
+            fmt::print(stderr, "{}\n", headline);
+        }
+        if constexpr (logWithStacktrace)
+        {
+            NES_ERROR("{}{}", ansiColorReset, formatStacktrace(e.trace(), true))
         }
     }
     catch (const std::exception& e)
     {
-        auto msg = formatLogMessage(e);
-        NES_ERROR("{}", msg);
+        const auto headline = fmt::format("failed to process with error : {}", e.what());
+        NES_ERROR("{}", headline);
         if (auto logger = Logger::getInstance(); logger && !logger->isConsoleLoggingEnabled())
         {
-            fmt::print(stderr, "{}\n", msg);
+            fmt::print(stderr, "{}\n", headline);
+        }
+        if constexpr (logWithStacktrace)
+        {
+            NES_ERROR("{}{}", ansiColorReset, formatStacktrace(cpptrace::from_current_exception(), true));
         }
     }
     catch (...) /// NOLINT(no-raw-catch-all)

--- a/nes-runtime/interface/Configuration/WorkerConfiguration.hpp
+++ b/nes-runtime/interface/Configuration/WorkerConfiguration.hpp
@@ -22,6 +22,7 @@
 #include <Configurations/Enums/EnumOption.hpp>
 #include <Configurations/ScalarOption.hpp>
 #include <Configurations/Validation/FloatValidation.hpp>
+#include <Configurations/Validation/NonZeroValidation.hpp>
 #include <Configurations/Validation/NumberValidation.hpp>
 #include <Configurations/Validation/PowerOfTwoValidation.hpp>
 #include <Util/DumpMode.hpp>
@@ -50,7 +51,7 @@ public:
         = {"total_memory_in_bytes",
            "268435456",
            "Total memory budget in bytes for the global buffer pool (pooled + unpooled).",
-           {std::make_shared<NumberValidation>()}};
+           {std::make_shared<NumberValidation>(), std::make_shared<NonZeroValidation>()}};
 
     /// Share (0.0-1.0) of total_memory_in_bytes reserved for unpooled (variable-sized) buffers, used by operator state
     /// (hash maps, paged vectors, var-sized data). On breach, the requesting query fails with CannotAllocateBuffer

--- a/nes-single-node-worker/src/SingleNodeWorkerStarter.cpp
+++ b/nes-single-node-worker/src/SingleNodeWorkerStarter.cpp
@@ -12,24 +12,29 @@
     limitations under the License.
 */
 
-/// The POSIX signal APIs used below are not provided by the C++ <csignal> header.
-/// NOLINTNEXTLINE(modernize-deprecated-headers)
 #include <cstdlib>
 #include <exception>
 #include <iostream>
+#include <optional>
 #include <sstream>
+#include <stop_token>
 #include <string>
 #include <vector>
+#include <pthread.h>
+/// The POSIX signal APIs used below are not provided by the C++ <csignal> header.
+/// NOLINTNEXTLINE(modernize-deprecated-headers)
 #include <signal.h>
 #include <Configurations/Util.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Plugins/BuiltinPlugins.hpp>
+#include <Util/Files.hpp>
 #include <Util/Logger/LogLevel.hpp>
 #include <Util/Logger/Logger.hpp>
 #include <Util/Logger/impl/NesLogger.hpp>
 #include <Util/Signal.hpp>
 #include <argparse/argparse.hpp>
 #include <cpptrace/from_current.hpp>
+#include <folly/Synchronized.h>
 #include <grpcpp/security/server_credentials.h>
 #include <grpcpp/server_builder.h>
 #include <ErrorHandling.hpp>
@@ -38,9 +43,58 @@
 #include <SingleNodeWorkerConfiguration.hpp>
 #include <Thread.hpp>
 #include <Version.hpp>
+#include <scope_guard.hpp>
 
 namespace
 {
+
+class Cleanup
+{
+    static constexpr int SIGNAL_EXIT_CODE_OFFSET = 128;
+
+    struct Internal
+    {
+        std::optional<int> terminationSignal;
+        grpc::Server* server = nullptr;
+    };
+
+    folly::Synchronized<Internal> cleanupMutex;
+
+public:
+    std::optional<int> clearServerAndGetTerminationSignal()
+    {
+        auto cleanup = cleanupMutex.wlock();
+        cleanup->server = nullptr;
+        auto result = cleanup->terminationSignal;
+        cleanup->terminationSignal.reset();
+        return result;
+    }
+
+    std::optional<int> setServerIfNotTerminated(grpc::Server* server)
+    {
+        auto cleanup = cleanupMutex.wlock();
+        if (cleanup->terminationSignal)
+        {
+            return cleanup->terminationSignal;
+        }
+        cleanup->server = server;
+        return std::nullopt;
+    }
+
+    void requestTermination(int signal)
+    {
+        auto cleanup = cleanupMutex.wlock();
+        cleanup->terminationSignal = signal + SIGNAL_EXIT_CODE_OFFSET;
+        if (cleanup->server != nullptr)
+        {
+            cleanup->server->Shutdown();
+        }
+    }
+};
+
+/// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+Cleanup cleanup;
+
 /// Block termination signals before any worker threads are created. All subsequently created threads inherit this mask, allowing
 /// a dedicated thread to synchronously wait for the signals without doing non-async-signal-safe work in a signal handler.
 /// sigset_t is provided by <signal.h>, but clang-tidy's include-cleaner does not recognize the indirect platform typedef.
@@ -53,23 +107,38 @@ bool blockTerminationSignals(sigset_t& terminationSignals)
     return pthread_sigmask(SIG_BLOCK, &terminationSignals, nullptr) == 0;
 }
 
-NES::Thread shutdownHook(grpc::Server& server, const sigset_t terminationSignals)
+/// Waits from the start of the process and can terminate even if the GRPC server is not running yet
+NES::Thread terminationThread(const sigset_t terminationSignals)
 {
     return {
         "shutdown-hook",
-        [&, terminationSignals]() mutable
+        [terminationSignals](const std::stop_token& stopToken) mutable
         {
+            /// Wake sigwait with a thread-directed signal when the thread is asked to stop during a clean shutdown.
+            const auto waitingThread = pthread_self();
+            const std::stop_callback stopCallback(
+                stopToken,
+                [waitingThread]
+                {
+                    if (const auto error = pthread_kill(waitingThread, SIGINT); error != 0)
+                    {
+                        NES_ERROR("Failed to wake the termination thread: {} ({})", NES::getErrorMessage(error), error);
+                    }
+                });
+
             int signal{};
             const auto error = sigwait(&terminationSignals, &signal);
             if (error != 0)
             {
-                NES_ERROR("Failed to wait for a termination signal: {}", error)
+                NES_ERROR("Failed to wait for a termination signal: {} ({})", NES::getErrorMessage(error), error);
+                return;
             }
-            else
+            if (stopToken.stop_requested())
             {
-                NES_INFO("Received signal {}. Shutting down.", signal);
+                return;
             }
-            server.Shutdown();
+            NES_INFO("Received signal {}. Shutting down.", signal);
+            cleanup.requestTermination(signal);
         }};
 }
 }
@@ -81,15 +150,26 @@ int main(const int argc, const char* argv[])
         NES::printVersion(NES::SingleNodeWorkerBinaryName);
         return 0;
     }
+    NES::setupSignalHandlers();
+    sigset_t terminationSignals{};
+    if (!blockTerminationSignals(terminationSignals))
+    {
+        return 1;
+    }
+    NES::Logger::setupLogging("singleNodeWorker.log", NES::LogLevel::LOG_DEBUG);
+    SCOPE_EXIT
+    {
+        if (const auto logger = NES::Logger::getInstance())
+        {
+            logger->forceFlush();
+        }
+    };
+
+    /// Register termination handler right now so that the process can be terminated before the rest of the system has started up.
+    const auto terminationHandler = terminationThread(terminationSignals);
+
     CPPTRACE_TRY
     {
-        NES::setupSignalHandlers();
-        sigset_t terminationSignals{};
-        if (!blockTerminationSignals(terminationSignals))
-        {
-            return 1;
-        }
-        NES::Logger::setupLogging("singleNodeWorker.log", NES::LogLevel::LOG_DEBUG);
         /// Register built-in plugins before any registry lookup.
         NES::loadBuiltinPlugins();
 
@@ -155,12 +235,18 @@ int main(const int argc, const char* argv[])
                 return 1;
             }
 
-            const auto hook = shutdownHook(*server, terminationSignals);
+            if (auto terminationSignal = cleanup.setServerIfNotTerminated(server.get()))
+            {
+                return *terminationSignal;
+            }
             NES_INFO("Server listening on {}", configuration->grpcAddressUri.getValue());
             server->Wait();
+            if (auto terminationSignal = cleanup.clearServerAndGetTerminationSignal())
+            {
+                return *terminationSignal;
+            }
             NES_INFO("GRPC Server was shutdown. Terminating the SingleNodeWorker");
         }
-        NES::Logger::getInstance()->forceFlush();
         return 0;
     }
     CPPTRACE_CATCH(...)

--- a/nes-single-node-worker/tests/offline.bats
+++ b/nes-single-node-worker/tests/offline.bats
@@ -69,7 +69,7 @@ teardown() {
 worker_timeout() {
   local duration="$1"
   shift
-  run timeout --kill-after=10s "$duration" "$NES_WORKER" "$@"
+  run timeout --kill-after=20s "$duration" "$NES_WORKER" "$@"
   [ "$status" -ne 137 ] # graceful termination must not require SIGKILL
 }
 
@@ -147,14 +147,16 @@ worker_timeout() {
   ! grep "enable_event_trace.*was already set" singleNodeWorker.log
 }
 
-# Locks the config contract for the memory-budget options. Degenerate values are rejected during BufferManager
-# construction at startup. The abort can happen in a startup thread while the main process lingers to the timeout,
-# so the exit code is not a reliable signal -- the logged error marker is. A healthy worker never logs these.
+# Locks the config contract for the memory-budget options. Degenerate values are rejected at config-parse time by
+# their validators, which log a clear error marker. Asserting on that marker (rather than the exit code) keeps the
+# check reliable across build types. A healthy worker never logs these.
 
 @test "worker rejects total_memory_in_bytes of 0" {
-  # A zero budget yields zero pooled buffers, which cannot back the internal MPMC queues.
+  # A zero budget yields zero pooled buffers, which cannot back the internal MPMC queues. NonZeroValidation rejects
+  # it at config-parse time.
   worker_timeout 5s -- --worker.total_memory_in_bytes=0
-  grep -E "capacity 0 is impossible|Precondition violated" singleNodeWorker.log
+  grep -E "invalid config parameter|Validator" singleNodeWorker.log
+  grep "total_memory_in_bytes" singleNodeWorker.log
 }
 
 @test "worker rejects unpooled_memory_fraction out of range" {


### PR DESCRIPTION
Even after https://github.com/nebulastream/nebulastream/pull/1889 , terminating from the outside doesn't work correctly and fails often in the CI when it comes before the signal handler was registered, for example because an exception was thrown.

This pr moves the registration of the system handler towards the beginning of the startup process, and instead of passing a reference to the grpc server, we later store it in an atomic when it was started up.

This implementation also handles triggered preconditions or direct returns correctly in contrast to https://github.com/nebulastream/nebulastream/pull/1940 , which only fixes the issue for exceptions.


EDIT: I also added a validation check for the buffer amount, since you cannot initialize the MPMC queue with a size of one, the precondition never gets reached.
Also, I split up the logging of exceptions and invariants into two, so that first the invariant/exception message is logged, and then the trace is gathered, because if an exception is thrown/invariant triggered during startup, collecting it takes 13 seconds or so which causes the tests to fail.
