### PR TITLE
fix(engine): unset requiresTermination when skipping stop-retry task

### DIFF
--- a/nes-query-engine/QueryEngine.cpp
+++ b/nes-query-engine/QueryEngine.cpp
@@ -652,6 +652,9 @@ bool ThreadPool::WorkerThread::operator()(StopPipelineTask& stopPipelineTask) co
                 /// A stage that cannot finish its stop (e.g. a network sink whose peer never accepted the channel) would otherwise
                 /// add this task into the queue forever, and the worker threads would never see an empty queue.
                 ENGINE_LOG_WARNING("Dropping pipeline stop retry during query engine termination");
+                /// Dropping the task destroys the node it still owns. Clear the termination flag first so the node satisfies the
+                /// ~RunningQueryPlanNode invariant instead of aborting on the `!requiresTermination` assertion.
+                stopPipelineTask.pipeline->requiresTermination = false;
                 return;
             }
 


### PR DESCRIPTION
Fixes crash in CI run, where it crashed with the invariant 
```
2026-08-27T11:34:06.9759743Z systest: /home/runner/work/nebulastream/nebulastream/nes-query-engine/RunningQueryPlan.cpp:118: NES::RunningQueryPlanNode::~RunningQueryPlanNode(): Assertion `!requiresTermination && "Node was destroyed without termination. This should not happen"' failed.
```

This is apparently a regression introduced by https://github.com/nebulastream/nebulastream/pull/1894 , because the pipeline is not moved, its dropped on return, which destructs the associated RunningQueryPlanNode and tiggers the invariant in its destructor.

We should probably improve the retry behavior of the network source/sink in general, but the quick fix for now is to just set the requireTermination flag to false.


