### PR TITLE
fix(worker): Increase offline test timeout to 40s

### DIFF
--- a/nes-single-node-worker/tests/offline.bats
+++ b/nes-single-node-worker/tests/offline.bats
@@ -69,7 +69,7 @@ teardown() {
 worker_timeout() {
   local duration="$1"
   shift
-  run timeout --kill-after=20s "$duration" "$NES_WORKER" "$@"
+  run timeout --kill-after=40s "$duration" "$NES_WORKER" "$@"
   [ "$status" -ne 137 ] # graceful termination must not require SIGKILL
 }
 


### PR DESCRIPTION
Even after https://github.com/nebulastream/nebulastream/pull/1961 the offline single-node-worker-tests are still sometimes failing just because symbolizing the stacktrace takes so long https://github.com/nebulastream/nebulastream/actions/runs/33093928688/job/98598419460?pr=1598

We can reduce the timeout again when the new config system lands where we don't rely on exceptions to propagate this error anymore https://github.com/nebulastream/nebulastream/pull/1946. 