### PR TITLE
fix(ci): increase endless mode timeout

### DIFF
--- a/.github/workflows/endless-mode.yml
+++ b/.github/workflows/endless-mode.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   run-endless-mode:
     name: "${{matrix.arch}}-${{matrix.stdlib}}-${{matrix.build_type}}-${{ matrix.sanitizer }} Endless"
-    timeout-minutes: 40
+    timeout-minutes: 80
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

Increase the Endless Mode CI job timeout from 40 to 80 minutes.

The Endless Mode job in Max's [SequenceOption parsing PR #1935](https://github.com/nebulastream/nebulastream/pull/1935) reached the existing 40-minute limit while still compiling, so the actual endless-mode test was skipped. See the [cancelled workflow job](https://github.com/nebulastream/nebulastream/actions/runs/32969261072/job/98182174643).

## Verifying this change

- Verified the workflow diff with git diff --check.
- No runtime tests were run because this change only adjusts the GitHub Actions job timeout.

## What components does this pull request potentially affect?

- CI
- Endless Mode end-to-end test workflow

## Documentation

No documentation changes are required.

## Issue Closed by this pull request:

None.