### PR TITLE
feat(Systest): Compare the expected error message, not only the error code

### DIFF
--- a/nes-systests/parser/WindowAggregationParser.test
+++ b/nes-systests/parser/WindowAggregationParser.test
@@ -67,7 +67,7 @@ WHERE id > 15
 WINDOW SLIDING(timestamp, size 1 sec, advance by 500 ms)
 INTO sinkStream;
 ----
-ERROR 2000 # invalid query syntax
+ERROR 2000
 
 # Negative test: Missing WINDOW definition
 SELECT SUM(value) as sumValue
@@ -76,4 +76,4 @@ WHERE id > 15
 GROUP BY id
 INTO sinkStream;
 ----
-ERROR 2000 # invalid query syntax
+ERROR 2000

--- a/nes-systests/systest/src/Runner/SystestRunner.cpp
+++ b/nes-systests/systest/src/Runner/SystestRunner.cpp
@@ -123,16 +123,24 @@ void processQueryWithError(
                     }));
 
                 /// The test passes if the expected error code is among the thrown exceptions. Additional errors are tolerated, because
-                /// a failure on one pipeline can raise secondary/cascading errors on connected pipelines
+                /// a failure on one pipeline can raise secondary/cascading errors on connected pipelines.
+                /// If the test also states an expected message, that message must appear verbatim in the matching exception,
+                /// so that tests can pin down the wording an error reports and not just its code.
                 const auto expectedErrorOccurred = std::ranges::any_of(
                     allExceptionByAddress | std::views::values,
-                    [&](const auto& exceptionRef) { return exceptionRef.get().code() == expectedError->code; });
+                    [&](const auto& exceptionRef)
+                    {
+                        return exceptionRef.get().code() == expectedError->code
+                            and (not expectedError->message.has_value()
+                                 or std::string_view{exceptionRef.get().what()}.find(expectedError->message.value())
+                                     != std::string_view::npos);
+                    });
 
                 if (!expectedErrorOccurred)
                 {
                     return fmt::format(
                         "Expected error \"{}({})\" to occur, but it did not! Actual: {}",
-                        expectedError->message,
+                        expectedError->message.value_or(""),
                         expectedError->code,
                         actualException);
                 }


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
`ERROR <code> "message"` in a `.test` file parsed the message and then discarded it, so a test could pin the error code but not a word of what the error said. The change list is as follows:
- Changed `SystestRunner` to require the expected message as a substring of the exception that matched the code.
- Kept the code-only behaviour when no message is given, so existing expectations are unaffected.
- Removed a trailing `# invalid query syntax` comment from two expectations, which the parser reads as an expected message.

## Verifying this change
This change is tested by
- Existing systests, which all still pass unchanged.
- The message assertions added in the stacked PR, which cannot fail without this change.

## What components does this pull request potentially affect?
- Systest