### PR TITLE
fix: Make the error messages for seven failing queries actionable (#1957)

### DIFF
--- a/nes-configurations/include/Configurations/Descriptor.hpp
+++ b/nes-configurations/include/Configurations/Descriptor.hpp
@@ -14,15 +14,18 @@
 
 #pragma once
 
+#include <algorithm>
 #include <concepts>
 #include <cstdint>
 #include <memory>
 #include <optional>
 #include <ostream>
+#include <ranges>
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include <variant>
+#include <vector>
 
 
 #include <Configurations/Enums/EnumWrapper.hpp>
@@ -33,6 +36,7 @@
 #include <fmt/base.h>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#include <fmt/ranges.h>
 #include <magic_enum/magic_enum.hpp>
 #include <ErrorHandling.hpp>
 #include <ProtobufHelper.hpp> /// NOLINT Descriptor equality operator does not compile without
@@ -161,7 +165,13 @@ public:
         {
             if (not SpecificConfiguration::parameterMap.contains(key))
             {
-                throw InvalidConfigParameter(fmt::format("Unknown configuration parameter: {}.", key));
+                auto accepted = SpecificConfiguration::parameterMap | std::views::keys | std::ranges::to<std::vector>();
+                std::ranges::sort(accepted);
+                throw InvalidConfigParameter(fmt::format(
+                    "Unknown configuration parameter: {}. Accepted parameters for {} are: {}.",
+                    key,
+                    implementationName,
+                    fmt::join(accepted, ", ")));
             }
         }
         /// Next, try to validate all config parameters.

--- a/nes-configurations/tests/CMakeLists.txt
+++ b/nes-configurations/tests/CMakeLists.txt
@@ -18,5 +18,6 @@ add_nes_unit_test(
     "UnitTests/Configurations/ConfigurationHelpMessageTests.cpp"
     "UnitTests/Configurations/ExplicitlySetTrackingTests.cpp"
     "UnitTests/Configurations/SequenceOptionTests.cpp"
+    "UnitTests/Configurations/SinkConfigTest.cpp"
     "UnitTests/Validation/EndpointValidationTest.cpp")
 set_tests_properties(${Tests} PROPERTIES TIMEOUT 35)

--- a/nes-configurations/tests/UnitTests/Configurations/SinkConfigTest.cpp
+++ b/nes-configurations/tests/UnitTests/Configurations/SinkConfigTest.cpp
@@ -1,0 +1,80 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <variant>
+#include <Configurations/Descriptor.hpp>
+#include <Util/Logger/LogLevel.hpp>
+#include <Util/Logger/Logger.hpp>
+#include <Util/Logger/impl/NesLogger.hpp>
+#include <gtest/gtest.h>
+#include <BaseIntegrationTest.hpp>
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+
+class SinkConfigTest : public Testing::BaseIntegrationTest
+{
+public:
+    static void SetUpTestSuite()
+    {
+        Logger::setupLogging("SinkConfigTest.log", LogLevel::LOG_DEBUG);
+        NES_INFO("Setup Sink Config test class.");
+    }
+};
+
+struct TestSinkConfig
+{
+    /// NOLINTNEXTLINE(cert-err58-cpp)
+    static inline const DescriptorConfig::ConfigParameter<std::string> FILE_PATH{
+        "FILE_PATH",
+        std::nullopt,
+        [](const std::unordered_map<std::string, std::string>& config) { return DescriptorConfig::tryGet(FILE_PATH, config); }};
+
+    /// NOLINTNEXTLINE(cert-err58-cpp)
+    static inline const DescriptorConfig::ConfigParameter<bool> APPEND{
+        "APPEND",
+        false,
+        [](const std::unordered_map<std::string, std::string>& config) { return DescriptorConfig::tryGet(APPEND, config); }};
+
+    static inline std::unordered_map<std::string, DescriptorConfig::ConfigParameterContainer> parameterMap
+        = DescriptorConfig::createConfigParameterContainerMap(FILE_PATH, APPEND);
+};
+
+TEST_F(SinkConfigTest, ShouldListAcceptedParametersForUnknownParameter)
+{
+    try
+    {
+        DescriptorConfig::validateAndFormat<TestSinkConfig>({{"FILEPATH", "/tmp/probe.csv"}}, "File");
+        FAIL() << "Expected an InvalidConfigParameter exception";
+    }
+    catch (const Exception& exception)
+    {
+        EXPECT_EQ(exception.code(), ErrorCode::InvalidConfigParameter);
+        EXPECT_EQ(
+            std::string{exception.what()},
+            "invalid config parameter; Unknown configuration parameter: FILEPATH. Accepted parameters for File are: APPEND, FILE_PATH.\n");
+    }
+}
+
+TEST_F(SinkConfigTest, ShouldAcceptKnownParameters)
+{
+    const auto config = DescriptorConfig::validateAndFormat<TestSinkConfig>({{"FILE_PATH", "/tmp/probe.csv"}}, "File");
+    EXPECT_EQ(std::get<std::string>(config.at("FILE_PATH")), "/tmp/probe.csv");
+    EXPECT_FALSE(std::get<bool>(config.at("APPEND")));
+}
+}

--- a/nes-logical-operators/include/Operators/Windows/Aggregations/SumAggregationLogicalFunction.hpp
+++ b/nes-logical-operators/include/Operators/Windows/Aggregations/SumAggregationLogicalFunction.hpp
@@ -22,6 +22,7 @@
 #include <DataTypes/DataType.hpp>
 #include <Functions/FieldAccessLogicalFunction.hpp>
 #include <Functions/LogicalFunction.hpp>
+#include <Identifiers/Identifier.hpp>
 #include <Operators/Windows/Aggregations/WindowAggregationLogicalFunction.hpp>
 #include <Schema/Field.hpp>
 #include <Schema/Schema.hpp>
@@ -51,7 +52,7 @@ public:
     static AggregationLogicalFunctionRegistryReturnType create(AggregationLogicalFunctionRegistryArguments arguments);
 
 private:
-    [[nodiscard]] static DataType inferFromInput(DataType inputType);
+    [[nodiscard]] static DataType inferFromInput(DataType inputType, const Identifier& inputFieldName);
 
     AggregationFieldAccess inputFunction;
     DataType aggregateType;

--- a/nes-logical-operators/src/Operators/Windows/Aggregations/AvgAggregationLogicalFunction.cpp
+++ b/nes-logical-operators/src/Operators/Windows/Aggregations/AvgAggregationLogicalFunction.cpp
@@ -34,6 +34,7 @@
 #include <Util/Reflection.hpp>
 #include <fmt/format.h>
 #include <folly/hash/Hash.h>
+#include <magic_enum/magic_enum.hpp>
 #include <AggregationLogicalFunctionRegistry.hpp>
 #include <ErrorHandling.hpp>
 
@@ -85,7 +86,11 @@ AvgAggregationLogicalFunction AvgAggregationLogicalFunction::withInferredType(co
     const auto newInputFunction = inferFieldAccess(inputFunction, schema);
     if (!newInputFunction->getDataType().isNumeric())
     {
-        throw CannotInferStamp("Cannot calculate average over non-numeric function (got {})", newInputFunction->getDataType());
+        throw UnsupportedQuery(
+            "{} is only supported on numeric fields, but field {} has type {}",
+            NAME,
+            newInputFunction->getField().getLastName(),
+            magic_enum::enum_name(newInputFunction->getDataType().type));
     }
     auto newAggFunction = AvgAggregationLogicalFunction{newInputFunction};
     newAggFunction.nullable = newInputFunction->getDataType().nullable;

--- a/nes-logical-operators/src/Operators/Windows/Aggregations/MaxAggregationLogicalFunction.cpp
+++ b/nes-logical-operators/src/Operators/Windows/Aggregations/MaxAggregationLogicalFunction.cpp
@@ -33,6 +33,7 @@
 #include <Util/Reflection.hpp>
 #include <fmt/format.h>
 #include <folly/hash/Hash.h>
+#include <magic_enum/magic_enum.hpp>
 #include <AggregationLogicalFunctionRegistry.hpp>
 #include <ErrorHandling.hpp>
 
@@ -89,7 +90,11 @@ MaxAggregationLogicalFunction MaxAggregationLogicalFunction::withInferredType(co
 
     if (!newInputFunction->getDataType().isNumeric())
     {
-        throw CannotInferStamp("Cannot calculate maximum value on non-numeric function {}.", *newInputFunction);
+        throw UnsupportedQuery(
+            "{} is only supported on numeric fields, but field {} has type {}",
+            NAME,
+            newInputFunction->getField().getLastName(),
+            magic_enum::enum_name(newInputFunction->getDataType().type));
     }
     return MaxAggregationLogicalFunction{newInputFunction, newInputFunction->getDataType()};
 }

--- a/nes-logical-operators/src/Operators/Windows/Aggregations/MedianAggregationLogicalFunction.cpp
+++ b/nes-logical-operators/src/Operators/Windows/Aggregations/MedianAggregationLogicalFunction.cpp
@@ -24,6 +24,7 @@
 #include <Functions/LogicalFunction.hpp>
 #include <Operators/Windows/Aggregations/WindowAggregationLogicalFunction.hpp>
 #include <fmt/format.h>
+#include <magic_enum/magic_enum.hpp>
 #include <ErrorHandling.hpp>
 
 #include <utility>
@@ -86,7 +87,11 @@ MedianAggregationLogicalFunction MedianAggregationLogicalFunction::withInferredT
     auto newInputFunction = inferFieldAccess(inputFunction, schema);
     if (!newInputFunction->getDataType().isNumeric())
     {
-        throw CannotInferStamp("Cannot calculate median over non numeric field (got {}).", newInputFunction->getDataType());
+        throw UnsupportedQuery(
+            "{} is only supported on numeric fields, but field {} has type {}",
+            NAME,
+            newInputFunction->getField().getLastName(),
+            magic_enum::enum_name(newInputFunction->getDataType().type));
     }
     MedianAggregationLogicalFunction newAgg{newInputFunction};
     newAgg.nullable = newInputFunction->getDataType().nullable;

--- a/nes-logical-operators/src/Operators/Windows/Aggregations/MinAggregationLogicalFunction.cpp
+++ b/nes-logical-operators/src/Operators/Windows/Aggregations/MinAggregationLogicalFunction.cpp
@@ -33,6 +33,7 @@
 #include <Util/Reflection.hpp>
 #include <fmt/format.h>
 #include <folly/hash/Hash.h>
+#include <magic_enum/magic_enum.hpp>
 #include <AggregationLogicalFunctionRegistry.hpp>
 #include <ErrorHandling.hpp>
 
@@ -88,7 +89,11 @@ MinAggregationLogicalFunction MinAggregationLogicalFunction::withInferredType(co
     auto newInputFunction = inferFieldAccess(inputFunction, schema);
     if (!newInputFunction->getDataType().isNumeric())
     {
-        throw CannotInferStamp("Cannot calculate minimum value on non-numeric function {}.", *newInputFunction);
+        throw UnsupportedQuery(
+            "{} is only supported on numeric fields, but field {} has type {}",
+            NAME,
+            newInputFunction->getField().getLastName(),
+            magic_enum::enum_name(newInputFunction->getDataType().type));
     }
     return MinAggregationLogicalFunction{newInputFunction, newInputFunction->getDataType()};
 }

--- a/nes-logical-operators/src/Operators/Windows/Aggregations/SumAggregationLogicalFunction.cpp
+++ b/nes-logical-operators/src/Operators/Windows/Aggregations/SumAggregationLogicalFunction.cpp
@@ -26,23 +26,40 @@
 #include <DataTypes/DataTypeProvider.hpp>
 #include <Functions/FieldAccessLogicalFunction.hpp>
 #include <Functions/LogicalFunction.hpp>
+#include <Functions/UnboundFieldAccessLogicalFunction.hpp>
+#include <Identifiers/Identifier.hpp>
 #include <Operators/Windows/Aggregations/WindowAggregationLogicalFunction.hpp>
 #include <Schema/Field.hpp>
 #include <Schema/Schema.hpp>
 #include <Schema/SchemaFwd.hpp>
 #include <Serialization/LogicalFunctionReflection.hpp>
+#include <Util/Overloaded.hpp>
 #include <Util/PlanRenderer.hpp>
 #include <Util/Reflection.hpp>
 #include <fmt/format.h>
 #include <folly/hash/Hash.h>
+#include <magic_enum/magic_enum.hpp>
 #include <AggregationLogicalFunctionRegistry.hpp>
 #include <ErrorHandling.hpp>
 
 namespace NES
 {
+namespace
+{
+Identifier fieldNameOf(const AggregationFieldAccess& inputFunction)
+{
+    return std::visit(
+        Overloaded{
+            [](const TypedLogicalFunction<UnboundFieldAccessLogicalFunction>& unbound) { return unbound->getFieldName(); },
+            [](const TypedLogicalFunction<FieldAccessLogicalFunction>& bound) { return bound->getField().getLastName(); }},
+        inputFunction);
+}
+}
+
 SumAggregationLogicalFunction::SumAggregationLogicalFunction(AggregationFieldAccess inputFunction)
     : inputFunction(inputFunction)
-    , aggregateType(inferFromInput(std::visit([](const auto& input) { return input->getDataType(); }, inputFunction)))
+    , aggregateType(
+          inferFromInput(std::visit([](const auto& input) { return input->getDataType(); }, inputFunction), fieldNameOf(inputFunction)))
 {
 }
 
@@ -66,7 +83,7 @@ std::string_view SumAggregationLogicalFunction::getName() const noexcept
 /// PostgreSQL: integers are promoted to the widest available integer type (sum(int2/int4) -> int8), while floats keep their type
 /// (sum(real) -> real) since they saturate to infinity instead of wrapping around. Sums exceeding the 64-bit integer range still
 /// wrap around silently.
-DataType SumAggregationLogicalFunction::inferFromInput(const DataType inputType)
+DataType SumAggregationLogicalFunction::inferFromInput(const DataType inputType, const Identifier& inputFieldName)
 {
     if (inputType.type == DataType::Type::UNDEFINED)
     {
@@ -87,13 +104,14 @@ DataType SumAggregationLogicalFunction::inferFromInput(const DataType inputType)
     {
         return inputType;
     }
-    throw CannotInferStamp("aggregations on non numeric fields is not supported (got {})", inputType);
+    throw UnsupportedQuery(
+        "{} is only supported on numeric fields, but field {} has type {}", NAME, inputFieldName, magic_enum::enum_name(inputType.type));
 }
 
 SumAggregationLogicalFunction SumAggregationLogicalFunction::withInferredType(const Schema<Field, Unordered>& schema) const
 {
     const auto newInputFunction = inferFieldAccess(inputFunction, schema);
-    const DataType outputType = inferFromInput(newInputFunction->getDataType());
+    const DataType outputType = inferFromInput(newInputFunction->getDataType(), newInputFunction->getField().getLastName());
     return SumAggregationLogicalFunction{newInputFunction, outputType};
 }
 

--- a/nes-logical-operators/tests/AggregationInputTypeTest.cpp
+++ b/nes-logical-operators/tests/AggregationInputTypeTest.cpp
@@ -1,0 +1,116 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <algorithm>
+#include <array>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <unordered_map>
+
+#include <gtest/gtest.h>
+
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/DataTypeProvider.hpp>
+#include <DataTypes/UnboundField.hpp>
+#include <Functions/LogicalFunction.hpp>
+#include <Functions/UnboundFieldAccessLogicalFunction.hpp>
+#include <Identifiers/Identifier.hpp>
+#include <Identifiers/Identifiers.hpp>
+#include <Operators/LogicalOperator.hpp>
+#include <Operators/Sources/SourceDescriptorLogicalOperator.hpp>
+#include <Operators/Windows/Aggregations/WindowAggregationLogicalFunction.hpp>
+#include <Schema/Schema.hpp>
+#include <Schema/SchemaFwd.hpp>
+#include <Sources/LogicalSource.hpp>
+#include <Sources/SourceCatalog.hpp>
+#include <Sources/SourceDescriptor.hpp>
+#include <Util/Strings.hpp>
+#include <fmt/format.h>
+#include <AggregationLogicalFunctionRegistry.hpp>
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+namespace
+{
+
+constexpr std::array NonNumericAggregations{std::string_view{"COUNT"}};
+
+class AggregationInputTypeTest : public ::testing::Test
+{
+public:
+    static Schema<UnqualifiedUnboundField, Ordered> createSchema()
+    {
+        return Schema<UnqualifiedUnboundField, Ordered>{
+            {Identifier::parse("key"), DataTypeProvider::provideDataType(DataType::Type::VARSIZED)},
+            {Identifier::parse("i8"), DataTypeProvider::provideDataType(DataType::Type::INT8)}};
+    }
+
+    static TypedLogicalOperator<SourceDescriptorLogicalOperator> makeSource(SourceCatalog& catalog)
+    {
+        const auto logical = catalog.addLogicalSource(Identifier::parse("agg_src"), createSchema()).value();
+        const std::unordered_map<Identifier, std::string> sourceConfig{{Identifier::parse("file_path"), "/dev/null"}};
+        const std::unordered_map<Identifier, std::string> parserConfig{{Identifier::parse("type"), "CSV"}};
+        const auto descriptor
+            = catalog.addPhysicalSource(logical, Identifier::parse("file"), Host{"localhost"}, sourceConfig, parserConfig).value();
+        return SourceDescriptorLogicalOperator::create(descriptor);
+    }
+
+    static WindowAggregationLogicalFunction createAggregation(const std::string& name, const Identifier& field)
+    {
+        const TypedLogicalFunction<UnboundFieldAccessLogicalFunction> fieldAccess{UnboundFieldAccessLogicalFunction{field}};
+        return AggregationLogicalFunctionRegistry::instance().find(name).value()(
+            AggregationLogicalFunctionRegistryArguments{.on = {fieldAccess}, .includeNullValues = false});
+    }
+};
+
+TEST_F(AggregationInputTypeTest, RejectsNonNumericInput)
+{
+    SourceCatalog catalog;
+    const auto schema = makeSource(catalog)->getOutputSchema();
+
+    for (const auto& name : AggregationLogicalFunctionRegistry::instance().getRegisteredNames())
+    {
+        if (std::ranges::contains(NonNumericAggregations, name))
+        {
+            continue;
+        }
+        SCOPED_TRACE(name);
+        try
+        {
+            std::ignore = createAggregation(name, Identifier::parse("key")).withInferredType(schema);
+            ADD_FAILURE() << "Expected an UnsupportedQuery exception";
+        }
+        catch (const Exception& exception)
+        {
+            EXPECT_EQ(exception.code(), ErrorCode::UnsupportedQuery);
+            EXPECT_TRUE(toUpperCase(exception.what()).contains(fmt::format("{} IS ONLY SUPPORTED ON NUMERIC FIELDS", name)));
+        }
+    }
+}
+
+TEST_F(AggregationInputTypeTest, AcceptsNumericInput)
+{
+    SourceCatalog catalog;
+    const auto schema = makeSource(catalog)->getOutputSchema();
+
+    for (const auto& name : AggregationLogicalFunctionRegistry::instance().getRegisteredNames())
+    {
+        SCOPED_TRACE(name);
+        EXPECT_NO_THROW(std::ignore = createAggregation(name, Identifier::parse("i8")).withInferredType(schema));
+    }
+}
+}
+}

--- a/nes-logical-operators/tests/CMakeLists.txt
+++ b/nes-logical-operators/tests/CMakeLists.txt
@@ -25,3 +25,5 @@ if (ENABLE_INFERENCE_TESTS)
 endif ()
 
 add_nes_logical_operators_test(nes-join-logical-operator-test "JoinLogicalOperatorTest.cpp")
+
+add_nes_logical_operators_test(aggregation-input-type-test "AggregationInputTypeTest.cpp")

--- a/nes-sql-parser/private/AntlrSQLParser/AntlrSQLHelper.hpp
+++ b/nes-sql-parser/private/AntlrSQLParser/AntlrSQLHelper.hpp
@@ -39,7 +39,10 @@ namespace NES::Parsers
 
 class AntlrSQLHelper
 {
+public:
     using Projection = std::pair<std::optional<Identifier>, LogicalFunction>;
+
+private:
     std::vector<LogicalFunction> whereClauses; ///where and having clauses need to be accessed in reverse
     std::vector<LogicalFunction> havingClauses;
     std::optional<Identifier> source;
@@ -76,6 +79,7 @@ public:
 
     std::optional<Windowing::TimeBasedWindowType> windowType;
     std::vector<std::pair<WindowAggregationLogicalFunction, std::optional<Identifier>>> windowAggs;
+    std::vector<Identifier> userAggregationAliases;
     std::vector<SinkDescriptor> sinkDescriptor;
     std::vector<std::string> constantBuilder;
     std::vector<LogicalFunction> functionBuilder;
@@ -101,6 +105,10 @@ public:
     /// E.g., AVG(i + UINT64(1)) becomes: Projection(*, i + UINT64(1) AS _AGG_INPUT_0) → AVG(_AGG_INPUT_0).
     std::vector<Projection> preAggregationProjections;
     size_t aggExprCounter = 0;
+
+    /// Number of aggregations collected before the HAVING clause was entered, so that aggregations written
+    /// inside HAVING can be distinguished from the ones the SELECT list already projects.
+    size_t aggCountBeforeHaving = 0;
 
     /// Flag set while parsing a MODEL_INFERENCE TVF source to suppress identifier capture as FROM source
     bool isModelInference = false;

--- a/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
+++ b/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
@@ -1405,7 +1405,13 @@ void AntlrSQLQueryPlanCreator::exitFunctionCall(AntlrSQLParser::FunctionCallCont
                 }
                 else
                 {
-                    throw InvalidQuerySyntax("Unknown (aggregation) function: {}, resolved to token type: {}", funcName, tokenType);
+                    auto registeredNamesAggregation
+                        = AggregationLogicalFunctionRegistry::instance().getRegisteredNames() | std::ranges::to<std::vector>();
+                    std::ranges::sort(registeredNamesAggregation);
+                    throw InvalidQuerySyntax(
+                        "Unknown function: {}. Supported aggregation functions are {}.",
+                        funcName,
+                        fmt::join(registeredNamesAggregation, ", "));
                 }
             }
     }

--- a/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
+++ b/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
@@ -56,6 +56,7 @@
 #include <Functions/LogicalFunctionProvider.hpp>
 #include <Functions/UnboundFieldAccessLogicalFunction.hpp>
 #include <Identifiers/Identifier.hpp>
+#include <Iterators/BFSIterator.hpp>
 #include <Operators/ProjectionLogicalOperator.hpp>
 #include <Operators/Windows/Aggregations/AvgAggregationLogicalFunction.hpp>
 #include <Operators/Windows/Aggregations/CountAggregationLogicalFunction.hpp>
@@ -287,6 +288,31 @@ void validateSourceQualifiers(const AntlrSQLHelper& helper)
         if (qualifier != expectedQualifier.value())
         {
             throw InvalidQuerySyntax("Unknown source qualifier {}, expected {}", qualifier, expectedQualifier.value());
+        }
+    }
+}
+
+void validateAggregatedSelectList(AntlrSQLHelper& helper)
+{
+    const auto isAvailableAfterAggregation = [&helper](const Identifier& field)
+    {
+        return field == Identifier::parse("start") or field == Identifier::parse("end")
+            or std::ranges::any_of(helper.groupByFields, [&field](const auto& key) { return key.getFieldName() == field; })
+            or std::ranges::any_of(
+                   helper.windowAggs, [&field](const auto& agg) { return agg.second.has_value() and agg.second.value() == field; });
+    };
+
+    for (const auto& projection : helper.getProjections() | std::views::values)
+    {
+        for (const auto& function : BFSRange{projection})
+        {
+            if (const auto access = function.tryGetAs<UnboundFieldAccessLogicalFunction>();
+                access.has_value() and not isAvailableAfterAggregation(access.value()->getFieldName()))
+            {
+                throw InvalidQuerySyntax(
+                    R"(column "{}" must appear in the GROUP BY clause or be used in an aggregate function)",
+                    access.value()->getFieldName().getOriginalString());
+            }
         }
     }
 }
@@ -823,6 +849,7 @@ void AntlrSQLQueryPlanCreator::exitPrimaryQuery(AntlrSQLParser::PrimaryQueryCont
                 currentWindowTimestampOpt.has_value() ? "two" : "none");
         }
         auto characteristic = std::get<Windowing::UnboundTimeCharacteristic>(currentWindowTimestampOpt.value());
+        validateAggregatedSelectList(helpers.top());
         auto aggregations = helpers.top().windowAggs
             | std::views::transform(
                                 [](auto& agg)

--- a/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
+++ b/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
@@ -507,7 +507,13 @@ void AntlrSQLQueryPlanCreator::exitBoolComparison(AntlrSQLParser::BoolComparison
     }
     else
     {
-        throw UnsupportedQuery("Predicate is currently not supported: {}", comparison->getText());
+        /// `kind` stores the operator token (LIKE, RLIKE, DISTINCT, ...) to include in the error output.
+        INVARIANT(comparison->kind != nullptr, "Predicates without a kind token are handled above, but got {}", comparison->getText());
+        const auto keyword = toUpperCase(comparison->kind->getText());
+        const auto* const isPrefix = comparison->IS() != nullptr ? "IS " : "";
+        const auto* const negation = comparison->NOT() != nullptr ? "NOT " : "";
+        const auto* const distinctSuffix = comparison->DISTINCT() != nullptr ? " FROM" : "";
+        throw UnsupportedQuery("{}{}{}{} is not supported: {}", isPrefix, negation, keyword, distinctSuffix, comparison->getText());
     }
 
     functions.push_back(std::move(function));

--- a/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
+++ b/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
@@ -14,6 +14,7 @@
 
 #include <AntlrSQLParser/AntlrSQLQueryPlanCreator.hpp>
 
+#include <algorithm>
 #include <array>
 #include <cctype>
 #include <cstddef>
@@ -69,6 +70,7 @@
 #include <Plans/LogicalPlanBuilder.hpp>
 #include <Util/Overloaded.hpp>
 #include <Util/PlanRenderer.hpp>
+#include <Util/Strings.hpp>
 #include <WindowTypes/Measures/TimeCharacteristic.hpp>
 #include <WindowTypes/Measures/TimeMeasure.hpp>
 #include <WindowTypes/Types/SlidingWindow.hpp>
@@ -81,6 +83,32 @@
 
 namespace NES::Parsers
 {
+
+namespace
+{
+/// Renders an aggregation back as SQL (COUNT(VALUE)) so error messages quote the caller's own expression.
+/// An argument that was desugared into a pre-aggregation projection is rendered as the expression the caller wrote,
+/// not as the generated _AGG_INPUT_N field.
+std::string
+describeAggregation(const WindowAggregationLogicalFunction& aggregation, const std::vector<AntlrSQLHelper::Projection>& desugaredArguments)
+{
+    const auto input = aggregation.getInputFunction();
+    const auto field = [&]
+    {
+        if (const auto* unbound = std::get_if<TypedLogicalFunction<UnboundFieldAccessLogicalFunction>>(&input))
+        {
+            const auto desugared = std::ranges::find_if(
+                desugaredArguments, [&unbound](const auto& projection) { return projection.first == (*unbound)->getFieldName(); });
+            if (desugared != std::ranges::end(desugaredArguments))
+            {
+                return desugared->second.explain(ExplainVerbosity::Short);
+            }
+        }
+        return std::visit([](const auto& access) { return access->explain(ExplainVerbosity::Short); }, input);
+    }();
+    return fmt::format("{}({})", toUpperCase(aggregation.getName()), field);
+}
+}
 
 LogicalPlan AntlrSQLQueryPlanCreator::getQueryPlan() const
 {
@@ -701,6 +729,7 @@ void AntlrSQLQueryPlanCreator::enterIdentifier(AntlrSQLParser::IdentifierContext
             helpers.top().windowAggs.pop_back();
             aggFunc.second = bindIdentifier(context);
             helpers.top().windowAggs.push_back(aggFunc);
+            helpers.top().userAggregationAliases.push_back(aggFunc.second.value());
             helpers.top().addProjection(aggFunc.second, UnboundFieldAccessLogicalFunction{aggFunc.second.value()});
         }
         else
@@ -994,12 +1023,41 @@ void AntlrSQLQueryPlanCreator::exitCastExpression(AntlrSQLParser::CastExpression
 void AntlrSQLQueryPlanCreator::enterHavingClause(AntlrSQLParser::HavingClauseContext* context)
 {
     helpers.top().isWhereOrHaving = true;
+    helpers.top().aggCountBeforeHaving = helpers.top().windowAggs.size();
     AntlrSQLBaseListener::enterHavingClause(context);
 }
 
 void AntlrSQLQueryPlanCreator::exitHavingClause(AntlrSQLParser::HavingClauseContext* context)
 {
     helpers.top().isWhereOrHaving = false;
+    /// An aggregation written inside HAVING is a second aggregation, not a reference to the projected one.
+    /// Refuse it and report the alias that already exists.
+    const auto& aggregations = helpers.top().windowAggs;
+    if (aggregations.size() > helpers.top().aggCountBeforeHaving)
+    {
+        const auto& havingAggregation = aggregations[helpers.top().aggCountBeforeHaving].first;
+        const auto expression = describeAggregation(havingAggregation, helpers.top().preAggregationProjections);
+        const auto projectedAlias = [&]() -> std::optional<Identifier>
+        {
+            for (const auto& [aggregation, alias] : aggregations | std::views::take(helpers.top().aggCountBeforeHaving))
+            {
+                if (aggregation == havingAggregation and alias.has_value()
+                    and std::ranges::contains(helpers.top().userAggregationAliases, alias.value()))
+                {
+                    return alias;
+                }
+            }
+            return std::nullopt;
+        }();
+        if (projectedAlias.has_value())
+        {
+            throw InvalidQuerySyntax(
+                "HAVING must use the projected alias: write {} instead of {}", projectedAlias.value().getOriginalString(), expression);
+        }
+        throw InvalidQuerySyntax(
+            "HAVING can only use fields the SELECT list projects: add {} AS <alias> to the SELECT list and use <alias> in HAVING",
+            expression);
+    }
     if (helpers.top().functionBuilder.size() != 1)
     {
         throw InvalidQuerySyntax("There was more than one function in the functionBuilder in exitHavingClause.");

--- a/nes-sql-parser/tests/StatementBinderTest.cpp
+++ b/nes-sql-parser/tests/StatementBinderTest.cpp
@@ -1100,6 +1100,25 @@ TEST_F(StatementBinderTest, LowercaseFullJoinParsesToOuterFullJoinType)
     EXPECT_EQ(JoinLogicalOperator::JoinType::OUTER_FULL_JOIN, joins.at(0)->getJoinType());
 }
 
+TEST_F(StatementBinderTest, BindQueryWithUnsupportedPredicateNamesEveryKeywordOfThePredicate)
+{
+    const std::vector<std::pair<std::string, std::string>> predicates{
+        {"b IS TRUE", "IS TRUE is not supported"},
+        {"b IS NOT TRUE", "IS NOT TRUE is not supported"},
+        {"b IS DISTINCT FROM UINT32(5)", "IS DISTINCT FROM is not supported"},
+        {"b LIKE VARSIZED('a%')", "LIKE is not supported"},
+        {"b NOT LIKE VARSIZED('a%')", "NOT LIKE is not supported"}};
+
+    for (const auto& [predicate, expectedMessage] : predicates)
+    {
+        SCOPED_TRACE(predicate);
+        const auto statement = binder->parseAndBindSingle(fmt::format("SELECT a FROM inputStream WHERE {} INTO outputStream", predicate));
+        ASSERT_FALSE(statement.has_value());
+        EXPECT_EQ(statement.error().code(), ErrorCode::UnsupportedQuery);
+        EXPECT_TRUE(std::string{statement.error().what()}.contains(expectedMessage));
+    }
+}
+
 ///NOLINTEND(bugprone-unchecked-optional-access)
 }
 }

--- a/nes-systests/operator/aggregation/WindowAggregationCount.test
+++ b/nes-systests/operator/aggregation/WindowAggregationCount.test
@@ -91,3 +91,13 @@ INTO sinkCountBothKeyed;
 150,250,1,1,1
 150,250,2,1,0
 200,300,2,1,0
+
+
+# COUNT(1) should be accepted and should count rows like COUNT(*).
+SELECT start, end, COUNT(1) AS rowCount
+FROM stream WINDOW TUMBLING(ts, size 100 ms)
+INTO sinkCountStar;
+----
+0,100,3
+100,200,2
+200,300,1

--- a/nes-systests/operator/aggregation/WindowAggregationProjection.test
+++ b/nes-systests/operator/aggregation/WindowAggregationProjection.test
@@ -143,3 +143,21 @@ INTO sinkStreamNested;
 1,4
 1,2
 
+# A column that is neither grouped nor aggregated is rejected while the query is still being parsed.
+SELECT id, COUNT(id) AS count_id
+FROM stream
+WHERE id > UINT64(15)
+WINDOW TUMBLING(timestamp, size 1 sec)
+INTO sinkStreamNested;
+----
+ERROR 2000 "column "id" must appear in the GROUP BY clause or be used in an aggregate function"
+
+# Control for the case above: with the column in GROUP BY the same query should be accepted.
+SELECT id, COUNT(id) AS count_id
+FROM stream
+WHERE id > UINT64(15)
+GROUP BY id
+WINDOW TUMBLING(timestamp, size 1 sec)
+INTO sinkStreamNested;
+----
+16,1

--- a/nes-systests/operator/aggregation/WindowAggregationVarSizedMinimal.test
+++ b/nes-systests/operator/aggregation/WindowAggregationVarSizedMinimal.test
@@ -17,4 +17,3 @@ FROM stream GROUP BY (key) WINDOW TUMBLING(ts, size 100 ms) INTO FILE ();
 0,100,apple,1
 0,100,book,1
 0,100,cat,1
-

--- a/nes-systests/parser/VarSizedSupport.test
+++ b/nes-systests/parser/VarSizedSupport.test
@@ -48,3 +48,8 @@ WHERE text1 IN (VARSIZED('test3')) INTO sinkStreamWithText;
 ----
 11,2,test3,test2
 11,3,test3,test1
+
+# An unknown scalar function should be reported and specify the set of supported functions.
+SELECT UPPER(text1) AS t FROM streamWithText INTO sinkStreamWithText;
+----
+ERROR 2000 "Unknown function: UPPER. Supported aggregation functions are AVG, COUNT, MAX, MEDIAN, MIN, SUM."

--- a/nes-systests/parser/VarSizedSupport.test
+++ b/nes-systests/parser/VarSizedSupport.test
@@ -36,3 +36,15 @@ SELECT * FROM streamWithText INTO sinkStreamWithText;
 2,3,test1,test1
 6,4,test1,test2
 8,5,test1,test2
+
+# LIKE should be refused by name.
+SELECT text1 FROM streamWithText WHERE text1 LIKE VARSIZED('test%') INTO sinkStreamWithText;
+----
+ERROR 2008 "LIKE is not supported"
+
+# Control for the case above: IN over the same column should be supported.
+SELECT id, value, text1, text2 FROM streamWithText
+WHERE text1 IN (VARSIZED('test3')) INTO sinkStreamWithText;
+----
+11,2,test3,test2
+11,3,test3,test1

--- a/nes-systests/parser/WindowAggregationParser.test
+++ b/nes-systests/parser/WindowAggregationParser.test
@@ -59,6 +59,50 @@ INTO sinkStream;
 2000,3000,16,2
 1500,2500,16,2
 
+# HAVING that repeats the aggregate expression should be refused.
+# The error message should hint to use an alias from the SELECT list.
+SELECT start, end, id, SUM(value) as sumValue
+FROM stream
+WHERE id > 15
+WINDOW SLIDING(timestamp, size 1 sec, advance by 500 ms)
+GROUP BY id
+HAVING SUM(value) > UINT64(0)
+INTO sinkStream;
+----
+ERROR 2000 "HAVING must use the projected alias: write sumValue instead of SUM(VALUE)"
+
+SELECT start, end, id, SUM(value)
+FROM stream
+WHERE id > 15
+WINDOW SLIDING(timestamp, size 1 sec, advance by 500 ms)
+GROUP BY id
+HAVING SUM(value) > UINT64(0)
+INTO sinkStream;
+----
+ERROR 2000 "add SUM(VALUE) AS <alias> to the SELECT list"
+
+SELECT start, end, id, SUM(value + UINT64(1)) AS sumValue
+FROM stream
+WHERE id > 15
+WINDOW SLIDING(timestamp, size 1 sec, advance by 500 ms)
+GROUP BY id
+HAVING SUM(value + UINT64(1)) > UINT64(0)
+INTO sinkStream;
+----
+ERROR 2000 "add SUM(VALUE + 1) AS <alias> to the SELECT list"
+
+# Control for the case above: HAVING on the projected alias should be accepted.
+SELECT start, end, id, SUM(value) as sumValue
+FROM stream
+WHERE id > 15
+WINDOW SLIDING(timestamp, size 1 sec, advance by 500 ms)
+GROUP BY id
+HAVING sumValue > UINT64(0)
+INTO sinkStream;
+----
+2000,3000,16,2
+1500,2500,16,2
+
 # Negative test: GroupBy before where
 SELECT SUM(value) as sumValue
 FROM stream


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
The seven queries in #1957 fail for good reasons, but their errors name internal identifiers, the wrong category, or a clause that is correct. One commit per query, each pairing a test case with the change that produces the message. The change list is as follows:
- Changed the SQL parser to refuse an aggregate repeated in `HAVING` by naming the SELECT alias, instead of failing on the generated name `VALUE_COUNT`.
- Changed projection schema inference to name the stage that dropped a column, instead of reporting the column as non-existent.
- Changed all five aggregations to reject non-numeric input as `UnsupportedQuery`, naming the field and its type.
- Changed the parser to name an unsupported predicate operator (`LIKE`) and to report an unknown function without aggregation wording or a grammar token id.
- Changed descriptor validation to list the accepted parameters for the sink or source type.
- Added `COUNT(1)` coverage; `COUNT(*)` and `COUNT(1)` are already accepted, so that commit is tests only.

## Verifying this change
This change is tested by
- Added a test case per query, each asserting the error code and the load-bearing phrase of its message.
- Added the controls from the issue's acceptance criteria (`HAVING` on the alias, `IN`, `COUNT`, `GROUP BY`) where not already covered.
- Full local `ctest`, plus the six touched `.test` files run directly.

## What components does this pull request potentially affect?
- SQLParser
- LogicalOperators
- Configurations
- Systest

## Documentation
- The change is reflected in the necessary documentation, e.g., design document, in-code documentation.
- All necessary methods (no getter, setter, or constructor) have a documentation.

## Issue Closed by this pull request:

This PR closes #1957.

Three of its reports are stale against `main` and needed no message change: `IN` and `COUNT(*)`/`COUNT(1)` are already supported, and the non-numeric aggregation had already moved off `cannot deserialize` to `cannot infer stamp` — still a code whose name does not match the cause, hence the move to `UnsupportedQuery`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eg3WxK1EqcW8VFzNnbV7dQ