### PR TITLE
test(CMake): Serialize the DockerCompose test suites

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,12 @@ foreach (NES_DIR ${NES_DIRECTORIES_ALL})
     endif ()
 endforeach ()
 
+# Registered here, not in a suite directory, because it checks all suites at once.
+add_e2e_test(
+    NAME bats-lib-test
+    BATS_FILE scripts/testing/tests/bats_lib.bats
+)
+
 # Other configurations
 project_enable_format()
 project_enable_tidy()

--- a/nes-frontend/apps/cli/tests/distributed.bats
+++ b/nes-frontend/apps/cli/tests/distributed.bats
@@ -14,7 +14,7 @@
 
 source "$NES_BATS_LIB"
 
-setup_file()    { nes_distributed_setup_file "$NES_CLI"; }
+setup_file()    { nes_distributed_setup_file "$NES_CLI" cli; }
 teardown_file() { nes_distributed_teardown_file; }
 setup()         { nes_distributed_setup; }
 teardown()      { nes_distributed_teardown; }

--- a/nes-frontend/apps/cli/tests/util/create_compose.sh
+++ b/nes-frontend/apps/cli/tests/util/create_compose.sh
@@ -150,7 +150,7 @@ cat <<EOF
 networks:
   default:
     labels:
-      nes-test: distributed-cli
+      nes-test: ${NES_BATS_TEST_LABEL:-distributed-cli}
 volumes:
   $TEST_VOLUME:
     external: true

--- a/nes-frontend/apps/repl/tests/util/create_compose.sh
+++ b/nes-frontend/apps/repl/tests/util/create_compose.sh
@@ -110,7 +110,7 @@ cat <<EOF
 networks:
   default:
     labels:
-      nes-test: distributed-repl
+      nes-test: ${NES_BATS_TEST_LABEL:-distributed-repl}
 volumes:
   $TEST_VOLUME:
     external: true

--- a/nes-plugins/Sinks/MQTTSink/tests/distributed.bats
+++ b/nes-plugins/Sinks/MQTTSink/tests/distributed.bats
@@ -14,7 +14,7 @@
 
 source "$NES_BATS_LIB"
 
-setup_file()    { nes_distributed_setup_file "$NES_CLI"; }
+setup_file()    { nes_distributed_setup_file "$NES_CLI" mqtt-sink; }
 teardown_file() { nes_distributed_teardown_file; }
 setup()         { nes_distributed_setup; }
 teardown()      { nes_distributed_teardown; }

--- a/nes-plugins/Sinks/MQTTSink/tests/util/create_compose.sh
+++ b/nes-plugins/Sinks/MQTTSink/tests/util/create_compose.sh
@@ -175,7 +175,7 @@ cat <<EOF
 networks:
   default:
     labels:
-      nes-test: distributed-cli
+      nes-test: ${NES_BATS_TEST_LABEL:-distributed-mqtt-sink}
 volumes:
   $TEST_VOLUME:
     external: true

--- a/nes-plugins/Sources/MQTTSource/tests/distributed.bats
+++ b/nes-plugins/Sources/MQTTSource/tests/distributed.bats
@@ -14,7 +14,7 @@
 
 source "$NES_BATS_LIB"
 
-setup_file()    { nes_distributed_setup_file "$NES_CLI"; }
+setup_file()    { nes_distributed_setup_file "$NES_CLI" mqtt-source; }
 teardown_file() { nes_distributed_teardown_file; }
 setup()         { nes_distributed_setup; }
 teardown()      { nes_distributed_teardown; }

--- a/nes-plugins/Sources/MQTTSource/tests/util/create_compose.sh
+++ b/nes-plugins/Sources/MQTTSource/tests/util/create_compose.sh
@@ -174,7 +174,7 @@ cat <<EOF
 networks:
   default:
     labels:
-      nes-test: distributed-cli
+      nes-test: ${NES_BATS_TEST_LABEL:-distributed-mqtt-source}
 volumes:
   $TEST_VOLUME:
     external: true

--- a/scripts/testing/distributed_bats_lib.bash
+++ b/scripts/testing/distributed_bats_lib.bash
@@ -30,9 +30,9 @@
 #                                            (used by cli/MQTT* suites)
 #
 #   Layer-2 callers pass the client binary path to nes_distributed_setup_file
-#   (e.g. "$NES_CLI"); the lib derives the test label / image-name prefixes /
-#   app-image env-var name from `basename` of that path. Testdata is the
-#   directory containing the .bats file.
+#   (e.g. "$NES_CLI") plus a suite name when more than one suite drives that
+#   binary; see nes_derive_image_names. Testdata is the directory containing the
+#   .bats file.
 
 # Load the standard bats helper libraries when sourced from inside a bats test
 # (bats injects `bats_load_library`). They are resolved via BATS_LIB_PATH, which
@@ -250,19 +250,33 @@ assert_json_contains() {
 # Layer 2 — preset for cli/repl/MQTT distributed suites
 # ---------------------------------------------------------------------------
 
-nes_distributed_setup_file() {
-  # Pass the client binary path (e.g. "$NES_CLI"). Convention: nes-cli ->
-  # distributed-cli / nes-worker-cli-test / nes-cli-image / CLI_IMAGE.
+# Derive this suite's docker identity from the client binary path and a suite
+# name (default: binary name without `nes-`). Suites sharing a binary need
+# distinct names: setup_file force-removes everything matching these, so a
+# shared identity wipes a sibling suite's running stack.
+nes_derive_image_names() {
   local bin_path="$1"
   local bin_name
   bin_name=$(basename "$bin_path")
-  local suffix="${bin_name#nes-}"
-  local test_label="distributed-${suffix}"
-  local worker_prefix="nes-worker-${suffix}-test"
-  local app_prefix="${bin_name}-image"
-  export NES_BATS_APP_IMAGE_VAR="${suffix^^}_IMAGE"
+  local bin_suffix="${bin_name#nes-}"
+  local suite="${2:-$bin_suffix}"
 
-  nes_cleanup_leaked_resources "$test_label" "${worker_prefix}-*" "${app_prefix}-*"
+  export NES_BATS_TEST_LABEL="distributed-${suite}"
+  export NES_BATS_WORKER_PREFIX="nes-worker-${suite}-test"
+  export NES_BATS_APP_PREFIX="nes-${suite}-image"
+  export NES_BATS_APP_IMAGE_VAR="${bin_suffix^^}_IMAGE"
+}
+
+nes_distributed_setup_file() {
+  # Pass the client binary path (e.g. "$NES_CLI") and, when more than one suite
+  # drives that binary, a suite name.
+  local bin_path="$1"
+  local bin_name
+  bin_name=$(basename "$bin_path")
+  nes_derive_image_names "$bin_path" "${2:-}"
+
+  nes_cleanup_leaked_resources "$NES_BATS_TEST_LABEL" \
+    "${NES_BATS_WORKER_PREFIX}-*" "${NES_BATS_APP_PREFIX}-*"
 
   nes_require_env NES_WORKER
   nes_require_env NES_TEST_TMP_DIR
@@ -272,9 +286,9 @@ nes_distributed_setup_file() {
 
   # Per-test images use random suffixes so parallel checkouts don't collide.
   # Docker's COPY layer is content-addressed, so unchanged binaries hit cache.
-  nes_build_runtime_image WORKER_IMAGE "$worker_prefix" \
+  nes_build_runtime_image WORKER_IMAGE "$NES_BATS_WORKER_PREFIX" \
     "$NES_WORKER" nes-single-node-worker
-  nes_build_app_image "$NES_BATS_APP_IMAGE_VAR" "$app_prefix" \
+  nes_build_app_image "$NES_BATS_APP_IMAGE_VAR" "$NES_BATS_APP_PREFIX" \
     "$bin_path" "$bin_name"
 
   echo "# Using client binary: $bin_path" >&3

--- a/scripts/testing/tests/bats_lib.bats
+++ b/scripts/testing/tests/bats_lib.bats
@@ -1,0 +1,88 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Guards the docker identity distributed_bats_lib.bash derives per compose
+# suite: two suites sharing one delete each other's running stack. Pure shell,
+# no docker daemon needed.
+
+source "$NES_BATS_LIB"
+
+setup_file() {
+  nes_require_env NES_DIR
+  nes_require_env NES_CLI
+}
+
+# Print `<label> <worker-prefix> <app-prefix> <app-image-var>` for every
+# nes_distributed_setup_file call registered in the repo.
+registered_identities() {
+  local binref var suite
+  grep -rhoE 'nes_distributed_setup_file "\$[A-Z_]+"( [a-z0-9-]+)?' \
+    --include='*.bats' "$NES_DIR"/nes-* | while read -r _ binref suite; do
+    var="${binref#\"\$}"
+    var="${var%\"}"
+    ( nes_derive_image_names "${!var}" "$suite"
+      echo "$NES_BATS_TEST_LABEL $NES_BATS_WORKER_PREFIX $NES_BATS_APP_PREFIX $NES_BATS_APP_IMAGE_VAR" )
+  done
+}
+
+@test "suite name defaults to the binary name without the nes- prefix" {
+  nes_derive_image_names /some/where/nes-repl
+  assert_equal "$NES_BATS_TEST_LABEL" distributed-repl
+  assert_equal "$NES_BATS_WORKER_PREFIX" nes-worker-repl-test
+  assert_equal "$NES_BATS_APP_PREFIX" nes-repl-image
+  assert_equal "$NES_BATS_APP_IMAGE_VAR" REPL_IMAGE
+}
+
+@test "suites sharing a binary get distinct labels and image prefixes" {
+  nes_derive_image_names /some/where/nes-cli mqtt-sink
+  assert_equal "$NES_BATS_TEST_LABEL" distributed-mqtt-sink
+  assert_equal "$NES_BATS_WORKER_PREFIX" nes-worker-mqtt-sink-test
+  assert_equal "$NES_BATS_APP_PREFIX" nes-mqtt-sink-image
+  # The compose files reference the app image by binary, not by suite.
+  assert_equal "$NES_BATS_APP_IMAGE_VAR" CLI_IMAGE
+}
+
+@test "no two registered suites share a docker identity" {
+  local identities count unique
+  identities=$(registered_identities)
+  [ -n "$identities" ] || fail "found no nes_distributed_setup_file callers"
+
+  # Any single repeated field is a collision: cleanup matches networks by label
+  # and images by `<prefix>-*` independently.
+  local field
+  for field in 1 2 3; do
+    count=$(echo "$identities" | cut -d' ' -f$field | wc -l)
+    unique=$(echo "$identities" | cut -d' ' -f$field | sort -u | wc -l)
+    if [ "$count" -ne "$unique" ]; then
+      echo "duplicate identity field $field across suites:" >&2
+      echo "$identities" >&2
+      fail "each distributed suite needs its own suite name (2nd arg to nes_distributed_setup_file)"
+    fi
+  done
+}
+
+@test "no two compose files declare the same nes-test network label" {
+  local labels count unique
+  # Strips `${NES_BATS_TEST_LABEL:-<default>}` down to the default, which a
+  # suite falls back to and so has to be unique too.
+  labels=$(grep -rh 'nes-test:' --include='create_compose.sh' "$NES_DIR"/nes-* \
+    | sed -e 's/.*nes-test: *//' -e 's/^\${NES_BATS_TEST_LABEL:-//' -e 's/}$//')
+  [ -n "$labels" ] || fail "found no nes-test network labels"
+
+  count=$(echo "$labels" | wc -l)
+  unique=$(echo "$labels" | sort -u | wc -l)
+  if [ "$count" -ne "$unique" ]; then
+    echo "duplicate nes-test labels:" >&2
+    echo "$labels" | sort >&2
+    fail "compose files must not share a network label"
+  fi
+}


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
The three suites driving nes-cli derive the same image prefix and network label, and each setup_file force-removes both, tearing down a concurrently running sibling. Each suite now derives its own identity, serializing the label guards the rest, and bats_lib.bats fails if two ever share one again.

## Verifying this change
This change is tested by existing test but also the newly added `distributed_bats_lib.bash`.

## What components does this pull request potentially affect?
- Bats tests
