### PR TITLE
fix(engine): synchronize delayed task shutdown

### DIFF
--- a/nes-query-engine/DelayedTaskSubmitter.hpp
+++ b/nes-query-engine/DelayedTaskSubmitter.hpp
@@ -52,38 +52,61 @@ private:
         bool operator()(const ScheduledTask& left, const ScheduledTask& right) const { return left.deadline > right.deadline; }
     };
 
+    using TaskQueue = std::priority_queue<ScheduledTask, std::vector<ScheduledTask>, TaskComparator>;
+
+    struct State
+    {
+        TaskQueue taskQueue;
+        bool acceptingTasks = true;
+    };
+
     SubmitFn submitFn;
 
     std::condition_variable_any cv;
-    folly::Synchronized<std::priority_queue<ScheduledTask, std::vector<ScheduledTask>, TaskComparator>, std::mutex> taskQueueMtx;
+    folly::Synchronized<State, std::mutex> stateMtx;
 
     /// The DelayedTaskSubmitter is implemented as its own dedicated thread. Most of the time is spent blocking on an empty task queue
     /// or waiting until the deadline has passed to submit the next task.
+    std::once_flag shutdownOnce;
     Thread workerThread;
 
     void workerLoop(const std::stop_token& stop);
+    static void failTaskDuringShutdown(Task& task);
 
 public:
     explicit DelayedTaskSubmitter(SubmitFn submitFn);
 
     /// Template function to accept any std::chrono::duration type
+    /// The task will be submitted via the submit function after a delay.
+    /// If the DelayedTaskSubmitter is shutdown the task will trigger onFailure and onComplete.
     template <typename Rep, typename Period>
     void submitTaskIn(Task task, std::chrono::duration<Rep, Period> delay)
     {
         auto deadline = ClockType::now() + delay;
 
-        auto taskQueue = taskQueueMtx.lock();
-        const bool isEarliest = taskQueue->empty() || deadline < taskQueue->top().deadline;
-        taskQueue->emplace(ScheduledTask{std::move(task), deadline});
+        auto state = stateMtx.lock();
+        if (!state->acceptingTasks)
+        {
+            state.unlock();
+            failTaskDuringShutdown(task);
+            return;
+        }
+
+        const bool isEarliest = state->taskQueue.empty() || deadline < state->taskQueue.top().deadline;
+        state->taskQueue.emplace(ScheduledTask{std::move(task), deadline});
 
         /// Wake up the worker thread if this task has an earlier deadline or if the taskqueue was empty.
         /// This is necessary, as we need to set the cv_wait_until to ensure no task being missed.
         if (isEarliest)
         {
-            taskQueue.unlock();
+            state.unlock();
             cv.notify_one();
         }
     }
+
+    /// Stops the submitter thread and fails all outstanding tasks. Concurrent calls block until the single shutdown operation has
+    /// completed. Tasks submitted after shutdown are failed synchronously by submitTaskIn().
+    void shutdown();
 
     /// Non-copyable and non-movable
     DelayedTaskSubmitter(const DelayedTaskSubmitter&) = delete;
@@ -91,6 +114,7 @@ public:
     DelayedTaskSubmitter(DelayedTaskSubmitter&&) = delete;
     DelayedTaskSubmitter& operator=(DelayedTaskSubmitter&&) = delete;
 
+    /// The destructor will shutdown the DelayedTaskSubmitter failing any pending tasks.
     ~DelayedTaskSubmitter();
 };
 
@@ -103,18 +127,18 @@ DelayedTaskSubmitter<CT>::DelayedTaskSubmitter(SubmitFn submitFn)
 template <typename CT>
 void DelayedTaskSubmitter<CT>::workerLoop(const std::stop_token& stop)
 {
-    auto taskQueue = taskQueueMtx.lock();
+    auto state = stateMtx.lock();
     while (!stop.stop_requested())
     {
-        if (taskQueue->empty())
+        if (state->taskQueue.empty())
         {
             /// Wait for tasks to be added or shutdown signal
-            cv.wait(taskQueue.as_lock(), stop, [&taskQueue] { return !taskQueue->empty(); });
+            cv.wait(state.as_lock(), stop, [&state] { return !state->taskQueue.empty(); });
             continue;
         }
 
         auto now = ClockType::now();
-        const auto& nextTask = taskQueue->top();
+        const auto& nextTask = state->taskQueue.top();
 
         if (nextTask.deadline <= now)
         {
@@ -124,40 +148,71 @@ void DelayedTaskSubmitter<CT>::workerLoop(const std::stop_token& stop)
             /// Since we have exclusive access to the queue, and we are removing the task from the queue anyways and the underlying memory has to be mutable, stripping away the constness is ok (I think).
             /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
             auto task = std::move(const_cast<ScheduledTask&>(nextTask).task);
-            taskQueue->pop();
+            state->taskQueue.pop();
 
             /// Release lock while calling submit function to avoid blocking other operations
-            taskQueue.unlock();
+            state.unlock();
             submitFn(std::move(task));
-            taskQueue = taskQueueMtx.lock();
+            state = stateMtx.lock();
         }
         else
         {
             auto nextDeadline = nextTask.deadline;
             /// Wait until the next task deadline or until notified of new more urgent task
             cv.wait_until(
-                taskQueue.as_lock(),
+                state.as_lock(),
                 stop,
                 nextDeadline,
-                [&taskQueue, nextDeadline] { return !taskQueue->empty() && taskQueue->top().deadline < nextDeadline; });
+                [&state, nextDeadline] { return !state->taskQueue.empty() && state->taskQueue.top().deadline < nextDeadline; });
         }
     }
 }
 
 template <typename CT>
+void DelayedTaskSubmitter<CT>::failTaskDuringShutdown(Task& task)
+{
+    failTask(task, SkippingDelayedTaskDuringShutdown());
+    completeTask(task);
+}
+
+template <typename CT>
+void DelayedTaskSubmitter<CT>::shutdown()
+{
+    std::call_once(
+        shutdownOnce,
+        [this]
+        {
+            {
+                auto state = stateMtx.lock();
+                state->acceptingTasks = false;
+            }
+
+            /// Joining guarantees that no task submission into the engine task queue is still in flight when shutdown returns.
+            workerThread = {};
+
+            /// Run callbacks without holding the state mutex. Callbacks can re-enter submitTaskIn(), which will synchronously reject the
+            /// task because acceptingTasks is false.
+            while (true)
+            {
+                auto state = stateMtx.lock();
+                if (state->taskQueue.empty())
+                {
+                    break;
+                }
+
+                /// Priority queue's API only returns a const reference. We have exclusive access and immediately remove the element.
+                /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+                auto task = std::move(const_cast<ScheduledTask&>(state->taskQueue.top()).task);
+                state->taskQueue.pop();
+                state.unlock();
+                failTaskDuringShutdown(task);
+            }
+        });
+}
+
+template <typename CT>
 DelayedTaskSubmitter<CT>::~DelayedTaskSubmitter()
 {
-    /// Signal shutdown and wake up worker threads.
-    workerThread = {};
-
-    /// Throw away all pending tasks, as the engine is about to shutdown and trying to actually execute these tasks is unlikely to
-    /// succeed, in addition to potentially creating infinite cycles.
-    auto taskQueue = taskQueueMtx.lock();
-    while (!taskQueue->empty())
-    {
-        auto task = std::move(const_cast<ScheduledTask&>(taskQueue->top()).task);
-        taskQueue->pop();
-        failTask(task, SkippingDelayedTaskDuringShutdown());
-    }
+    shutdown();
 }
 }

--- a/nes-query-engine/QueryEngine.cpp
+++ b/nes-query-engine/QueryEngine.cpp
@@ -499,6 +499,7 @@ bool ThreadPool::WorkerThread::operator()(WorkTask& task) const
     if (auto pipeline = task.pipeline.lock())
     {
         ENGINE_LOG_DEBUG("Handle Task for {}-{}. Tuples: {}", task.queryId, pipeline->id, task.buf.getNumberOfTuples());
+        std::optional<std::pair<TupleBuffer, std::chrono::milliseconds>> requiresTaskRepetition;
         DefaultPEC pec(
             pool.numberOfThreads(),
             WorkerThread::id,
@@ -519,21 +520,30 @@ bool ThreadPool::WorkerThread::operator()(WorkTask& task) const
             },
             [&](const TupleBuffer& tupleBuffer, std::chrono::milliseconds duration)
             {
-                if (duration.count() > 0)
-                {
-                    pool.delayedTaskSubmitter.submitTaskIn(
-                        WorkTask(task.queryId, pipeline->id, pipeline, tupleBuffer, std::move(task.callback)), duration);
-                }
-                else
-                {
-                    pool.addInternalTask(WorkTask(task.queryId, pipeline->id, pipeline, tupleBuffer, std::move(task.callback)));
-                }
-                pool.statistic->onEvent(TaskEmit{id, task.queryId, pipeline->id, pipeline->id, taskId, tupleBuffer.getNumberOfTuples()});
+                INVARIANT(!requiresTaskRepetition.has_value(), "Pipeline attempts to repeat the task multiple times");
+                requiresTaskRepetition = std::make_pair(tupleBuffer, duration);
             }
 
         );
         pool.statistic->onEvent(TaskExecutionStart{WorkerThread::id, task.queryId, pipeline->id, taskId, task.buf.getNumberOfTuples()});
         pipeline->stage->execute(task.buf, pec);
+
+        if (requiresTaskRepetition)
+        {
+            auto [repeatedBuffer, duration] = std::move(requiresTaskRepetition).value();
+            const auto numberOfTuples = repeatedBuffer.getNumberOfTuples();
+            Task repeatedTask = WorkTask(task.queryId, pipeline->id, pipeline, std::move(repeatedBuffer), std::move(task.callback));
+            if (duration.count() > 0)
+            {
+                pool.delayedTaskSubmitter.submitTaskIn(std::move(repeatedTask), duration);
+            }
+            else
+            {
+                pool.addInternalTask(std::move(repeatedTask));
+            }
+            pool.statistic->onEvent(TaskEmit{id, task.queryId, pipeline->id, pipeline->id, taskId, numberOfTuples});
+        }
+
         pool.statistic->onEvent(TaskExecutionComplete{WorkerThread::id, task.queryId, pipeline->id, taskId});
         return true;
     }
@@ -634,6 +644,7 @@ bool ThreadPool::WorkerThread::operator()(StopPipelineTask& stopPipelineTask) co
 {
     LogContext logContext("Task", fmt::format("{}-{}", stopPipelineTask.queryId, stopPipelineTask.pipeline->id));
     ENGINE_LOG_DEBUG("Stop Pipeline Task for {}-{}", stopPipelineTask.queryId, stopPipelineTask.pipeline->id);
+    std::optional<std::chrono::milliseconds> requiresTaskRepetition;
     DefaultPEC pec(
         pool.numberOfThreads(),
         WorkerThread::id,
@@ -658,22 +669,28 @@ bool ThreadPool::WorkerThread::operator()(StopPipelineTask& stopPipelineTask) co
         },
         [&](const TupleBuffer&, std::chrono::milliseconds duration)
         {
-            StopPipelineTask repeatedTask(
-                stopPipelineTask.queryId, std::move(stopPipelineTask.pipeline), std::move(stopPipelineTask.callback));
-            if (duration.count() > 0)
-            {
-                pool.delayedTaskSubmitter.submitTaskIn(std::move(repeatedTask), duration);
-            }
-            else
-            {
-                pool.addInternalTask(std::move(repeatedTask));
-            }
+            INVARIANT(!requiresTaskRepetition.has_value(), "Pipeline attempts to repeat the task multiple times");
+            requiresTaskRepetition = duration;
         });
 
     ENGINE_LOG_DEBUG("Stopping Pipeline {}-{}", stopPipelineTask.queryId, stopPipelineTask.pipeline->id);
     auto pipelineId = stopPipelineTask.pipeline->id;
     auto queryId = stopPipelineTask.queryId;
     stopPipelineTask.pipeline->stage->stop(pec);
+
+    if (requiresTaskRepetition)
+    {
+        const auto duration = requiresTaskRepetition.value();
+        StopPipelineTask repeatedTask{stopPipelineTask.queryId, std::move(stopPipelineTask.pipeline), std::move(stopPipelineTask.callback)};
+        if (duration.count() > 0)
+        {
+            pool.delayedTaskSubmitter.submitTaskIn(std::move(repeatedTask), duration);
+        }
+        else
+        {
+            pool.addInternalTask(std::move(repeatedTask));
+        }
+    }
     pool.statistic->onEvent(PipelineStop{WorkerThread::id, queryId, pipelineId});
     return true;
 }

--- a/nes-query-engine/QueryEngine.cpp
+++ b/nes-query-engine/QueryEngine.cpp
@@ -418,6 +418,17 @@ public:
     {
     }
 
+    ~ThreadPool() override
+    {
+        /// Request shutdown for every worker before joining any individual thread. This lets all workers leave their normal processing
+        /// loop and synchronously coordinate shutdown of the delayed task submitter before they perform the final task queue drain.
+        for (auto& worker : pool)
+        {
+            worker.requestStop();
+        }
+        pool.clear();
+    }
+
     /// Reserves the initial WorkerThreadId for the terminator thread, which is the thread which is calling shutdown.
     /// This allows the thread to access into the internal task queue, which is prohibited for non-worker threads.
     /// The terminator thread does not count towards the numberOfThreads
@@ -647,17 +658,6 @@ bool ThreadPool::WorkerThread::operator()(StopPipelineTask& stopPipelineTask) co
         },
         [&](const TupleBuffer&, std::chrono::milliseconds duration)
         {
-            if (terminating)
-            {
-                /// A stage that cannot finish its stop (e.g. a network sink whose peer never accepted the channel) would otherwise
-                /// add this task into the queue forever, and the worker threads would never see an empty queue.
-                ENGINE_LOG_WARNING("Dropping pipeline stop retry during query engine termination");
-                /// Dropping the task destroys the node it still owns. Clear the termination flag first so the node satisfies the
-                /// ~RunningQueryPlanNode invariant instead of aborting on the `!requiresTermination` assertion.
-                stopPipelineTask.pipeline->requiresTermination = false;
-                return;
-            }
-
             StopPipelineTask repeatedTask(
                 stopPipelineTask.queryId, std::move(stopPipelineTask.pipeline), std::move(stopPipelineTask.callback));
             if (duration.count() > 0)
@@ -766,6 +766,10 @@ void ThreadPool::addThread(const Host& host)
                     handleTask(worker, std::move(*task));
                 }
             }
+
+            /// The task delayer could add another task after the workers observe an empty task queue. Synchronously shutting it down first
+            /// guarantees that no delayed submission is in flight and that later delayed submissions are failed instead of queued.
+            delayedTaskSubmitter.shutdown();
 
             ENGINE_LOG_INFO("WorkerThread {} shutting down", id);
             /// Worker in termination mode will not emit further work and eventually clear the task queue and terminate.

--- a/nes-query-engine/tests/DelayedTaskSubmitterTest.cpp
+++ b/nes-query-engine/tests/DelayedTaskSubmitterTest.cpp
@@ -15,6 +15,7 @@
 #include <DelayedTaskSubmitter.hpp>
 
 #include <atomic>
+#include <barrier>
 #include <chrono>
 #include <cstddef>
 #include <memory>
@@ -39,10 +40,25 @@
 
 namespace NES::Testing
 {
-
-static QueryId randomQueryId()
+namespace
+{
+QueryId randomQueryId()
 {
     return QueryId::createLocal(LocalQueryId(generateUUID()));
+}
+
+WorkTask createTrackedTask(std::atomic<int>& completeCount, std::atomic<int>& failureCount)
+{
+    return {
+        randomQueryId(),
+        PipelineId(1),
+        std::weak_ptr<RunningQueryPlanNode>(),
+        TupleBuffer(),
+        TaskCallback(
+            TaskCallback::OnComplete([&completeCount] { ++completeCount; }),
+
+            TaskCallback::OnFailure([&failureCount](const Exception&) { ++failureCount; }))};
+}
 }
 
 /// While the test attempts to bypass handling real time by using a TestClock, this test cannot ensure that the condition variable
@@ -265,14 +281,7 @@ TEST_F(DelayedTaskSubmitterTest, testDestructorCleanup)
         auto submitter = DelayedTaskSubmitter([&submittedCount](Task /*task*/) noexcept { ++submittedCount; });
 
         /// Submit a task with long delay and custom onComplete and onFailure callbacks
-        auto task = WorkTask(
-            randomQueryId(),
-            PipelineId(1),
-            std::weak_ptr<RunningQueryPlanNode>(),
-            TupleBuffer(),
-            TaskCallback(
-                TaskCallback::OnComplete([&completeCount] { ++completeCount; }),
-                TaskCallback::OnFailure([&failureCount](const Exception&) { ++failureCount; })));
+        auto task = createTrackedTask(completeCount, failureCount);
         submitter.submitTaskIn(std::move(task), std::chrono::milliseconds(1000));
         TestClock::advance(std::chrono::milliseconds(100), true);
         /// Destructor should be called here, cleaning up pending tasks
@@ -281,7 +290,65 @@ TEST_F(DelayedTaskSubmitterTest, testDestructorCleanup)
     TestClock::advance(std::chrono::milliseconds(1000), true);
     /// Task should not be executed since submitter was destroyed, but the failure callback should be called
     EXPECT_EQ(submittedCount.load(), 0);
-    EXPECT_EQ(completeCount.load(), 0);
+    EXPECT_EQ(completeCount.load(), 1);
+    EXPECT_EQ(failureCount.load(), 1);
+}
+
+TEST_F(DelayedTaskSubmitterTest, testShutdownFailsPendingTask)
+{
+    std::atomic submittedCount{0};
+    std::atomic failureCount{0};
+    std::atomic completeCount{0};
+
+    auto submitter = DelayedTaskSubmitter([&submittedCount](Task /*task*/) noexcept { ++submittedCount; });
+    submitter.submitTaskIn(createTrackedTask(completeCount, failureCount), std::chrono::hours(1));
+
+    submitter.shutdown();
+
+    EXPECT_EQ(submittedCount.load(), 0);
+    EXPECT_EQ(completeCount.load(), 1);
+    EXPECT_EQ(failureCount.load(), 1);
+}
+
+TEST_F(DelayedTaskSubmitterTest, testConcurrentShutdown)
+{
+    auto submitter = DelayedTaskSubmitter([](Task /*task*/) noexcept { });
+
+    constexpr size_t numberOfShutdownThreads = 10;
+    std::atomic<size_t> completedShutdowns{0};
+    std::barrier shutdownBarrier(numberOfShutdownThreads + 1);
+
+    std::vector<std::jthread> shutdownThreads;
+    shutdownThreads.reserve(numberOfShutdownThreads);
+    for (size_t index = 0; index < numberOfShutdownThreads; ++index)
+    {
+        shutdownThreads.emplace_back(
+            [&submitter, &shutdownBarrier, &completedShutdowns]
+            {
+                shutdownBarrier.arrive_and_wait();
+                submitter.shutdown();
+                ++completedShutdowns;
+            });
+    }
+    shutdownBarrier.arrive_and_wait();
+    shutdownThreads.clear();
+
+    EXPECT_EQ(completedShutdowns.load(), numberOfShutdownThreads);
+}
+
+TEST_F(DelayedTaskSubmitterTest, testSubmissionAfterShutdownFailsSynchronously)
+{
+    std::atomic submittedCount{0};
+    std::atomic failureCount{0};
+    std::atomic completeCount{0};
+
+    auto submitter = DelayedTaskSubmitter([&submittedCount](Task /*task*/) noexcept { ++submittedCount; });
+    submitter.shutdown();
+
+    submitter.submitTaskIn(createTrackedTask(completeCount, failureCount), std::chrono::milliseconds(1));
+
+    EXPECT_EQ(submittedCount.load(), 0);
+    EXPECT_EQ(completeCount.load(), 1);
     EXPECT_EQ(failureCount.load(), 1);
 }
 


### PR DESCRIPTION
## Summary

The DelayedTaskSubmitter could previously insert a task after the worker
threads have drained the queue. This caused the dtor of the queue to destroy
task's target pipelines would trip over the invariant that all pipelines
need to be terminated.

The new implementation initializes the shutdown on the DelayedTaskSubmitter,
which will fail all pending tasks, and reject and future delayed task submissions.

This ensures that the queue is truly empty after it is drained.

This would have manifested in flakey tests:

```
  systest: /home/runner/work/nebulastream/nebulastream/nes-query-engine/RunningQueryPlan.cpp:118: NES::RunningQueryPlanNode::~RunningQueryPlanNode(): Assertion `!requiresTermination && "Node was destroyed without termination. This should not happen"' failed.
  ```
  
  https://github.com/nebulastream/nebulastream/actions/runs/33396979743/job/99507861717