### PR TITLE
[PoC Statistics]: Add reservoir sample statistic build and probe

### DIFF
--- a/nes-common/include/ExceptionDefinitions.inc
+++ b/nes-common/include/ExceptionDefinitions.inc
@@ -95,6 +95,7 @@ EXCEPTION(RunningRoutineFailure, 4001, "error in running routine of SourceThread
 EXCEPTION(CannotOpenSource, 4002, "failed to open a source")
 EXCEPTION(FormattingError, 4003, "error during formatting")
 EXCEPTION(CannotOpenSink, 4004, "failed to open a sink")
+EXCEPTION(CannotProbeStatistic, 4005, "stored statistic does not match what the probe expects")
 
 /// 5XXX API errors
 EXCEPTION(QueryNotFound, 5000, "query is not registered")

--- a/nes-logical-operators/include/Operators/Statistic/StatisticStoreReaderLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Statistic/StatisticStoreReaderLogicalOperator.hpp
@@ -1,0 +1,166 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <Operators/Statistic/StatisticBlobType.hpp>
+#include <Operators/Statistic/StatisticWindowMatch.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/UnboundField.hpp>
+#include <Identifiers/Identifier.hpp>
+#include <Identifiers/Identifiers.hpp>
+#include <Identifiers/StatisticIdentifiers.hpp>
+#include <Operators/LogicalOperator.hpp>
+#include <Operators/LogicalOperatorFwd.hpp>
+#include <Operators/OriginIdAssigner.hpp>
+#include <Schema/Schema.hpp>
+#include <Schema/SchemaFwd.hpp>
+#include <Serialization/ReflectedOperator.hpp>
+#include <Traits/TraitSet.hpp>
+#include <Util/PlanRenderer.hpp>
+#include <Util/Reflection.hpp>
+
+namespace NES
+{
+
+/// Reads a statistic back out of the statistic store, whatever its payload layout.
+///
+/// The payload is opaque, so the probe is told how to decode it: `blobName` selects the decoder and `payloadFields`
+/// names the columns it produces -- one field for a scalar aggregation, one per sampled column for a reservoir
+/// sample. The name is also what lets a probe reject a statistic some other build wrote.
+///
+/// Only the window bounds come from the incoming record; the statisticId is a member. That is deliberate. It keeps
+/// the operator usable in both settings -- chained directly after the build, and driven by impulse tuples from a
+/// source -- and it avoids depending on a STATISTICID field surviving a pipeline boundary, which it would not: the
+/// writer adds that field to the record but it is not part of any logical output schema, so an Emit between the two
+/// would silently drop it.
+class StatisticStoreReaderLogicalOperator final : public OriginIdAssigner, public ManagedByOperator
+{
+public:
+    /// One decoded column of the payload: a scalar contributes exactly one, a reservoir sample one per sampled field.
+    using PayloadField = std::pair<Identifier, DataType>;
+
+    StatisticStoreReaderLogicalOperator(
+        WeakLogicalOperator self,
+        StatisticId statisticId,
+        StatisticBlobType typeName,
+        std::vector<PayloadField> payloadFields,
+        StatisticWindowMatch windowMatch);
+    StatisticStoreReaderLogicalOperator(
+        WeakLogicalOperator self,
+        LogicalOperator child,
+        StatisticId statisticId,
+        StatisticBlobType typeName,
+        std::vector<PayloadField> payloadFields,
+        StatisticWindowMatch windowMatch);
+
+    static TypedLogicalOperator<StatisticStoreReaderLogicalOperator>
+    create(StatisticId statisticId, StatisticBlobType typeName, std::vector<PayloadField> payloadFields, StatisticWindowMatch windowMatch);
+    static TypedLogicalOperator<StatisticStoreReaderLogicalOperator> create(
+        LogicalOperator child,
+        StatisticId statisticId,
+        StatisticBlobType typeName,
+        std::vector<PayloadField> payloadFields,
+        StatisticWindowMatch windowMatch);
+
+    [[nodiscard]] StatisticId getStatisticId() const { return statisticId; }
+
+    [[nodiscard]] const StatisticBlobType& getTypeName() const { return typeName; }
+
+    [[nodiscard]] const std::vector<PayloadField>& getPayloadFields() const { return payloadFields; }
+
+    [[nodiscard]] StatisticWindowMatch getWindowMatch() const { return windowMatch; }
+
+    [[nodiscard]] bool operator==(const StatisticStoreReaderLogicalOperator& rhs) const;
+
+    [[nodiscard]] StatisticStoreReaderLogicalOperator withTraitSet(TraitSet traitSet) const;
+    [[nodiscard]] TraitSet getTraitSet() const;
+
+    [[nodiscard]] StatisticStoreReaderLogicalOperator withChildrenUnsafe(std::vector<LogicalOperator> children) const;
+    [[nodiscard]] StatisticStoreReaderLogicalOperator withChildren(std::vector<LogicalOperator> children) const;
+    [[nodiscard]] std::vector<LogicalOperator> getChildren() const;
+    [[nodiscard]] LogicalOperator getChild() const;
+    [[nodiscard]] Schema<Field, Unordered> getOutputSchema() const;
+
+    [[nodiscard]] std::string explain(ExplainVerbosity verbosity, OperatorId id) const;
+    [[nodiscard]] std::string_view getName() const noexcept;
+
+    [[nodiscard]] StatisticStoreReaderLogicalOperator withInferredSchema() const;
+
+private:
+    static constexpr std::string_view NAME = "StatisticStoreReader";
+
+    void inferLocalSchema();
+
+    std::optional<LogicalOperator> child;
+    StatisticId statisticId;
+    StatisticBlobType typeName;
+    std::vector<PayloadField> payloadFields;
+    StatisticWindowMatch windowMatch;
+
+    /// Set during schema inference.
+    std::optional<Schema<UnqualifiedUnboundField, Unordered>> outputSchema;
+
+    TraitSet traitSet;
+    friend struct std::hash<StatisticStoreReaderLogicalOperator>;
+};
+
+namespace detail
+{
+/// Strong types are flattened to their underlying representation so no Reflector specialisation is needed for
+/// StatisticId.
+struct ReflectedStatisticStoreReaderLogicalOperator
+{
+    OperatorId operatorId{OperatorId::INVALID};
+    uint64_t statisticId{};
+    std::string typeName;
+    std::vector<StatisticStoreReaderLogicalOperator::PayloadField> payloadFields;
+    uint8_t windowMatch{};
+};
+}
+
+template <>
+struct Reflector<TypedLogicalOperator<StatisticStoreReaderLogicalOperator>>
+{
+    Reflected operator()(const TypedLogicalOperator<StatisticStoreReaderLogicalOperator>& op, const ReflectionContext& context) const;
+};
+
+template <>
+struct Unreflector<TypedLogicalOperator<StatisticStoreReaderLogicalOperator>>
+{
+    using ContextType = std::shared_ptr<ReflectedPlan>;
+    ContextType plan;
+    explicit Unreflector(ContextType operatorMapping);
+    TypedLogicalOperator<StatisticStoreReaderLogicalOperator> operator()(const Reflected& rfl, const ReflectionContext& context) const;
+};
+
+static_assert(LogicalOperatorConcept<StatisticStoreReaderLogicalOperator>);
+
+}
+
+template <>
+struct std::hash<NES::StatisticStoreReaderLogicalOperator>
+{
+    size_t operator()(const NES::StatisticStoreReaderLogicalOperator& op) const noexcept;
+};

--- a/nes-logical-operators/include/Operators/Statistic/StatisticStoreWriterLogicalOperator.hpp
+++ b/nes-logical-operators/include/Operators/Statistic/StatisticStoreWriterLogicalOperator.hpp
@@ -1,0 +1,142 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <Identifiers/Identifier.hpp>
+#include <Identifiers/Identifiers.hpp>
+#include <Identifiers/StatisticIdentifiers.hpp>
+#include <Operators/LogicalOperator.hpp>
+#include <Operators/LogicalOperatorFwd.hpp>
+#include <Operators/Statistic/StatisticBlobType.hpp>
+#include <Schema/Field.hpp>
+#include <Schema/Schema.hpp>
+#include <Schema/SchemaFwd.hpp>
+#include <Serialization/ReflectedOperator.hpp>
+#include <Traits/Trait.hpp>
+#include <Traits/TraitSet.hpp>
+#include <Util/PlanRenderer.hpp>
+#include <Util/Reflection.hpp>
+
+namespace NES
+{
+
+/// Writes the statistic payload produced by an upstream windowed aggregation into the worker's statistic store.
+/// Expects the child schema to contain the aggregation's window bounds, its payload and its measurement count,
+/// and re-emits per input record:
+/// [statisticId: UINT64, statisticStart: UINT64, statisticEnd: UINT64, statisticNumberOfSeenMeasurements: UINT64]
+/// (i.e., the blob is dropped from the stream after it has been stored).
+class StatisticStoreWriterLogicalOperator final : public ManagedByOperator
+{
+public:
+    struct FieldNames
+    {
+        Identifier inputStatisticStart;
+        Identifier inputStatisticEnd;
+        Identifier inputStatisticData;
+        Identifier inputNumberOfSeenMeasurements;
+    };
+
+    StatisticStoreWriterLogicalOperator(WeakLogicalOperator self, StatisticId statisticId, StatisticBlobType typeName);
+    StatisticStoreWriterLogicalOperator(
+        WeakLogicalOperator self, LogicalOperator child, StatisticId statisticId, StatisticBlobType typeName);
+
+    static TypedLogicalOperator<StatisticStoreWriterLogicalOperator> create(StatisticId statisticId, StatisticBlobType typeName);
+    static TypedLogicalOperator<StatisticStoreWriterLogicalOperator>
+    create(LogicalOperator child, StatisticId statisticId, StatisticBlobType typeName);
+
+    [[nodiscard]] StatisticId getStatisticId() const;
+    [[nodiscard]] const StatisticBlobType& getTypeName() const;
+    [[nodiscard]] FieldNames getFieldNames() const;
+
+    [[nodiscard]] bool operator==(const StatisticStoreWriterLogicalOperator& rhs) const;
+
+    [[nodiscard]] StatisticStoreWriterLogicalOperator withTraitSet(TraitSet traitSet) const;
+    [[nodiscard]] TraitSet getTraitSet() const;
+
+    [[nodiscard]] StatisticStoreWriterLogicalOperator withChildrenUnsafe(std::vector<LogicalOperator> children) const;
+    [[nodiscard]] StatisticStoreWriterLogicalOperator withChildren(std::vector<LogicalOperator> children) const;
+    [[nodiscard]] std::vector<LogicalOperator> getChildren() const;
+    [[nodiscard]] LogicalOperator getChild() const;
+
+    [[nodiscard]] Schema<Field, Unordered> getOutputSchema() const;
+
+    [[nodiscard]] std::string explain(ExplainVerbosity verbosity, OperatorId) const;
+    [[nodiscard]] std::string_view getName() const noexcept;
+
+    [[nodiscard]] StatisticStoreWriterLogicalOperator withInferredSchema() const;
+
+private:
+    static constexpr std::string_view NAME = "StatisticStoreWriter";
+
+    StatisticId statisticId;
+    StatisticBlobType typeName;
+
+    std::optional<LogicalOperator> child;
+
+    void inferLocalSchema();
+    /// Set during schema inference
+    std::optional<Schema<UnqualifiedUnboundField, Unordered>> outputSchema;
+    std::optional<FieldNames> fieldNames;
+
+    TraitSet traitSet;
+
+    friend struct std::hash<StatisticStoreWriterLogicalOperator>;
+    friend Reflector<TypedLogicalOperator<StatisticStoreWriterLogicalOperator>>;
+};
+
+namespace detail
+{
+struct ReflectedStatisticStoreWriterLogicalOperator
+{
+    OperatorId operatorId{OperatorId::INVALID};
+    StatisticId statisticId{StatisticId::INVALID};
+    std::string typeName;
+};
+}
+
+template <>
+struct Reflector<TypedLogicalOperator<StatisticStoreWriterLogicalOperator>>
+{
+    Reflected operator()(const TypedLogicalOperator<StatisticStoreWriterLogicalOperator>& op, const ReflectionContext& context) const;
+};
+
+template <>
+struct Unreflector<TypedLogicalOperator<StatisticStoreWriterLogicalOperator>>
+{
+    using ContextType = std::shared_ptr<ReflectedPlan>;
+    ContextType plan;
+    explicit Unreflector(ContextType plan);
+    TypedLogicalOperator<StatisticStoreWriterLogicalOperator>
+    operator()(const Reflected& reflected, const ReflectionContext& context) const;
+};
+
+static_assert(LogicalOperatorConcept<StatisticStoreWriterLogicalOperator>);
+
+}
+
+template <>
+struct std::hash<NES::StatisticStoreWriterLogicalOperator>
+{
+    std::size_t operator()(const NES::StatisticStoreWriterLogicalOperator& statisticStoreWriterLogicalOperator) const noexcept;
+};

--- a/nes-logical-operators/include/Operators/Statistic/StatisticWindowMatch.hpp
+++ b/nes-logical-operators/include/Operators/Statistic/StatisticWindowMatch.hpp
@@ -1,0 +1,32 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+
+namespace NES
+{
+
+/// How a probe selects stored statistics for the window bounds it is given.
+///
+/// A probe chained onto a build sees one exact window per record and wants that one statistic. A probe driven by
+/// an impulse over a time range wants every window falling inside it, so the same bounds mean something different.
+enum class StatisticWindowMatch : uint8_t
+{
+    ExactWindow,
+    WithinRange
+};
+
+}

--- a/nes-logical-operators/include/Operators/Windows/Aggregations/ReservoirSampleAggregationLogicalFunction.hpp
+++ b/nes-logical-operators/include/Operators/Windows/Aggregations/ReservoirSampleAggregationLogicalFunction.hpp
@@ -1,0 +1,82 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <string_view>
+
+#include <DataTypes/DataType.hpp>
+#include <Operators/Windows/Aggregations/WindowAggregationLogicalFunction.hpp>
+#include <Schema/Field.hpp>
+#include <Schema/Schema.hpp>
+#include <Schema/SchemaFwd.hpp>
+#include <Util/PlanRenderer.hpp>
+#include <Util/Reflection.hpp>
+#include <SerializableVariantDescriptor.pb.h>
+
+namespace NES
+{
+
+class ReservoirSampleAggregationLogicalFunction
+{
+public:
+    ReservoirSampleAggregationLogicalFunction(uint64_t sampleSize, uint64_t seed);
+    ReservoirSampleAggregationLogicalFunction(AggregationFieldAccess inputFunction, uint64_t sampleSize, uint64_t seed);
+
+    [[nodiscard]] ReservoirSampleAggregationLogicalFunction withInferredType(const Schema<Field, Unordered>& schema) const;
+    [[nodiscard]] std::string_view getName() const noexcept;
+    [[nodiscard]] static DataType getAggregateType();
+    [[nodiscard]] AggregationFieldAccess getInputFunction() const;
+    [[nodiscard]] static bool shallIncludeNullValues() noexcept;
+    [[nodiscard]] static bool requiresAllInputFields() noexcept;
+    [[nodiscard]] uint64_t getSampleSize() const;
+    [[nodiscard]] uint64_t getSeed() const;
+    [[nodiscard]] std::string explain(ExplainVerbosity verbosity) const;
+    [[nodiscard]] bool operator==(const ReservoirSampleAggregationLogicalFunction& other) const;
+
+    static constexpr std::string_view NAME = "ReservoirSample";
+
+private:
+    AggregationFieldAccess inputFunction;
+    uint64_t sampleSize;
+    uint64_t seed;
+    static constexpr std::string_view PlaceholderFieldName = "RESERVOIRSAMPLEINPUT";
+    static constexpr DataType::Type finalAggregateStampType = DataType::Type::VARSIZED;
+};
+
+template <>
+struct Reflector<ReservoirSampleAggregationLogicalFunction>
+{
+    Reflected operator()(const ReservoirSampleAggregationLogicalFunction& function, const ReflectionContext& context) const;
+};
+
+template <>
+struct Unreflector<ReservoirSampleAggregationLogicalFunction>
+{
+    ReservoirSampleAggregationLogicalFunction operator()(const Reflected& reflected, const ReflectionContext& context) const;
+};
+
+}
+
+template <>
+struct std::hash<NES::ReservoirSampleAggregationLogicalFunction>
+{
+    size_t operator()(const NES::ReservoirSampleAggregationLogicalFunction& aggregationFunction) const noexcept;
+};
+
+static_assert(NES::WindowAggregationFunctionConcept<NES::ReservoirSampleAggregationLogicalFunction>);

--- a/nes-logical-operators/include/Operators/Windows/Aggregations/WindowAggregationLogicalFunction.hpp
+++ b/nes-logical-operators/include/Operators/Windows/Aggregations/WindowAggregationLogicalFunction.hpp
@@ -99,6 +99,7 @@ struct ErasedWindowAggregationFunction
     [[nodiscard]] virtual AggregationFieldAccess getInputFunction() const = 0;
 
     [[nodiscard]] virtual bool shallIncludeNullValues() const noexcept = 0;
+    [[nodiscard]] virtual bool requiresAllInputFields() const noexcept = 0;
     [[nodiscard]] virtual WindowAggregationLogicalFunction withInferredType(const Schema<Field, Unordered>& schema) const = 0;
 
     friend bool operator==(const ErasedWindowAggregationFunction& lhs, const ErasedWindowAggregationFunction& rhs)
@@ -269,6 +270,8 @@ struct TypedWindowAggregationLogicalFunction
 
     [[nodiscard]] bool shallIncludeNullValues() const noexcept { return self->shallIncludeNullValues(); }
 
+    [[nodiscard]] bool requiresAllInputFields() const noexcept { return self->requiresAllInputFields(); }
+
     [[nodiscard]] TypedWindowAggregationLogicalFunction withInferredType(const Schema<Field, Unordered>& schema) const
     {
         return self->withInferredType(schema);
@@ -305,6 +308,18 @@ struct WindowAggregationFunctionModel : ErasedWindowAggregationFunction
     [[nodiscard]] Reflected reflect(const ReflectionContext& context) const override { return context.reflect(impl); }
 
     [[nodiscard]] bool shallIncludeNullValues() const noexcept override { return impl.shallIncludeNullValues(); }
+
+    [[nodiscard]] bool requiresAllInputFields() const noexcept override
+    {
+        if constexpr (requires { impl.requiresAllInputFields(); })
+        {
+            return impl.requiresAllInputFields();
+        }
+        else
+        {
+            return false;
+        }
+    }
 
     [[nodiscard]] size_t hash() const override { return std::hash<FunctionType>{}(impl); }
 

--- a/nes-logical-operators/include/Plans/LogicalPlanBuilder.hpp
+++ b/nes-logical-operators/include/Plans/LogicalPlanBuilder.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -25,8 +26,11 @@
 #include <Functions/LogicalFunction.hpp>
 #include <Functions/UnboundFieldAccessLogicalFunction.hpp>
 #include <Identifiers/Identifier.hpp>
+#include <Identifiers/StatisticIdentifiers.hpp>
 #include <Operators/LogicalOperator.hpp>
 #include <Operators/ProjectionLogicalOperator.hpp>
+#include <Operators/Statistic/StatisticBlobType.hpp>
+#include <Operators/Statistic/StatisticStoreReaderLogicalOperator.hpp>
 #include <Operators/Windows/Aggregations/WindowAggregationLogicalFunction.hpp>
 #include <Operators/Windows/JoinLogicalOperator.hpp>
 #include <Operators/Windows/WindowedAggregationLogicalOperator.hpp>
@@ -73,6 +77,20 @@ public:
         std::vector<WindowedAggregationLogicalOperator::ProjectedAggregation> windowAggs,
         std::vector<UnboundFieldAccessLogicalFunction> onKeys,
         Windowing::TimeCharacteristic timeCharacteristic);
+
+    static LogicalPlan addStatisticBuild(
+        LogicalPlan queryPlan,
+        const Windowing::TimeBasedWindowType& windowType,
+        Windowing::TimeCharacteristic timeCharacteristic,
+        StatisticId statisticId,
+        const WindowAggregationLogicalFunction& statisticFunction);
+
+    static LogicalPlan addStatisticProbe(
+        LogicalPlan queryPlan,
+        StatisticId statisticId,
+        const StatisticBlobType& blobType,
+        std::vector<StatisticStoreReaderLogicalOperator::PayloadField> payloadFields,
+        StatisticWindowMatch windowMatch = StatisticWindowMatch::ExactWindow);
 
     /// @brief UnionOperator to combine two query plans
     /// @param leftLogicalPlan the left query plan to combine by the union

--- a/nes-logical-operators/src/Operators/CMakeLists.txt
+++ b/nes-logical-operators/src/Operators/CMakeLists.txt
@@ -22,6 +22,7 @@ add_source_files(nes-logical-operators
         InferModelNameLogicalOperator.cpp
 )
 
+add_subdirectory(Statistic)
 add_subdirectory(Sinks)
 add_subdirectory(Sources)
 add_subdirectory(Windows)

--- a/nes-logical-operators/src/Operators/Statistic/CMakeLists.txt
+++ b/nes-logical-operators/src/Operators/Statistic/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_unreflection_entry(LogicalOperator StatisticStoreWriter)
+add_unreflection_entry(LogicalOperator StatisticStoreReader)
+
+add_source_files(nes-logical-operators
+        StatisticStoreWriterLogicalOperator.cpp
+        StatisticStoreReaderLogicalOperator.cpp
+)

--- a/nes-logical-operators/src/Operators/Statistic/StatisticStoreReaderLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Statistic/StatisticStoreReaderLogicalOperator.cpp
@@ -1,0 +1,265 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Operators/Statistic/StatisticStoreReaderLogicalOperator.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <ranges>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/DataTypeProvider.hpp>
+#include <DataTypes/UnboundField.hpp>
+#include <Identifiers/Identifier.hpp>
+#include <Identifiers/StatisticIdentifiers.hpp>
+#include <Operators/LogicalOperator.hpp>
+#include <Operators/LogicalOperatorFwd.hpp>
+#include <Operators/Statistic/StatisticBlobType.hpp>
+#include <Operators/Statistic/StatisticFieldNames.hpp>
+#include <Schema/Binder.hpp>
+#include <Schema/Field.hpp>
+#include <Schema/Schema.hpp>
+#include <Schema/SchemaFwd.hpp>
+#include <Traits/TraitSet.hpp>
+#include <Util/PlanRenderer.hpp>
+#include <Util/Reflection.hpp>
+#include <fmt/format.h>
+#include <folly/hash/Hash.h>
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+
+StatisticStoreReaderLogicalOperator::StatisticStoreReaderLogicalOperator(
+    WeakLogicalOperator self,
+    const StatisticId statisticId,
+    StatisticBlobType typeName,
+    std::vector<StatisticStoreReaderLogicalOperator::PayloadField> payloadFields,
+    const StatisticWindowMatch windowMatch)
+    : ManagedByOperator(std::move(self))
+    , statisticId(statisticId)
+    , typeName(std::move(typeName))
+    , payloadFields(std::move(payloadFields))
+    , windowMatch(windowMatch)
+{
+}
+
+StatisticStoreReaderLogicalOperator::StatisticStoreReaderLogicalOperator(
+    WeakLogicalOperator self,
+    LogicalOperator child,
+    const StatisticId statisticId,
+    StatisticBlobType typeName,
+    std::vector<StatisticStoreReaderLogicalOperator::PayloadField> payloadFields,
+    const StatisticWindowMatch windowMatch)
+    : ManagedByOperator(std::move(self))
+    , child(std::move(child))
+    , statisticId(statisticId)
+    , typeName(std::move(typeName))
+    , payloadFields(std::move(payloadFields))
+    , windowMatch(windowMatch)
+{
+    inferLocalSchema();
+}
+
+TypedLogicalOperator<StatisticStoreReaderLogicalOperator> StatisticStoreReaderLogicalOperator::create(
+    const StatisticId statisticId,
+    StatisticBlobType typeName,
+    std::vector<StatisticStoreReaderLogicalOperator::PayloadField> payloadFields,
+    const StatisticWindowMatch windowMatch)
+{
+    return TypedLogicalOperator<StatisticStoreReaderLogicalOperator>{
+        statisticId, std::move(typeName), std::move(payloadFields), windowMatch};
+}
+
+TypedLogicalOperator<StatisticStoreReaderLogicalOperator> StatisticStoreReaderLogicalOperator::create(
+    LogicalOperator child,
+    const StatisticId statisticId,
+    StatisticBlobType typeName,
+    std::vector<StatisticStoreReaderLogicalOperator::PayloadField> payloadFields,
+    const StatisticWindowMatch windowMatch)
+{
+    return TypedLogicalOperator<StatisticStoreReaderLogicalOperator>{
+        std::move(child), statisticId, std::move(typeName), std::move(payloadFields), windowMatch};
+}
+
+std::string_view StatisticStoreReaderLogicalOperator::getName() const noexcept
+{
+    return NAME;
+}
+
+bool StatisticStoreReaderLogicalOperator::operator==(const StatisticStoreReaderLogicalOperator& rhs) const
+{
+    return statisticId == rhs.statisticId and typeName == rhs.typeName and payloadFields == rhs.payloadFields
+        and windowMatch == rhs.windowMatch and outputSchema == rhs.outputSchema and traitSet == rhs.traitSet;
+}
+
+std::string StatisticStoreReaderLogicalOperator::explain(ExplainVerbosity verbosity, OperatorId opId) const
+{
+    if (verbosity == ExplainVerbosity::Debug)
+    {
+        return fmt::format(
+            "STATISTICSTOREREADER(opId: {}, statisticId: {}, type: {}, payloadFields: {}, traitSet: {})",
+            opId,
+            statisticId.getRawValue(),
+            typeName.getRawValue(),
+            fmt::join(std::views::keys(payloadFields), ", "),
+            traitSet.explain(verbosity));
+    }
+    return fmt::format("STATISTICSTOREREADER({}, {})", typeName.getRawValue(), statisticId.getRawValue());
+}
+
+void StatisticStoreReaderLogicalOperator::inferLocalSchema()
+{
+    PRECONDITION(child.has_value(), "Child not set when calling schema inference");
+    const auto inputSchema = child->getOutputSchema();
+
+    /// The window bounds are the only thing taken from the incoming record, so they have to be there.
+    for (const auto& required :
+         {Identifier::parse(std::string{StatisticFieldNames::START_TS}), Identifier::parse(std::string{StatisticFieldNames::END_TS})})
+    {
+        if (not inputSchema.contains(required))
+        {
+            throw CannotInferSchema(
+                "StatisticStoreReader expects the field {} in its input, which provides: {}",
+                required,
+                fmt::join(inputSchema.getUniqueFieldNames(), ", "));
+        }
+    }
+
+    /// A fresh stream rather than a pass-through: one row per stored statistic in the probed range, carrying the
+    /// lookup key back alongside the reconstructed value.
+    const auto uint64Type = DataTypeProvider::provideDataType(DataType::Type::UINT64, DataType::NULLABLE::NOT_NULLABLE);
+    std::vector<UnqualifiedUnboundField> outputFields{
+        UnqualifiedUnboundField{Identifier::parse(std::string{StatisticFieldNames::STATISTIC_ID}), uint64Type},
+        UnqualifiedUnboundField{Identifier::parse(std::string{StatisticFieldNames::START_TS}), uint64Type},
+        UnqualifiedUnboundField{Identifier::parse(std::string{StatisticFieldNames::END_TS}), uint64Type},
+        UnqualifiedUnboundField{Identifier::parse(std::string{StatisticFieldNames::NUMBER_OF_SEEN_TUPLES}), uint64Type}};
+    for (const auto& [name, dataType] : payloadFields)
+    {
+        outputFields.emplace_back(name, dataType);
+    }
+
+    auto schemaOrCollisions = Schema<UnqualifiedUnboundField, Unordered>::tryCreateCollisionFree(outputFields);
+    if (not schemaOrCollisions.has_value())
+    {
+        throw CannotInferSchema(
+            "Found collisions in the StatisticStoreReader output schema: {}",
+            Schema<UnqualifiedUnboundField, Unordered>::createCollisionString(schemaOrCollisions.error()));
+    }
+    outputSchema = std::move(schemaOrCollisions.value());
+}
+
+StatisticStoreReaderLogicalOperator StatisticStoreReaderLogicalOperator::withInferredSchema() const
+{
+    PRECONDITION(child.has_value(), "Child not set when calling schema inference");
+    auto copy = *this;
+    copy.child = copy.child->withInferredSchema();
+    copy.inferLocalSchema();
+    return copy;
+}
+
+TraitSet StatisticStoreReaderLogicalOperator::getTraitSet() const
+{
+    return traitSet;
+}
+
+StatisticStoreReaderLogicalOperator StatisticStoreReaderLogicalOperator::withTraitSet(TraitSet traitSet) const
+{
+    auto copy = *this;
+    copy.traitSet = std::move(traitSet);
+    return copy;
+}
+
+StatisticStoreReaderLogicalOperator StatisticStoreReaderLogicalOperator::withChildrenUnsafe(std::vector<LogicalOperator> children) const
+{
+    PRECONDITION(children.size() == 1, "Can only set exactly one child for a scalar statistic probe, got {}", children.size());
+    auto copy = *this;
+    copy.child = std::move(children.at(0));
+    return copy;
+}
+
+StatisticStoreReaderLogicalOperator StatisticStoreReaderLogicalOperator::withChildren(std::vector<LogicalOperator> children) const
+{
+    PRECONDITION(children.size() == 1, "Can only set exactly one child for a scalar statistic probe, got {}", children.size());
+    auto copy = *this;
+    copy.child = std::move(children.at(0));
+    copy.inferLocalSchema();
+    return copy;
+}
+
+Schema<Field, Unordered> StatisticStoreReaderLogicalOperator::getOutputSchema() const
+{
+    INVARIANT(outputSchema.has_value(), "Accessed output schema before calling schema inference");
+    return NES::bindToOperator(self.lock(), outputSchema.value());
+}
+
+std::vector<LogicalOperator> StatisticStoreReaderLogicalOperator::getChildren() const
+{
+    if (child.has_value())
+    {
+        return {*child};
+    }
+    return {};
+}
+
+LogicalOperator StatisticStoreReaderLogicalOperator::getChild() const
+{
+    PRECONDITION(child.has_value(), "Child not set when trying to retrieve child");
+    return child.value();
+}
+
+Reflected Reflector<TypedLogicalOperator<StatisticStoreReaderLogicalOperator>>::operator()(
+    const TypedLogicalOperator<StatisticStoreReaderLogicalOperator>& op, const ReflectionContext& context) const
+{
+    return context.reflect(detail::ReflectedStatisticStoreReaderLogicalOperator{
+        .operatorId = op.getId(),
+        .statisticId = op->getStatisticId().getRawValue(),
+        .typeName = op->getTypeName().getRawValue(),
+        .payloadFields = op->getPayloadFields(),
+        .windowMatch = static_cast<uint8_t>(op->getWindowMatch())});
+}
+
+Unreflector<TypedLogicalOperator<StatisticStoreReaderLogicalOperator>>::Unreflector(ContextType operatorMapping)
+    : plan(std::move(operatorMapping))
+{
+}
+
+TypedLogicalOperator<StatisticStoreReaderLogicalOperator>
+Unreflector<TypedLogicalOperator<StatisticStoreReaderLogicalOperator>>::operator()(
+    const Reflected& rfl, const ReflectionContext& context) const
+{
+    auto [id, statisticId, typeName, payloadFields, windowMatch]
+        = context.unreflect<detail::ReflectedStatisticStoreReaderLogicalOperator>(rfl);
+    auto children = plan->getChildrenFor(id, context);
+    if (children.size() != 1)
+    {
+        throw CannotDeserialize("StatisticStoreReaderLogicalOperator requires exactly one child, but got {}", children.size());
+    }
+    return StatisticStoreReaderLogicalOperator::create(
+        children.at(0),
+        StatisticId{statisticId},
+        StatisticBlobType{typeName},
+        std::move(payloadFields),
+        static_cast<StatisticWindowMatch>(windowMatch));
+}
+
+}
+
+size_t std::hash<NES::StatisticStoreReaderLogicalOperator>::operator()(const NES::StatisticStoreReaderLogicalOperator& op) const noexcept
+{
+    return folly::hash::hash_combine(op.statisticId.getRawValue(), op.typeName.getRawValue());
+}

--- a/nes-logical-operators/src/Operators/Statistic/StatisticStoreWriterLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Statistic/StatisticStoreWriterLogicalOperator.cpp
@@ -1,0 +1,242 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Operators/Statistic/StatisticStoreWriterLogicalOperator.hpp>
+
+#include <cstddef>
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/UnboundField.hpp>
+#include <Identifiers/Identifier.hpp>
+#include <Identifiers/Identifiers.hpp>
+#include <Identifiers/StatisticIdentifiers.hpp>
+#include <Operators/LogicalOperator.hpp>
+#include <Operators/LogicalOperatorFwd.hpp>
+#include <Operators/Statistic/StatisticBlobType.hpp>
+#include <Operators/Statistic/StatisticFieldNames.hpp>
+#include <Schema/Binder.hpp>
+#include <Schema/Field.hpp>
+#include <Schema/Schema.hpp>
+#include <Schema/SchemaFwd.hpp>
+#include <Traits/Trait.hpp>
+#include <Util/Hash.hpp>
+#include <Util/PlanRenderer.hpp>
+#include <Util/Reflection.hpp>
+#include <fmt/format.h>
+#include <folly/hash/Hash.h>
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+
+StatisticStoreWriterLogicalOperator::StatisticStoreWriterLogicalOperator(
+    WeakLogicalOperator self, const StatisticId statisticId, StatisticBlobType typeName)
+    : ManagedByOperator(std::move(self)), statisticId(statisticId), typeName(std::move(typeName))
+{
+}
+
+StatisticStoreWriterLogicalOperator::StatisticStoreWriterLogicalOperator(
+    WeakLogicalOperator self, LogicalOperator child, const StatisticId statisticId, StatisticBlobType typeName)
+    : ManagedByOperator(std::move(self)), statisticId(statisticId), typeName(std::move(typeName)), child(std::move(child))
+{
+    inferLocalSchema();
+}
+
+TypedLogicalOperator<StatisticStoreWriterLogicalOperator>
+StatisticStoreWriterLogicalOperator::create(const StatisticId statisticId, StatisticBlobType typeName)
+{
+    return TypedLogicalOperator<StatisticStoreWriterLogicalOperator>{statisticId, std::move(typeName)};
+}
+
+TypedLogicalOperator<StatisticStoreWriterLogicalOperator>
+StatisticStoreWriterLogicalOperator::create(LogicalOperator child, const StatisticId statisticId, StatisticBlobType typeName)
+{
+    return TypedLogicalOperator<StatisticStoreWriterLogicalOperator>{std::move(child), statisticId, std::move(typeName)};
+}
+
+void StatisticStoreWriterLogicalOperator::inferLocalSchema()
+{
+    PRECONDITION(child.has_value(), "Child not set when calling schema inference");
+    const auto& inputSchema = child->getOutputSchema();
+
+    /// The writer consumes the output schema of a windowed aggregation: its window bounds are named start/end,
+    /// the payload is the aggregation result named per-statisticId (e.g. STATISTICDATA_1), and the measurement
+    /// count is a plain Count aggregation projected onto the statistic's own field name.
+    const auto resolveInputField = [&inputSchema](const Identifier& requiredField)
+    {
+        const auto found = inputSchema.getFieldByName(requiredField);
+        if (not found.has_value())
+        {
+            throw CannotInferSchema(
+                "StatisticStoreWriter requires the field {} in its input schema, but got: {}", requiredField, inputSchema);
+        }
+        return Identifier{found->getFullyQualifiedName()};
+    };
+
+    const auto outputStatisticId = Identifier::parse(std::string{StatisticFieldNames::STATISTIC_ID});
+    const auto outputStatisticStart = Identifier::parse(std::string{StatisticFieldNames::START_TS});
+    const auto outputStatisticEnd = Identifier::parse(std::string{StatisticFieldNames::END_TS});
+    const auto outputNumberOfSeenMeasurements = Identifier::parse(std::string{StatisticFieldNames::NUMBER_OF_SEEN_MEASUREMENTS});
+
+    fieldNames = FieldNames{
+        .inputStatisticStart = resolveInputField(Identifier::parse("start")),
+        .inputStatisticEnd = resolveInputField(Identifier::parse("end")),
+        .inputStatisticData = resolveInputField(Identifier::parse(statisticDataFieldName(statisticId))),
+        .inputNumberOfSeenMeasurements
+        = resolveInputField(Identifier::parse(std::string{StatisticFieldNames::NUMBER_OF_SEEN_MEASUREMENTS}))};
+
+    const std::vector<UnqualifiedUnboundField> outputFields
+        = {UnqualifiedUnboundField{outputStatisticId, DataType::Type::UINT64},
+           UnqualifiedUnboundField{outputStatisticStart, DataType::Type::UINT64},
+           UnqualifiedUnboundField{outputStatisticEnd, DataType::Type::UINT64},
+           UnqualifiedUnboundField{outputNumberOfSeenMeasurements, DataType::Type::UINT64}};
+    const auto outputSchemaOrCollisions = Schema<UnqualifiedUnboundField, Unordered>::tryCreateCollisionFree(outputFields);
+    INVARIANT(outputSchemaOrCollisions.has_value(), "The fixed statistic store writer output fields must not collide");
+    outputSchema = outputSchemaOrCollisions.value();
+}
+
+std::string_view StatisticStoreWriterLogicalOperator::getName() const noexcept
+{
+    return NAME;
+}
+
+std::string StatisticStoreWriterLogicalOperator::explain(ExplainVerbosity verbosity, OperatorId id) const
+{
+    if (verbosity == ExplainVerbosity::Debug)
+    {
+        return fmt::format("STATISTIC STORE WRITER(opId: {}, statisticId: {}, typeName: {})", id, statisticId, typeName.getRawValue());
+    }
+    return fmt::format("STATISTIC STORE WRITER(statisticId: {})", statisticId);
+}
+
+bool StatisticStoreWriterLogicalOperator::operator==(const StatisticStoreWriterLogicalOperator& rhs) const
+{
+    return statisticId == rhs.statisticId && typeName == rhs.typeName && outputSchema == rhs.outputSchema && traitSet == rhs.traitSet;
+}
+
+StatisticStoreWriterLogicalOperator StatisticStoreWriterLogicalOperator::withInferredSchema() const
+{
+    PRECONDITION(child.has_value(), "Child not set when calling schema inference");
+    auto copy = *this;
+    copy.child = copy.child->withInferredSchema();
+    copy.inferLocalSchema();
+    return copy;
+}
+
+TraitSet StatisticStoreWriterLogicalOperator::getTraitSet() const
+{
+    return traitSet;
+}
+
+StatisticStoreWriterLogicalOperator StatisticStoreWriterLogicalOperator::withTraitSet(TraitSet traitSet) const
+{
+    auto copy = *this;
+    copy.traitSet = std::move(traitSet);
+    return copy;
+}
+
+StatisticStoreWriterLogicalOperator StatisticStoreWriterLogicalOperator::withChildrenUnsafe(std::vector<LogicalOperator> children) const
+{
+    PRECONDITION(children.size() == 1, "Can only set exactly one child for statistic store writer, got {}", children.size());
+    auto copy = *this;
+    copy.child = std::move(children.at(0));
+    return copy;
+}
+
+StatisticStoreWriterLogicalOperator StatisticStoreWriterLogicalOperator::withChildren(std::vector<LogicalOperator> children) const
+{
+    PRECONDITION(children.size() == 1, "Can only set exactly one child for statistic store writer, got {}", children.size());
+    auto copy = *this;
+    copy.child = std::move(children.at(0));
+    copy.inferLocalSchema();
+    return copy;
+}
+
+Schema<Field, Unordered> StatisticStoreWriterLogicalOperator::getOutputSchema() const
+{
+    INVARIANT(outputSchema.has_value(), "Retrieving output schema before calling schema inference");
+    return NES::bindToOperator(self.lock(), outputSchema.value());
+}
+
+std::vector<LogicalOperator> StatisticStoreWriterLogicalOperator::getChildren() const
+{
+    if (child.has_value())
+    {
+        return {*child};
+    }
+    return {};
+}
+
+LogicalOperator StatisticStoreWriterLogicalOperator::getChild() const
+{
+    PRECONDITION(child.has_value(), "Child not set when trying to retrieve child");
+    return child.value();
+}
+
+StatisticId StatisticStoreWriterLogicalOperator::getStatisticId() const
+{
+    return statisticId;
+}
+
+const StatisticBlobType& StatisticStoreWriterLogicalOperator::getTypeName() const
+{
+    return typeName;
+}
+
+StatisticStoreWriterLogicalOperator::FieldNames StatisticStoreWriterLogicalOperator::getFieldNames() const
+{
+    INVARIANT(fieldNames.has_value(), "Retrieving the field names before calling schema inference");
+    return fieldNames.value();
+}
+
+Reflected Reflector<TypedLogicalOperator<StatisticStoreWriterLogicalOperator>>::operator()(
+    const TypedLogicalOperator<StatisticStoreWriterLogicalOperator>& op, const ReflectionContext& context) const
+{
+    return context.reflect(detail::ReflectedStatisticStoreWriterLogicalOperator{
+        .operatorId = op.getId(), .statisticId = op->getStatisticId(), .typeName = op->getTypeName().getRawValue()});
+}
+
+Unreflector<TypedLogicalOperator<StatisticStoreWriterLogicalOperator>>::Unreflector(ContextType plan) : plan(std::move(plan))
+{
+}
+
+TypedLogicalOperator<StatisticStoreWriterLogicalOperator>
+Unreflector<TypedLogicalOperator<StatisticStoreWriterLogicalOperator>>::operator()(
+    const Reflected& reflected, const ReflectionContext& context) const
+{
+    auto [id, statisticId, typeName] = context.unreflect<detail::ReflectedStatisticStoreWriterLogicalOperator>(reflected);
+    auto children = plan->getChildrenFor(id, context);
+    if (children.size() != 1)
+    {
+        throw CannotDeserialize("StatisticStoreWriterLogicalOperator must have exactly one child, but got {}", children.size());
+    }
+    return StatisticStoreWriterLogicalOperator::create(children.at(0), statisticId, StatisticBlobType{typeName});
+}
+
+}
+
+std::size_t std::hash<NES::StatisticStoreWriterLogicalOperator>::operator()(
+    const NES::StatisticStoreWriterLogicalOperator& statisticStoreWriterLogicalOperator) const noexcept
+{
+    return folly::hash::hash_combine_generic(
+        NES::Hash{},
+        statisticStoreWriterLogicalOperator.statisticId.getRawValue(),
+        statisticStoreWriterLogicalOperator.typeName.getRawValue());
+}

--- a/nes-logical-operators/src/Operators/Windows/Aggregations/CMakeLists.txt
+++ b/nes-logical-operators/src/Operators/Windows/Aggregations/CMakeLists.txt
@@ -18,6 +18,7 @@ add_source_files(nes-logical-operators
         MaxAggregationLogicalFunction.cpp
         MedianAggregationLogicalFunction.cpp
         MinAggregationLogicalFunction.cpp
+        ReservoirSampleAggregationLogicalFunction.cpp
         SumAggregationLogicalFunction.cpp
 )
 
@@ -27,6 +28,7 @@ add_unreflection_entry(AggregationLogicalFunction Count)
 add_unreflection_entry(AggregationLogicalFunction Max)
 add_unreflection_entry(AggregationLogicalFunction Median)
 add_unreflection_entry(AggregationLogicalFunction Min)
+add_unreflection_entry(AggregationLogicalFunction ReservoirSample)
 add_unreflection_entry(AggregationLogicalFunction Sum)
 
 add_registry_entry(AggregationLogicalFunction Avg)

--- a/nes-logical-operators/src/Operators/Windows/Aggregations/ReservoirSampleAggregationLogicalFunction.cpp
+++ b/nes-logical-operators/src/Operators/Windows/Aggregations/ReservoirSampleAggregationLogicalFunction.cpp
@@ -1,0 +1,154 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Operators/Windows/Aggregations/ReservoirSampleAggregationLogicalFunction.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/DataTypeProvider.hpp>
+#include <Functions/FieldAccessLogicalFunction.hpp>
+#include <Functions/LogicalFunction.hpp>
+#include <Functions/UnboundFieldAccessLogicalFunction.hpp>
+#include <Identifiers/Identifier.hpp>
+#include <Operators/Windows/Aggregations/WindowAggregationLogicalFunction.hpp>
+#include <Schema/Field.hpp>
+#include <Schema/Schema.hpp>
+#include <Schema/SchemaFwd.hpp>
+#include <Serialization/LogicalFunctionReflection.hpp>
+#include <Util/PlanRenderer.hpp>
+#include <Util/Reflection.hpp>
+#include <fmt/format.h>
+#include <folly/hash/Hash.h>
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+
+ReservoirSampleAggregationLogicalFunction::ReservoirSampleAggregationLogicalFunction(const uint64_t sampleSize, const uint64_t seed)
+    : ReservoirSampleAggregationLogicalFunction(
+          TypedLogicalFunction<UnboundFieldAccessLogicalFunction>{
+              UnboundFieldAccessLogicalFunction{Identifier::parse(std::string{PlaceholderFieldName})}},
+          sampleSize,
+          seed)
+{
+}
+
+ReservoirSampleAggregationLogicalFunction::ReservoirSampleAggregationLogicalFunction(
+    AggregationFieldAccess inputFunction, const uint64_t sampleSize, const uint64_t seed)
+    : inputFunction(std::move(inputFunction)), sampleSize(sampleSize), seed(seed)
+{
+}
+
+std::string_view ReservoirSampleAggregationLogicalFunction::getName() const noexcept
+{
+    return NAME;
+}
+
+DataType ReservoirSampleAggregationLogicalFunction::getAggregateType()
+{
+    return DataTypeProvider::provideDataType(finalAggregateStampType);
+}
+
+bool ReservoirSampleAggregationLogicalFunction::shallIncludeNullValues() noexcept
+{
+    return true;
+}
+
+bool ReservoirSampleAggregationLogicalFunction::requiresAllInputFields() noexcept
+{
+    return true;
+}
+
+AggregationFieldAccess ReservoirSampleAggregationLogicalFunction::getInputFunction() const
+{
+    return inputFunction;
+}
+
+uint64_t ReservoirSampleAggregationLogicalFunction::getSampleSize() const
+{
+    return sampleSize;
+}
+
+uint64_t ReservoirSampleAggregationLogicalFunction::getSeed() const
+{
+    return seed;
+}
+
+std::string ReservoirSampleAggregationLogicalFunction::explain(const ExplainVerbosity verbosity) const
+{
+    if (verbosity == ExplainVerbosity::Short)
+    {
+        return fmt::format("{}({})", NAME, sampleSize);
+    }
+    return fmt::format("{}(sampleSize: {}, seed: {})", NAME, sampleSize, seed);
+}
+
+bool ReservoirSampleAggregationLogicalFunction::operator==(const ReservoirSampleAggregationLogicalFunction& other) const
+{
+    return inputFunction == other.inputFunction and sampleSize == other.sampleSize and seed == other.seed;
+}
+
+ReservoirSampleAggregationLogicalFunction
+ReservoirSampleAggregationLogicalFunction::withInferredType(const Schema<Field, Unordered>& schema) const
+{
+    PRECONDITION(schema.size() >= 1, "A reservoir sample needs at least one input field");
+    const auto placeholderField
+        = std::ranges::min_element(schema, {}, [](const auto& field) { return fmt::format("{}", field.getFullyQualifiedName()); });
+    const TypedLogicalFunction<FieldAccessLogicalFunction> newInputFunction{FieldAccessLogicalFunction{*placeholderField}};
+    return ReservoirSampleAggregationLogicalFunction{newInputFunction, sampleSize, seed};
+}
+
+namespace detail
+{
+struct ReflectedReservoirSampleAggregationLogicalFunction
+{
+    AggregationFieldAccess inputFunction;
+    uint64_t sampleSize;
+    uint64_t seed;
+};
+}
+
+Reflected Reflector<ReservoirSampleAggregationLogicalFunction>::operator()(
+    const ReservoirSampleAggregationLogicalFunction& function, const ReflectionContext& context) const
+{
+    return context.reflect(detail::ReflectedReservoirSampleAggregationLogicalFunction{
+        .inputFunction = function.getInputFunction(), .sampleSize = function.getSampleSize(), .seed = function.getSeed()});
+}
+
+ReservoirSampleAggregationLogicalFunction
+Unreflector<ReservoirSampleAggregationLogicalFunction>::operator()(const Reflected& reflected, const ReflectionContext& context) const
+{
+    auto [inputFunction, sampleSize, seed] = context.unreflect<detail::ReflectedReservoirSampleAggregationLogicalFunction>(reflected);
+    return ReservoirSampleAggregationLogicalFunction{std::move(inputFunction), sampleSize, seed};
+}
+
+}
+
+size_t std::hash<NES::ReservoirSampleAggregationLogicalFunction>::operator()(
+    const NES::ReservoirSampleAggregationLogicalFunction& aggregationFunction) const noexcept
+{
+    return folly::hash::hash_combine(
+        aggregationFunction.getInputFunction(),
+        aggregationFunction.getName(),
+        aggregationFunction.getSampleSize(),
+        aggregationFunction.getSeed());
+}

--- a/nes-logical-operators/src/Plans/LogicalPlanBuilder.cpp
+++ b/nes-logical-operators/src/Plans/LogicalPlanBuilder.cpp
@@ -30,6 +30,7 @@
 #include <Functions/LogicalFunction.hpp>
 #include <Functions/UnboundFieldAccessLogicalFunction.hpp>
 #include <Identifiers/Identifier.hpp>
+#include <Identifiers/StatisticIdentifiers.hpp>
 #include <Operators/EventTimeWatermarkAssignerLogicalOperator.hpp>
 #include <Operators/InferModelNameLogicalOperator.hpp>
 #include <Operators/IngestionTimeWatermarkAssignerLogicalOperator.hpp>
@@ -41,7 +42,15 @@
 #include <Operators/Sinks/SinkLogicalOperator.hpp>
 #include <Operators/Sources/AnonymousSourceLogicalOperator.hpp>
 #include <Operators/Sources/SourceNameLogicalOperator.hpp>
+
+#include <Operators/Statistic/StatisticBlobType.hpp>
+#include <Operators/Statistic/StatisticFieldNames.hpp>
+#include <Operators/Statistic/StatisticStoreReaderLogicalOperator.hpp>
+#include <Operators/Statistic/StatisticStoreWriterLogicalOperator.hpp>
+#include <Operators/Statistic/StatisticWindowMatch.hpp>
 #include <Operators/UnionLogicalOperator.hpp>
+#include <Operators/Windows/Aggregations/CountAggregationLogicalFunction.hpp>
+#include <Operators/Windows/Aggregations/ReservoirSampleAggregationLogicalFunction.hpp>
 #include <Operators/Windows/Aggregations/WindowAggregationLogicalFunction.hpp>
 #include <Operators/Windows/JoinLogicalOperator.hpp>
 #include <Operators/Windows/WindowedAggregationLogicalOperator.hpp>
@@ -122,6 +131,40 @@ LogicalPlan LogicalPlanBuilder::addWindowAggregation(
         queryPlan,
         WindowedAggregationLogicalOperator::create(
             std::move(keysWithNames), std::move(windowAggs), windowType, std::move(timeCharacteristic)));
+}
+
+LogicalPlan LogicalPlanBuilder::addStatisticBuild(
+    LogicalPlan queryPlan,
+    const Windowing::TimeBasedWindowType& windowType,
+    Windowing::TimeCharacteristic timeCharacteristic,
+    const StatisticId statisticId,
+    const WindowAggregationLogicalFunction& statisticFunction)
+{
+    PRECONDITION(not queryPlan.getRootOperators().empty(), "invalid query plan, as the root operator is empty");
+
+    const CountAggregationLogicalFunction measurementCount{statisticFunction.getInputFunction(), true};
+    std::vector windowAggs{
+        WindowedAggregationLogicalOperator::ProjectedAggregation{
+            .function = statisticFunction, .name = Identifier::parse(statisticDataFieldName(statisticId))},
+        WindowedAggregationLogicalOperator::ProjectedAggregation{
+            .function = WindowAggregationLogicalFunction{measurementCount},
+            .name = Identifier::parse(std::string{StatisticFieldNames::NUMBER_OF_SEEN_MEASUREMENTS})}};
+
+    queryPlan = addWindowAggregation(std::move(queryPlan), windowType, std::move(windowAggs), {}, std::move(timeCharacteristic));
+    return promoteOperatorToRoot(
+        queryPlan, StatisticStoreWriterLogicalOperator::create(statisticId, StatisticBlobType{statisticFunction.getName()}));
+}
+
+LogicalPlan LogicalPlanBuilder::addStatisticProbe(
+    LogicalPlan queryPlan,
+    const StatisticId statisticId,
+    const StatisticBlobType& blobType,
+    std::vector<StatisticStoreReaderLogicalOperator::PayloadField> payloadFields,
+    const StatisticWindowMatch windowMatch)
+{
+    PRECONDITION(not queryPlan.getRootOperators().empty(), "invalid query plan, as the root operator is empty");
+    return promoteOperatorToRoot(
+        queryPlan, StatisticStoreReaderLogicalOperator::create(statisticId, blobType, std::move(payloadFields), windowMatch));
 }
 
 LogicalPlan LogicalPlanBuilder::addUnion(LogicalPlan leftLogicalPlan, LogicalPlan rightLogicalPlan)

--- a/nes-nautilus/include/Interface/PagedVector/PagedVectorRef.hpp
+++ b/nes-nautilus/include/Interface/PagedVector/PagedVectorRef.hpp
@@ -100,6 +100,12 @@ public:
     /// The entryPos refers to the record's global position in the paged vector and is not page-specific.
     [[nodiscard]] Record at(const nautilus::val<uint64_t>& entryPos) const;
 
+    /// Overwrites the record at entryPos in place; the total number of records stays unchanged.
+    /// A varsized field gets a fresh slot in the containing page's varsized child buffers, and the slot previously
+    /// referenced by the replaced record stays allocated until the page buffer is released.
+    void replaceRecord(
+        const Record& record, const nautilus::val<uint64_t>& entryPos, const nautilus::val<AbstractBufferProvider*>& bufferProvider);
+
     [[nodiscard]] PagedVectorRefIter begin() const;
     [[nodiscard]] PagedVectorRefIterSentinel end() const;
 
@@ -107,6 +113,9 @@ public:
     [[nodiscard]] nautilus::val<uint64_t> getNumberOfRecords() const;
 
 private:
+    [[nodiscard]] nautilus::val<int8_t*>
+    resolveRecordAddress(const NautilusBuffer& pageBuffer, const nautilus::val<uint64_t>& entryBufferPos) const;
+
     /// @brief Holds a reference to the main paged vector buffer
     NautilusBuffer pagedVectorBuffer;
     /// @brief specifies how tuples are stored in the paged vector's pages

--- a/nes-nautilus/src/Interface/PagedVector/PagedVectorRef.cpp
+++ b/nes-nautilus/src/Interface/PagedVector/PagedVectorRef.cpp
@@ -105,73 +105,110 @@ auto makeVarSizedLoadFunction(const NautilusBuffer& pageBuffer)
     };
 }
 
+/// NOLINTNEXTLINE(bugprone-exception-escape): nautilus::invoke ignores the exception spec; INVARIANT may throw on bad input.
+int8_t* allocateVarSized(TupleBuffer* pageBuffer, AbstractBufferProvider* bufferProvider, int8_t* fieldSlot, uint64_t allocationSize)
+{
+    INVARIANT(pageBuffer != nullptr, "Page buffer must not be null");
+    INVARIANT(bufferProvider != nullptr, "BufferProvider must not be null");
+
+    auto numChildren = pageBuffer->getNumberOfChildBuffers();
+    if (numChildren > 0)
+    {
+        auto lastVarSizedBufferIndex = ChildBufferIndex{static_cast<uint32_t>(numChildren - 1)};
+        TupleBuffer lastVarSizedBuffer = pageBuffer->loadChildBuffer(lastVarSizedBufferIndex);
+        const uint64_t lastVarSizedBufferSize = lastVarSizedBuffer.getBufferSize();
+        const uint64_t lastVarSizedBufferNumTuples = lastVarSizedBuffer.getNumberOfTuples();
+        if (lastVarSizedBufferNumTuples + allocationSize <= lastVarSizedBufferSize)
+        {
+            lastVarSizedBuffer.setNumberOfTuples(allocationSize + lastVarSizedBufferNumTuples);
+            /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): fieldSlot is the typed VariableSizedAccess slot.
+            *reinterpret_cast<VariableSizedAccess*>(fieldSlot) = VariableSizedAccess{
+                lastVarSizedBufferIndex,
+                VariableSizedAccess::Offset{lastVarSizedBufferNumTuples},
+                VariableSizedAccess::Size{allocationSize}};
+            /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): TupleBuffer hands out int8_t spans by design.
+            return reinterpret_cast<int8_t*>(lastVarSizedBuffer
+                                                 .getAvailableMemoryArea<>() /// NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+                                                 .subspan(lastVarSizedBufferNumTuples)
+                                                 .data());
+        }
+    }
+    TupleBuffer newVarSizedBuffer;
+    if (allocationSize <= bufferProvider->getBufferSize())
+    {
+        newVarSizedBuffer = bufferProvider->getBufferBlocking();
+    }
+    else
+    {
+        /// The pooled buffer size can't hold this value; fall back to an unpooled buffer sized to fit it exactly.
+        auto unpooledBuffer = bufferProvider->getUnpooledBuffer(allocationSize);
+        if (not unpooledBuffer.has_value())
+        {
+            throw BufferAllocationFailure("No unpooled TupleBuffer available for oversized varsized value.");
+        }
+        newVarSizedBuffer = std::move(unpooledBuffer.value());
+    }
+    auto childIndex = pageBuffer->storeChildBuffer(newVarSizedBuffer);
+    newVarSizedBuffer = pageBuffer->loadChildBuffer(childIndex);
+    /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): fieldSlot is the typed VariableSizedAccess slot.
+    *reinterpret_cast<VariableSizedAccess*>(fieldSlot)
+        = VariableSizedAccess{childIndex, VariableSizedAccess::Offset{0}, VariableSizedAccess::Size{allocationSize}};
+    newVarSizedBuffer.setNumberOfTuples(allocationSize);
+    /// NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks,cppcoreguidelines-pro-type-reinterpret-cast)
+    return reinterpret_cast<int8_t*>(newVarSizedBuffer.getAvailableMemoryArea<>().data());
+}
+
+/// NOLINTNEXTLINE(bugprone-exception-escape): nautilus::invoke ignores the exception spec; INVARIANT may throw on bad input.
+int8_t* replaceVarSized(TupleBuffer* pageBuffer, AbstractBufferProvider* bufferProvider, int8_t* fieldSlot, uint64_t allocationSize)
+{
+    INVARIANT(pageBuffer != nullptr, "Page buffer must not be null");
+    /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): fieldSlot is the typed VariableSizedAccess slot.
+    const auto previous = *reinterpret_cast<const VariableSizedAccess*>(fieldSlot);
+    const auto childIndex = previous.getIndex();
+    if (previous.getSize().getRawSize() >= allocationSize and childIndex.getRawValue() < pageBuffer->getNumberOfChildBuffers())
+    {
+        TupleBuffer varSizedBuffer = pageBuffer->loadChildBuffer(childIndex);
+        const uint64_t offset = previous.getOffset().getRawOffset();
+        if (offset + allocationSize <= varSizedBuffer.getBufferSize())
+        {
+            /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): fieldSlot is the typed VariableSizedAccess slot.
+            *reinterpret_cast<VariableSizedAccess*>(fieldSlot)
+                = VariableSizedAccess{childIndex, VariableSizedAccess::Offset{offset}, VariableSizedAccess::Size{allocationSize}};
+            /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): TupleBuffer hands out int8_t spans by design.
+            return reinterpret_cast<int8_t*>(varSizedBuffer
+                                                 .getAvailableMemoryArea<>() /// NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+                                                 .subspan(offset)
+                                                 .data());
+        }
+    }
+    return allocateVarSized(pageBuffer, bufferProvider, fieldSlot, allocationSize);
+}
+
 /// Factory method that returns the lambda function to write a record at a specific memory address in a paged vector page.
 /// The lastPageBuffer argument is the capture variable pointing to the last page of the paged vector.
 /// When the lambda is invoked, its arguments should be the memory pointing to the start where the record will be written to and the record's size.
-auto makeVarSizedAllocFunction(const NautilusBuffer& lastPageBuffer, const nautilus::val<AbstractBufferProvider*>& bufferProvider)
+auto makeVarSizedWriteFunction(
+    const NautilusBuffer& lastPageBuffer,
+    const nautilus::val<AbstractBufferProvider*>& bufferProvider,
+    int8_t* (*proxy)(TupleBuffer*, AbstractBufferProvider*, int8_t*, uint64_t))
 {
     return /// NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
-        /// NOLINTNEXTLINE(bugprone-exception-escape): nautilus::invoke ignores the lambda's exception spec; INVARIANT may throw on bad input.
-        [lastPageBuffer,
-         bufferProvider](const nautilus::val<int8_t*>& fieldSlot, const nautilus::val<uint64_t>& allocationSize) -> nautilus::val<int8_t*>
+        [lastPageBuffer, bufferProvider, proxy](
+            const nautilus::val<int8_t*>& fieldSlot, const nautilus::val<uint64_t>& allocationSize) -> nautilus::val<int8_t*>
     {
-        return invoke( /// NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
-            +[](TupleBuffer* pageBuffer, AbstractBufferProvider* bufferProvider, int8_t* fieldSlot, uint64_t allocationSize) -> int8_t*
-            {
-                INVARIANT(pageBuffer != nullptr, "Page buffer must not be null");
-                INVARIANT(bufferProvider != nullptr, "BufferProvider must not be null");
-
-                auto numChildren = pageBuffer->getNumberOfChildBuffers();
-                if (numChildren > 0)
-                {
-                    auto lastVarSizedBufferIndex = ChildBufferIndex{static_cast<uint32_t>(numChildren - 1)};
-                    TupleBuffer lastVarSizedBuffer = pageBuffer->loadChildBuffer(lastVarSizedBufferIndex);
-                    const uint64_t lastVarSizedBufferSize = lastVarSizedBuffer.getBufferSize();
-                    const uint64_t lastVarSizedBufferNumTuples = lastVarSizedBuffer.getNumberOfTuples();
-                    if (lastVarSizedBufferNumTuples + allocationSize <= lastVarSizedBufferSize)
-                    {
-                        lastVarSizedBuffer.setNumberOfTuples(allocationSize + lastVarSizedBufferNumTuples);
-                        /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): fieldSlot is the typed VariableSizedAccess slot.
-                        *reinterpret_cast<VariableSizedAccess*>(fieldSlot) = VariableSizedAccess{
-                            lastVarSizedBufferIndex,
-                            VariableSizedAccess::Offset{lastVarSizedBufferNumTuples},
-                            VariableSizedAccess::Size{allocationSize}};
-                        /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): TupleBuffer hands out int8_t spans by design.
-                        return reinterpret_cast<int8_t*>(lastVarSizedBuffer
-                                                             .getAvailableMemoryArea<>() /// NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
-                                                             .subspan(lastVarSizedBufferNumTuples)
-                                                             .data());
-                    }
-                }
-                TupleBuffer newVarSizedBuffer;
-                if (allocationSize <= bufferProvider->getBufferSize())
-                {
-                    newVarSizedBuffer = bufferProvider->getBufferBlocking();
-                }
-                else
-                {
-                    /// The pooled buffer size can't hold this value; fall back to an unpooled buffer sized to fit it exactly.
-                    auto unpooledBuffer = bufferProvider->getUnpooledBuffer(allocationSize);
-                    if (not unpooledBuffer.has_value())
-                    {
-                        throw BufferAllocationFailure("No unpooled TupleBuffer available for oversized varsized value.");
-                    }
-                    newVarSizedBuffer = std::move(unpooledBuffer.value());
-                }
-                auto childIndex = pageBuffer->storeChildBuffer(newVarSizedBuffer);
-                newVarSizedBuffer = pageBuffer->loadChildBuffer(childIndex);
-                /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): fieldSlot is the typed VariableSizedAccess slot.
-                *reinterpret_cast<VariableSizedAccess*>(fieldSlot)
-                    = VariableSizedAccess{childIndex, VariableSizedAccess::Offset{0}, VariableSizedAccess::Size{allocationSize}};
-                newVarSizedBuffer.setNumberOfTuples(allocationSize);
-                /// NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks,cppcoreguidelines-pro-type-reinterpret-cast)
-                return reinterpret_cast<int8_t*>(newVarSizedBuffer.getAvailableMemoryArea<>().data());
-            },
-            lastPageBuffer.asArg(),
-            bufferProvider,
-            fieldSlot,
-            allocationSize);
+        /// NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
+        return invoke(proxy, lastPageBuffer.asArg(), bufferProvider, fieldSlot, allocationSize);
     };
+}
+
+auto makeVarSizedAllocFunction(const NautilusBuffer& lastPageBuffer, const nautilus::val<AbstractBufferProvider*>& bufferProvider)
+{
+    return makeVarSizedWriteFunction(lastPageBuffer, bufferProvider, allocateVarSized);
+}
+
+auto makeVarSizedReplaceFunction(const NautilusBuffer& pageBuffer, const nautilus::val<AbstractBufferProvider*>& bufferProvider)
+{
+    return makeVarSizedWriteFunction(pageBuffer, bufferProvider, replaceVarSized);
 }
 }
 
@@ -330,13 +367,10 @@ void PagedVectorRef::pushBack(const Record& record, const nautilus::val<Abstract
         lastPageBuffer.asArg());
 }
 
-Record PagedVectorRef::at(const nautilus::val<uint64_t>& entryPos) const
+nautilus::val<int8_t*>
+PagedVectorRef::resolveRecordAddress(const NautilusBuffer& pageBuffer, const nautilus::val<uint64_t>& entryBufferPos) const
 {
-    /// Resolve the page and materialize the page buffer (needed for varsized child loads); return the in-page index.
-    OwnedNautilusBuffer pageBuffer;
-    auto entryBufferPos = invoke(loadPageForEntryProxy, pagedVectorBuffer.asArg(), entryPos, pageBuffer.asArg());
-
-    auto recordAddress = invoke(
+    return invoke(
         +[](const TupleBuffer* pagedVectorBuffer, TupleBuffer* pageBuffer, const uint64_t entryBufferPos) -> int8_t*
         {
             const PagedVector pagedVector = PagedVector::load(*pagedVectorBuffer);
@@ -348,8 +382,29 @@ Record PagedVectorRef::at(const nautilus::val<uint64_t>& entryPos) const
         pagedVectorBuffer.asArg(),
         pageBuffer.asArg(),
         entryBufferPos);
+}
+
+Record PagedVectorRef::at(const nautilus::val<uint64_t>& entryPos) const
+{
+    /// Resolve the page and materialize the page buffer (needed for varsized child loads); return the in-page index.
+    OwnedNautilusBuffer pageBuffer;
+    auto entryBufferPos = invoke(loadPageForEntryProxy, pagedVectorBuffer.asArg(), entryPos, pageBuffer.asArg());
+
+    auto recordAddress = resolveRecordAddress(pageBuffer, entryBufferPos);
 
     return tupleLayout->readRecord(recordAddress, makeVarSizedLoadFunction(pageBuffer));
+}
+
+void PagedVectorRef::replaceRecord(
+    const Record& record, const nautilus::val<uint64_t>& entryPos, const nautilus::val<AbstractBufferProvider*>& bufferProvider)
+{
+    /// Resolve the page and materialize the page buffer (needed for varsized child allocations); return the in-page index.
+    OwnedNautilusBuffer pageBuffer;
+    auto entryBufferPos = invoke(loadPageForEntryProxy, pagedVectorBuffer.asArg(), entryPos, pageBuffer.asArg());
+
+    auto recordAddress = resolveRecordAddress(pageBuffer, entryBufferPos);
+
+    tupleLayout->writeRecord(record, recordAddress, makeVarSizedReplaceFunction(pageBuffer, bufferProvider));
 }
 
 PagedVectorRefIter PagedVectorRef::begin() const
@@ -446,5 +501,4 @@ nautilus::val<bool> PagedVectorRefIterSentinel::operator!=(const PagedVectorRefI
 {
     return other != *this;
 }
-
 }

--- a/nes-physical-operators/CMakeLists.txt
+++ b/nes-physical-operators/CMakeLists.txt
@@ -32,7 +32,7 @@ add_subdirectory(src)
 get_source(nes-physical-operators NES_PHYSICAL_OPERATORS_SOURCE_FILES)
 target_sources(nes-physical-operators PRIVATE ${NES_PHYSICAL_OPERATORS_SOURCE_FILES})
 find_package(OpenSSL REQUIRED)
-target_link_libraries(nes-physical-operators PUBLIC nes-schema nes-sources nes-sinks nes-nautilus nes-logical-operators nes-input-formatter-provider PRIVATE nes-input-formatters nes-inference-runtime OpenSSL::Crypto)
+target_link_libraries(nes-physical-operators PUBLIC nes-schema nes-sources nes-sinks nes-nautilus nes-logical-operators nes-statistics nes-input-formatter-provider PRIVATE nes-input-formatters nes-inference-runtime OpenSSL::Crypto)
 target_include_directories(nes-physical-operators PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include/nebulastream/>)

--- a/nes-physical-operators/include/Statistics/ReservoirMerge.hpp
+++ b/nes-physical-operators/include/Statistics/ReservoirMerge.hpp
@@ -1,0 +1,50 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+
+namespace NES
+{
+
+/// Result of computeReservoirMergeSelection: the first `fromFirst` entries of positionsOut index into the
+/// left reservoir, the remaining `total - fromFirst` entries index into the right reservoir.
+struct ReservoirMergeSelection
+{
+    uint64_t fromFirst;
+    uint64_t total;
+};
+
+/// Selects which tuples survive when merging two reservoir samples into one of at most `capacity` tuples.
+///
+/// Both inputs are uniform samples of their populations (seenLeft and seenRight tuples). A statistically exact
+/// merge makes every tuple of the combined population equally likely to be in the result: the number of survivors
+/// taken from the left reservoir follows Hypergeometric(seenLeft + seenRight, capacity, seenLeft), and the chosen
+/// count of positions is then drawn uniformly without replacement from each reservoir.
+/// The draw is deterministic for fixed inputs and seed.
+///
+/// positionsOut must have room for min(capacity, storedLeft + storedRight) entries.
+/// Preconditions: storedLeft == min(seenLeft, capacity) and storedRight == min(seenRight, capacity), which
+/// guarantees the hypergeometric split is always satisfiable.
+ReservoirMergeSelection computeReservoirMergeSelection(
+    uint64_t seenLeft,
+    uint64_t storedLeft,
+    uint64_t seenRight,
+    uint64_t storedRight,
+    uint64_t capacity,
+    uint64_t seed,
+    uint64_t* positionsOut);
+
+}

--- a/nes-physical-operators/include/Statistics/ReservoirSampleAggregationPhysicalFunction.hpp
+++ b/nes-physical-operators/include/Statistics/ReservoirSampleAggregationPhysicalFunction.hpp
@@ -1,0 +1,93 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <Aggregation/Function/AggregationPhysicalFunction.hpp>
+#include <DataTypes/DataType.hpp>
+#include <Functions/PhysicalFunction.hpp>
+#include <Interface/PagedVector/PagedVectorRef.hpp>
+#include <Interface/Record.hpp>
+#include <Runtime/TupleBuffer.hpp>
+#include <Statistics/ReservoirSampleBlob.hpp>
+#include <AggregationPhysicalFunctionRegistry.hpp>
+#include <ExecutionContext.hpp>
+#include <val_concepts.hpp>
+#include <val_ptr.hpp>
+
+namespace NES
+{
+
+/// Builds a uniform reservoir sample (Algorithm R, Vitter 1985) of at most `sampleSize` whole input records
+/// per aggregation state. The sampled records are kept in a PagedVector stored as a child buffer of the parent
+/// hash-map buffer (same state model as MedianAggregationPhysicalFunction); lower() serializes the sample into
+/// a ReservoirSampleBlob emitted as VARSIZED data.
+///
+/// State layout: [childBufferIndex: uint32][numberOfSeenTuples: uint64].
+/// combine() merges two reservoirs statistically exactly (see ReservoirMerge.hpp).
+/// Eviction choices use a per-worker-thread RNG, so which records survive a full reservoir is not reproducible
+/// across runs; merge selections are deterministic for fixed inputs and seed.
+class ReservoirSampleAggregationPhysicalFunction final : public AggregationPhysicalFunction
+{
+public:
+    ReservoirSampleAggregationPhysicalFunction(
+        DataType inputType,
+        DataType resultType,
+        PhysicalFunction inputFunction,
+        Record::RecordFieldIdentifier resultFieldIdentifier,
+        std::shared_ptr<PagedVectorTupleLayout> tupleLayout,
+        uint64_t sampleSize,
+        uint64_t seed);
+
+    static AggregationPhysicalFunctionRegistryReturnType create(AggregationPhysicalFunctionRegistryArguments arguments);
+    void lift(
+        const nautilus::val<AggregationState*>& aggregationState,
+        nautilus::val<TupleBuffer*> parentBuffer,
+        PipelineMemoryProvider& pipelineMemoryProvider,
+        const Record& record) override;
+    void combine(
+        nautilus::val<AggregationState*> aggregationState1,
+        nautilus::val<TupleBuffer*> parentBuffer1,
+        nautilus::val<AggregationState*> aggregationState2,
+        nautilus::val<TupleBuffer*> parentBuffer2,
+        PipelineMemoryProvider& pipelineMemoryProvider) override;
+    Record lower(
+        nautilus::val<AggregationState*> aggregationState,
+        nautilus::val<TupleBuffer*> parentBuffer,
+        PipelineMemoryProvider& pipelineMemoryProvider) override;
+    void reset(
+        nautilus::val<AggregationState*> aggregationState,
+        nautilus::val<TupleBuffer*> parentBuffer,
+        PipelineMemoryProvider& pipelineMemoryProvider) override;
+    void cleanup(nautilus::val<AggregationState*> aggregationState) override;
+    [[nodiscard]] size_t getSizeOfStateInBytes() const override;
+    ~ReservoirSampleAggregationPhysicalFunction() override = default;
+
+private:
+    std::shared_ptr<PagedVectorTupleLayout> tupleLayout;
+    uint64_t sampleSize;
+    uint64_t seed;
+    /// Field order and types of the serialized sample tuples, derived from the tuple layout schema
+    std::vector<ReservoirSampleField> blobFields;
+    /// Sum of the serialized sizes of all fixed-size fields per tuple
+    uint64_t fixedFieldsSizePerTuple;
+    bool hasVarSizedFields{false};
+};
+
+}

--- a/nes-physical-operators/include/Statistics/StatisticStoreOperatorHandler.hpp
+++ b/nes-physical-operators/include/Statistics/StatisticStoreOperatorHandler.hpp
@@ -1,0 +1,40 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <Runtime/Execution/OperatorHandler.hpp>
+#include <Runtime/QueryTerminationType.hpp>
+#include <StatisticStore/AbstractStatisticStore.hpp>
+
+namespace NES
+{
+
+class StatisticStoreOperatorHandler final : public OperatorHandler
+{
+public:
+    explicit StatisticStoreOperatorHandler(AbstractStatisticStore& store) : store(store) { }
+
+    void start(PipelineExecutionContext&, uint32_t) override { }
+
+    void stop(QueryTerminationType, PipelineExecutionContext&) override { }
+
+    [[nodiscard]] AbstractStatisticStore& getStore() const { return store; }
+
+private:
+    AbstractStatisticStore& store;
+};
+
+}

--- a/nes-physical-operators/include/Statistics/StatisticStoreReaderPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Statistics/StatisticStoreReaderPhysicalOperator.hpp
@@ -1,0 +1,67 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+
+#include <Identifiers/StatisticIdentifiers.hpp>
+#include <Interface/Record.hpp>
+#include <Operators/Statistic/StatisticWindowMatch.hpp>
+#include <Runtime/Execution/OperatorHandler.hpp>
+#include <Statistics/StatisticIterator.hpp>
+#include <ExecutionContext.hpp>
+#include <PhysicalOperator.hpp>
+
+namespace NES
+{
+
+class StatisticStoreReaderPhysicalOperator final : public PhysicalOperatorConcept
+{
+public:
+    struct FieldIdentifiers
+    {
+        Record::RecordFieldIdentifier inputStatisticStart;
+        Record::RecordFieldIdentifier inputStatisticEnd;
+        Record::RecordFieldIdentifier outputStatisticId;
+        Record::RecordFieldIdentifier outputStatisticStart;
+        Record::RecordFieldIdentifier outputStatisticEnd;
+        Record::RecordFieldIdentifier outputNumberOfSeenTuples;
+    };
+
+    StatisticStoreReaderPhysicalOperator(
+        OperatorHandlerId operatorHandlerId,
+        StatisticId statisticId,
+        FieldIdentifiers fieldIdentifiers,
+        std::shared_ptr<StatisticIterator> statisticIterator,
+        StatisticWindowMatch windowMatch);
+
+    void execute(ExecutionContext& executionCtx, Record& record) const override;
+
+    [[nodiscard]] std::optional<PhysicalOperator> getChild() const override;
+    void setChild(PhysicalOperator child) override;
+
+private:
+    OperatorHandlerId operatorHandlerId;
+    StatisticId statisticId;
+    FieldIdentifiers fieldIdentifiers;
+    std::shared_ptr<StatisticIterator> statisticIterator;
+    StatisticWindowMatch windowMatch;
+
+    std::optional<PhysicalOperator> child;
+};
+
+}

--- a/nes-physical-operators/include/Statistics/StatisticStoreWriterPhysicalOperator.hpp
+++ b/nes-physical-operators/include/Statistics/StatisticStoreWriterPhysicalOperator.hpp
@@ -1,0 +1,71 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <Operators/Statistic/StatisticBlobType.hpp>
+
+#include <optional>
+#include <string>
+#include <DataTypes/DataType.hpp>
+#include <Identifiers/StatisticIdentifiers.hpp>
+#include <Interface/Record.hpp>
+#include <Runtime/Execution/OperatorHandler.hpp>
+#include <ExecutionContext.hpp>
+#include <PhysicalOperator.hpp>
+
+namespace NES
+{
+
+/// Writes the statistic payload built by the upstream windowed aggregation into the worker's statistic store and
+/// re-emits the statistic metadata record
+/// [statisticId, statisticStart, statisticEnd, statisticNumberOfSeenMeasurements].
+class StatisticStoreWriterPhysicalOperator final : public PhysicalOperatorConcept
+{
+public:
+    struct FieldIdentifiers
+    {
+        Record::RecordFieldIdentifier inputStatisticStart;
+        Record::RecordFieldIdentifier inputStatisticEnd;
+        Record::RecordFieldIdentifier inputStatisticData;
+        Record::RecordFieldIdentifier inputNumberOfSeenMeasurements;
+        Record::RecordFieldIdentifier outputStatisticId;
+        Record::RecordFieldIdentifier outputStatisticStart;
+        Record::RecordFieldIdentifier outputStatisticEnd;
+        Record::RecordFieldIdentifier outputNumberOfSeenMeasurements;
+    };
+
+    StatisticStoreWriterPhysicalOperator(
+        OperatorHandlerId operatorHandlerId,
+        StatisticId statisticId,
+        StatisticBlobType typeName,
+        FieldIdentifiers fieldIdentifiers,
+        DataType payloadType);
+
+    void execute(ExecutionContext& executionCtx, Record& record) const override;
+
+    [[nodiscard]] std::optional<PhysicalOperator> getChild() const override;
+    void setChild(PhysicalOperator child) override;
+
+private:
+    OperatorHandlerId operatorHandlerId;
+    StatisticId statisticId;
+    StatisticBlobType typeName;
+    FieldIdentifiers fieldIdentifiers;
+    DataType payloadType;
+
+    std::optional<PhysicalOperator> child;
+};
+
+}

--- a/nes-physical-operators/registry/include/AggregationPhysicalFunctionRegistry.hpp
+++ b/nes-physical-operators/registry/include/AggregationPhysicalFunctionRegistry.hpp
@@ -23,6 +23,7 @@
 #include <Functions/PhysicalFunction.hpp>
 #include <Interface/PagedVector/PagedVectorRef.hpp>
 #include <Interface/Record.hpp>
+#include <Operators/Windows/Aggregations/WindowAggregationLogicalFunction.hpp>
 #include <Util/RuntimeRegistry.hpp>
 
 namespace NES
@@ -37,7 +38,7 @@ struct AggregationPhysicalFunctionRegistryArguments
     PhysicalFunction inputFunction;
     Record::RecordFieldIdentifier resultFieldIdentifier;
     std::optional<std::shared_ptr<PagedVectorTupleLayout>> tupleLayout;
-    bool includeNullValues;
+    WindowAggregationLogicalFunction logicalFunction;
 };
 
 using AggregationPhysicalFunctionFn

--- a/nes-physical-operators/src/Aggregation/Function/CountAggregationPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Aggregation/Function/CountAggregationPhysicalFunction.cpp
@@ -126,7 +126,7 @@ CountAggregationPhysicalFunction::create(AggregationPhysicalFunctionRegistryArgu
         std::move(arguments.resultType),
         arguments.inputFunction,
         arguments.resultFieldIdentifier,
-        arguments.includeNullValues);
+        arguments.logicalFunction.shallIncludeNullValues());
 }
 
 }

--- a/nes-physical-operators/src/CMakeLists.txt
+++ b/nes-physical-operators/src/CMakeLists.txt
@@ -28,6 +28,7 @@ add_source_files(nes-physical-operators
         WindowProbePhysicalOperator.cpp)
 
 add_subdirectory(Aggregation)
+add_subdirectory(Statistics)
 add_subdirectory(Watermark)
 add_subdirectory(Join)
 add_subdirectory(SliceStore)

--- a/nes-physical-operators/src/Statistics/CMakeLists.txt
+++ b/nes-physical-operators/src/Statistics/CMakeLists.txt
@@ -10,9 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(StatisticStore)
-add_subdirectory(Statistics)
-
-add_source_files(nes-statistics
-        StatisticTuple.cpp
+add_source_files(nes-physical-operators
+        ReservoirMerge.cpp
+        ReservoirSampleAggregationPhysicalFunction.cpp
+        StatisticStoreReaderPhysicalOperator.cpp
+        StatisticStoreWriterPhysicalOperator.cpp
 )
+
+add_registry_entry(AggregationPhysicalFunction ReservoirSample)

--- a/nes-physical-operators/src/Statistics/ReservoirMerge.cpp
+++ b/nes-physical-operators/src/Statistics/ReservoirMerge.cpp
@@ -1,0 +1,78 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Statistics/ReservoirMerge.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <random>
+#include <ranges>
+#include <folly/hash/Hash.h>
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+namespace
+{
+
+void drawDistinctPositions(const uint64_t populationSize, const uint64_t count, std::mt19937_64& gen, uint64_t*& positionsOut)
+{
+    const auto population = std::views::iota(uint64_t{0}, populationSize);
+    positionsOut = std::ranges::sample(population, positionsOut, count, gen);
+}
+
+}
+
+ReservoirMergeSelection computeReservoirMergeSelection(
+    const uint64_t seenLeft,
+    const uint64_t storedLeft,
+    const uint64_t seenRight,
+    const uint64_t storedRight,
+    const uint64_t capacity,
+    const uint64_t seed,
+    uint64_t* positionsOut)
+{
+    PRECONDITION(positionsOut != nullptr, "positionsOut must not be null");
+    PRECONDITION(storedLeft == std::min(seenLeft, capacity), "left reservoir must hold min(seen, capacity) tuples");
+    PRECONDITION(storedRight == std::min(seenRight, capacity), "right reservoir must hold min(seen, capacity) tuples");
+
+    const uint64_t total = std::min(capacity, storedLeft + storedRight);
+
+    /// Deterministic for fixed inputs; mixing in the seen counts decorrelates concurrent merges with the same seed.
+    std::mt19937_64 gen(folly::hash::hash_combine(seed, seenLeft, seenRight, capacity));
+
+    /// Sequential urn draws: each of the `total` survivor slots picks a tuple uniformly from the remaining
+    /// combined population, giving fromFirst ~ Hypergeometric(seenLeft + seenRight, total, seenLeft).
+    uint64_t fromFirst = 0;
+    uint64_t remainingLeft = seenLeft;
+    uint64_t remaining = seenLeft + seenRight;
+    std::uniform_int_distribution<uint64_t> dis;
+    for (uint64_t i = 0; i < total; ++i)
+    {
+        if (dis(gen, std::uniform_int_distribution<uint64_t>::param_type{0, remaining - 1}) < remainingLeft)
+        {
+            ++fromFirst;
+            --remainingLeft;
+        }
+        --remaining;
+    }
+
+    /// fromFirst <= storedLeft holds: fromFirst <= min(total, seenLeft) <= min(capacity, seenLeft) = storedLeft.
+    drawDistinctPositions(storedLeft, fromFirst, gen, positionsOut);
+    drawDistinctPositions(storedRight, total - fromFirst, gen, positionsOut);
+
+    return {.fromFirst = fromFirst, .total = total};
+}
+
+}

--- a/nes-physical-operators/src/Statistics/ReservoirSampleAggregationPhysicalFunction.cpp
+++ b/nes-physical-operators/src/Statistics/ReservoirSampleAggregationPhysicalFunction.cpp
@@ -1,0 +1,384 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Statistics/ReservoirSampleAggregationPhysicalFunction.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <utility>
+#include <vector>
+#include <folly/hash/Hash.h>
+
+#include <Aggregation/Function/AggregationPhysicalFunction.hpp>
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/DataTypesUtil.hpp>
+#include <DataTypes/UnboundSchema.hpp>
+#include <DataTypes/VarVal.hpp>
+#include <DataTypes/VariableSizedData.hpp>
+#include <Functions/PhysicalFunction.hpp>
+#include <Interface/NautilusBuffer.hpp>
+#include <Interface/PagedVector/PagedVector.hpp>
+#include <Interface/PagedVector/PagedVectorRef.hpp>
+#include <Interface/Record.hpp>
+#include <Operators/Windows/Aggregations/ReservoirSampleAggregationLogicalFunction.hpp>
+#include <Runtime/AbstractBufferProvider.hpp>
+#include <Runtime/TupleBuffer.hpp>
+#include <Statistics/ReservoirMerge.hpp>
+#include <Statistics/ReservoirSampleBlob.hpp>
+#include <nautilus/function.hpp>
+#include <AggregationPhysicalFunctionRegistry.hpp>
+#include <ErrorHandling.hpp>
+#include <ExecutionContext.hpp>
+#include <static.hpp>
+#include <val_arith.hpp>
+#include <val_memcpy.hpp>
+#include <val_ptr.hpp>
+
+namespace NES
+{
+namespace
+{
+
+/// Offsets into the aggregation state: [childBufferIndex: uint32][numberOfSeenTuples: uint64]
+constexpr uint64_t NUMBER_OF_SEEN_TUPLES_OFFSET = sizeof(uint32_t);
+
+/// Draws the position an arriving record would take among the numberOfSeenTuples + 1 records seen so far
+uint64_t getRandomSlotProxy(const uint64_t numberOfSeenTuples, const uint64_t seed)
+{
+    std::mt19937_64 gen(folly::hash::hash_combine(seed, numberOfSeenTuples));
+    std::uniform_int_distribution<uint64_t> dis(0, numberOfSeenTuples);
+    return dis(gen);
+}
+
+/// Loads the paged vector child buffer referenced by the uint32 index at the beginning of the aggregation state.
+OwnedNautilusBuffer
+loadPagedVectorBuffer(const nautilus::val<AggregationState*>& aggregationState, const nautilus::val<TupleBuffer*>& parentBuffer)
+{
+    OwnedNautilusBuffer pagedVectorBuffer;
+    nautilus::invoke(
+        +[](TupleBuffer* parent, TupleBuffer* out, const uint32_t* indexPtr)
+        { *out = parent->loadChildBuffer(ChildBufferIndex{*indexPtr}); },
+        parentBuffer,
+        pagedVectorBuffer.asArg(),
+        static_cast<nautilus::val<uint32_t*>>(static_cast<nautilus::val<int8_t*>>(aggregationState)));
+    return pagedVectorBuffer;
+}
+
+/// Allocates a fresh, empty paged vector as a child buffer of the parent and returns its child buffer index.
+nautilus::val<uint32_t> allocateFreshPagedVector(
+    const nautilus::val<TupleBuffer*>& parentBuffer,
+    const nautilus::val<AbstractBufferProvider*>& bufferProvider,
+    const nautilus::val<uint64_t>& tupleSize)
+{
+    return nautilus::invoke(
+        +[](TupleBuffer* parentBuffer, AbstractBufferProvider* bufferProvider, const uint64_t tupleSize)
+        {
+            if (auto pagedVectorBufferOpt = bufferProvider->getUnpooledBuffer(PagedVector::getMainBufferSize()))
+            {
+                auto pagedVectorBuffer = pagedVectorBufferOpt.value();
+                PagedVector::init(pagedVectorBuffer, bufferProvider->getBufferSize(), tupleSize);
+                return parentBuffer->storeChildBuffer(pagedVectorBuffer).getRawValue();
+            }
+            throw BufferAllocationFailure("No unpooled TupleBuffer available for the reservoir sample paged vector!");
+        },
+        parentBuffer,
+        bufferProvider,
+        tupleSize);
+}
+
+uint64_t computeReservoirMergeSelectionProxy(
+    const uint64_t seenLeft,
+    const uint64_t storedLeft,
+    const uint64_t seenRight,
+    const uint64_t storedRight,
+    const uint64_t capacity,
+    const uint64_t seed,
+    int8_t* positionsOut)
+{
+    /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): arena memory used as a uint64_t position array
+    const auto selection = computeReservoirMergeSelection(
+        seenLeft, storedLeft, seenRight, storedRight, capacity, seed, reinterpret_cast<uint64_t*>(positionsOut));
+    return selection.fromFirst;
+}
+
+}
+
+ReservoirSampleAggregationPhysicalFunction::ReservoirSampleAggregationPhysicalFunction(
+    DataType inputType,
+    DataType resultType,
+    PhysicalFunction inputFunction,
+    Record::RecordFieldIdentifier resultFieldIdentifier,
+    std::shared_ptr<PagedVectorTupleLayout> tupleLayout,
+    const uint64_t sampleSize,
+    const uint64_t seed)
+    : AggregationPhysicalFunction(std::move(inputType), std::move(resultType), std::move(inputFunction), std::move(resultFieldIdentifier))
+    , tupleLayout(std::move(tupleLayout))
+    , sampleSize(sampleSize)
+    , seed(seed)
+    , fixedFieldsSizePerTuple(0)
+{
+    PRECONDITION(this->sampleSize > 0, "The reservoir sample size must be greater than zero");
+    for (const auto& field : this->tupleLayout->getSchema())
+    {
+        PRECONDITION(not field.getDataType().nullable, "Reservoir samples do not support nullable input fields, but got {}", field);
+        blobFields.emplace_back(field.getFullyQualifiedName(), field.getDataType());
+        if (field.getDataType().type == DataType::Type::VARSIZED)
+        {
+            hasVarSizedFields = true;
+        }
+        else
+        {
+            fixedFieldsSizePerTuple += field.getDataType().getSizeInBytesWithoutNull();
+        }
+    }
+}
+
+void ReservoirSampleAggregationPhysicalFunction::lift(
+    const nautilus::val<AggregationState*>& aggregationState,
+    nautilus::val<TupleBuffer*> parentBuffer,
+    PipelineMemoryProvider& pipelineMemoryProvider,
+    const Record& record)
+{
+    const auto statePtr = static_cast<nautilus::val<int8_t*>>(aggregationState);
+    const auto numberOfSeenTuplesRef = statePtr + nautilus::val<uint64_t>{NUMBER_OF_SEEN_TUPLES_OFFSET};
+    const auto numberOfSeenTuples = readValueFromMemRef<uint64_t>(numberOfSeenTuplesRef);
+
+    if (numberOfSeenTuples < nautilus::val<uint64_t>{sampleSize})
+    {
+        auto pagedVectorBuffer = loadPagedVectorBuffer(aggregationState, parentBuffer);
+        PagedVectorRef pagedVectorRef(BorrowedNautilusBuffer::from(pagedVectorBuffer.asArg()), tupleLayout);
+        pagedVectorRef.pushBack(record, pipelineMemoryProvider.bufferProvider);
+    }
+    else
+    {
+        /// Algorithm R: replace a reservoir slot with gradually decreasing probability sampleSize / (seen + 1)
+        const auto randomSlot = invoke(getRandomSlotProxy, numberOfSeenTuples, nautilus::val<uint64_t>{seed});
+        if (randomSlot < nautilus::val<uint64_t>{sampleSize})
+        {
+            auto pagedVectorBuffer = loadPagedVectorBuffer(aggregationState, parentBuffer);
+            PagedVectorRef pagedVectorRef(BorrowedNautilusBuffer::from(pagedVectorBuffer.asArg()), tupleLayout);
+            pagedVectorRef.replaceRecord(record, randomSlot, pipelineMemoryProvider.bufferProvider);
+        }
+    }
+
+    VarVal{numberOfSeenTuples + nautilus::val<uint64_t>{1}}.writeToMemory(numberOfSeenTuplesRef);
+}
+
+void ReservoirSampleAggregationPhysicalFunction::combine(
+    nautilus::val<AggregationState*> aggregationState1,
+    nautilus::val<TupleBuffer*> parentBuffer1,
+    nautilus::val<AggregationState*> aggregationState2,
+    nautilus::val<TupleBuffer*> parentBuffer2,
+    PipelineMemoryProvider& pipelineMemoryProvider)
+{
+    const auto statePtr1 = static_cast<nautilus::val<int8_t*>>(aggregationState1);
+    const auto statePtr2 = static_cast<nautilus::val<int8_t*>>(aggregationState2);
+    const auto numberOfSeenTuplesRef1 = statePtr1 + nautilus::val<uint64_t>{NUMBER_OF_SEEN_TUPLES_OFFSET};
+    const auto numberOfSeenTuplesRef2 = statePtr2 + nautilus::val<uint64_t>{NUMBER_OF_SEEN_TUPLES_OFFSET};
+    const auto seen1 = readValueFromMemRef<uint64_t>(numberOfSeenTuplesRef1);
+    const auto seen2 = readValueFromMemRef<uint64_t>(numberOfSeenTuplesRef2);
+
+    auto pagedVectorBuffer1 = loadPagedVectorBuffer(aggregationState1, parentBuffer1);
+    auto pagedVectorBuffer2 = loadPagedVectorBuffer(aggregationState2, parentBuffer2);
+    const PagedVectorRef pagedVectorRef1(BorrowedNautilusBuffer::from(pagedVectorBuffer1.asArg()), tupleLayout);
+    const PagedVectorRef pagedVectorRef2(BorrowedNautilusBuffer::from(pagedVectorBuffer2.asArg()), tupleLayout);
+    const auto stored1 = pagedVectorRef1.getNumberOfRecords();
+    const auto stored2 = pagedVectorRef2.getNumberOfRecords();
+
+    if (stored1 + stored2 <= nautilus::val<uint64_t>{sampleSize})
+    {
+        /// Neither reservoir ever evicted (stored == seen), so concatenating is an exact sample of the union.
+        nautilus::invoke(
+            +[](AbstractBufferProvider* bufferProvider, TupleBuffer* pagedVectorBuffer1, const TupleBuffer* pagedVectorBuffer2) -> void
+            {
+                auto vector1 = PagedVector::load(*pagedVectorBuffer1);
+                const auto vector2 = PagedVector::load(*pagedVectorBuffer2);
+                vector1.copyPagesFrom(*bufferProvider, vector2);
+            },
+            pipelineMemoryProvider.bufferProvider,
+            pagedVectorBuffer1.asArg(),
+            pagedVectorBuffer2.asArg());
+    }
+    else
+    {
+        /// Statistically exact merge: select which tuples survive host-side (see ReservoirMerge.hpp), then
+        /// materialize the survivors into a fresh paged vector that replaces the left reservoir.
+        const auto positionsMemory = pipelineMemoryProvider.arena.allocateMemory(nautilus::val<uint64_t>{sampleSize * sizeof(uint64_t)});
+        const auto fromFirst = invoke(
+            computeReservoirMergeSelectionProxy,
+            seen1,
+            stored1,
+            seen2,
+            stored2,
+            nautilus::val<uint64_t>{sampleSize},
+            nautilus::val<uint64_t>{seed},
+            positionsMemory);
+
+        const nautilus::val<uint64_t> tupleSize = getSizeInBytes(tupleLayout->getSchema());
+        const auto freshIndex = allocateFreshPagedVector(parentBuffer1, pipelineMemoryProvider.bufferProvider, tupleSize);
+
+        OwnedNautilusBuffer freshPagedVectorBuffer;
+        nautilus::invoke(
+            +[](TupleBuffer* parent, TupleBuffer* out, const uint32_t index) { *out = parent->loadChildBuffer(ChildBufferIndex{index}); },
+            parentBuffer1,
+            freshPagedVectorBuffer.asArg(),
+            freshIndex);
+        PagedVectorRef freshPagedVectorRef(BorrowedNautilusBuffer::from(freshPagedVectorBuffer.asArg()), tupleLayout);
+
+        for (nautilus::val<uint64_t> i = 0; i < nautilus::val<uint64_t>{sampleSize}; i = i + 1)
+        {
+            const auto position = readValueFromMemRef<uint64_t>(positionsMemory + (i * nautilus::val<uint64_t>{sizeof(uint64_t)}));
+            if (i < fromFirst)
+            {
+                const auto record = pagedVectorRef1.at(position);
+                freshPagedVectorRef.pushBack(record, pipelineMemoryProvider.bufferProvider);
+            }
+            else
+            {
+                const auto record = pagedVectorRef2.at(position);
+                freshPagedVectorRef.pushBack(record, pipelineMemoryProvider.bufferProvider);
+            }
+        }
+
+        /// Point the left state at the fresh reservoir. The previous child buffer stays with the parent buffer
+        /// until the parent is released.
+        VarVal{freshIndex}.writeToMemory(statePtr1);
+    }
+
+    VarVal{seen1 + seen2}.writeToMemory(numberOfSeenTuplesRef1);
+}
+
+Record ReservoirSampleAggregationPhysicalFunction::lower(
+    nautilus::val<AggregationState*> aggregationState,
+    nautilus::val<TupleBuffer*> parentBuffer,
+    PipelineMemoryProvider& pipelineMemoryProvider)
+{
+    const auto statePtr = static_cast<nautilus::val<int8_t*>>(aggregationState);
+    const auto numberOfSeenTuples = readValueFromMemRef<uint64_t>(statePtr + nautilus::val<uint64_t>{NUMBER_OF_SEEN_TUPLES_OFFSET});
+
+    auto pagedVectorBuffer = loadPagedVectorBuffer(aggregationState, parentBuffer);
+    const PagedVectorRef pagedVectorRef(BorrowedNautilusBuffer::from(pagedVectorBuffer.asArg()), tupleLayout);
+    const auto tupleCount = pagedVectorRef.getNumberOfRecords();
+
+    /// First pass: compute the serialized size of the sample tuples
+    nautilus::val<uint64_t> dataSize = tupleCount * nautilus::val<uint64_t>{fixedFieldsSizePerTuple};
+    if (hasVarSizedFields)
+    {
+        for (const auto& record : pagedVectorRef)
+        {
+            for (nautilus::static_val<uint64_t> i = 0; i < blobFields.size(); ++i)
+            {
+                if (blobFields[i].type.type == DataType::Type::VARSIZED)
+                {
+                    const auto varSizedValue = record.read(blobFields[i].name).getRawValueAs<VariableSizedData>();
+                    dataSize
+                        = dataSize + varSizedValue.getSize() + nautilus::val<uint64_t>{ReservoirSampleBlob::VARSIZED_LENGTH_PREFIX_SIZE};
+                }
+            }
+        }
+    }
+
+    /// Second pass: serialize the tuples into the blob
+    const auto blobSize = nautilus::val<uint64_t>{ReservoirSampleBlob::HEADER_SIZE} + dataSize;
+    const auto blobMemory = pipelineMemoryProvider.arena.allocateMemory(blobSize);
+    writeReservoirSampleBlobHeader(blobMemory, tupleCount, dataSize);
+    auto cursor = getReservoirSampleBlobDataArea(blobMemory);
+    for (const auto& record : pagedVectorRef)
+    {
+        for (nautilus::static_val<uint64_t> i = 0; i < blobFields.size(); ++i)
+        {
+            const auto& [name, type] = blobFields[i];
+            const auto& value = record.read(name);
+            if (type.type == DataType::Type::VARSIZED)
+            {
+                const auto varSizedValue = value.getRawValueAs<VariableSizedData>();
+                const auto contentSize = varSizedValue.getSize();
+                VarVal{static_cast<nautilus::val<uint32_t>>(contentSize)}.writeToMemory(cursor);
+                cursor = cursor + nautilus::val<uint64_t>{ReservoirSampleBlob::VARSIZED_LENGTH_PREFIX_SIZE};
+                nautilus::memcpy(cursor, varSizedValue.getContent(), contentSize);
+                cursor = cursor + contentSize;
+            }
+            else if (const auto storeFunction = storeValueFunctionMap.find(type.type); storeFunction != storeValueFunctionMap.end())
+            {
+                storeFunction->second(value, cursor);
+                cursor = cursor + nautilus::val<uint64_t>{type.getSizeInBytesWithoutNull()};
+            }
+            else
+            {
+                throw UnknownDataType("Physical Type: {} is currently not supported", type);
+            }
+        }
+    }
+
+    Record resultRecord;
+    resultRecord.write(resultFieldIdentifier, VarVal{VariableSizedData{blobMemory, blobSize}});
+    return resultRecord;
+}
+
+void ReservoirSampleAggregationPhysicalFunction::reset(
+    nautilus::val<AggregationState*> aggregationState,
+    nautilus::val<TupleBuffer*> parentBuffer,
+    PipelineMemoryProvider& pipelineMemoryProvider)
+{
+    const nautilus::val<uint64_t> tupleSize = getSizeInBytes(tupleLayout->getSchema());
+    const auto childBufferIndex = allocateFreshPagedVector(parentBuffer, pipelineMemoryProvider.bufferProvider, tupleSize);
+
+    const auto statePtr = static_cast<nautilus::val<int8_t*>>(aggregationState);
+    VarVal{childBufferIndex}.writeToMemory(statePtr);
+    VarVal{nautilus::val<uint64_t>{0}}.writeToMemory(statePtr + nautilus::val<uint64_t>{NUMBER_OF_SEEN_TUPLES_OFFSET});
+}
+
+void ReservoirSampleAggregationPhysicalFunction::cleanup(nautilus::val<AggregationState*> /*aggregationState*/)
+{
+    /// No-op: the paged vector buffer is stored as a child of the parent hash map TupleBuffer and
+    /// is released automatically when the parent is released.
+}
+
+size_t ReservoirSampleAggregationPhysicalFunction::getSizeOfStateInBytes() const
+{
+    /// uint32_t child buffer index + uint64_t number of seen tuples
+    return sizeof(uint32_t) + sizeof(uint64_t);
+}
+
+AggregationPhysicalFunctionRegistryReturnType
+ReservoirSampleAggregationPhysicalFunction::create(AggregationPhysicalFunctionRegistryArguments arguments)
+{
+    INVARIANT(arguments.tupleLayout.has_value(), "Tuple layout paged vector not set");
+    for (const auto& field : arguments.tupleLayout.value()->getSchema())
+    {
+        if (field.getDataType().nullable)
+        {
+            throw NotImplemented(
+                "Reservoir samples do not support nullable input fields yet, but the input contains {}. "
+                "Cast or filter the field to a non-nullable type before the RESERVOIR aggregation.",
+                field);
+        }
+    }
+
+    const auto reservoirSample = arguments.logicalFunction.tryGetAs<ReservoirSampleAggregationLogicalFunction>();
+    INVARIANT(reservoirSample.has_value(), "Expected a reservoir sample aggregation, but got {}", arguments.logicalFunction->getName());
+
+    return std::make_shared<ReservoirSampleAggregationPhysicalFunction>(
+        std::move(arguments.inputType),
+        std::move(arguments.resultType),
+        arguments.inputFunction,
+        arguments.resultFieldIdentifier,
+        arguments.tupleLayout.value(),
+        (*reservoirSample)->getSampleSize(),
+        (*reservoirSample)->getSeed());
+}
+
+}

--- a/nes-physical-operators/src/Statistics/StatisticStoreReaderPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Statistics/StatisticStoreReaderPhysicalOperator.cpp
@@ -1,0 +1,221 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Statistics/StatisticStoreReaderPhysicalOperator.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <DataTypes/VarVal.hpp>
+#include <Identifiers/StatisticIdentifiers.hpp>
+#include <Interface/NESStrongTypeRef.hpp>
+#include <Interface/Record.hpp>
+#include <Interface/TimestampRef.hpp>
+#include <Operators/Statistic/StatisticBlobType.hpp>
+#include <Runtime/Execution/OperatorHandler.hpp>
+#include <StatisticStore/AbstractStatisticStore.hpp>
+#include <Statistics/StatisticIterator.hpp>
+#include <Statistics/StatisticStoreOperatorHandler.hpp>
+#include <Time/Timestamp.hpp>
+#include <nautilus/function.hpp>
+#include <ErrorHandling.hpp>
+#include <ExecutionContext.hpp>
+#include <PhysicalOperator.hpp>
+#include <StatisticTuple.hpp>
+#include <val_arith.hpp>
+#include <val_enum.hpp>
+#include <val_ptr.hpp>
+
+namespace NES
+{
+
+namespace
+{
+
+thread_local std::unordered_map<uint64_t, std::vector<AbstractStatisticStore::StatisticRef>> tProbeStatistics;
+
+/// A probe declares what it expects to read, but the store is keyed by statisticId alone, so a probe can reach a
+/// statistic some other build wrote. Reading it anyway would reinterpret the stored bytes -- a FLOAT64 average read
+/// as a UINT64 count -- or read past a shorter payload. Fail loudly instead.
+void validateAgainstProbe(
+    const std::vector<AbstractStatisticStore::StatisticRef>& statistics,
+    const StatisticId statisticId,
+    const StatisticBlobType& expectedTypeName,
+    const uint64_t expectedPayloadSizeInBytes)
+{
+    for (const auto& statistic : statistics)
+    {
+        if (statistic->getTypeName() != expectedTypeName)
+        {
+            throw CannotProbeStatistic(
+                "StatisticTuple {} was built as {} but is probed as {}",
+                statisticId.getRawValue(),
+                statistic->getTypeName().getRawValue(),
+                expectedTypeName.getRawValue());
+        }
+        if (expectedPayloadSizeInBytes != 0 and statistic->getStatisticDataSize() != expectedPayloadSizeInBytes)
+        {
+            throw CannotProbeStatistic(
+                "StatisticTuple {} persisted a {}-byte payload but is probed as a {}-byte type",
+                statisticId.getRawValue(),
+                statistic->getStatisticDataSize(),
+                expectedPayloadSizeInBytes);
+        }
+    }
+}
+
+uint64_t loadStatisticsProxy(
+    OperatorHandler* ptrOpHandler,
+    const uint64_t readerId,
+    const StatisticId statisticId,
+    const Timestamp startTs,
+    const Timestamp endTs,
+    const StatisticIterator* statisticIterator,
+    const StatisticWindowMatch windowMatch)
+{
+    PRECONDITION(ptrOpHandler != nullptr, "opHandler context should not be null!");
+    PRECONDITION(statisticIterator != nullptr, "the statistic iterator should not be null!");
+
+    auto& store = dynamic_cast<StatisticStoreOperatorHandler*>(ptrOpHandler)->getStore();
+    std::vector<AbstractStatisticStore::StatisticRef> statistics;
+    if (windowMatch == StatisticWindowMatch::ExactWindow)
+    {
+        if (auto statistic = store.getSingleStatistic(statisticId, Timestamp{startTs.getRawValue()}, Timestamp{endTs.getRawValue()}))
+        {
+            statistics.push_back(std::move(statistic.value()));
+        }
+    }
+    else
+    {
+        statistics = store.getStatistics(statisticId, Timestamp{startTs.getRawValue()}, Timestamp{endTs.getRawValue()});
+    }
+
+    validateAgainstProbe(
+        statistics, statisticId, statisticIterator->getStatisticBlobType(), statisticIterator->getExpectedPayloadSizeInBytes());
+    auto& frame = tProbeStatistics[readerId];
+    frame = std::move(statistics);
+    return frame.size();
+}
+
+void releaseStatisticsProxy(const uint64_t readerId)
+{
+    tProbeStatistics[readerId].clear();
+}
+
+int8_t* getStatisticDataByIndexProxy(const uint64_t readerId, const uint64_t index)
+{
+    const auto& statistics = tProbeStatistics[readerId];
+    /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast): the reader only reads; nautilus record access needs int8_t*.
+    return index < statistics.size() ? const_cast<int8_t*>(statistics[index]->getStatisticData()) : nullptr;
+}
+
+uint64_t getSeenTuplesByIndexProxy(const uint64_t readerId, const uint64_t index)
+{
+    const auto& statistics = tProbeStatistics[readerId];
+    return index < statistics.size() ? statistics[index]->getNumberOfSeenMeasurements() : 0;
+}
+
+uint64_t getStartTsByIndexProxy(const uint64_t readerId, const uint64_t index)
+{
+    const auto& statistics = tProbeStatistics[readerId];
+    return index < statistics.size() ? statistics[index]->getStartTs().getRawValue() : 0;
+}
+
+uint64_t getEndTsByIndexProxy(const uint64_t readerId, const uint64_t index)
+{
+    const auto& statistics = tProbeStatistics[readerId];
+    return index < statistics.size() ? statistics[index]->getEndTs().getRawValue() : 0;
+}
+
+}
+
+StatisticStoreReaderPhysicalOperator::StatisticStoreReaderPhysicalOperator(
+    const OperatorHandlerId operatorHandlerId,
+    const StatisticId statisticId,
+    FieldIdentifiers fieldIdentifiers,
+    std::shared_ptr<StatisticIterator> statisticIterator,
+    const StatisticWindowMatch windowMatch)
+    : operatorHandlerId(operatorHandlerId)
+    , statisticId(statisticId)
+    , fieldIdentifiers(std::move(fieldIdentifiers))
+    , statisticIterator(std::move(statisticIterator))
+    , windowMatch(windowMatch)
+{
+}
+
+void StatisticStoreReaderPhysicalOperator::execute(ExecutionContext& executionCtx, Record& record) const
+{
+    /// Only the probed window comes from the record; which statistic to read is operator state.
+    const nautilus::val<StatisticId> statisticIdVal{statisticId};
+    const nautilus::val<Timestamp> startTs{
+        record.read(fieldIdentifiers.inputStatisticStart).getRawValueAs<nautilus::val<Timestamp::Underlying>>()};
+    const nautilus::val<Timestamp> endTs{
+        record.read(fieldIdentifiers.inputStatisticEnd).getRawValueAs<nautilus::val<Timestamp::Underlying>>()};
+    const nautilus::val<const StatisticIterator*> iteratorRef{statisticIterator.get()};
+    const nautilus::val<StatisticWindowMatch> windowMatchVal{windowMatch};
+    const nautilus::val<uint64_t> readerId{operatorHandlerId.getRawValue()};
+
+    const auto statisticCount = invoke(
+        loadStatisticsProxy,
+        executionCtx.getGlobalOperatorHandler(operatorHandlerId),
+        readerId,
+        statisticIdVal,
+        startTs,
+        endTs,
+        iteratorRef,
+        windowMatchVal);
+
+    for (nautilus::val<uint64_t> i = 0; i < statisticCount; i = i + 1)
+    {
+        const auto payload = invoke(getStatisticDataByIndexProxy, readerId, i);
+        if (payload != nullptr)
+        {
+            /// The window bounds reported are the stored statistic's own, not the probed range, so a caller that
+            /// asked over a span learns which window each row actually belongs to.
+            const auto statisticStart = invoke(getStartTsByIndexProxy, readerId, i);
+            const auto statisticEnd = invoke(getEndTsByIndexProxy, readerId, i);
+            const auto numberOfSeenTuples = invoke(getSeenTuplesByIndexProxy, readerId, i);
+
+            statisticIterator->forEachRecord(
+                payload,
+                [&](Record& statisticRecord)
+                {
+                    statisticRecord.write(fieldIdentifiers.outputStatisticId, statisticIdVal.convertToValue());
+                    statisticRecord.write(fieldIdentifiers.outputStatisticStart, VarVal{statisticStart});
+                    statisticRecord.write(fieldIdentifiers.outputStatisticEnd, VarVal{statisticEnd});
+                    statisticRecord.write(fieldIdentifiers.outputNumberOfSeenTuples, VarVal{numberOfSeenTuples});
+                    executeChild(executionCtx, statisticRecord);
+                });
+        }
+    }
+
+    invoke(releaseStatisticsProxy, readerId);
+}
+
+std::optional<PhysicalOperator> StatisticStoreReaderPhysicalOperator::getChild() const
+{
+    return child;
+}
+
+void StatisticStoreReaderPhysicalOperator::setChild(PhysicalOperator child)
+{
+    this->child = std::move(child);
+}
+
+}

--- a/nes-physical-operators/src/Statistics/StatisticStoreWriterPhysicalOperator.cpp
+++ b/nes-physical-operators/src/Statistics/StatisticStoreWriterPhysicalOperator.cpp
@@ -1,0 +1,151 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Statistics/StatisticStoreWriterPhysicalOperator.hpp>
+
+#include <DataTypes/DataType.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include <DataTypes/VarVal.hpp>
+#include <DataTypes/VariableSizedData.hpp>
+#include <Identifiers/StatisticIdentifiers.hpp>
+#include <Interface/Record.hpp>
+#include <Operators/Statistic/StatisticBlobType.hpp>
+#include <Runtime/Execution/OperatorHandler.hpp>
+#include <StatisticStore/AbstractStatisticStore.hpp>
+#include <Statistics/StatisticStoreOperatorHandler.hpp>
+#include <Time/Timestamp.hpp>
+#include <nautilus/function.hpp>
+#include <ErrorHandling.hpp>
+#include <ExecutionContext.hpp>
+#include <PhysicalOperator.hpp>
+#include <StatisticTuple.hpp>
+#include <val.hpp>
+#include <val_ptr.hpp>
+
+namespace NES
+{
+namespace
+{
+
+void insertStatisticIntoStoreProxy(
+    OperatorHandler* ptrOpHandler,
+    const uint64_t statisticId,
+    const int8_t* typeNamePtr,
+    const uint64_t typeNameSize,
+    const uint64_t startTs,
+    const uint64_t endTs,
+    const uint64_t numberOfSeenMeasurements,
+    const int8_t* data,
+    const uint64_t statisticDataSize)
+{
+    PRECONDITION(ptrOpHandler != nullptr, "opHandler context should not be null!");
+    PRECONDITION(data != nullptr, "The statistic data pointer must not be null");
+
+    /// The blob lives in arena memory owned by the emitting pipeline, so it must be copied into the store.
+    /// NOLINTNEXTLINE(modernize-avoid-c-arrays) dynamic byte buffer requires array form
+    auto statisticData = std::make_shared<std::byte[]>(statisticDataSize);
+    std::memcpy(statisticData.get(), data, statisticDataSize);
+
+    auto* opHandler = dynamic_cast<StatisticStoreOperatorHandler*>(ptrOpHandler);
+    opHandler->getStore().insertStatistic(
+        StatisticId(statisticId),
+        StatisticTuple{
+            StatisticId(statisticId),
+            StatisticBlobType{std::string_view(reinterpret_cast<const char*>(typeNamePtr), typeNameSize)},
+            Timestamp(startTs),
+            Timestamp(endTs),
+            numberOfSeenMeasurements,
+            std::move(statisticData),
+            statisticDataSize});
+}
+
+}
+
+StatisticStoreWriterPhysicalOperator::StatisticStoreWriterPhysicalOperator(
+    const OperatorHandlerId operatorHandlerId,
+    const StatisticId statisticId,
+    StatisticBlobType typeName,
+    FieldIdentifiers fieldIdentifiers,
+    DataType payloadType)
+    : operatorHandlerId(operatorHandlerId)
+    , statisticId(statisticId)
+    , typeName(std::move(typeName))
+    , fieldIdentifiers(std::move(fieldIdentifiers))
+    , payloadType(std::move(payloadType))
+{
+}
+
+void StatisticStoreWriterPhysicalOperator::execute(ExecutionContext& executionCtx, Record& record) const
+{
+    const auto startTs = record.read(fieldIdentifiers.inputStatisticStart).getRawValueAs<nautilus::val<uint64_t>>();
+    const auto endTs = record.read(fieldIdentifiers.inputStatisticEnd).getRawValueAs<nautilus::val<uint64_t>>();
+    const auto numberOfSeenMeasurements
+        = record.read(fieldIdentifiers.inputNumberOfSeenMeasurements).getRawValueAs<nautilus::val<uint64_t>>();
+    const auto& payloadValue = record.read(fieldIdentifiers.inputStatisticData);
+    nautilus::val<const int8_t*> payloadPtr{nullptr};
+    nautilus::val<uint64_t> payloadSize{0};
+    if (payloadType.type == DataType::Type::VARSIZED)
+    {
+        const auto statisticData = payloadValue.getRawValueAs<VariableSizedData>();
+        payloadPtr = statisticData.getContent();
+        payloadSize = statisticData.getSize();
+    }
+    else
+    {
+        payloadSize = nautilus::val<uint64_t>{payloadType.getSizeInBytesWithoutNull()};
+        const auto payloadMemory = executionCtx.pipelineMemoryProvider.arena.allocateMemory(payloadSize);
+        payloadValue.writeToMemory(payloadMemory);
+        payloadPtr = payloadMemory;
+    }
+
+    invoke(
+        insertStatisticIntoStoreProxy,
+        executionCtx.getGlobalOperatorHandler(operatorHandlerId),
+        nautilus::val<uint64_t>{statisticId.getRawValue()},
+        nautilus::val<const int8_t*>{reinterpret_cast<const int8_t*>(typeName.view().data())},
+        nautilus::val<uint64_t>{typeName.view().size()},
+        startTs,
+        endTs,
+        numberOfSeenMeasurements,
+        payloadPtr,
+        payloadSize);
+
+    /// Re-emit the statistic metadata (without the blob) to the next operator
+    Record outputRecord;
+    outputRecord.write(fieldIdentifiers.outputStatisticId, VarVal{nautilus::val<uint64_t>{statisticId.getRawValue()}});
+    outputRecord.write(fieldIdentifiers.outputStatisticStart, VarVal{startTs});
+    outputRecord.write(fieldIdentifiers.outputStatisticEnd, VarVal{endTs});
+    outputRecord.write(fieldIdentifiers.outputNumberOfSeenMeasurements, VarVal{numberOfSeenMeasurements});
+    executeChild(executionCtx, outputRecord);
+}
+
+std::optional<PhysicalOperator> StatisticStoreWriterPhysicalOperator::getChild() const
+{
+    return child;
+}
+
+void StatisticStoreWriterPhysicalOperator::setChild(PhysicalOperator child)
+{
+    this->child = std::move(child);
+}
+
+}

--- a/nes-query-compiler/include/QueryCompiler.hpp
+++ b/nes-query-compiler/include/QueryCompiler.hpp
@@ -39,7 +39,7 @@ struct QueryCompilationRequest
 class QueryCompiler
 {
 public:
-    explicit QueryCompiler(QueryExecutionConfiguration defaultQueryExecution) : defaultQueryExecution(std::move(defaultQueryExecution)) { };
+    explicit QueryCompiler(QueryExecutionConfiguration defaultQueryExecution) : defaultQueryExecution(std::move(defaultQueryExecution)) { }
 
     std::unique_ptr<CompiledQueryPlan> compileQuery(std::unique_ptr<QueryCompilationRequest> request);
 

--- a/nes-query-compiler/private/LoweringRules/LowerToPhysical/LowerToPhysicalStatisticStoreReader.hpp
+++ b/nes-query-compiler/private/LoweringRules/LowerToPhysical/LowerToPhysicalStatisticStoreReader.hpp
@@ -1,0 +1,35 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <utility>
+#include <LoweringRules/AbstractLoweringRule.hpp>
+#include <Operators/LogicalOperator.hpp>
+#include <QueryExecutionConfiguration.hpp>
+
+namespace NES
+{
+
+struct LowerToPhysicalStatisticStoreReader : AbstractLoweringRule
+{
+    explicit LowerToPhysicalStatisticStoreReader(QueryExecutionConfiguration conf) : conf(std::move(conf)) { }
+
+    LoweringRuleResultSubgraph apply(LogicalOperator logicalOperator) override;
+
+private:
+    QueryExecutionConfiguration conf;
+};
+
+}

--- a/nes-query-compiler/private/LoweringRules/LowerToPhysical/LowerToPhysicalStatisticStoreWriter.hpp
+++ b/nes-query-compiler/private/LoweringRules/LowerToPhysical/LowerToPhysicalStatisticStoreWriter.hpp
@@ -1,0 +1,35 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <utility>
+#include <LoweringRules/AbstractLoweringRule.hpp>
+#include <Operators/LogicalOperator.hpp>
+#include <QueryExecutionConfiguration.hpp>
+
+namespace NES
+{
+
+struct LowerToPhysicalStatisticStoreWriter : AbstractLoweringRule
+{
+    explicit LowerToPhysicalStatisticStoreWriter(QueryExecutionConfiguration conf) : conf(std::move(conf)) { }
+
+    LoweringRuleResultSubgraph apply(LogicalOperator logicalOperator) override;
+
+private:
+    QueryExecutionConfiguration conf;
+};
+
+}

--- a/nes-query-compiler/private/LoweringRules/LowerToPhysical/StatisticFieldResolution.hpp
+++ b/nes-query-compiler/private/LoweringRules/LowerToPhysical/StatisticFieldResolution.hpp
@@ -1,0 +1,52 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <DataTypes/UnboundField.hpp>
+#include <Identifiers/Identifier.hpp>
+#include <Identifiers/QualifiedIdentifier.hpp>
+#include <Schema/Schema.hpp>
+#include <Schema/SchemaFwd.hpp>
+#include <ErrorHandling.hpp>
+
+namespace NES
+{
+
+/// Resolves the physical record field identifier of a logical field in a physical schema.
+/// Physical field names always start with the logical field's last name (DecideFieldMappings only ever appends
+/// qualifiers, e.g. a trailing "new" on write-read conflicts), so matching on the first identifier is unambiguous
+/// for the fixed statistic field names.
+inline QualifiedIdentifier
+resolvePhysicalFieldName(const Schema<QualifiedUnboundField, Ordered>& physicalSchema, const Identifier& logicalFieldName)
+{
+    for (const auto& field : physicalSchema)
+    {
+        if (*field.getFullyQualifiedName().begin() == logicalFieldName)
+        {
+            return field.getFullyQualifiedName();
+        }
+    }
+    throw CannotInferSchema("Field {} not found in physical schema {}", logicalFieldName, physicalSchema);
+}
+
+inline QualifiedIdentifier
+resolvePhysicalFieldName(const Schema<QualifiedUnboundField, Ordered>& physicalSchema, const std::string_view logicalFieldName)
+{
+    return resolvePhysicalFieldName(physicalSchema, Identifier::parse(std::string{logicalFieldName}));
+}
+
+}

--- a/nes-query-compiler/registry/include/LoweringRuleRegistry.hpp
+++ b/nes-query-compiler/registry/include/LoweringRuleRegistry.hpp
@@ -17,6 +17,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <utility>
 #include <LoweringRules/AbstractLoweringRule.hpp>
 #include <Util/RuntimeRegistry.hpp>
 #include <QueryExecutionConfiguration.hpp>
@@ -33,13 +34,11 @@ struct LoweringRuleRegistryArguments
 
 using LoweringRuleFn = std::function<LoweringRuleRegistryReturnType(LoweringRuleRegistryArguments)>;
 
-/// Creates the registry entry for a lowering rule: rules are constructed from the query
-/// execution configuration.
 template <typename LoweringRuleImpl>
 LoweringRuleFn makeLoweringRule()
 {
     return [](LoweringRuleRegistryArguments arguments) -> LoweringRuleRegistryReturnType
-    { return std::make_unique<LoweringRuleImpl>(arguments.conf); };
+    { return std::make_unique<LoweringRuleImpl>(std::move(arguments.conf)); };
 }
 
 class LoweringRuleRegistry : public RuntimeRegistry<LoweringRuleRegistry, std::string, LoweringRuleFn, /*CaseSensitive*/ false>

--- a/nes-query-compiler/src/LoweringRules/LowerToPhysical/CMakeLists.txt
+++ b/nes-query-compiler/src/LoweringRules/LowerToPhysical/CMakeLists.txt
@@ -16,12 +16,14 @@ add_source_files(nes-query-compiler
         LowerToPhysicalSelection.cpp
         LowerToPhysicalProjection.cpp
         LowerToPhysicalWindowedAggregation.cpp
+        LowerToPhysicalStatisticStoreWriter.cpp
         LowerToPhysicalUnion.cpp
         LowerToPhysicalSink.cpp
         LowerToPhysicalSource.cpp
         LowerToPhysicalIngestionTimeWatermarkAssigner.cpp
         LowerToPhysicalEventTimeWatermarkAssigner.cpp
         LowerToPhysicalInferModel.cpp
+        LowerToPhysicalStatisticStoreReader.cpp
 )
 
 add_registry_entry(LoweringRule NLJoin)
@@ -29,6 +31,8 @@ add_registry_entry(LoweringRule HashJoin)
 add_registry_entry(LoweringRule Selection)
 add_registry_entry(LoweringRule Projection)
 add_registry_entry(LoweringRule WindowedAggregation)
+add_registry_entry(LoweringRule StatisticStoreWriter)
+add_registry_entry(LoweringRule StatisticStoreReader)
 add_registry_entry(LoweringRule Union)
 add_registry_entry(LoweringRule Sink)
 add_registry_entry(LoweringRule Source KEY SourceDescriptor)

--- a/nes-query-compiler/src/LoweringRules/LowerToPhysical/LowerToPhysicalStatisticStoreReader.cpp
+++ b/nes-query-compiler/src/LoweringRules/LowerToPhysical/LowerToPhysicalStatisticStoreReader.cpp
@@ -1,0 +1,106 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <LoweringRules/LowerToPhysical/LowerToPhysicalStatisticStoreReader.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <utility>
+#include <Identifiers/StatisticIdentifiers.hpp>
+#include <LoweringRules/AbstractLoweringRule.hpp>
+#include <LoweringRules/LowerToPhysical/StatisticFieldResolution.hpp>
+#include <Operators/LogicalOperator.hpp>
+#include <Operators/Statistic/StatisticStoreReaderLogicalOperator.hpp>
+#include <Operators/Windows/Aggregations/ReservoirSampleAggregationLogicalFunction.hpp>
+#include <StatisticStore/AbstractStatisticStore.hpp>
+#include <Statistics/ReservoirSampleBlob.hpp>
+#include <Statistics/ReservoirSampleStatisticIterator.hpp>
+#include <Statistics/ScalarStatisticIterator.hpp>
+#include <Statistics/StatisticIterator.hpp>
+#include <Statistics/StatisticStoreOperatorHandler.hpp>
+#include <Statistics/StatisticStoreReaderPhysicalOperator.hpp>
+#include <Traits/MemoryLayoutTypeTrait.hpp>
+#include <Util/SchemaFactory.hpp>
+#include <ErrorHandling.hpp>
+#include <LoweringRuleRegistry.hpp>
+#include <PhysicalOperator.hpp>
+
+#include <Operators/Statistic/StatisticFieldNames.hpp>
+
+namespace NES
+{
+
+LoweringRuleResultSubgraph LowerToPhysicalStatisticStoreReader::apply(LogicalOperator logicalOperator)
+{
+    const auto probe = logicalOperator.getAs<StatisticStoreReaderLogicalOperator>();
+    const auto traitSet = logicalOperator.getTraitSet();
+
+    const auto memoryLayoutTypeTrait = traitSet.get<MemoryLayoutTypeTrait>();
+    const auto memoryLayoutType = memoryLayoutTypeTrait->memoryLayout;
+
+    const auto outputSchema = createPhysicalOutputSchema(traitSet);
+    const auto inputSchema = createPhysicalOutputSchema(probe->getChild().getTraitSet());
+
+    auto handlerId = getNextOperatorHandlerId();
+    auto handler = std::make_shared<StatisticStoreOperatorHandler>(globalStatisticStore());
+
+    const StatisticStoreReaderPhysicalOperator::FieldIdentifiers fieldIdentifiers{
+        .inputStatisticStart = resolvePhysicalFieldName(inputSchema, StatisticFieldNames::START_TS),
+        .inputStatisticEnd = resolvePhysicalFieldName(inputSchema, StatisticFieldNames::END_TS),
+        .outputStatisticId = resolvePhysicalFieldName(outputSchema, StatisticFieldNames::STATISTIC_ID),
+        .outputStatisticStart = resolvePhysicalFieldName(outputSchema, StatisticFieldNames::START_TS),
+        .outputStatisticEnd = resolvePhysicalFieldName(outputSchema, StatisticFieldNames::END_TS),
+        .outputNumberOfSeenTuples = resolvePhysicalFieldName(outputSchema, StatisticFieldNames::NUMBER_OF_SEEN_TUPLES)};
+
+    /// The payload columns, resolved to their physical names. Their declared order is the order the blob stores
+    /// them in, so it must survive lowering untouched.
+    std::vector<ReservoirSampleField> payloadFields;
+    for (const auto& [name, dataType] : probe->getPayloadFields())
+    {
+        payloadFields.emplace_back(resolvePhysicalFieldName(outputSchema, name.getOriginalString()), dataType);
+    }
+
+    /// Which decoder reads the blob is decided by the aggregation that wrote it. A sample is a run of records,
+    /// anything else is the single scalar the aggregation reduced its window to.
+    auto statisticIterator = [&]() -> std::shared_ptr<StatisticIterator>
+    {
+        if (probe->getTypeName() == StatisticBlobType{ReservoirSampleAggregationLogicalFunction::NAME})
+        {
+            return std::make_shared<ReservoirSampleStatisticIterator>(std::move(payloadFields));
+        }
+        INVARIANT(
+            payloadFields.size() == 1, "A scalar statistic decodes to exactly one column, but {} were declared", payloadFields.size());
+        return std::make_shared<ScalarStatisticIterator>(probe->getTypeName(), payloadFields.front().type, payloadFields.front().name);
+    }();
+
+    const StatisticStoreReaderPhysicalOperator reader{
+        handlerId, probe->getStatisticId(), fieldIdentifiers, std::move(statisticIterator), probe->getWindowMatch()};
+
+    const auto wrapper = std::make_shared<PhysicalOperatorWrapper>(
+        reader,
+        inputSchema,
+        outputSchema,
+        memoryLayoutType,
+        memoryLayoutType,
+        handlerId,
+        handler,
+        PhysicalOperatorWrapper::PipelineLocation::INTERMEDIATE);
+
+    std::vector leaves(logicalOperator.getChildren().size(), wrapper);
+    return {.root = wrapper, .leaves = {leaves}};
+}
+
+}

--- a/nes-query-compiler/src/LoweringRules/LowerToPhysical/LowerToPhysicalStatisticStoreWriter.cpp
+++ b/nes-query-compiler/src/LoweringRules/LowerToPhysical/LowerToPhysicalStatisticStoreWriter.cpp
@@ -1,0 +1,88 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <LoweringRules/LowerToPhysical/LowerToPhysicalStatisticStoreWriter.hpp>
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <Identifiers/StatisticIdentifiers.hpp>
+#include <LoweringRules/AbstractLoweringRule.hpp>
+#include <LoweringRules/LowerToPhysical/StatisticFieldResolution.hpp>
+#include <Operators/LogicalOperator.hpp>
+#include <Operators/Statistic/StatisticStoreWriterLogicalOperator.hpp>
+#include <Runtime/Execution/OperatorHandler.hpp>
+#include <StatisticStore/AbstractStatisticStore.hpp>
+#include <Statistics/StatisticStoreOperatorHandler.hpp>
+#include <Statistics/StatisticStoreWriterPhysicalOperator.hpp>
+#include <Traits/MemoryLayoutTypeTrait.hpp>
+#include <Util/SchemaFactory.hpp>
+#include <ErrorHandling.hpp>
+#include <LoweringRuleRegistry.hpp>
+#include <PhysicalOperator.hpp>
+
+#include <Operators/Statistic/StatisticFieldNames.hpp>
+
+namespace NES
+{
+
+LoweringRuleResultSubgraph LowerToPhysicalStatisticStoreWriter::apply(LogicalOperator logicalOperator)
+{
+    const auto statisticStoreWriter = logicalOperator.getAs<StatisticStoreWriterLogicalOperator>();
+    const auto traitSet = logicalOperator.getTraitSet();
+
+    const auto memoryLayoutTypeTrait = traitSet.get<MemoryLayoutTypeTrait>();
+    const auto memoryLayoutType = memoryLayoutTypeTrait->memoryLayout;
+
+    const auto physicalInputSchema = createPhysicalOutputSchema(statisticStoreWriter->getChild()->getTraitSet());
+    const auto physicalOutputSchema = createPhysicalOutputSchema(traitSet);
+
+    const auto statisticId = statisticStoreWriter->getStatisticId();
+    const auto fieldNames = statisticStoreWriter->getFieldNames();
+
+    const auto payloadFieldName = resolvePhysicalFieldName(physicalInputSchema, fieldNames.inputStatisticData);
+    const auto payloadField = physicalInputSchema[payloadFieldName];
+    INVARIANT(payloadField.has_value(), "The statistic payload field must be part of the physical input schema");
+
+    StatisticStoreWriterPhysicalOperator::FieldIdentifiers fieldIdentifiers{
+        .inputStatisticStart = resolvePhysicalFieldName(physicalInputSchema, fieldNames.inputStatisticStart),
+        .inputStatisticEnd = resolvePhysicalFieldName(physicalInputSchema, fieldNames.inputStatisticEnd),
+        .inputStatisticData = payloadFieldName,
+        .inputNumberOfSeenMeasurements = resolvePhysicalFieldName(physicalInputSchema, fieldNames.inputNumberOfSeenMeasurements),
+        .outputStatisticId = resolvePhysicalFieldName(physicalOutputSchema, StatisticFieldNames::STATISTIC_ID),
+        .outputStatisticStart = resolvePhysicalFieldName(physicalOutputSchema, StatisticFieldNames::START_TS),
+        .outputStatisticEnd = resolvePhysicalFieldName(physicalOutputSchema, StatisticFieldNames::END_TS),
+        .outputNumberOfSeenMeasurements = resolvePhysicalFieldName(physicalOutputSchema, StatisticFieldNames::NUMBER_OF_SEEN_MEASUREMENTS),
+    };
+
+    auto handlerId = getNextOperatorHandlerId();
+    auto handler = std::make_shared<StatisticStoreOperatorHandler>(globalStatisticStore());
+    StatisticStoreWriterPhysicalOperator physicalOperator{
+        handlerId, statisticId, statisticStoreWriter->getTypeName(), std::move(fieldIdentifiers), payloadField.value().getDataType()};
+    const auto wrapper = std::make_shared<PhysicalOperatorWrapper>(
+        std::move(physicalOperator),
+        physicalInputSchema,
+        physicalOutputSchema,
+        memoryLayoutType,
+        memoryLayoutType,
+        handlerId,
+        handler,
+        PhysicalOperatorWrapper::PipelineLocation::INTERMEDIATE);
+
+    std::vector leaves{logicalOperator.getChildren().size(), wrapper};
+    return {.root = wrapper, .leaves = {leaves}};
+}
+
+}

--- a/nes-query-compiler/src/LoweringRules/LowerToPhysical/LowerToPhysicalWindowedAggregation.cpp
+++ b/nes-query-compiler/src/LoweringRules/LowerToPhysical/LowerToPhysicalWindowedAggregation.cpp
@@ -111,7 +111,7 @@ getAggregationPhysicalFunctions(const WindowedAggregationLogicalOperator& logica
             std::move(aggregationInputFunction),
             resultFieldIdentifier,
             tupleLayout,
-            descriptor.function.shallIncludeNullValues());
+            descriptor.function);
         if (const auto aggregationFactory = AggregationPhysicalFunctionRegistry::instance().find(std::string{name}))
         {
             aggregationPhysicalFunctions.push_back((*aggregationFactory)(std::move(aggregationArguments)));

--- a/nes-query-compiler/src/Phases/LowerToPhysicalOperators.cpp
+++ b/nes-query-compiler/src/Phases/LowerToPhysicalOperators.cpp
@@ -121,7 +121,7 @@ lowerOperatorRecursively(const LogicalOperator& logicalOperator, const LoweringR
     return root;
 }
 
-PhysicalPlan apply(const LogicalPlan& queryPlan, const QueryExecutionConfiguration& conf) /// NOLINT
+PhysicalPlan apply(const LogicalPlan& queryPlan, const QueryExecutionConfiguration& conf)
 {
     const auto registryArgument = LoweringRuleRegistryArguments{conf};
     std::vector<std::shared_ptr<PhysicalOperatorWrapper>> newRootOperators;

--- a/nes-query-optimizer/src/Rules/Static/ProjectionPushdownRule.cpp
+++ b/nes-query-optimizer/src/Rules/Static/ProjectionPushdownRule.cpp
@@ -407,6 +407,14 @@ pushBeyondWindowedAggregation(const TypedLogicalOperator<WindowedAggregationLogi
         }
     }
 
+    if (std::ranges::any_of(newAggregations, [](const auto& agg) { return agg.function.requiresAllInputFields(); }))
+    {
+        newRequired.clear();
+        for (const auto& field : op->getChild().getOutputSchema())
+        {
+            newRequired.insert(field);
+        }
+    }
 
     return {.operatorContext = {newAggregations}, .downContexts = {{op->getChild(), newRequired}}};
 }

--- a/nes-sql-parser/private/AntlrSQLParser/AntlrSQLHelper.hpp
+++ b/nes-sql-parser/private/AntlrSQLParser/AntlrSQLHelper.hpp
@@ -16,6 +16,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -23,6 +24,10 @@
 #include <variant>
 #include <vector>
 #include <Functions/LogicalFunction.hpp>
+#include <Identifiers/StatisticIdentifiers.hpp>
+#include <Operators/Statistic/StatisticBlobType.hpp>
+#include <Operators/Statistic/StatisticStoreReaderLogicalOperator.hpp>
+#include <Operators/Statistic/StatisticWindowMatch.hpp>
 #include <Operators/Windows/Aggregations/WindowAggregationLogicalFunction.hpp>
 #include <Operators/Windows/JoinLogicalOperator.hpp>
 #include <Plans/LogicalPlan.hpp>
@@ -76,6 +81,25 @@ public:
 
     std::optional<Windowing::TimeBasedWindowType> windowType;
     std::vector<std::pair<WindowAggregationLogicalFunction, std::optional<Identifier>>> windowAggs;
+
+    struct StatisticBuildInfo
+    {
+        StatisticId statisticId;
+        WindowAggregationLogicalFunction statisticFunction;
+        std::string functionName;
+    };
+
+    std::optional<StatisticBuildInfo> statisticBuild;
+
+    struct StatisticProbeInfo
+    {
+        StatisticId statisticId;
+        StatisticBlobType blobType;
+        std::vector<StatisticStoreReaderLogicalOperator::PayloadField> payloadFields;
+        StatisticWindowMatch windowMatch;
+    };
+
+    std::optional<StatisticProbeInfo> statisticProbe;
     std::vector<SinkDescriptor> sinkDescriptor;
     std::vector<std::string> constantBuilder;
     std::vector<LogicalFunction> functionBuilder;

--- a/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
+++ b/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
@@ -55,12 +55,16 @@
 #include <Functions/LogicalFunctionProvider.hpp>
 #include <Functions/UnboundFieldAccessLogicalFunction.hpp>
 #include <Identifiers/Identifier.hpp>
+#include <Identifiers/StatisticIdentifiers.hpp>
 #include <Operators/ProjectionLogicalOperator.hpp>
+#include <Operators/Statistic/StatisticBlobType.hpp>
+#include <Operators/Statistic/StatisticStoreReaderLogicalOperator.hpp>
 #include <Operators/Windows/Aggregations/AvgAggregationLogicalFunction.hpp>
 #include <Operators/Windows/Aggregations/CountAggregationLogicalFunction.hpp>
 #include <Operators/Windows/Aggregations/MaxAggregationLogicalFunction.hpp>
 #include <Operators/Windows/Aggregations/MedianAggregationLogicalFunction.hpp>
 #include <Operators/Windows/Aggregations/MinAggregationLogicalFunction.hpp>
+#include <Operators/Windows/Aggregations/ReservoirSampleAggregationLogicalFunction.hpp>
 #include <Operators/Windows/Aggregations/SumAggregationLogicalFunction.hpp>
 #include <Operators/Windows/Aggregations/WindowAggregationLogicalFunction.hpp>
 #include <Operators/Windows/JoinLogicalOperator.hpp>
@@ -190,6 +194,181 @@ bool isInsideDataTypeConstructorArgument(antlr4::ParserRuleContext* context)
 LogicalFunction createRawLiteralFunction(std::string literal)
 {
     return ConstantValueLogicalFunction(DataTypeProvider::provideDataType(DataType::Type::UNDEFINED), std::move(literal));
+}
+
+/// The seed RESERVOIR uses when the query does not name one; eviction and merge decisions are driven by it.
+constexpr uint64_t DEFAULT_RESERVOIR_SEED = 42;
+
+uint64_t
+parseUnsignedConstantArgument(const LogicalFunction& argument, const std::string_view description, const std::string_view queryText)
+{
+    const auto constant = argument.tryGetAs<ConstantValueLogicalFunction>();
+    if (not constant)
+    {
+        throw InvalidQuerySyntax("Expected an unsigned integer constant for {} at {}", description, queryText);
+    }
+    const auto parsed = NES::from_chars<uint64_t>(constant.value()->getConstantValue());
+    if (not parsed.has_value())
+    {
+        throw InvalidQuerySyntax(
+            "Expected an unsigned integer constant for {}, but got {} at {}", description, constant.value()->getConstantValue(), queryText);
+    }
+    return parsed.value();
+}
+
+/// RESERVOIR(statisticId, sampleSize): builds a reservoir sample over the whole input records of a window
+AntlrSQLHelper::StatisticBuildInfo bindReservoirBuild(const std::vector<LogicalFunction>& arguments, const std::string_view queryText)
+{
+    if (arguments.size() < 2 or arguments.size() > 3)
+    {
+        throw InvalidQuerySyntax("RESERVOIR expects two or three arguments (statisticId, sampleSize[, seed]) at {}", queryText);
+    }
+    const auto statisticId = parseUnsignedConstantArgument(arguments[0], "the RESERVOIR statisticId", queryText);
+    const auto sampleSize = parseUnsignedConstantArgument(arguments[1], "the RESERVOIR sampleSize", queryText);
+    if (statisticId == StatisticId::INVALID or sampleSize == 0)
+    {
+        throw InvalidQuerySyntax("RESERVOIR requires a valid statisticId and a sampleSize greater than zero at {}", queryText);
+    }
+    const auto seed
+        = arguments.size() == 3 ? parseUnsignedConstantArgument(arguments[2], "the RESERVOIR seed", queryText) : DEFAULT_RESERVOIR_SEED;
+    return {
+        .statisticId = StatisticId(statisticId),
+        .statisticFunction = WindowAggregationLogicalFunction{ReservoirSampleAggregationLogicalFunction{sampleSize, seed}},
+        .functionName = "RESERVOIR"};
+}
+
+std::vector<StatisticStoreReaderLogicalOperator::PayloadField> parsePayloadFields(
+    const std::vector<LogicalFunction>& arguments,
+    const size_t firstArgumentIdx,
+    const std::string_view functionName,
+    const std::string_view queryText)
+{
+    std::vector<StatisticStoreReaderLogicalOperator::PayloadField> payloadFields;
+    for (size_t argumentIdx = firstArgumentIdx; argumentIdx < arguments.size(); argumentIdx += 2)
+    {
+        const auto fieldAccess = arguments[argumentIdx].tryGetAs<UnboundFieldAccessLogicalFunction>();
+        const auto typeAccess = arguments[argumentIdx + 1].tryGetAs<UnboundFieldAccessLogicalFunction>();
+        if (not fieldAccess or not typeAccess)
+        {
+            throw InvalidQuerySyntax("{} expects (fieldName, typeName) pairs at {}", functionName, queryText);
+        }
+        const auto typeName = toUpperCase(std::string{typeAccess.value()->getFieldName().getOriginalString()});
+        const auto dataType = DataTypeProvider::tryProvideDataType(typeName);
+        if (not dataType.has_value())
+        {
+            throw InvalidQuerySyntax("{} got an unknown data type {} at {}", functionName, typeName, queryText);
+        }
+        payloadFields.emplace_back(fieldAccess.value()->getFieldName(), dataType.value());
+    }
+    return payloadFields;
+}
+
+AntlrSQLHelper::StatisticProbeInfo bindReservoirProbe(const std::vector<LogicalFunction>& arguments, const std::string_view queryText)
+{
+    if (arguments.size() < 3 or arguments.size() % 2 == 0)
+    {
+        throw InvalidQuerySyntax("RESERVOIR_PROBE expects a statisticId followed by (fieldName, typeName) pairs at {}", queryText);
+    }
+    const auto statisticId = parseUnsignedConstantArgument(arguments[0], "the RESERVOIR_PROBE statisticId", queryText);
+    if (statisticId == StatisticId::INVALID)
+    {
+        throw InvalidQuerySyntax("RESERVOIR_PROBE requires a valid statisticId at {}", queryText);
+    }
+    return {
+        .statisticId = StatisticId(statisticId),
+        .blobType = StatisticBlobType{ReservoirSampleAggregationLogicalFunction::NAME},
+        .payloadFields = parsePayloadFields(arguments, 1, "RESERVOIR_PROBE", queryText),
+        .windowMatch = StatisticWindowMatch::ExactWindow};
+}
+
+std::string
+parseStringConstantArgument(const LogicalFunction& argument, const std::string_view description, const std::string_view queryText)
+{
+    const auto constant = argument.tryGetAs<ConstantValueLogicalFunction>();
+    if (not constant)
+    {
+        throw InvalidQuerySyntax("Expected a quoted string constant for {} at {}", description, queryText);
+    }
+    const auto raw = constant.value()->getConstantValue();
+    if (raw.size() < 2 or raw.front() != '\'' or raw.back() != '\'')
+    {
+        throw InvalidQuerySyntax("Expected a quoted string constant for {}, but got {} at {}", description, raw, queryText);
+    }
+    return raw.substr(1, raw.size() - 2);
+}
+
+WindowAggregationLogicalFunction
+bindStatisticAggregation(const std::string& metricName, const AggregationFieldAccess& field, const std::string_view queryText)
+{
+    const auto metric = toUpperCase(metricName);
+    if (metric == "AVG")
+    {
+        return WindowAggregationLogicalFunction{AvgAggregationLogicalFunction{field}};
+    }
+    if (metric == "MIN")
+    {
+        return WindowAggregationLogicalFunction{MinAggregationLogicalFunction{field}};
+    }
+    if (metric == "MAX")
+    {
+        return WindowAggregationLogicalFunction{MaxAggregationLogicalFunction{field}};
+    }
+    if (metric == "SUM")
+    {
+        return WindowAggregationLogicalFunction{SumAggregationLogicalFunction{field}};
+    }
+    if (metric == "COUNT")
+    {
+        return WindowAggregationLogicalFunction{CountAggregationLogicalFunction{field, true}};
+    }
+    throw InvalidQuerySyntax("STATISTIC_BUILD got an unknown metric {} at {}", metricName, queryText);
+}
+
+AntlrSQLHelper::StatisticBuildInfo bindStatisticBuild(const std::vector<LogicalFunction>& arguments, const std::string_view queryText)
+{
+    if (arguments.size() != 3)
+    {
+        throw InvalidQuerySyntax("STATISTIC_BUILD expects exactly three arguments (statisticId, metricName, field) at {}", queryText);
+    }
+    const auto statisticId = parseUnsignedConstantArgument(arguments[0], "the STATISTIC_BUILD statisticId", queryText);
+    if (statisticId == StatisticId::INVALID)
+    {
+        throw InvalidQuerySyntax("STATISTIC_BUILD requires a valid statisticId at {}", queryText);
+    }
+    const auto metricName = parseStringConstantArgument(arguments[1], "the STATISTIC_BUILD metric name", queryText);
+    const auto fieldAccess = arguments[2].tryGetAs<UnboundFieldAccessLogicalFunction>();
+    if (not fieldAccess)
+    {
+        throw InvalidQuerySyntax("STATISTIC_BUILD expects a field name as its third argument at {}", queryText);
+    }
+    return {
+        .statisticId = StatisticId(statisticId),
+        .statisticFunction = bindStatisticAggregation(metricName, arguments[2].getAs<UnboundFieldAccessLogicalFunction>(), queryText),
+        .functionName = "STATISTIC_BUILD"};
+}
+
+AntlrSQLHelper::StatisticProbeInfo bindStatisticProbe(
+    const std::vector<LogicalFunction>& arguments,
+    const std::string_view functionName,
+    const StatisticWindowMatch windowMatch,
+    const std::string_view queryText)
+{
+    if (arguments.size() < 4 or arguments.size() % 2 != 0)
+    {
+        throw InvalidQuerySyntax(
+            "{} expects a statisticId and a blob type followed by (fieldName, typeName) pairs at {}", functionName, queryText);
+    }
+    const auto statisticId = parseUnsignedConstantArgument(arguments[0], fmt::format("the {} statisticId", functionName), queryText);
+    if (statisticId == StatisticId::INVALID)
+    {
+        throw InvalidQuerySyntax("{} requires a valid statisticId at {}", functionName, queryText);
+    }
+    const auto blobType = parseStringConstantArgument(arguments[1], fmt::format("the {} blob type", functionName), queryText);
+    return {
+        .statisticId = StatisticId(statisticId),
+        .blobType = StatisticBlobType{blobType},
+        .payloadFields = parsePayloadFields(arguments, 2, functionName, queryText),
+        .windowMatch = windowMatch};
 }
 
 LogicalFunction createNegatedNumericLiteralFunction(const ConstantValueLogicalFunction& constantFunction)
@@ -783,7 +962,37 @@ void AntlrSQLQueryPlanCreator::exitPrimaryQuery(AntlrSQLParser::PrimaryQueryCont
     }
 
     auto windowTypeOpt = helpers.top().windowType;
-    if (windowTypeOpt.has_value() && helpers.top().joinKeyRelationHelper.empty())
+    if (helpers.top().statisticBuild.has_value())
+    {
+        const auto& functionName = helpers.top().statisticBuild->functionName;
+        if (!windowTypeOpt.has_value() || !helpers.top().joinKeyRelationHelper.empty())
+        {
+            throw InvalidQuerySyntax("{} requires a time-based window and cannot be combined with a join", functionName);
+        }
+        if (!helpers.top().windowAggs.empty() || !helpers.top().groupByFields.empty())
+        {
+            throw InvalidQuerySyntax("{} cannot be combined with other aggregation functions or GROUP BY", functionName);
+        }
+        const auto currentWindowTimestampOpt = helpers.top().windowTimestamp;
+        if (!currentWindowTimestampOpt.has_value()
+            || !std::holds_alternative<Windowing::UnboundTimeCharacteristic>(currentWindowTimestampOpt.value()))
+        {
+            throw InvalidQuerySyntax(
+                "{} requires exactly one time characteristic, got {}",
+                functionName,
+                currentWindowTimestampOpt.has_value() ? "two" : "none");
+        }
+        auto characteristic = std::get<Windowing::UnboundTimeCharacteristic>(currentWindowTimestampOpt.value());
+        queryPlan = LogicalPlanBuilder::addStatisticBuild(
+            queryPlan,
+            windowTypeOpt.value(),
+            std::move(characteristic),
+            helpers.top().statisticBuild->statisticId,
+            helpers.top().statisticBuild->statisticFunction);
+        /// The statistic store writer already emits exactly the statistic metadata fields
+        helpers.top().asterisk = true;
+    }
+    else if (windowTypeOpt.has_value() && helpers.top().joinKeyRelationHelper.empty())
     {
         const auto currentWindowTimestampOpt = helpers.top().windowTimestamp;
         if (!currentWindowTimestampOpt.has_value()
@@ -810,6 +1019,17 @@ void AntlrSQLQueryPlanCreator::exitPrimaryQuery(AntlrSQLParser::PrimaryQueryCont
             aggregations | std::ranges::to<std::vector>(),
             helpers.top().groupByFields,
             std::move(characteristic));
+    }
+
+    if (helpers.top().statisticProbe.has_value())
+    {
+        queryPlan = LogicalPlanBuilder::addStatisticProbe(
+            queryPlan,
+            helpers.top().statisticProbe->statisticId,
+            helpers.top().statisticProbe->blobType,
+            std::move(helpers.top().statisticProbe->payloadFields),
+            helpers.top().statisticProbe->windowMatch);
+        helpers.top().asterisk = true;
     }
 
     auto projections = helpers.top().getProjections()
@@ -1274,8 +1494,51 @@ void AntlrSQLQueryPlanCreator::exitFunctionCall(AntlrSQLParser::FunctionCallCont
                 std::nullopt);
             isAggregation = true;
             break;
-        default:
+        default: {
             helpers.top().hasUnnamedAggregation = false;
+            if (funcName == "RESERVOIR" or funcName == "RESERVOIR_PROBE" or funcName == "STATISTIC_BUILD" or funcName == "STATISTIC_PROBE"
+                or funcName == "STATISTIC_PROBE_RANGE")
+            {
+                const auto numArgs = context->argument.size();
+                if (numArgs > helpers.top().functionBuilder.size())
+                {
+                    throw InvalidQuerySyntax(
+                        "Function '{}' expects {} arguments but only {} are available",
+                        funcName,
+                        numArgs,
+                        helpers.top().functionBuilder.size());
+                }
+                const auto argsBegin = helpers.top().functionBuilder.end() - static_cast<std::ptrdiff_t>(numArgs);
+                const std::vector<LogicalFunction> statisticArgs(argsBegin, helpers.top().functionBuilder.end());
+                helpers.top().functionBuilder.resize(helpers.top().functionBuilder.size() - numArgs);
+                if (funcName == "RESERVOIR" or funcName == "STATISTIC_BUILD")
+                {
+                    if (helpers.top().statisticBuild.has_value())
+                    {
+                        throw InvalidQuerySyntax("Only one statistic build is supported per query at {}", context->getText());
+                    }
+                    helpers.top().statisticBuild = funcName == "RESERVOIR" ? bindReservoirBuild(statisticArgs, context->getText())
+                                                                           : bindStatisticBuild(statisticArgs, context->getText());
+                }
+                else
+                {
+                    if (helpers.top().statisticProbe.has_value())
+                    {
+                        throw InvalidQuerySyntax("Only one statistic probe is supported per query at {}", context->getText());
+                    }
+                    if (funcName == "RESERVOIR_PROBE")
+                    {
+                        helpers.top().statisticProbe = bindReservoirProbe(statisticArgs, context->getText());
+                    }
+                    else
+                    {
+                        const auto windowMatch
+                            = funcName == "STATISTIC_PROBE_RANGE" ? StatisticWindowMatch::WithinRange : StatisticWindowMatch::ExactWindow;
+                        helpers.top().statisticProbe = bindStatisticProbe(statisticArgs, funcName, windowMatch, context->getText());
+                    }
+                }
+                break;
+            }
             /// Check if the function is a constructor for a datatype
             if (const auto dataType = DataTypeProvider::tryProvideDataType(funcName); dataType.has_value())
             {
@@ -1317,6 +1580,7 @@ void AntlrSQLQueryPlanCreator::exitFunctionCall(AntlrSQLParser::FunctionCallCont
                     throw InvalidQuerySyntax("Unknown (aggregation) function: {}, resolved to token type: {}", funcName, tokenType);
                 }
             }
+        }
     }
 
     /// For aggregation functions, generate an auto-name for the result field and replace the raw

--- a/nes-statistics/include/Statistics/ReservoirSampleBlob.hpp
+++ b/nes-statistics/include/Statistics/ReservoirSampleBlob.hpp
@@ -1,0 +1,68 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include <DataTypes/DataType.hpp>
+#include <Interface/Record.hpp>
+#include <val_arith.hpp>
+#include <val_ptr.hpp>
+
+namespace NES
+{
+
+/// Layout of the serialized reservoir sample statistic blob:
+/// | tupleCount: uint64 @ 0 | dataSizeBytes: uint64 @ 8 | tuple data @ 16 |
+/// Tuples are stored back-to-back in the field order of the build's input schema, without null bytes
+/// (nullable input fields are rejected during lowering). Fixed-size fields take getSizeInBytesWithoutNull()
+/// bytes; VARSIZED fields are stored as a uint32 length prefix followed by the content.
+struct ReservoirSampleBlob
+{
+    static constexpr uint64_t TUPLE_COUNT_OFFSET = 0;
+    static constexpr uint64_t DATA_SIZE_OFFSET = 8;
+    static constexpr uint64_t HEADER_SIZE = 16;
+    static constexpr uint64_t VARSIZED_LENGTH_PREFIX_SIZE = sizeof(uint32_t);
+};
+
+/// A field of the sample tuples as declared by the probe (or derived from the build's input schema).
+struct ReservoirSampleField
+{
+    Record::RecordFieldIdentifier name;
+    DataType type;
+};
+
+/// Nautilus accessors for the blob header
+void writeReservoirSampleBlobHeader(
+    const nautilus::val<int8_t*>& blobMemArea, const nautilus::val<uint64_t>& tupleCount, const nautilus::val<uint64_t>& dataSizeBytes);
+[[nodiscard]] nautilus::val<uint64_t> readReservoirSampleBlobTupleCount(const nautilus::val<int8_t*>& blobMemArea);
+[[nodiscard]] nautilus::val<int8_t*> getReservoirSampleBlobDataArea(const nautilus::val<int8_t*>& blobMemArea);
+
+/// Iterates the sample tuples of a reservoir sample blob. Not a full C++ iterator: the caller drives the
+/// loop with the tuple count from the header.
+class ReservoirSampleBlobRowReader
+{
+public:
+    ReservoirSampleBlobRowReader(const nautilus::val<int8_t*>& blobMemArea, const std::vector<ReservoirSampleField>& fields);
+
+    /// Reads the tuple at the current position into a Record and advances the cursor past it.
+    [[nodiscard]] Record readNextTuple();
+
+private:
+    nautilus::val<int8_t*> cursor;
+    const std::vector<ReservoirSampleField>& fields;
+};
+
+}

--- a/nes-statistics/include/Statistics/ReservoirSampleStatisticIterator.hpp
+++ b/nes-statistics/include/Statistics/ReservoirSampleStatisticIterator.hpp
@@ -1,0 +1,41 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+#include <Interface/Record.hpp>
+#include <Statistics/ReservoirSampleBlob.hpp>
+#include <Statistics/StatisticIterator.hpp>
+#include <val_ptr.hpp>
+
+namespace NES
+{
+
+class ReservoirSampleStatisticIterator final : public StatisticIterator
+{
+public:
+    explicit ReservoirSampleStatisticIterator(std::vector<ReservoirSampleField> sampleFields);
+
+    [[nodiscard]] uint64_t getExpectedPayloadSizeInBytes() const override;
+    void forEachRecord(const nautilus::val<int8_t*>& payload, const std::function<void(Record&)>& emit) const override;
+
+private:
+    std::vector<ReservoirSampleField> sampleFields;
+};
+
+}

--- a/nes-statistics/include/Statistics/ScalarStatisticIterator.hpp
+++ b/nes-statistics/include/Statistics/ScalarStatisticIterator.hpp
@@ -1,0 +1,42 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+
+#include <DataTypes/DataType.hpp>
+#include <Interface/Record.hpp>
+#include <Operators/Statistic/StatisticBlobType.hpp>
+#include <Statistics/StatisticIterator.hpp>
+#include <val_ptr.hpp>
+
+namespace NES
+{
+
+class ScalarStatisticIterator final : public StatisticIterator
+{
+public:
+    ScalarStatisticIterator(StatisticBlobType typeName, DataType valueType, Record::RecordFieldIdentifier outputValueFieldName);
+
+    [[nodiscard]] uint64_t getExpectedPayloadSizeInBytes() const override;
+    void forEachRecord(const nautilus::val<int8_t*>& payload, const std::function<void(Record&)>& emit) const override;
+
+private:
+    DataType valueType;
+    Record::RecordFieldIdentifier outputValueFieldName;
+};
+
+}

--- a/nes-statistics/include/Statistics/StatisticIterator.hpp
+++ b/nes-statistics/include/Statistics/StatisticIterator.hpp
@@ -1,0 +1,47 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <Operators/Statistic/StatisticBlobType.hpp>
+
+#include <Interface/Record.hpp>
+#include <val_ptr.hpp>
+
+namespace NES
+{
+
+class StatisticIterator
+{
+public:
+    explicit StatisticIterator(StatisticBlobType typeName);
+    virtual ~StatisticIterator() = default;
+    StatisticIterator(const StatisticIterator&) = delete;
+    StatisticIterator& operator=(const StatisticIterator&) = delete;
+    StatisticIterator(StatisticIterator&&) = delete;
+    StatisticIterator& operator=(StatisticIterator&&) = delete;
+
+    [[nodiscard]] const StatisticBlobType& getStatisticBlobType() const;
+
+    [[nodiscard]] virtual uint64_t getExpectedPayloadSizeInBytes() const = 0;
+
+    virtual void forEachRecord(const nautilus::val<int8_t*>& payload, const std::function<void(Record&)>& emit) const = 0;
+
+private:
+    StatisticBlobType typeName;
+};
+
+}

--- a/nes-statistics/src/Statistics/CMakeLists.txt
+++ b/nes-statistics/src/Statistics/CMakeLists.txt
@@ -10,9 +10,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(StatisticStore)
-add_subdirectory(Statistics)
-
 add_source_files(nes-statistics
-        StatisticTuple.cpp
+        ReservoirSampleBlob.cpp
+        StatisticIterator.cpp
+        ScalarStatisticIterator.cpp
+        ReservoirSampleStatisticIterator.cpp
 )

--- a/nes-statistics/src/Statistics/ReservoirSampleBlob.cpp
+++ b/nes-statistics/src/Statistics/ReservoirSampleBlob.cpp
@@ -1,0 +1,76 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Statistics/ReservoirSampleBlob.hpp>
+
+#include <cstdint>
+#include <vector>
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/DataTypesUtil.hpp>
+#include <DataTypes/VarVal.hpp>
+#include <DataTypes/VariableSizedData.hpp>
+#include <Interface/Record.hpp>
+#include <static.hpp>
+#include <val_arith.hpp>
+#include <val_ptr.hpp>
+
+namespace NES
+{
+
+void writeReservoirSampleBlobHeader(
+    const nautilus::val<int8_t*>& blobMemArea, const nautilus::val<uint64_t>& tupleCount, const nautilus::val<uint64_t>& dataSizeBytes)
+{
+    VarVal{tupleCount}.writeToMemory(blobMemArea + nautilus::val<uint64_t>{ReservoirSampleBlob::TUPLE_COUNT_OFFSET});
+    VarVal{dataSizeBytes}.writeToMemory(blobMemArea + nautilus::val<uint64_t>{ReservoirSampleBlob::DATA_SIZE_OFFSET});
+}
+
+nautilus::val<uint64_t> readReservoirSampleBlobTupleCount(const nautilus::val<int8_t*>& blobMemArea)
+{
+    return readValueFromMemRef<uint64_t>(blobMemArea + nautilus::val<uint64_t>{ReservoirSampleBlob::TUPLE_COUNT_OFFSET});
+}
+
+nautilus::val<int8_t*> getReservoirSampleBlobDataArea(const nautilus::val<int8_t*>& blobMemArea)
+{
+    return blobMemArea + nautilus::val<uint64_t>{ReservoirSampleBlob::HEADER_SIZE};
+}
+
+ReservoirSampleBlobRowReader::ReservoirSampleBlobRowReader(
+    const nautilus::val<int8_t*>& blobMemArea, const std::vector<ReservoirSampleField>& fields)
+    : cursor(getReservoirSampleBlobDataArea(blobMemArea)), fields(fields)
+{
+}
+
+Record ReservoirSampleBlobRowReader::readNextTuple()
+{
+    Record record;
+    for (nautilus::static_val<uint64_t> i = 0; i < fields.size(); ++i)
+    {
+        const auto& [name, type] = fields[i];
+        if (type.type == DataType::Type::VARSIZED)
+        {
+            const auto contentSize = static_cast<nautilus::val<uint64_t>>(readValueFromMemRef<uint32_t>(cursor));
+            const auto contentPtr = cursor + nautilus::val<uint64_t>{ReservoirSampleBlob::VARSIZED_LENGTH_PREFIX_SIZE};
+            record.write(name, VarVal{VariableSizedData{contentPtr, contentSize}});
+            cursor = contentPtr + contentSize;
+        }
+        else
+        {
+            record.write(name, VarVal::readNonNullableVarValFromMemory(cursor, type));
+            cursor = cursor + nautilus::val<uint64_t>{type.getSizeInBytesWithoutNull()};
+        }
+    }
+    return record;
+}
+
+}

--- a/nes-statistics/src/Statistics/ReservoirSampleStatisticIterator.cpp
+++ b/nes-statistics/src/Statistics/ReservoirSampleStatisticIterator.cpp
@@ -1,0 +1,53 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Statistics/ReservoirSampleStatisticIterator.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <utility>
+#include <vector>
+
+#include <Interface/Record.hpp>
+#include <Operators/Statistic/StatisticBlobType.hpp>
+#include <Operators/Windows/Aggregations/ReservoirSampleAggregationLogicalFunction.hpp>
+#include <Statistics/ReservoirSampleBlob.hpp>
+#include <val_arith.hpp>
+#include <val_ptr.hpp>
+
+namespace NES
+{
+
+ReservoirSampleStatisticIterator::ReservoirSampleStatisticIterator(std::vector<ReservoirSampleField> sampleFields)
+    : StatisticIterator(StatisticBlobType{ReservoirSampleAggregationLogicalFunction::NAME}), sampleFields(std::move(sampleFields))
+{
+}
+
+uint64_t ReservoirSampleStatisticIterator::getExpectedPayloadSizeInBytes() const
+{
+    return 0;
+}
+
+void ReservoirSampleStatisticIterator::forEachRecord(const nautilus::val<int8_t*>& payload, const std::function<void(Record&)>& emit) const
+{
+    const auto tupleCount = readReservoirSampleBlobTupleCount(payload);
+    ReservoirSampleBlobRowReader rowReader(payload, sampleFields);
+    for (nautilus::val<uint64_t> i = 0; i < tupleCount; i = i + 1)
+    {
+        Record sampleRecord = rowReader.readNextTuple();
+        emit(sampleRecord);
+    }
+}
+
+}

--- a/nes-statistics/src/Statistics/ScalarStatisticIterator.cpp
+++ b/nes-statistics/src/Statistics/ScalarStatisticIterator.cpp
@@ -1,0 +1,48 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Statistics/ScalarStatisticIterator.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <utility>
+
+#include <DataTypes/DataType.hpp>
+#include <DataTypes/VarVal.hpp>
+#include <Interface/Record.hpp>
+#include <Operators/Statistic/StatisticBlobType.hpp>
+#include <val_ptr.hpp>
+
+namespace NES
+{
+
+ScalarStatisticIterator::ScalarStatisticIterator(
+    StatisticBlobType typeName, DataType valueType, Record::RecordFieldIdentifier outputValueFieldName)
+    : StatisticIterator(std::move(typeName)), valueType(std::move(valueType)), outputValueFieldName(std::move(outputValueFieldName))
+{
+}
+
+uint64_t ScalarStatisticIterator::getExpectedPayloadSizeInBytes() const
+{
+    return valueType.getSizeInBytesWithoutNull();
+}
+
+void ScalarStatisticIterator::forEachRecord(const nautilus::val<int8_t*>& payload, const std::function<void(Record&)>& emit) const
+{
+    Record statisticRecord;
+    statisticRecord.write(outputValueFieldName, VarVal::readNonNullableVarValFromMemory(payload, valueType));
+    emit(statisticRecord);
+}
+
+}

--- a/nes-statistics/src/Statistics/StatisticIterator.cpp
+++ b/nes-statistics/src/Statistics/StatisticIterator.cpp
@@ -1,0 +1,32 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <Statistics/StatisticIterator.hpp>
+
+#include <utility>
+#include <Operators/Statistic/StatisticBlobType.hpp>
+
+namespace NES
+{
+
+StatisticIterator::StatisticIterator(StatisticBlobType typeName) : typeName(std::move(typeName))
+{
+}
+
+const StatisticBlobType& StatisticIterator::getStatisticBlobType() const
+{
+    return typeName;
+}
+
+}


### PR DESCRIPTION
Ports the reservoir sample from the ESPAT fork and reworks it against the current logical and physical operator APIs. Rather than registering the sample as a window aggregation function alongside Sum and Avg, it gets its own StatisticBuild logical operator: it aggregates all tuples of a time-based window into a single opaque statistic blob instead of per-key aggregates, so its output schema is fixed to the statistic metadata.

Adds nes-statistics, holding the per-worker statistic store (Statistic, AbstractStatisticStore, DefaultStatisticStore), and three logical operators: StatisticBuild, StatisticStoreWriter, which persists the blob and re-emits the metadata, and ReservoirProbe, which unpacks a stored sample back into a record stream.

The physical side reuses the windowed-aggregation machinery through ReservoirSamplePhysicalFunction (Algorithm R), keeping the sample in a PagedVector child buffer of the hash map. Combining two reservoirs draws the survivors from a hypergeometric distribution (ReservoirMerge) instead of concatenating them, so a merged sample stays uniform over the union. In-place eviction required the new PagedVectorRef::replaceRecord.

Lowering rules receive the worker's statistic store through LoweringRuleRegistryArguments; a rule that needs it declares a constructor taking the whole arguments struct.

SQL surface: RESERVOIR(statisticId, sampleSize) builds a sample over the window, RESERVOIR_PROBE(statisticId, field, type, ...) reads it back.

Known limitations: nullable input fields are rejected during lowering, the seed is fixed and not exposed in SQL, and the statistic store never evicts.

## Purpose of the Change and Brief Change Log
**(for example:)** 
This pull request adds support for variable sized data to the nested loop join. The change list is as follows:
- Added a `write()` and `read()` method to the `PagedVector` that supports variable sized data.
- Changed the `NLJBuild` to call the `write()` method when adding a tuple to the `PagedVector`.
- Changed the `NLJProbe` to call the `read()` method when reading a tuple from the `PagedVector`.

## Verifying this change
This change is tested by
*(for example:)*
- *Added integration tests for end-to-end deployment with large payloads (100MB)*
- *Extended integration test for recovery after main failure*
- *Added test that validates that TaskInfo is transferred only once across recoveries*

## What components does this pull request potentially affect?
*(for example:)*
- Dependencies (does it add or upgrade a dependency)
- ExecutionEngine
- QueryCompiler
- QueryEngine
- RestAPI

## Documentation
- The change is reflected in the necessary documentation, e.g., design document, in-code documentation.
- All necessary methods (no getter, setter, or constructor) have a documentation.

## Issue Closed by this pull request:

This PR closes #<issue number>
