### PR TITLE
refactor(SinkDescriptor): Move backpressure threshold config parameters to Network Sink configuration

### DIFF
--- a/nes-frontend/apps/repl/tests/distributed.bats
+++ b/nes-frontend/apps/repl/tests/distributed.bats
@@ -36,7 +36,7 @@ docker_nes_repl() {
   assert_json_equal '[{"worker":"sink-node:8080"}]' "${lines[0]}"
   assert_json_equal '[{"schema":[{"name":"TS","type":"UINT64"}],"source_name":"ENDLESS"}]' "${lines[1]}"
   assert_json_equal '[{"host":"sink-node:8080","input_formatter_config":{"ALLOW_COMMAS_IN_STRINGS":true,"FIELD_DELIMITER":",","TUPLE_DELIMITER":"\n","type":"CSV"},"physical_source_id":1,"schema":[{"name":"TS","type":"UINT64"}],"source_config":[{"FLUSH_INTERVAL_MS":10},{"GENERATOR_RATE_CONFIG":"emit_rate 10"},{"GENERATOR_RATE_TYPE":"FIXED"},{"GENERATOR_SCHEMA":"SEQUENCE UINT64 0 10000000 1"},{"MAX_INFLIGHT_BUFFERS":0},{"MAX_RUNTIME_MS":10000000},{"SEED":1},{"STOP_GENERATOR_WHEN_SEQUENCE_FINISHES":"ALL"}],"source_name":"ENDLESS","source_type":"GENERATOR"}]' "${lines[2]}"
-  assert_json_equal '[{"format_config":[],"host":"sink-node:8080","schema":[{"name":"TS","type":"UINT64"}],"sink_config":[{"ADD_TIMESTAMP":false},{"APPEND":false},{"BACKPRESSURE_LOWER_THRESHOLD":200},{"BACKPRESSURE_UPPER_THRESHOLD":1000},{"FILE_PATH":"out.csv"},{"OUTPUT_FORMAT":"CSV"}],"sink_name":"SOMESINK","sink_type":"FILE"}]' "${lines[3]}"
+  assert_json_equal '[{"format_config":[],"host":"sink-node:8080","schema":[{"name":"TS","type":"UINT64"}],"sink_config":[{"ADD_TIMESTAMP":false},{"APPEND":false},{"FILE_PATH":"out.csv"},{"OUTPUT_FORMAT":"CSV"}],"sink_name":"SOMESINK","sink_type":"FILE"}]' "${lines[3]}"
   assert_json_equal '[]' "${lines[4]}"
   QUERY_ID=$(echo ${lines[5]} | jq -r '.[0].query_id')
 

--- a/nes-frontend/apps/repl/tests/embedded.bats
+++ b/nes-frontend/apps/repl/tests/embedded.bats
@@ -33,7 +33,7 @@ setup()         { nes_offline_setup; }
 
   assert_json_equal '[{"schema":[{"name":"TS","type":"UINT64"}],"source_name":"ENDLESS"}]' "${lines[0]}"
   assert_json_equal '[{"host":"localhost:8080","input_formatter_config":{"ALLOW_COMMAS_IN_STRINGS":true,"FIELD_DELIMITER":",","TUPLE_DELIMITER":"\n","type":"CSV"},"physical_source_id":1,"schema":[{"name":"TS","type":"UINT64"}],"source_config":[{"FLUSH_INTERVAL_MS":10},{"GENERATOR_RATE_CONFIG":"emit_rate 10"},{"GENERATOR_RATE_TYPE":"FIXED"},{"GENERATOR_SCHEMA":"SEQUENCE UINT64 0 10000000 1"},{"MAX_INFLIGHT_BUFFERS":0},{"MAX_RUNTIME_MS":10000000},{"SEED":1},{"STOP_GENERATOR_WHEN_SEQUENCE_FINISHES":"ALL"}],"source_name":"ENDLESS","source_type":"GENERATOR"}]' "${lines[1]}"
-  assert_json_equal '[{"format_config":[],"host":"localhost:8080","schema":[{"name":"TS","type":"UINT64"}],"sink_config":[{"ADD_TIMESTAMP":false},{"APPEND":false},{"BACKPRESSURE_LOWER_THRESHOLD":200},{"BACKPRESSURE_UPPER_THRESHOLD":1000},{"FILE_PATH":"out.csv"},{"OUTPUT_FORMAT":"CSV"}],"sink_name":"SOMESINK","sink_type":"FILE"}]' "${lines[2]}"
+  assert_json_equal '[{"format_config":[],"host":"localhost:8080","schema":[{"name":"TS","type":"UINT64"}],"sink_config":[{"ADD_TIMESTAMP":false},{"APPEND":false},{"FILE_PATH":"out.csv"},{"OUTPUT_FORMAT":"CSV"}],"sink_name":"SOMESINK","sink_type":"FILE"}]' "${lines[2]}"
   assert_json_equal '[]' "${lines[3]}"
   QUERY_ID=$(echo ${lines[4]} | jq -r '.[0].query_id')
 

--- a/nes-plugins/Sinks/MQTTSink/MQTTSink.cpp
+++ b/nes-plugins/Sinks/MQTTSink/MQTTSink.cpp
@@ -63,8 +63,8 @@ MQTTSink::MQTTSink(BackpressureController backpressureController, const SinkDesc
     , retained(sinkDescriptor.getFromConfig(ConfigParametersMQTTSink::RETAINED))
     , maxOutstandingMessages(sinkDescriptor.getFromConfig(ConfigParametersMQTTSink::MAX_OUTSTANDING_MESSAGES))
     , backpressureHandler(
-          sinkDescriptor.getFromConfig(SinkDescriptor::BACKPRESSURE_UPPER_THRESHOLD),
-          sinkDescriptor.getFromConfig(SinkDescriptor::BACKPRESSURE_LOWER_THRESHOLD))
+          sinkDescriptor.getFromConfig(ConfigParametersMQTTSink::BACKPRESSURE_UPPER_THRESHOLD),
+          sinkDescriptor.getFromConfig(ConfigParametersMQTTSink::BACKPRESSURE_LOWER_THRESHOLD))
 {
 }
 

--- a/nes-plugins/Sinks/MQTTSink/MQTTSink.hpp
+++ b/nes-plugins/Sinks/MQTTSink/MQTTSink.hpp
@@ -133,9 +133,31 @@ struct ConfigParametersMQTTSink
         [](const std::unordered_map<std::string, std::string>& config)
         { return DescriptorConfig::tryGet(MAX_OUTSTANDING_MESSAGES, config); }};
 
+    /// NOLINTNEXTLINE(cert-err58-cpp)
+    static inline const DescriptorConfig::ConfigParameter<size_t> BACKPRESSURE_UPPER_THRESHOLD{
+        "BACKPRESSURE_UPPER_THRESHOLD",
+        1000,
+        [](const std::unordered_map<std::string, std::string>& config)
+        { return DescriptorConfig::tryGet(BACKPRESSURE_UPPER_THRESHOLD, config); }};
+
+    /// NOLINTNEXTLINE(cert-err58-cpp)
+    static inline const DescriptorConfig::ConfigParameter<size_t> BACKPRESSURE_LOWER_THRESHOLD{
+        "BACKPRESSURE_LOWER_THRESHOLD",
+        200,
+        [](const std::unordered_map<std::string, std::string>& config)
+        { return DescriptorConfig::tryGet(BACKPRESSURE_LOWER_THRESHOLD, config); }};
+
     static inline std::unordered_map<std::string, DescriptorConfig::ConfigParameterContainer> parameterMap
         = DescriptorConfig::createConfigParameterContainerMap(
-            SinkDescriptor::parameterMap, SERVER_URI, CLIENT_ID, TOPIC, QOS, RETAINED, MAX_OUTSTANDING_MESSAGES);
+            SinkDescriptor::parameterMap,
+            SERVER_URI,
+            CLIENT_ID,
+            TOPIC,
+            QOS,
+            RETAINED,
+            MAX_OUTSTANDING_MESSAGES,
+            BACKPRESSURE_UPPER_THRESHOLD,
+            BACKPRESSURE_LOWER_THRESHOLD);
     ///NOLINTEND(cert-err58-cpp)
 };
 

--- a/nes-sinks/include/Sinks/NetworkSink.hpp
+++ b/nes-sinks/include/Sinks/NetworkSink.hpp
@@ -107,9 +107,30 @@ struct ConfigParametersNetworkSink
         size_t{0},
         [](const std::unordered_map<std::string, std::string>& config) { return DescriptorConfig::tryGet(MAX_PENDING_ACKS, config); }};
 
+    /// NOLINTNEXTLINE(cert-err58-cpp)
+    static inline const DescriptorConfig::ConfigParameter<size_t> BACKPRESSURE_UPPER_THRESHOLD{
+        "BACKPRESSURE_UPPER_THRESHOLD",
+        1000,
+        [](const std::unordered_map<std::string, std::string>& config)
+        { return DescriptorConfig::tryGet(BACKPRESSURE_UPPER_THRESHOLD, config); }};
+
+    /// NOLINTNEXTLINE(cert-err58-cpp)
+    static inline const DescriptorConfig::ConfigParameter<size_t> BACKPRESSURE_LOWER_THRESHOLD{
+        "BACKPRESSURE_LOWER_THRESHOLD",
+        200,
+        [](const std::unordered_map<std::string, std::string>& config)
+        { return DescriptorConfig::tryGet(BACKPRESSURE_LOWER_THRESHOLD, config); }};
+
     static inline std::unordered_map<std::string, DescriptorConfig::ConfigParameterContainer> parameterMap
         = DescriptorConfig::createConfigParameterContainerMap(
-            SinkDescriptor::parameterMap, DATA_ENDPOINT, CHANNEL, BIND, SENDER_QUEUE_SIZE, MAX_PENDING_ACKS);
+            SinkDescriptor::parameterMap,
+            DATA_ENDPOINT,
+            CHANNEL,
+            BIND,
+            SENDER_QUEUE_SIZE,
+            MAX_PENDING_ACKS,
+            BACKPRESSURE_UPPER_THRESHOLD,
+            BACKPRESSURE_LOWER_THRESHOLD);
 };
 
 /// NOLINTEND(cert-err58-cpp)

--- a/nes-sinks/include/Sinks/SinkDescriptor.hpp
+++ b/nes-sinks/include/Sinks/SinkDescriptor.hpp
@@ -176,24 +176,8 @@ public:
         [](const std::unordered_map<std::string, std::string>& config) { return DescriptorConfig::tryGet(ADD_TIMESTAMP, config); }};
 
     /// NOLINTNEXTLINE(cert-err58-cpp)
-    static inline const DescriptorConfig::ConfigParameter<size_t> BACKPRESSURE_UPPER_THRESHOLD{
-        "BACKPRESSURE_UPPER_THRESHOLD",
-        1000,
-        [](const std::unordered_map<std::string, std::string>& config)
-        { return DescriptorConfig::tryGet(BACKPRESSURE_UPPER_THRESHOLD, config); }};
-
-    /// NOLINTNEXTLINE(cert-err58-cpp)
-    static inline const DescriptorConfig::ConfigParameter<size_t> BACKPRESSURE_LOWER_THRESHOLD{
-        "BACKPRESSURE_LOWER_THRESHOLD",
-        200,
-        [](const std::unordered_map<std::string, std::string>& config)
-        { return DescriptorConfig::tryGet(BACKPRESSURE_LOWER_THRESHOLD, config); }};
-
-
-    /// NOLINTNEXTLINE(cert-err58-cpp)
     static inline std::unordered_map<std::string, DescriptorConfig::ConfigParameterContainer> parameterMap
-        = DescriptorConfig::createConfigParameterContainerMap(
-            OUTPUT_FORMAT, ADD_TIMESTAMP, BACKPRESSURE_UPPER_THRESHOLD, BACKPRESSURE_LOWER_THRESHOLD);
+        = DescriptorConfig::createConfigParameterContainerMap(OUTPUT_FORMAT, ADD_TIMESTAMP);
 
     static std::optional<DescriptorConfig::Config>
     validateAndFormatConfig(std::string_view sinkType, std::unordered_map<Identifier, std::string> configPairs);

--- a/nes-sinks/src/NetworkSink.cpp
+++ b/nes-sinks/src/NetworkSink.cpp
@@ -51,8 +51,8 @@ NetworkSink::NetworkSink(BackpressureController backpressureController, const Si
     : Sink(std::move(backpressureController))
     , tupleSize(getSizeInBytes(*NES::get<std::shared_ptr<const Schema<UnqualifiedUnboundField, Ordered>>>(sinkDescriptor.getSchema())))
     , backpressureHandler(
-          sinkDescriptor.getFromConfig(SinkDescriptor::BACKPRESSURE_UPPER_THRESHOLD),
-          sinkDescriptor.getFromConfig(SinkDescriptor::BACKPRESSURE_LOWER_THRESHOLD))
+          sinkDescriptor.getFromConfig(ConfigParametersNetworkSink::BACKPRESSURE_UPPER_THRESHOLD),
+          sinkDescriptor.getFromConfig(ConfigParametersNetworkSink::BACKPRESSURE_LOWER_THRESHOLD))
     , channelId(sinkDescriptor.getFromConfig(ConfigParametersNetworkSink::CHANNEL))
     , connectionAddr(sinkDescriptor.getFromConfig(ConfigParametersNetworkSink::DATA_ENDPOINT))
     , thisConnection(sinkDescriptor.getFromConfig(ConfigParametersNetworkSink::BIND))


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
The sink config parameters `BACKPRESSURE_UPPER_THRESHOLD` and `BACKPRESSURE_LOWER_THRESHOLD` are currently `SinkDescriptor` configuration parameters, even though they are only relevant for the `NetworkSink` and the `MQTTSink` plugin. This pull request removes both config parameters from the sink descriptor and adds them to the parameters of the `NetworkSink` and `MQTTSink`.
## Verifying this change
This change is tested by
- Setting these parameters still works exactly the same. Adjusted repl .bats test by removing the parameters from the expected configurations of the FILE sink

## What components does this pull request potentially affect?
- nes-sinks
- MQTTSink plugin

## Issue Closed by this pull request:

This PR closes #1964 