### PR TITLE
fix(AntlrSQLQueryPlanCreator): Use correct check for unnamed aggregations in enterIdentifier

### DIFF
--- a/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
+++ b/nes-sql-parser/src/AntlrSQLQueryPlanCreator.cpp
@@ -735,7 +735,7 @@ void AntlrSQLQueryPlanCreator::enterIdentifier(AntlrSQLParser::IdentifierContext
     }
     else if (
         AntlrSQLParser::RuleNamedExpression == parentRuleIndex and helpers.top().isInFunctionCall() and not helpers.top().isJoinRelation
-        and not helpers.top().isInAggFunction())
+        and not helpers.top().hasUnnamedAggregation)
     {
         /// handle renames of identifiers
         if (helpers.top().isArithmeticBinary)
@@ -751,7 +751,7 @@ void AntlrSQLQueryPlanCreator::enterIdentifier(AntlrSQLParser::IdentifierContext
             helpers.top().addProjection(bindIdentifier(context), attribute);
         }
     }
-    else if (helpers.top().isInAggFunction() and AntlrSQLParser::RuleNamedExpression == parentRuleIndex)
+    else if (helpers.top().hasUnnamedAggregation and AntlrSQLParser::RuleNamedExpression == parentRuleIndex)
     {
         const auto expression = helpers.top().functionBuilder.back();
         helpers.top().functionBuilder.pop_back();

--- a/nes-systests/parser/RenameAfterAgg.test
+++ b/nes-systests/parser/RenameAfterAgg.test
@@ -1,0 +1,59 @@
+# name: parser/RenameAfterAgg.test
+# description: Checks if the AntlrSQLQueryPlanCreator correctly assigns AS renames
+# groups: [Parser]
+
+CREATE LOGICAL SOURCE input(
+    id UINT64 NOT NULL,
+    value UINT64 NOT NULL,
+    ts UINT64 NOT NULL
+);
+
+CREATE PHYSICAL SOURCE FOR input TYPE File;
+ATTACH INLINE
+1,10,1000
+1,20,1010
+
+CREATE SINK output(
+    id UINT64 NOT NULL,
+    sumValue UINT64 NOT NULL,
+    startValue UINT64 NOT NULL
+) TYPE File;
+
+CREATE SINK output2(
+    id UINT64 NOT NULL,
+    sumValue UINT64 NOT NULL,
+    start UINT64 NOT NULL
+) TYPE File;
+
+SELECT id, SUM(value) AS sumValue, start as startValue
+FROM input
+GROUP BY id
+WINDOW SLIDING(ts, size 10 ms, advance by 5 ms)
+INTO output;
+----
+1 10 995
+1 10 1000
+1 20 1005
+1 20 1010
+
+SELECT id, start as startValue, SUM(value) AS sumValue
+FROM input
+GROUP BY id
+WINDOW SLIDING(ts, size 10 ms, advance by 5 ms)
+INTO output;
+----
+1 10 995
+1 10 1000
+1 20 1005
+1 20 1010
+
+SELECT id, SUM(value) AS sumValue, start
+FROM input
+GROUP BY id
+WINDOW SLIDING(ts, size 10 ms, advance by 5 ms)
+INTO output2;
+----
+1 10 995
+1 10 1000
+1 20 1005
+1 20 1010


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log 
This pull request fixes a bug in `AntlrSQLQueryPlanCreator::enterIdentifier`, in which `AntlrSQLHelper::isInAggFunction` is used to check if an `AS <name>` rename belongs to an aggregation. This is a bug, as this function merely checks if any aggregations were found during the parse of the token. This causes any AS renames of any expression listed after an aggregation in a SELECT to falsely overwrite the name of the last found aggregation instead of the expression the AS belongs to. The bug can be observed in queries like

```sql
CREATE LOGICAL SOURCE input(
    id UINT64 NOT NULL,
    value UINT64 NOT NULL,
    ts UINT64 NOT NULL
);

CREATE PHYSICAL SOURCE FOR input TYPE File;
ATTACH INLINE
1,10,1000
1,20,1010

CREATE SINK output(
    id UINT64 NOT NULL,
    sumValue UINT64 NOT NULL,
    startValue UINT64 NOT NULL
) TYPE File;

CREATE SINK output2(
    id UINT64 NOT NULL,
    sumValue UINT64 NOT NULL,
    start UINT64 NOT NULL
) TYPE File;

SELECT id, SUM(value) AS sumValue, start as startValue
FROM input
GROUP BY id
WINDOW SLIDING(ts, size 10 ms, advance by 5 ms)
INTO output;
----
1 10 995
1 10 1000
1 20 1005
1 20 1010
```
in which startValue would be falsely assigned as name of the SUM(value) aggregation, since start is listed after SUM(value) in the aggregation. This leads to an error in which the field sumValue cannot be found in the inferred schema.

This bug is solved by checking the hasUnnamedAggregation flag of the Helper instead when checking if the rename belongs to the latest found aggregation.

## Verifying this change
This change is tested by
- Added nes-systests/parser/RenameAfterAgg.test test which covers queries in which an aggregation as well as another non-aggregation expression is renamed
## What components does this pull request potentially affect?
- nes-sql-parser

## Documentation
- Simple change, no additional documentation needed
## Issue Closed by this pull request:

This PR closes #1786 
