### PR TITLE
chore(OperatorHandler): Removed unused localStateVariableId

### DIFF
--- a/nes-physical-operators/include/EmitOperatorHandler.hpp
+++ b/nes-physical-operators/include/EmitOperatorHandler.hpp
@@ -60,7 +60,7 @@ class EmitOperatorHandler final : public OperatorHandler
 public:
     void setChunkNumber(bool isEndOfIncomingChunk, ChunkNumber incomingChunkNumber, bool isIncomingBufferTheLastChunk, TupleBuffer& buffer);
 
-    void start(PipelineExecutionContext& pipelineExecutionContext, uint32_t localStateVariableId) override;
+    void start(PipelineExecutionContext& pipelineExecutionContext) override;
     void stop(QueryTerminationType terminationType, PipelineExecutionContext& pipelineExecutionContext) override;
 
     folly::Synchronized<std::map<SequenceNumberForOriginId, SequenceState>> sequenceStates;

--- a/nes-physical-operators/include/WindowBasedOperatorHandler.hpp
+++ b/nes-physical-operators/include/WindowBasedOperatorHandler.hpp
@@ -64,7 +64,7 @@ public:
 
     ~WindowBasedOperatorHandler() override = default;
 
-    void start(PipelineExecutionContext& pipelineExecutionContext, uint32_t localStateVariableId) override;
+    void start(PipelineExecutionContext& pipelineExecutionContext) override;
     void stop(QueryTerminationType queryTerminationType, PipelineExecutionContext& pipelineExecutionContext) override;
 
     WindowSlicesStoreInterface& getSliceAndWindowStore() const;

--- a/nes-physical-operators/src/EmitOperatorHandler.cpp
+++ b/nes-physical-operators/src/EmitOperatorHandler.cpp
@@ -82,7 +82,7 @@ void EmitOperatorHandler::setChunkNumber(
     }
 }
 
-void EmitOperatorHandler::start(PipelineExecutionContext&, uint32_t)
+void EmitOperatorHandler::start(PipelineExecutionContext&)
 {
 }
 

--- a/nes-physical-operators/src/WindowBasedOperatorHandler.cpp
+++ b/nes-physical-operators/src/WindowBasedOperatorHandler.cpp
@@ -41,7 +41,7 @@ WindowBasedOperatorHandler::WindowBasedOperatorHandler(
 {
 }
 
-void WindowBasedOperatorHandler::start(PipelineExecutionContext& pipelineExecutionContext, uint32_t)
+void WindowBasedOperatorHandler::start(PipelineExecutionContext& pipelineExecutionContext)
 {
     numberOfWorkerThreads = pipelineExecutionContext.getNumberOfWorkerThreads();
 }

--- a/nes-physical-operators/src/WindowProbePhysicalOperator.cpp
+++ b/nes-physical-operators/src/WindowProbePhysicalOperator.cpp
@@ -56,7 +56,7 @@ void setupProxy(OperatorHandler* ptrOpHandler, PipelineExecutionContext* pipelin
     PRECONDITION(pipelineCtx != nullptr, "pipeline context should not be null!");
 
     auto* opHandler = dynamic_cast<WindowBasedOperatorHandler*>(ptrOpHandler);
-    opHandler->start(*pipelineCtx, 0);
+    opHandler->start(*pipelineCtx);
 }
 
 void terminateProxy(OperatorHandler* ptrOpHandler, PipelineExecutionContext* pipelineCtx)

--- a/nes-runtime/include/Runtime/Execution/OperatorHandler.hpp
+++ b/nes-runtime/include/Runtime/Execution/OperatorHandler.hpp
@@ -43,7 +43,7 @@ public:
 
     virtual ~OperatorHandler() = default;
 
-    virtual void start(PipelineExecutionContext& pipelineExecutionContext, uint32_t localStateVariableId) = 0;
+    virtual void start(PipelineExecutionContext& pipelineExecutionContext) = 0;
 
     virtual void stop(QueryTerminationType terminationType, PipelineExecutionContext& pipelineExecutionContext) = 0;
 };


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Removed the unused `localStateVariableId` in `OperatorHandler::start()`

## Verifying this change
This change is tested by existing tests.