### PR TITLE
feat(systest): layer worker configs from command line, topology, and testfile

### DIFF
--- a/.github/workflows/large_test.yml
+++ b/.github/workflows/large_test.yml
@@ -90,6 +90,7 @@ jobs:
               --workingDir=build/nes-systests/large_scale \
               --data build/nes-systests/testdata \
               --groups large \
+              --permit-conflicting-options \
               -- \
               --worker.default_query_execution.execution_mode=COMPILER \
               --worker.query_engine.number_of_worker_threads=${{ inputs.number_of_worker_threads }} \

--- a/nes-distributed/include/WorkerCatalog.hpp
+++ b/nes-distributed/include/WorkerCatalog.hpp
@@ -25,7 +25,7 @@
 #include <Schema/Schema.hpp>
 #include <Schema/SchemaFwd.hpp>
 #include <NetworkTopology.hpp>
-#include <WorkerConfig.hpp>
+#include <WorkerCatalogEntry.hpp>
 
 namespace NES
 {
@@ -39,13 +39,13 @@ inline void addWorkers()
 /// query decomposition and placement validation.
 class WorkerCatalog
 {
-    std::unordered_map<Host, WorkerConfig> workers;
+    std::unordered_map<Host, WorkerCatalogEntry> workers;
     NetworkTopology topology;
     uint64_t version = 0;
 
 public:
     WorkerCatalog() = default;
-    explicit WorkerCatalog(const std::vector<WorkerConfig>& workers);
+    explicit WorkerCatalog(const std::vector<WorkerCatalogEntry>& workers);
 
     bool addWorker(
         const Host& host,
@@ -53,10 +53,10 @@ public:
         Capacity maxOperators,
         const std::vector<Host>& downstream,
         Schema<LiteralConfigValue, Ordered> config = {}); /// NOLINT(fuchsia-default-arguments-declarations)
-    std::optional<WorkerConfig> removeWorker(const Host& hostAddr);
-    [[nodiscard]] std::optional<WorkerConfig> getWorker(const Host& hostAddr) const;
+    std::optional<WorkerCatalogEntry> removeWorker(const Host& hostAddr);
+    [[nodiscard]] std::optional<WorkerCatalogEntry> getWorker(const Host& hostAddr) const;
     [[nodiscard]] size_t size() const;
-    [[nodiscard]] std::vector<WorkerConfig> getAllWorkers() const;
+    [[nodiscard]] std::vector<WorkerCatalogEntry> getAllWorkers() const;
     [[nodiscard]] NetworkTopology getTopology() const;
 
     /// Every change to the workerCatalog increments the version. This allows other components to check if the catalog has changed.

--- a/nes-distributed/include/WorkerCatalogEntry.hpp
+++ b/nes-distributed/include/WorkerCatalogEntry.hpp
@@ -40,7 +40,7 @@ struct Limited
 
 using Capacity = std::variant<CapacityKind::Unlimited, CapacityKind::Limited>;
 
-struct WorkerConfig
+struct WorkerCatalogEntry
 {
     Host host; /// gRPC management endpoint, used as primary worker identity
     std::string dataAddress; /// Data-plane address for network sources/sinks (set via --data_address)

--- a/nes-distributed/src/WorkerCatalog.cpp
+++ b/nes-distributed/src/WorkerCatalog.cpp
@@ -24,13 +24,12 @@
 #include <Configurations/ConfigLiteral.hpp>
 #include <Identifiers/Identifiers.hpp>
 #include <Schema/Schema.hpp>
-#include <Schema/SchemaFwd.hpp>
-#include <WorkerConfig.hpp>
+#include <WorkerCatalogEntry.hpp>
 
 namespace NES
 {
 
-WorkerCatalog::WorkerCatalog(const std::vector<WorkerConfig>& workers)
+WorkerCatalog::WorkerCatalog(const std::vector<WorkerCatalogEntry>& workers)
 {
     for (const auto& [host, data, capacity, downstream, config] : workers)
     {
@@ -48,7 +47,7 @@ bool WorkerCatalog::addWorker(
     const bool added = workers
                            .try_emplace(
                                host,
-                               WorkerConfig{
+                               WorkerCatalogEntry{
                                    .host = host,
                                    .dataAddress = std::move(dataAddress),
                                    .maxOperators = maxOperators,
@@ -63,7 +62,7 @@ bool WorkerCatalog::addWorker(
     return added;
 }
 
-std::optional<WorkerConfig> WorkerCatalog::removeWorker(const Host& hostAddr)
+std::optional<WorkerCatalogEntry> WorkerCatalog::removeWorker(const Host& hostAddr)
 {
     if (const auto node = workers.extract(hostAddr); not node.empty())
     {
@@ -74,7 +73,7 @@ std::optional<WorkerConfig> WorkerCatalog::removeWorker(const Host& hostAddr)
     return std::nullopt;
 }
 
-[[nodiscard]] std::optional<WorkerConfig> WorkerCatalog::getWorker(const Host& hostAddr) const
+[[nodiscard]] std::optional<WorkerCatalogEntry> WorkerCatalog::getWorker(const Host& hostAddr) const
 {
     if (workers.contains(hostAddr))
     {
@@ -93,9 +92,9 @@ NetworkTopology WorkerCatalog::getTopology() const
     return topology; /// Copy constructor creates a snapshot
 }
 
-std::vector<WorkerConfig> WorkerCatalog::getAllWorkers() const
+std::vector<WorkerCatalogEntry> WorkerCatalog::getAllWorkers() const
 {
-    return workers | std::views::values | std::ranges::to<std::vector<WorkerConfig>>();
+    return workers | std::views::values | std::ranges::to<std::vector<WorkerCatalogEntry>>();
 }
 
 uint64_t WorkerCatalog::getVersion() const

--- a/nes-distributed/tests/UnitTests/WorkerCatalogTest.cpp
+++ b/nes-distributed/tests/UnitTests/WorkerCatalogTest.cpp
@@ -14,7 +14,7 @@
 
 #include <variant>
 #include <WorkerCatalog.hpp>
-#include <WorkerConfig.hpp>
+#include <WorkerCatalogEntry.hpp>
 
 #include <Identifiers/Identifiers.hpp>
 #include <Util/Logger/LogLevel.hpp>
@@ -91,7 +91,7 @@ TEST_F(WorkerCatalogTest, AddWorkerWithLimitedCapacity)
     EXPECT_THAT(std::get<CapacityKind::Limited>(retrieved->maxOperators).value, Eq(100U));
 }
 
-/// RemoveWorker: removing existing worker returns the WorkerConfig, size() decreases
+/// RemoveWorker: removing existing worker returns the WorkerCatalogEntry, size() decreases
 TEST_F(WorkerCatalogTest, RemoveWorker)
 {
     WorkerCatalog catalog;

--- a/nes-frontend/apps/repl/ReplStarter.cpp
+++ b/nes-frontend/apps/repl/ReplStarter.cpp
@@ -75,7 +75,7 @@
 #ifdef EMBED_ENGINE
     #include <QueryManager/EmbeddedWorkerQuerySubmissionBackend.hpp>
     #include <SingleNodeWorkerConfiguration.hpp>
-    #include <WorkerConfig.hpp>
+    #include <WorkerCatalogEntry.hpp>
 #endif
 
 /// If repl is executed with an embedded worker, this switch prevents actual port allocation and routes all inter-worker communication
@@ -293,7 +293,7 @@ int main(int argc, char** argv)
         const auto grpcBind = singleNodeWorkerConfig.grpcAddressUri;
         const auto grpcAddr = "localhost" + grpcBind.substr(grpcBind.rfind(':'));
         const auto dataAddr = singleNodeWorkerConfig.dataAddress;
-        const NES::WorkerConfig workerConfig{
+        const NES::WorkerCatalogEntry workerConfig{
             .host = NES::Host(grpcAddr),
             .dataAddress = dataAddr,
             .maxOperators = NES::Capacity(NES::CapacityKind::Unlimited{}),
@@ -304,7 +304,7 @@ int main(int argc, char** argv)
         /// Embedded workers resolve their config from two layers (lowest priority first): the CLI
         /// worker/optimizer literals, then the per-worker registration config (topology wins). Conflicting
         /// values are an error in the repl — there is no override switch here.
-        auto resolveWorkerConfiguration = [workerOptimizerLiterals](const NES::WorkerConfig& worker)
+        auto resolveWorkerConfiguration = [workerOptimizerLiterals](const NES::WorkerCatalogEntry& worker)
         {
             auto [literals, overwrites] = NES::mergeConfigLayers(
                 {NES::ConfigLayer{.name = "command line", .literals = workerOptimizerLiterals},

--- a/nes-frontend/include/QueryManager/EmbeddedWorkerQuerySubmissionBackend.hpp
+++ b/nes-frontend/include/QueryManager/EmbeddedWorkerQuerySubmissionBackend.hpp
@@ -25,7 +25,7 @@
 #include <QueryStatus.hpp>
 #include <SingleNodeWorkerConfiguration.hpp>
 #include <Version.hpp>
-#include <WorkerConfig.hpp>
+#include <WorkerCatalogEntry.hpp>
 #include <WorkerStatus.hpp>
 
 namespace NES
@@ -43,13 +43,13 @@ class Channel;
 /// systest) so that the policy — which config layers apply, their precedence, and whether
 /// conflicting values are permitted — lives with the caller, not the backend. Throws if the
 /// worker's configuration is invalid.
-using WorkerConfigResolver = std::function<SingleNodeWorkerConfiguration(const WorkerConfig&)>;
+using WorkerConfigResolver = std::function<SingleNodeWorkerConfiguration(const WorkerCatalogEntry&)>;
 
 class EmbeddedWorkerQuerySubmissionBackend final : public QuerySubmissionBackend
 {
 public:
     ~EmbeddedWorkerQuerySubmissionBackend() override;
-    EmbeddedWorkerQuerySubmissionBackend(WorkerConfig config, const WorkerConfigResolver& resolveWorkerConfiguration);
+    EmbeddedWorkerQuerySubmissionBackend(WorkerCatalogEntry config, const WorkerConfigResolver& resolveWorkerConfiguration);
     [[nodiscard]] std::expected<QueryId, Exception> start(LogicalPlan) override;
     std::expected<void, Exception> stop(QueryId) override;
     [[nodiscard]] std::expected<LocalQueryStatusSnapshot, Exception> status(QueryId) const override;

--- a/nes-frontend/include/QueryManager/GRPCQuerySubmissionBackend.hpp
+++ b/nes-frontend/include/QueryManager/GRPCQuerySubmissionBackend.hpp
@@ -26,6 +26,7 @@
 #include <QueryStatus.hpp>
 #include <SingleNodeWorkerRPCService.grpc.pb.h>
 #include <Version.hpp>
+#include <WorkerCatalogEntry.hpp>
 #include <WorkerStatus.hpp>
 
 namespace NES
@@ -33,10 +34,10 @@ namespace NES
 class GRPCQuerySubmissionBackend final : public QuerySubmissionBackend
 {
     std::unique_ptr<WorkerRPCService::Stub> stub;
-    WorkerConfig workerConfig;
+    WorkerCatalogEntry workerConfig;
 
 public:
-    explicit GRPCQuerySubmissionBackend(WorkerConfig config);
+    explicit GRPCQuerySubmissionBackend(WorkerCatalogEntry config);
     [[nodiscard]] std::expected<QueryId, Exception> start(LogicalPlan) override;
     std::expected<void, Exception> stop(QueryId) override;
     [[nodiscard]] std::expected<LocalQueryStatusSnapshot, Exception> status(QueryId) const override;

--- a/nes-frontend/include/QueryManager/QueryManager.hpp
+++ b/nes-frontend/include/QueryManager/QueryManager.hpp
@@ -32,7 +32,7 @@
 #include <QueryStatus.hpp>
 #include <Version.hpp>
 #include <WorkerCatalog.hpp>
-#include <WorkerConfig.hpp>
+#include <WorkerCatalogEntry.hpp>
 #include <WorkerStatus.hpp>
 
 namespace NES
@@ -50,7 +50,7 @@ public:
 };
 
 /// std::move_only_function is the C++23 equivalent but is not yet available in libc++19.
-using BackendProvider = absl::AnyInvocable<UniquePtr<QuerySubmissionBackend>(const WorkerConfig&)>;
+using BackendProvider = absl::AnyInvocable<UniquePtr<QuerySubmissionBackend>(const WorkerCatalogEntry&)>;
 
 struct QueryManagerState
 {
@@ -71,7 +71,7 @@ class QueryManager
         mutable std::unordered_map<Host, UniquePtr<QuerySubmissionBackend>> backends;
         mutable uint64_t cachedWorkerCatalogVersion = 0;
         static std::unordered_map<Host, UniquePtr<QuerySubmissionBackend>>
-        createBackends(const std::vector<WorkerConfig>& workers, BackendProvider& provider);
+        createBackends(const std::vector<WorkerCatalogEntry>& workers, BackendProvider& provider);
         void rebuildBackendsIfNeeded() const;
 
     public:

--- a/nes-frontend/src/QueryManager/EmbeddedWorkerQuerySubmissionBackend.cpp
+++ b/nes-frontend/src/QueryManager/EmbeddedWorkerQuerySubmissionBackend.cpp
@@ -34,7 +34,7 @@
 #include <SingleNodeWorkerConfiguration.hpp>
 #include <Thread.hpp>
 #include <Version.hpp>
-#include <WorkerConfig.hpp>
+#include <WorkerCatalogEntry.hpp>
 #include <WorkerStatus.hpp>
 
 namespace NES::detail
@@ -100,7 +100,7 @@ class Channel
 public:
     /// Resolving in the constructor (not the worker thread) surfaces configuration errors —
     /// e.g. conflicting config layers — as an exception to whoever creates the backend.
-    Channel(WorkerConfig cfg, const WorkerConfigResolver& resolveWorkerConfiguration)
+    Channel(WorkerCatalogEntry cfg, const WorkerConfigResolver& resolveWorkerConfiguration)
         : config(std::move(cfg))
         , workerConfiguration(resolveWorkerConfiguration(this->config))
         , thread(
@@ -133,7 +133,7 @@ private:
         const std::stop_token& stopToken,
         folly::UMPSCQueue<Request, /*MayBlock*/ true>& requests,
         folly::USPSCQueue<Reply, /*MayBlock*/ true>& replies,
-        const WorkerConfig& config,
+        const WorkerCatalogEntry& config,
         SingleNodeWorkerConfiguration workerConfiguration)
     {
         /// The injected resolver already produced the configuration (see the Channel
@@ -187,7 +187,7 @@ private:
     mutable folly::UMPSCQueue<Request, /*MayBlock*/ true> requests;
     mutable folly::USPSCQueue<Reply, /*MayBlock*/ true> replies;
     mutable std::mutex submitMutex;
-    WorkerConfig config;
+    WorkerCatalogEntry config;
     SingleNodeWorkerConfiguration workerConfiguration;
     /// Must be declared last: its body references the queues above, and on
     /// destruction the jthread requests stop and joins before earlier members go.
@@ -199,7 +199,7 @@ namespace NES
 {
 
 EmbeddedWorkerQuerySubmissionBackend::EmbeddedWorkerQuerySubmissionBackend(
-    WorkerConfig config, const WorkerConfigResolver& resolveWorkerConfiguration)
+    WorkerCatalogEntry config, const WorkerConfigResolver& resolveWorkerConfiguration)
     : channel(std::make_unique<detail::Channel>(std::move(config), resolveWorkerConfiguration))
 {
 }
@@ -234,7 +234,7 @@ std::expected<VersionInfo, Exception> EmbeddedWorkerQuerySubmissionBackend::vers
 BackendProvider createEmbeddedBackend(WorkerConfigResolver resolveWorkerConfiguration)
 {
     return [resolveWorkerConfiguration
-            = std::move(resolveWorkerConfiguration)](const WorkerConfig& config) /// NOLINT(bugprone-exception-escape)
+            = std::move(resolveWorkerConfiguration)](const WorkerCatalogEntry& config) /// NOLINT(bugprone-exception-escape)
     { return std::make_unique<EmbeddedWorkerQuerySubmissionBackend>(config, resolveWorkerConfiguration); };
 }
 

--- a/nes-frontend/src/QueryManager/GRPCQuerySubmissionBackend.cpp
+++ b/nes-frontend/src/QueryManager/GRPCQuerySubmissionBackend.cpp
@@ -38,11 +38,12 @@
 #include <QueryStatus.hpp>
 #include <SingleNodeWorkerRPCService.grpc.pb.h>
 #include <SingleNodeWorkerRPCService.pb.h>
+#include <WorkerCatalogEntry.hpp>
 #include <WorkerStatus.hpp>
 
 namespace NES
 {
-GRPCQuerySubmissionBackend::GRPCQuerySubmissionBackend(WorkerConfig config)
+GRPCQuerySubmissionBackend::GRPCQuerySubmissionBackend(WorkerCatalogEntry config)
     : stub{WorkerRPCService::NewStub(grpc::CreateChannel(config.host.getRawValue(), grpc::InsecureChannelCredentials()))}
     , workerConfig{std::move(config)}
 {
@@ -190,7 +191,7 @@ std::expected<void, Exception> GRPCQuerySubmissionBackend::stop(QueryId queryId)
 
 BackendProvider createGRPCBackend()
 {
-    return [](const WorkerConfig& config) { return std::make_unique<GRPCQuerySubmissionBackend>(config); };
+    return [](const WorkerCatalogEntry& config) { return std::make_unique<GRPCQuerySubmissionBackend>(config); };
 }
 
 }

--- a/nes-frontend/src/QueryManager/QueryManager.cpp
+++ b/nes-frontend/src/QueryManager/QueryManager.cpp
@@ -40,7 +40,7 @@
 #include <QueryId.hpp>
 #include <QueryStatus.hpp>
 #include <WorkerCatalog.hpp>
-#include <WorkerConfig.hpp>
+#include <WorkerCatalogEntry.hpp>
 
 namespace NES
 {
@@ -69,7 +69,7 @@ std::expected<DistributedQuery, Exception> QueryManager::getQuery(DistributedQue
 }
 
 std::unordered_map<Host, UniquePtr<QuerySubmissionBackend>>
-QueryManager::QueryManagerBackends::createBackends(const std::vector<WorkerConfig>& workers, BackendProvider& provider)
+QueryManager::QueryManagerBackends::createBackends(const std::vector<WorkerCatalogEntry>& workers, BackendProvider& provider)
 {
     std::unordered_map<Host, UniquePtr<QuerySubmissionBackend>> backends;
     for (const auto& workerConfig : workers)

--- a/nes-frontend/src/Statements/StatementHandler.cpp
+++ b/nes-frontend/src/Statements/StatementHandler.cpp
@@ -58,7 +58,7 @@
 #include <ModelCatalog.hpp>
 #include <QueryOptimizer.hpp>
 #include <WorkerCatalog.hpp>
-#include <WorkerConfig.hpp>
+#include <WorkerCatalogEntry.hpp>
 
 namespace NES
 {

--- a/nes-frontend/tests/DistributedPlanningTest.cpp
+++ b/nes-frontend/tests/DistributedPlanningTest.cpp
@@ -83,7 +83,7 @@ struct PhysicalSource
     std::string host;
 };
 
-struct WorkerConfig
+struct WorkerCatalogEntry
 {
     std::string host;
     std::optional<std::string> dataAddress;
@@ -97,7 +97,7 @@ struct QueryConfig
     std::vector<Sink> sinks;
     std::vector<LogicalSource> logical;
     std::vector<PhysicalSource> physical;
-    std::vector<WorkerConfig> workers;
+    std::vector<WorkerCatalogEntry> workers;
 };
 }
 
@@ -139,9 +139,9 @@ struct convert<NES::Test::PhysicalSource>
 };
 
 template <>
-struct convert<NES::Test::WorkerConfig>
+struct convert<NES::Test::WorkerCatalogEntry>
 {
-    static bool decode(const Node& node, NES::Test::WorkerConfig& rhs)
+    static bool decode(const Node& node, NES::Test::WorkerCatalogEntry& rhs)
     {
         rhs.host = node["host"].as<std::string>();
         rhs.dataAddress
@@ -164,7 +164,7 @@ struct convert<NES::Test::QueryConfig>
         rhs.sinks = node["sinks"].as<std::vector<NES::Test::Sink>>();
         rhs.logical = node["logical"].as<std::vector<NES::Test::LogicalSource>>();
         rhs.physical = node["physical"].as<std::vector<NES::Test::PhysicalSource>>();
-        rhs.workers = node["workers"].as<std::vector<NES::Test::WorkerConfig>>();
+        rhs.workers = node["workers"].as<std::vector<NES::Test::WorkerCatalogEntry>>();
         rhs.query = node["query"].as<std::string>();
         return true;
     }

--- a/nes-frontend/tests/GRPCQuerySubmissionBackendTest.cpp
+++ b/nes-frontend/tests/GRPCQuerySubmissionBackendTest.cpp
@@ -24,7 +24,7 @@
 #include <BaseUnitTest.hpp>
 #include <ErrorHandling.hpp>
 #include <SingleNodeWorkerRPCService.grpc.pb.h>
-#include <WorkerConfig.hpp>
+#include <WorkerCatalogEntry.hpp>
 
 namespace NES::Test
 {
@@ -40,7 +40,7 @@ class OldWorkerService final : public WorkerRPCService::Service
 GRPCQuerySubmissionBackend backendFor(const std::string& host)
 {
     return GRPCQuerySubmissionBackend{
-        WorkerConfig{.host = Host{host}, .dataAddress = {}, .maxOperators = {}, .downstream = {}, .config = {}}};
+        WorkerCatalogEntry{.host = Host{host}, .dataAddress = {}, .maxOperators = {}, .downstream = {}, .config = {}}};
 }
 }
 

--- a/nes-query-optimizer/src/Placement/BottomUpPlacement.cpp
+++ b/nes-query-optimizer/src/Placement/BottomUpPlacement.cpp
@@ -43,7 +43,7 @@
 #include <util/HighsInt.h>
 #include <ErrorHandling.hpp>
 #include <NetworkTopology.hpp>
-#include <WorkerConfig.hpp>
+#include <WorkerCatalogEntry.hpp>
 #include <scope_guard.hpp>
 
 namespace NES

--- a/nes-query-optimizer/src/Placement/QueryDecomposition.cpp
+++ b/nes-query-optimizer/src/Placement/QueryDecomposition.cpp
@@ -55,7 +55,7 @@
 #include <QueryId.hpp>
 #include <QueryOptimizerNetworkConfiguration.hpp>
 #include <WorkerCatalog.hpp>
-#include <WorkerConfig.hpp>
+#include <WorkerCatalogEntry.hpp>
 
 #include <Configurations/ConfigField.hpp>
 #include <DataTypes/UnboundField.hpp>

--- a/nes-systests/configs/topologies/two-node.yaml
+++ b/nes-systests/configs/topologies/two-node.yaml
@@ -9,19 +9,11 @@ workers:
   - host: "sink-node:8080"
     data_address: "sink-node:9090"
     max_operators: 10000
-    config:
-      worker:
-        query_engine:
-          number_of_worker_threads: 1
   - host: "source-node:8080"
     data_address: "source-node:9090"
     max_operators: 2
     downstream:
       - "sink-node:8080"
-    config:
-      worker:
-        query_engine:
-          number_of_worker_threads: 1
 
 allow_source_placement:
   - "source-node:8080"

--- a/nes-systests/systest/CMakeLists.txt
+++ b/nes-systests/systest/CMakeLists.txt
@@ -113,7 +113,7 @@ foreach (enableSliceCache IN LISTS sliceCacheValues)
         endif ()
         ExternalData_Add_Test(test-data
                 NAME systest_interpreter_${joinStrategy}_sliceCache_${enableSliceCache}
-                COMMAND systest -n 20 --show-query-performance --workingDir=${CMAKE_CURRENT_BINARY_DIR}/interpreter_${joinStrategy}_sliceCache_${enableSliceCache} --exclude-groups ${interpreterExcludeGroups} --data ${EXPANDED_TEST_DATA_PATH} -- --optimizer.join_strategy=${joinStrategy} --worker.query_engine.number_of_worker_threads=4 --worker.default_query_execution.execution_mode=INTERPRETER --worker.total_memory_in_bytes=${SYSTEST_JOIN_TOTAL_MEMORY_BYTES} --worker.unpooled_memory_fraction=${SYSTEST_JOIN_UNPOOLED_FRACTION} --worker.default_query_execution.slice_cache.enable_slice_cache=${enableSliceCache})
+                COMMAND systest -n 20 --show-query-performance --workingDir=${CMAKE_CURRENT_BINARY_DIR}/interpreter_${joinStrategy}_sliceCache_${enableSliceCache} --exclude-groups ${interpreterExcludeGroups} --data ${EXPANDED_TEST_DATA_PATH} --permit-conflicting-options -- --optimizer.join_strategy=${joinStrategy} --worker.query_engine.number_of_worker_threads=4 --worker.default_query_execution.execution_mode=INTERPRETER --worker.total_memory_in_bytes=${SYSTEST_JOIN_TOTAL_MEMORY_BYTES} --worker.unpooled_memory_fraction=${SYSTEST_JOIN_UNPOOLED_FRACTION} --worker.default_query_execution.slice_cache.enable_slice_cache=${enableSliceCache})
         set_tests_properties(systest_interpreter_${joinStrategy}_sliceCache_${enableSliceCache} PROPERTIES LABELS "Systest" PROCESSORS 4)
     endforeach ()
 endforeach ()
@@ -121,7 +121,7 @@ if (NOT CODE_COVERAGE)
     foreach (enableSliceCache IN LISTS sliceCacheValues)
         ExternalData_Add_Test(test-data
                 NAME systest_compiler_sliceCache_${enableSliceCache}
-                COMMAND systest -n 20 --show-query-performance --workingDir=${CMAKE_CURRENT_BINARY_DIR}/compiler_sliceCache_${enableSliceCache} --exclude-groups ${SYSTEST_EXCLUDE_GROUPS_COMPILER} --data ${EXPANDED_TEST_DATA_PATH} -- --worker.query_engine.number_of_worker_threads=4 --worker.default_query_execution.execution_mode=COMPILER --enable_event_trace=true --worker.total_memory_in_bytes=${SYSTEST_JOIN_TOTAL_MEMORY_BYTES} --worker.unpooled_memory_fraction=${SYSTEST_JOIN_UNPOOLED_FRACTION} --worker.default_query_execution.slice_cache.enable_slice_cache=${enableSliceCache})
+                COMMAND systest -n 20 --show-query-performance --workingDir=${CMAKE_CURRENT_BINARY_DIR}/compiler_sliceCache_${enableSliceCache} --exclude-groups ${SYSTEST_EXCLUDE_GROUPS_COMPILER} --data ${EXPANDED_TEST_DATA_PATH} --permit-conflicting-options -- --worker.query_engine.number_of_worker_threads=4 --worker.default_query_execution.execution_mode=COMPILER --enable_event_trace=true --worker.total_memory_in_bytes=${SYSTEST_JOIN_TOTAL_MEMORY_BYTES} --worker.unpooled_memory_fraction=${SYSTEST_JOIN_UNPOOLED_FRACTION} --worker.default_query_execution.slice_cache.enable_slice_cache=${enableSliceCache})
         set_tests_properties(systest_compiler_sliceCache_${enableSliceCache} PROPERTIES LABELS "Systest" PROCESSORS 4)
     endforeach ()
 
@@ -149,13 +149,13 @@ if (ENABLE_LARGE_TESTS)
     ExternalData_Add_Test(test-data
             # currently, 4 worker threads perform the best on the large systests (avoids lock contention on NEXMARK Query 5)
             NAME systest_large_${joinStrategy}
-            COMMAND systest -n 6 --show-query-performance --workingDir=${CMAKE_CURRENT_BINARY_DIR}/large_scale_${joinStrategy} --data ${EXPANDED_TEST_DATA_PATH} --groups large -- --optimizer.join_strategy=${joinStrategy} --worker.default_query_execution.execution_mode=COMPILER --worker.query_engine.number_of_worker_threads=4 --worker.total_memory_in_bytes=${LARGE_TEST_TOTAL_MEMORY_BYTES} --worker.unpooled_memory_fraction=${LARGE_TEST_UNPOOLED_FRACTION} --worker.default_query_execution.slice_cache.enable_slice_cache=true)
+            COMMAND systest -n 6 --show-query-performance --workingDir=${CMAKE_CURRENT_BINARY_DIR}/large_scale_${joinStrategy} --data ${EXPANDED_TEST_DATA_PATH} --groups large --permit-conflicting-options -- --optimizer.join_strategy=${joinStrategy} --worker.default_query_execution.execution_mode=COMPILER --worker.query_engine.number_of_worker_threads=4 --worker.total_memory_in_bytes=${LARGE_TEST_TOTAL_MEMORY_BYTES} --worker.unpooled_memory_fraction=${LARGE_TEST_UNPOOLED_FRACTION} --worker.default_query_execution.slice_cache.enable_slice_cache=true)
     set_tests_properties(systest_large_${joinStrategy} PROPERTIES LABELS "Systest" PROCESSORS 4)
 
     ExternalData_Add_Test(test-data
             # currently, 16 worker threads perform the best on the large systests (avoids lock contention on NEXMARK Query 5)
             NAME systest_large_benchmark_${joinStrategy}
-            COMMAND systest -b --show-query-performance --workingDir=${CMAKE_CURRENT_BINARY_DIR}/large_scale_benchmark_${joinStrategy} --data ${EXPANDED_TEST_DATA_PATH} --groups large -- --optimizer.join_strategy=${joinStrategy} --worker.default_query_execution.execution_mode=COMPILER --worker.query_engine.number_of_worker_threads=16 --worker.total_memory_in_bytes=${LARGE_TEST_TOTAL_MEMORY_BYTES} --worker.unpooled_memory_fraction=${LARGE_TEST_UNPOOLED_FRACTION} --worker.default_query_execution.slice_cache.enable_slice_cache=true)
+            COMMAND systest -b --show-query-performance --workingDir=${CMAKE_CURRENT_BINARY_DIR}/large_scale_benchmark_${joinStrategy} --data ${EXPANDED_TEST_DATA_PATH} --groups large --permit-conflicting-options -- --optimizer.join_strategy=${joinStrategy} --worker.default_query_execution.execution_mode=COMPILER --worker.query_engine.number_of_worker_threads=16 --worker.total_memory_in_bytes=${LARGE_TEST_TOTAL_MEMORY_BYTES} --worker.unpooled_memory_fraction=${LARGE_TEST_UNPOOLED_FRACTION} --worker.default_query_execution.slice_cache.enable_slice_cache=true)
     set_tests_properties(systest_large_benchmark_${joinStrategy} PROPERTIES LABELS "Systest" PROCESSORS 16)
 
     # Running here the Nexmark.test queries with NLJ to test it for larger data sets but the input data size
@@ -211,13 +211,13 @@ if (NOT CODE_COVERAGE)
             endforeach ()
             ExternalData_Add_Test(test-data
                     NAME systest_agg_${workerThreads}_sliceCache_${enableSliceCache}_interpreter
-                    COMMAND systest -n 6 --show-query-performance --groups Aggregation --exclude-groups ${SYSTEST_EXCLUDE_GROUPS} --workingDir=${CMAKE_CURRENT_BINARY_DIR}/${workerThreads}_sliceCache_${enableSliceCache}_interpreter_aggregation --data ${EXPANDED_TEST_DATA_PATH}
+                    COMMAND systest -n 6 --show-query-performance --groups Aggregation --exclude-groups ${SYSTEST_EXCLUDE_GROUPS} --workingDir=${CMAKE_CURRENT_BINARY_DIR}/${workerThreads}_sliceCache_${enableSliceCache}_interpreter_aggregation --data ${EXPANDED_TEST_DATA_PATH} --permit-conflicting-options
                     --
                     --worker.query_engine.number_of_worker_threads=${workerThreads} --worker.default_query_execution.execution_mode=INTERPRETER --worker.total_memory_in_bytes=163840000 --worker.default_query_execution.slice_cache.enable_slice_cache=${enableSliceCache})
             set_tests_properties(systest_agg_${workerThreads}_sliceCache_${enableSliceCache}_interpreter PROPERTIES LABELS "Systest" PROCESSORS ${workerThreads})
             ExternalData_Add_Test(test-data
                     NAME systest_agg_${workerThreads}_sliceCache_${enableSliceCache}_compiler
-                    COMMAND systest -n 6 --show-query-performance --groups Aggregation --exclude-groups ${SYSTEST_EXCLUDE_GROUPS_COMPILER} --workingDir=${CMAKE_CURRENT_BINARY_DIR}/${workerThreads}_sliceCache_${enableSliceCache}_compiler_aggregation --data ${EXPANDED_TEST_DATA_PATH}
+                    COMMAND systest -n 6 --show-query-performance --groups Aggregation --exclude-groups ${SYSTEST_EXCLUDE_GROUPS_COMPILER} --workingDir=${CMAKE_CURRENT_BINARY_DIR}/${workerThreads}_sliceCache_${enableSliceCache}_compiler_aggregation --data ${EXPANDED_TEST_DATA_PATH} --permit-conflicting-options
                     --
                     --worker.query_engine.number_of_worker_threads=${workerThreads} --worker.default_query_execution.execution_mode=COMPILER --worker.total_memory_in_bytes=163840000 --worker.default_query_execution.slice_cache.enable_slice_cache=${enableSliceCache})
             set_tests_properties(systest_agg_${workerThreads}_sliceCache_${enableSliceCache}_compiler PROPERTIES LABELS "Systest" PROCESSORS ${workerThreads})

--- a/nes-systests/systest/include/Config/Config.hpp
+++ b/nes-systests/systest/include/Config/Config.hpp
@@ -24,14 +24,14 @@
 #include <Schema/Schema.hpp>
 #include <Schema/SchemaFwd.hpp>
 #include <QueryOptimizerConfiguration.hpp>
-#include <WorkerConfig.hpp>
+#include <WorkerCatalogEntry.hpp>
 
 namespace NES
 {
 
 struct SystestClusterConfiguration
 {
-    std::vector<WorkerConfig> workers;
+    std::vector<WorkerCatalogEntry> workers;
     std::vector<Host> allowSourcePlacement;
     std::vector<Host> allowSinkPlacement;
 };
@@ -71,6 +71,9 @@ struct SystestConfiguration final
     std::string queryCompilerConfig;
     /// Use remote worker.
     bool remoteWorker = false;
+    /// Allow higher-priority config layers (systest file > topology > command line) to overwrite
+    /// conflicting values; every overwrite is printed. Without it, conflicting values fail the run.
+    bool permitConflictingOptions = false;
     /// Cluster configuration.
     std::string clusterConfigPath = TEST_CONFIGURATION_DIR "/topologies/two-node.yaml";
     /// Print per-query performance timing in the console output.
@@ -83,9 +86,9 @@ struct SystestConfiguration final
     std::vector<std::string> globalExcludedGroups;
 
     SystestClusterConfiguration clusterConfig;
-    /// Worker/optimizer config literals from the `-w` file and the command line after `--`
-    /// (empty = nothing passed). They stay literals so per-test-file configuration overrides can
-    /// be layered on top before resolving against SingleNodeWorkerConfiguration's declared schema.
+    /// Worker config literals passed on the command line after `--` (empty = nothing passed).
+    /// They stay literals end to end; the embedded backend merges them with the topology literals
+    /// and resolves against SingleNodeWorkerConfiguration's declared schema.
     Schema<LiteralConfigValue, Ordered> workerOptimizerConfigLiterals;
     /// Explicitly resolved defaults: tests construct SystestConfiguration without going through
     /// the starter (which overwrites this from the `--` section), and the config structs are not

--- a/nes-systests/systest/include/Runner/SystestRunner.hpp
+++ b/nes-systests/systest/include/Runner/SystestRunner.hpp
@@ -34,7 +34,6 @@
 #include <Sources/SourceCatalog.hpp>
 #include <rfl/Rename.hpp>
 #include <Progress.hpp>
-#include <SingleNodeWorkerConfiguration.hpp>
 #include <SystestState.hpp>
 
 namespace NES::Systest
@@ -67,9 +66,16 @@ inline std::string discardPerformanceMessage(RunningQuery&)
     SystestProgressTracker& progressTracker,
     const QueryPerformanceMessageBuilder& queryPerformanceMessage);
 
-/// Build the embedded-worker config resolver from the merged run-configuration literals
-/// (command line plus per-test-file overrides). The run configuration wins over the topology.
-[[nodiscard]] WorkerConfigResolver makeRunConfigResolver(Schema<LiteralConfigValue, Ordered> runConfigLiterals);
+/// Build the config policy for embedded workers spawned by systest: per worker, merge the config
+/// layers lowest priority first — command line, per-worker topology config, systest-file override —
+/// and resolve the result. Any overwrite (same name, differing value) fails the run unless
+/// `permitConflictingOptions` is set, in which case each overwrite is printed to stdout together
+/// with `overwriteContext` (the systest file(s) being run).
+[[nodiscard]] WorkerConfigResolver makeWorkerConfigResolver(
+    Schema<LiteralConfigValue, Ordered> commandLineLiterals,
+    Schema<LiteralConfigValue, Ordered> systestFileLiterals,
+    bool permitConflictingOptions,
+    std::string overwriteContext);
 
 /// Run queries locally ie not on single-node-worker in a separate process
 /// @return returns a collection of failed queries

--- a/nes-systests/systest/src/Config/ConfigParser.cpp
+++ b/nes-systests/systest/src/Config/ConfigParser.cpp
@@ -47,7 +47,7 @@
 #include <ErrorHandling.hpp>
 #include <QueryOptimizerConfiguration.hpp>
 #include <SingleNodeWorkerConfiguration.hpp>
-#include <WorkerConfig.hpp>
+#include <WorkerCatalogEntry.hpp>
 #include <WorkerOptimizerConfig.hpp>
 
 namespace
@@ -110,6 +110,10 @@ void configureArgumentParser(ArgumentParser& program)
     program.add_argument("-w", "--workerConfig")
         .help("worker/optimizer config file (.yaml) with fully qualified keys (worker.*, optimizer.*, ...); the lowest-priority config "
               "layer");
+    program.add_argument("--permit-conflicting-options")
+        .flag()
+        .help("allow higher-priority config layers (systest file > topology > command line) to overwrite conflicting values; every "
+              "overwrite is printed");
     program.add_argument("--endless").flag().help("continuously issue queries to the worker");
     program.add_argument("--")
         .help("arguments passed to the worker/optimizer config, e.g., `-- --worker.query_engine.number_of_worker_threads=10 "
@@ -361,6 +365,7 @@ void applyExecutionOptions(const ArgumentParser& program, NES::SystestConfigurat
     }
 
     config.remoteWorker = program.get<bool>("--remote");
+    config.permitConflictingOptions = program.get<bool>("--permit-conflicting-options");
 
     try
     {
@@ -380,7 +385,7 @@ void applyExecutionOptions(const ArgumentParser& program, NES::SystestConfigurat
                 config = NES::flattenYAMLConfig(worker["config"]);
             }
 
-            clusterConfig.workers.push_back(NES::WorkerConfig{
+            clusterConfig.workers.push_back(NES::WorkerCatalogEntry{
                 .host = worker["host"].as<NES::Host>(),
                 .dataAddress = worker["data_address"].as<std::string>(),
                 .maxOperators = worker["max_operators"].IsDefined()

--- a/nes-systests/systest/src/Runner/SystestRunner.cpp
+++ b/nes-systests/systest/src/Runner/SystestRunner.cpp
@@ -54,15 +54,17 @@
 #include <Schema/Schema.hpp>
 #include <Schema/SchemaFwd.hpp>
 #include <Util/Logger/Logger.hpp>
+#include <Util/Strings.hpp>
 #include <fmt/base.h>
 #include <fmt/color.h>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <DistributedQuery.hpp>
 #include <ErrorHandling.hpp>
-#include <SingleNodeWorkerConfiguration.hpp>
+
 #include <SystestState.hpp>
 #include <WorkerCatalog.hpp>
-#include <WorkerConfig.hpp>
+#include <WorkerCatalogEntry.hpp>
 #include <WorkerOptimizerConfig.hpp>
 
 namespace NES::Systest
@@ -446,25 +448,6 @@ std::vector<RunningQuery> runQueries(
 
 /// NOLINTEND(readability-function-cognitive-complexity)
 
-/// The run configuration (command line plus per-test-file overrides, already merged by the
-/// executor) is layered over the per-worker topology config and resolved against the declared
-/// schema. Matches the previous precedence: the run configuration wins over the topology.
-WorkerConfigResolver makeRunConfigResolver(Schema<LiteralConfigValue, Ordered> runConfigLiterals)
-{
-    return [runConfigLiterals = std::move(runConfigLiterals)](const WorkerConfig& worker)
-    {
-        auto [literals, overwrites] = mergeConfigLayers(
-            {ConfigLayer{.name = "topology", .literals = worker.config},
-             ConfigLayer{.name = "run configuration", .literals = runConfigLiterals}});
-        auto resolved = resolveConfiguration<WorkerOptimizerConfig>(literals);
-        if (not resolved.has_value())
-        {
-            throw InvalidConfigParameter("{}", resolved.error());
-        }
-        return std::move(resolved)->worker;
-    };
-}
-
 namespace
 {
 std::vector<RunningQuery>
@@ -486,6 +469,63 @@ serializeExecutionResults(const std::vector<RunningQuery>& queries, std::vector<
     }
     return failedQueries;
 }
+}
+
+WorkerConfigResolver makeWorkerConfigResolver(
+    Schema<LiteralConfigValue, Ordered> commandLineLiterals,
+    Schema<LiteralConfigValue, Ordered> systestFileLiterals,
+    const bool permitConflictingOptions,
+    std::string overwriteContext)
+{
+    return [commandLineLiterals = std::move(commandLineLiterals),
+            systestFileLiterals = std::move(systestFileLiterals),
+            permitConflictingOptions,
+            overwriteContext = std::move(overwriteContext)](const WorkerCatalogEntry& worker)
+    {
+        auto [literals, overwrites] = mergeConfigLayers(
+            {ConfigLayer{.name = "command line", .literals = commandLineLiterals},
+             ConfigLayer{.name = "topology", .literals = worker.config},
+             ConfigLayer{.name = "systest file", .literals = systestFileLiterals}});
+        if (!overwrites.empty())
+        {
+            const auto formatted = overwrites
+                | std::views::transform(
+                                       [](const ConfigOverwrite& overwrite)
+                                       {
+                                           return fmt::format(
+                                               "{}: {} ({}) overwrites {} ({})",
+                                               toLowerCase(fmt::format("{}", overwrite.name)),
+                                               overwrite.appliedValue,
+                                               overwrite.appliedLayer,
+                                               overwrite.overwrittenValue,
+                                               overwrite.overwrittenLayer);
+                                       })
+                | std::ranges::to<std::vector>();
+            if (!permitConflictingOptions)
+            {
+                throw InvalidConfigParameter(
+                    "Conflicting configuration values for worker {} ({}):\n{}\nPass --permit-conflicting-options to allow "
+                    "higher-priority layers to overwrite.",
+                    worker.host.getRawValue(),
+                    overwriteContext,
+                    fmt::join(formatted, "\n"));
+            }
+            for (const auto& line : formatted)
+            {
+                std::cout << fmt::format("[{}] worker {}: {}\n", overwriteContext, worker.host.getRawValue(), line);
+            }
+        }
+        auto resolved = resolveConfiguration<WorkerOptimizerConfig>(literals);
+        if (!resolved)
+        {
+            throw InvalidConfigParameter("{}", resolved.error());
+        }
+        NES_INFO(
+            "Configuration of embedded worker {}:\n{}",
+            worker.host.getRawValue(),
+            formatEffectiveConfig(literals, WorkerOptimizerConfig::getConfigSchema()));
+        return std::move(resolved)->worker;
+    };
 }
 
 std::vector<RunningQuery> runQueriesAndBenchmark(

--- a/nes-systests/systest/src/SystestExecutor.cpp
+++ b/nes-systests/systest/src/SystestExecutor.cpp
@@ -81,7 +81,7 @@ namespace
 using OverrideQueriesMap = std::unordered_map<Systest::ConfigurationOverride, std::vector<Systest::SystestQuery>>;
 
 /// A test file's per-query configuration overrides as the highest-priority config layer (see
-/// makeRunConfigResolver). Override keys are fully qualified (e.g. `worker.total_memory_in_bytes`);
+/// makeWorkerConfigResolver). Override keys are fully qualified (e.g. `worker.total_memory_in_bytes`);
 /// a leading `--` is tolerated as the old command-line-style overwrite stripped it.
 Schema<LiteralConfigValue, Ordered> buildOverrideLiterals(const Systest::ConfigurationOverride& overrideConfig)
 {
@@ -102,6 +102,16 @@ Schema<LiteralConfigValue, Ordered> buildOverrideLiterals(const Systest::Configu
         overrideLiterals.emplace_back(QualifiedIdentifier::parse(keyView), std::move(literal).value());
     }
     return createConfigLiteralSchema(std::move(overrideLiterals));
+}
+
+/// The systest files a group of queries came from, for the conflict/overwrite report.
+std::string testFilesLabel(const std::vector<Systest::SystestQuery>& queries)
+{
+    auto names = queries | std::views::transform([](const auto& query) { return query.testName; }) | std::ranges::to<std::vector>();
+    std::ranges::sort(names);
+    const auto [first, last] = std::ranges::unique(names);
+    names.erase(first, last);
+    return fmt::format("{}", fmt::join(names, ", "));
 }
 
 void exitOnFailureIfNeeded(const std::vector<Systest::RunningQuery>& failedQueries, const size_t totalQueries)
@@ -159,7 +169,7 @@ void exitOnFailureIfNeeded(const std::vector<Systest::RunningQuery>& failedQueri
     const uint64_t numberConcurrentQueries,
     const SystestClusterConfiguration& clusterConfig,
     const Schema<LiteralConfigValue, Ordered>& baseConfigLiterals,
-
+    const bool permitConflictingOptions,
     Systest::SystestProgressTracker& progressTracker)
 {
     while (true)
@@ -173,10 +183,8 @@ void exitOnFailureIfNeeded(const std::vector<Systest::RunningQuery>& failedQueri
         progressTracker.setTotalQueries(totalLocal);
         for (const auto& [overrideConfig, queriesForConfig] : queriesByOverride)
         {
-            auto [runConfigLiterals, overwrites] = mergeConfigLayers(
-                {ConfigLayer{.name = "command line", .literals = baseConfigLiterals},
-                 ConfigLayer{.name = "systest file", .literals = buildOverrideLiterals(overrideConfig)}});
-            auto workerConfigResolver = Systest::makeRunConfigResolver(std::move(runConfigLiterals));
+            auto workerConfigResolver = Systest::makeWorkerConfigResolver(
+                baseConfigLiterals, buildOverrideLiterals(overrideConfig), permitConflictingOptions, testFilesLabel(queriesForConfig));
 
             auto workerCatalog = std::make_shared<WorkerCatalog>(clusterConfig.workers);
 
@@ -286,7 +294,13 @@ void SystestExecutor::runEndlessMode(const std::vector<Systest::SystestQuery>& q
     else
     {
         runEndlessLocal(
-            queriesByOverride, rng, numberConcurrentQueries, config.clusterConfig, workerOptimizerConfigLiterals, progressTracker);
+            queriesByOverride,
+            rng,
+            numberConcurrentQueries,
+            config.clusterConfig,
+            workerOptimizerConfigLiterals,
+            config.permitConflictingOptions,
+            progressTracker);
     }
 }
 
@@ -402,12 +416,13 @@ SystestExecutorResult SystestExecutor::executeSystests()
                 progressTracker.setTotalQueries(benchmarkQueries.size());
                 for (const auto& [overrideConfig, queriesForConfig] : benchmarkQueriesByOverride)
                 {
-                    auto [runConfigLiterals, overwrites] = mergeConfigLayers(
-                        {ConfigLayer{.name = "command line", .literals = workerOptimizerConfigLiterals},
-                         ConfigLayer{.name = "systest file", .literals = buildOverrideLiterals(overrideConfig)}});
                     auto failed = runQueriesAndBenchmark(
                         queriesForConfig,
-                        Systest::makeRunConfigResolver(std::move(runConfigLiterals)),
+                        Systest::makeWorkerConfigResolver(
+                            workerOptimizerConfigLiterals,
+                            buildOverrideLiterals(overrideConfig),
+                            config.permitConflictingOptions,
+                            testFilesLabel(queriesForConfig)),
                         benchmarkResults,
                         config.clusterConfig,
                         progressTracker);
@@ -432,10 +447,11 @@ SystestExecutorResult SystestExecutor::executeSystests()
                 progressTracker.setTotalQueries(queries.size());
                 for (const auto& [overrideConfig, queriesForConfig] : queriesByOverride)
                 {
-                    auto [runConfigLiterals, overwrites] = mergeConfigLayers(
-                        {ConfigLayer{.name = "command line", .literals = workerOptimizerConfigLiterals},
-                         ConfigLayer{.name = "systest file", .literals = buildOverrideLiterals(overrideConfig)}});
-                    auto workerConfigResolver = Systest::makeRunConfigResolver(std::move(runConfigLiterals));
+                    auto workerConfigResolver = Systest::makeWorkerConfigResolver(
+                        workerOptimizerConfigLiterals,
+                        buildOverrideLiterals(overrideConfig),
+                        config.permitConflictingOptions,
+                        testFilesLabel(queriesForConfig));
                     const Systest::QueryPerformanceMessageBuilder performanceMessage = config.showQueryPerformance
                         ? Systest::QueryPerformanceMessageBuilder{[](Systest::RunningQuery& runningQuery)
                                                                   { return fmt::format(" in {}", runningQuery.getElapsedTime()); }}

--- a/nes-systests/systest/tests/Runner/SystestRunnerTest.cpp
+++ b/nes-systests/systest/tests/Runner/SystestRunnerTest.cpp
@@ -64,7 +64,7 @@
 #include <Util/Pointers.hpp>
 #include <SystestState.hpp>
 #include <WorkerCatalog.hpp>
-#include <WorkerConfig.hpp>
+#include <WorkerCatalogEntry.hpp>
 #include <WorkerStatus.hpp>
 
 namespace
@@ -188,7 +188,7 @@ std::pair<QuerySubmitter, MockQuerySubmissionBackend*> createQuerySubmitter()
     workerCatalog->addWorker(Host("localhost:8080"), "localhost:9090", Capacity(CapacityKind::Unlimited{}), {});
     QuerySubmitter submitter{std::make_unique<QueryManager>(
         std::move(workerCatalog),
-        [mockBackend = std::move(mockBackend)](const WorkerConfig&) mutable
+        [mockBackend = std::move(mockBackend)](const WorkerCatalogEntry&) mutable
         {
             INVARIANT(mockBackend != nullptr, "mockBackend should only be moved once");
             return std::move(mockBackend);

--- a/nes-systests/systest/tests/SystestE2ETests.cpp
+++ b/nes-systests/systest/tests/SystestE2ETests.cpp
@@ -27,7 +27,7 @@
 #include <Util/Logger/impl/NesLogger.hpp>
 #include <BaseUnitTest.hpp>
 #include <SystestExecutor.hpp>
-#include <WorkerConfig.hpp>
+#include <WorkerCatalogEntry.hpp>
 
 namespace
 {
@@ -73,7 +73,7 @@ TEST_F(SystestE2ETest, CheckThatOnlyWrongQueriesFailInFileWithManyQueries)
     config.directlySpecifiedTestFiles = fmt::format("{}/errors/{}", SYSTEST_DATA_DIR, testFileName);
     config.workingDir = fmt::format("{}/nes-systests/systest/MultipleCorrectAndIncorrect", PATH_TO_BINARY_DIR);
     config.clusterConfig = SystestClusterConfiguration{
-        .workers = {WorkerConfig{
+        .workers = {WorkerCatalogEntry{
             .host = Host("localhost:8080"),
             .dataAddress = "localhost:9090",
             .maxOperators = Capacity(CapacityKind::Limited{DEFAULT_WORKER_CAPACITY}),
@@ -108,7 +108,7 @@ TEST_P(SystestE2ETest, correctAndIncorrectSchemaTestFile)
     config.testFileExtension = std::string(EXTENSION);
     config.workingDir = fmt::format("{}/nes-systests/systest/{}", PATH_TO_BINARY_DIR, testFile);
     config.clusterConfig = SystestClusterConfiguration{
-        .workers = {WorkerConfig{
+        .workers = {WorkerCatalogEntry{
             .host = Host("localhost:8080"),
             .dataAddress = "localhost:9090",
             .maxOperators = Capacity(CapacityKind::Limited{DEFAULT_WORKER_CAPACITY}),


### PR DESCRIPTION
Config options for the system currently get merged in a somewhat unspecified/uncontrolled way. The order of precendence of the origins of the config options was never consciously decided, and we permit the specification of the same options in multiple places which can lead to unexpected configurations.

Embedded workers now resolve their configuration from three literal layers (lowest priority first): the command line / -w file, the topology's per-worker config, and the systest file's per-query configuration overrides. makeWorkerConfigResolver merges the layers per worker; conflicting values across layers are an error unless --permit-conflicting-options is passed, in which case every overwrite is printed.

WorkerConfig is renamed to WorkerCatalogEntry for less ambiguity.

