### PR TITLE
refactor(systest): drop the Systest namespace

### DIFF
--- a/nes-systests/systest/private/Progress.hpp
+++ b/nes-systests/systest/private/Progress.hpp
@@ -17,7 +17,7 @@
 #include <atomic>
 #include <cstddef>
 
-namespace NES::Systest
+namespace NES
 {
 
 class SystestProgressTracker

--- a/nes-systests/systest/private/Runner/QuerySubmitter.hpp
+++ b/nes-systests/systest/private/Runner/QuerySubmitter.hpp
@@ -23,7 +23,7 @@
 #include <DistributedQuery.hpp>
 #include <ErrorHandling.hpp>
 
-namespace NES::Systest
+namespace NES
 {
 
 /// Interface for submitting queries to a NebulaStream Worker.

--- a/nes-systests/systest/private/Runner/SystestRunner.hpp
+++ b/nes-systests/systest/private/Runner/SystestRunner.hpp
@@ -33,7 +33,7 @@
 #include <SingleNodeWorkerConfiguration.hpp>
 #include <SystestState.hpp>
 
-namespace NES::Systest
+namespace NES
 {
 /// Forward declarations
 struct SystestQuery;

--- a/nes-systests/systest/private/SystestBinder.hpp
+++ b/nes-systests/systest/private/SystestBinder.hpp
@@ -24,7 +24,7 @@
 #include <QueryOptimizerConfiguration.hpp>
 #include <SystestState.hpp>
 
-namespace NES::Systest
+namespace NES
 {
 /// The systest binder uses the SystestParser to create SystestQuery objects that contain everything to run and validate systest queries.
 /// It has to do more than a traditional binder to be able to extract some information required for validation,

--- a/nes-systests/systest/private/SystestExecutor.hpp
+++ b/nes-systests/systest/private/SystestExecutor.hpp
@@ -49,9 +49,9 @@ public:
     SystestExecutorResult executeSystests();
 
 private:
-    void runEndlessMode(const std::vector<Systest::SystestQuery>& queries, const RunPolicy& policy);
+    void runEndlessMode(const std::vector<SystestQuery>& queries, const RunPolicy& policy);
 
     SystestConfiguration config;
-    Systest::SystestProgressTracker progressTracker;
+    SystestProgressTracker progressTracker;
 };
 }

--- a/nes-systests/systest/private/SystestState.hpp
+++ b/nes-systests/systest/private/SystestState.hpp
@@ -47,7 +47,7 @@
 #include <DistributedQuery.hpp>
 #include <ErrorHandling.hpp>
 
-namespace NES::Systest
+namespace NES
 {
 
 class SystestRunner;
@@ -170,11 +170,11 @@ struct RunningQuery
 }
 
 template <>
-struct fmt::formatter<NES::Systest::RunningQuery> : formatter<std::string>
+struct fmt::formatter<NES::RunningQuery> : formatter<std::string>
 {
     static constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
 
-    static auto format(const NES::Systest::RunningQuery& runningQuery, format_context& ctx) -> decltype(ctx.out())
+    static auto format(const NES::RunningQuery& runningQuery, format_context& ctx) -> decltype(ctx.out())
     {
         return fmt::format_to(
             ctx.out(),

--- a/nes-systests/systest/src/Progress.cpp
+++ b/nes-systests/systest/src/Progress.cpp
@@ -14,7 +14,7 @@
 
 #include <Progress.hpp>
 
-namespace NES::Systest
+namespace NES
 {
 
 SystestProgressTracker::SystestProgressTracker() = default;

--- a/nes-systests/systest/src/Runner/QuerySubmitter.cpp
+++ b/nes-systests/systest/src/Runner/QuerySubmitter.cpp
@@ -33,7 +33,7 @@
 #include <DistributedQuery.hpp>
 #include <ErrorHandling.hpp>
 
-namespace NES::Systest
+namespace NES
 {
 
 QuerySubmitter::QuerySubmitter(std::unique_ptr<QueryManager> queryManager) : queryManager(std::move(queryManager))

--- a/nes-systests/systest/src/Runner/SystestRunner.cpp
+++ b/nes-systests/systest/src/Runner/SystestRunner.cpp
@@ -67,7 +67,7 @@
 #include <SystestState.hpp>
 #include <WorkerCatalog.hpp>
 
-namespace NES::Systest
+namespace NES
 {
 namespace
 {

--- a/nes-systests/systest/src/SystestBinder.cpp
+++ b/nes-systests/systest/src/SystestBinder.cpp
@@ -82,7 +82,7 @@
 #include <SystestState.hpp>
 #include <WorkerCatalog.hpp>
 
-namespace NES::Systest
+namespace NES
 {
 
 /// Helper class to model the two-step process of creating sinks in systest. We cannot create sink descriptors directly from sink definitions, because

--- a/nes-systests/systest/src/SystestExecutor.cpp
+++ b/nes-systests/systest/src/SystestExecutor.cpp
@@ -72,9 +72,9 @@ namespace NES
 {
 namespace
 {
-using OverrideQueriesMap = std::unordered_map<ConfigurationOverride, std::vector<Systest::SystestQuery>>;
+using OverrideQueriesMap = std::unordered_map<ConfigurationOverride, std::vector<SystestQuery>>;
 
-void exitOnFailureIfNeeded(const std::vector<Systest::RunningQuery>& failedQueries, const size_t totalQueries)
+void exitOnFailureIfNeeded(const std::vector<RunningQuery>& failedQueries, const size_t totalQueries)
 {
     if (failedQueries.empty())
     {
@@ -97,11 +97,11 @@ void exitOnFailureIfNeeded(const std::vector<Systest::RunningQuery>& failedQueri
     std::mt19937& rng,
     const uint64_t numberConcurrentQueries,
     const SystestClusterConfiguration& clusterConfig,
-    Systest::SystestProgressTracker& progressTracker)
+    SystestProgressTracker& progressTracker)
 {
     auto workerCatalog = std::make_shared<WorkerCatalog>(clusterConfig.workers);
 
-    Systest::QuerySubmitter querySubmitter(std::make_unique<QueryManager>(std::move(workerCatalog), createGRPCBackend()));
+    QuerySubmitter querySubmitter(std::make_unique<QueryManager>(std::move(workerCatalog), createGRPCBackend()));
 
     while (true)
     {
@@ -116,8 +116,8 @@ void exitOnFailureIfNeeded(const std::vector<Systest::RunningQuery>& failedQueri
         {
             auto shuffledQueries = entry.second;
             std::ranges::shuffle(shuffledQueries, rng);
-            const auto failedQueries = Systest::runQueries(
-                shuffledQueries, numberConcurrentQueries, querySubmitter, progressTracker, Systest::discardPerformanceMessage);
+            const auto failedQueries
+                = runQueries(shuffledQueries, numberConcurrentQueries, querySubmitter, progressTracker, discardPerformanceMessage);
             exitOnFailureIfNeeded(failedQueries, shuffledQueries.size());
         }
     }
@@ -129,7 +129,7 @@ void exitOnFailureIfNeeded(const std::vector<Systest::RunningQuery>& failedQueri
     const uint64_t numberConcurrentQueries,
     const SystestClusterConfiguration& clusterConfig,
     const SingleNodeWorkerConfiguration& baseConfiguration,
-    Systest::SystestProgressTracker& progressTracker)
+    SystestProgressTracker& progressTracker)
 {
     while (true)
     {
@@ -150,13 +150,12 @@ void exitOnFailureIfNeeded(const std::vector<Systest::RunningQuery>& failedQueri
 
             auto workerCatalog = std::make_shared<WorkerCatalog>(clusterConfig.workers);
 
-            Systest::QuerySubmitter querySubmitter(
-                std::make_unique<QueryManager>(std::move(workerCatalog), createEmbeddedBackend(configCopy)));
+            QuerySubmitter querySubmitter(std::make_unique<QueryManager>(std::move(workerCatalog), createEmbeddedBackend(configCopy)));
 
             auto shuffledQueries = queriesForConfig;
             std::ranges::shuffle(shuffledQueries, rng);
-            const auto failedQueries = Systest::runQueries(
-                shuffledQueries, numberConcurrentQueries, querySubmitter, progressTracker, Systest::discardPerformanceMessage);
+            const auto failedQueries
+                = runQueries(shuffledQueries, numberConcurrentQueries, querySubmitter, progressTracker, discardPerformanceMessage);
             exitOnFailureIfNeeded(failedQueries, shuffledQueries.size());
         }
     }
@@ -167,7 +166,7 @@ SystestExecutor::SystestExecutor(SystestConfiguration config) : config(std::move
 {
 }
 
-void SystestExecutor::runEndlessMode(const std::vector<Systest::SystestQuery>& queries, const RunPolicy& policy)
+void SystestExecutor::runEndlessMode(const std::vector<SystestQuery>& queries, const RunPolicy& policy)
 {
     std::cout << std::format("Running endlessly over a total of {} queries (across all configuration overrides).", queries.size()) << '\n';
 
@@ -212,7 +211,7 @@ SystestExecutorResult SystestExecutor::executeSystests()
         const WorkingDirectoryGuard workingDirectoryGuard{config.workingDir.getValue()};
 
         auto discoveredTestFiles = discoverTestFiles(config);
-        Systest::SystestBinder binder{
+        SystestBinder binder{
             config.workingDir.getValue(),
             config.testDataDir.getValue(),
             config.configDir.getValue(),
@@ -258,15 +257,15 @@ SystestExecutorResult SystestExecutor::executeSystests()
             std::ranges::shuffle(queries, rng);
         }
         const auto numberConcurrentQueries = policy.concurrency;
-        std::vector<Systest::RunningQuery> failedQueries;
+        std::vector<RunningQuery> failedQueries;
         if (config.remoteWorker.getValue())
         {
             progressTracker.reset();
             progressTracker.setTotalQueries(queries.size());
-            const Systest::QueryPerformanceMessageBuilder performanceMessage = config.showQueryPerformance.getValue()
-                ? Systest::QueryPerformanceMessageBuilder{[](Systest::RunningQuery& runningQuery)
-                                                          { return fmt::format(" in {}", runningQuery.getElapsedTime()); }}
-                : Systest::QueryPerformanceMessageBuilder{Systest::discardPerformanceMessage};
+            const QueryPerformanceMessageBuilder performanceMessage = config.showQueryPerformance.getValue()
+                ? QueryPerformanceMessageBuilder{[](RunningQuery& runningQuery)
+                                                 { return fmt::format(" in {}", runningQuery.getElapsedTime()); }}
+                : QueryPerformanceMessageBuilder{discardPerformanceMessage};
             auto failed
                 = runQueriesAtRemoteWorker(queries, numberConcurrentQueries, config.clusterConfig, progressTracker, performanceMessage);
             failedQueries.insert(failedQueries.end(), failed.begin(), failed.end());
@@ -284,8 +283,8 @@ SystestExecutorResult SystestExecutor::executeSystests()
             }
             if (policy.measureReport.has_value())
             {
-                std::vector<Systest::BenchmarkResult> benchmarkResults;
-                std::vector<Systest::SystestQuery> benchmarkQueries;
+                std::vector<BenchmarkResult> benchmarkResults;
+                std::vector<SystestQuery> benchmarkQueries;
                 benchmarkQueries.reserve(queries.size());
 
                 for (const auto& query : queries)
@@ -309,7 +308,7 @@ SystestExecutorResult SystestExecutor::executeSystests()
 
                 /// Benchmarked queries honour their configuration override just like the regular path does: queries
                 /// are grouped by override and each group runs against a worker configured with it.
-                std::unordered_map<ConfigurationOverride, std::vector<Systest::SystestQuery>> benchmarkQueriesByOverride;
+                std::unordered_map<ConfigurationOverride, std::vector<SystestQuery>> benchmarkQueriesByOverride;
                 for (const auto& query : benchmarkQueries)
                 {
                     benchmarkQueriesByOverride[query.configurationOverride].push_back(query);
@@ -337,7 +336,7 @@ SystestExecutorResult SystestExecutor::executeSystests()
             }
             else
             {
-                std::unordered_map<ConfigurationOverride, std::vector<Systest::SystestQuery>> queriesByOverride;
+                std::unordered_map<ConfigurationOverride, std::vector<SystestQuery>> queriesByOverride;
                 for (const auto& query : queries)
                 {
                     queriesByOverride[query.configurationOverride].push_back(query);
@@ -352,10 +351,10 @@ SystestExecutorResult SystestExecutor::executeSystests()
                     {
                         configCopy.overwriteConfigWithCommandLineInput({{key, value}});
                     }
-                    const Systest::QueryPerformanceMessageBuilder performanceMessage = config.showQueryPerformance.getValue()
-                        ? Systest::QueryPerformanceMessageBuilder{[](Systest::RunningQuery& runningQuery)
-                                                                  { return fmt::format(" in {}", runningQuery.getElapsedTime()); }}
-                        : Systest::QueryPerformanceMessageBuilder{Systest::discardPerformanceMessage};
+                    const QueryPerformanceMessageBuilder performanceMessage = config.showQueryPerformance.getValue()
+                        ? QueryPerformanceMessageBuilder{[](RunningQuery& runningQuery)
+                                                         { return fmt::format(" in {}", runningQuery.getElapsedTime()); }}
+                        : QueryPerformanceMessageBuilder{discardPerformanceMessage};
                     auto failed = runQueriesAtLocalWorker(
                         queriesForConfig, numberConcurrentQueries, config.clusterConfig, configCopy, progressTracker, performanceMessage);
                     failedQueries.insert(failedQueries.end(), failed.begin(), failed.end());

--- a/nes-systests/systest/src/SystestState.cpp
+++ b/nes-systests/systest/src/SystestState.cpp
@@ -48,7 +48,7 @@
 #include <DistributedQuery.hpp>
 #include <ErrorHandling.hpp>
 
-namespace NES::Systest
+namespace NES
 {
 
 std::filesystem::path

--- a/nes-systests/systest/tests/Runner/SystestRunnerTest.cpp
+++ b/nes-systests/systest/tests/Runner/SystestRunnerTest.cpp
@@ -89,12 +89,12 @@ makeSummary(const NES::QueryId& id, const NES::QueryStatus currState, const std:
     return queryStatus;
 }
 
-NES::Systest::SystestQuery makeQuery(
-    const std::expected<NES::Systest::SystestQuery::PlanInfo, NES::Exception> planInfoOrException,
+NES::SystestQuery makeQuery(
+    const std::expected<NES::SystestQuery::PlanInfo, NES::Exception> planInfoOrException,
     NES::Expectation expected,
     NES::SystestQueryId queryId)
 {
-    return NES::Systest::SystestQuery{
+    return NES::SystestQuery{
         .testName = NES::TestName{"test_query"},
         .queryIdInFile = queryId,
         .testFilePath = SYSTEST_DATA_DIR "filter.dummy",
@@ -109,7 +109,7 @@ NES::Systest::SystestQuery makeQuery(
 }
 }
 
-namespace NES::Systest
+namespace NES
 {
 
 class SystestRunnerTest : public Testing::BaseUnitTest

--- a/nes-systests/systest/tests/SystestE2ETests.cpp
+++ b/nes-systests/systest/tests/SystestE2ETests.cpp
@@ -39,7 +39,7 @@ size_t countFailedTests(const std::string_view failedTestString, const std::stri
 };
 }
 
-namespace NES::Systest
+namespace NES
 {
 
 struct E2ETestParameters

--- a/nes-systests/systest/tests/SystestStateTests.cpp
+++ b/nes-systests/systest/tests/SystestStateTests.cpp
@@ -24,7 +24,7 @@
 #include <SystestState.hpp>
 #include <TemporaryDirectory.hpp>
 
-namespace NES::Systest
+namespace NES
 {
 class SystestStateTest : public Testing::BaseUnitTest
 {


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

Stacked on #1998.

Moves everything under `NES::Systest` into `NES`. None of the names clash with the rest of the tree, and the extra namespace only made the systest code spell its own types differently from every other component. Dropping it before the refactoring in #1993, #1994, and #1996 keeps those diffs free of namespace changes.

The change list is as follows:
- Replaced `namespace NES::Systest` with `namespace NES` in 15 files under `nes-systests/systest`.
- Removed the `Systest::` qualifiers, mostly in `SystestExecutor.cpp`.

## Verifying this change

Compiles without a rename. Tested by the existing suites: `slt-parser-test` (49), `testfile-builder-test` (14), `slt-e2e-test` (12), and `sources/TCP.test` in the dev container.

## What components does this pull request potentially affect?

- nes-systests only.

## Documentation

- No documentation referred to the namespace.

## Issue Closed by this pull request:

This PR closes #2002, part of the systest refactoring epic #1920.

