### PR TITLE
build: robust vcpkg clone and python3 fallback for the dependency hash

### DIFF
--- a/cmake/EnableRust.cmake
+++ b/cmake/EnableRust.cmake
@@ -10,6 +10,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# The dependency image vendors the workspace from the root manifest alone and then builds offline.
+# That vendoring never sees a member that declares its own dependency, so the policy has to hold before a build starts.
+# The dependency hash script cannot check it, because the local image install computes the hash on a host that has no image yet.
+execute_process(
+        COMMAND python3 ${CMAKE_SOURCE_DIR}/scripts/check_rust_dependency_policy.py ${CMAKE_SOURCE_DIR}
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        ERROR_VARIABLE rust_dependency_policy_error
+        RESULT_VARIABLE rust_dependency_policy_result
+        ERROR_STRIP_TRAILING_WHITESPACE
+)
+if (NOT rust_dependency_policy_result EQUAL 0)
+    message(FATAL_ERROR "${rust_dependency_policy_error}")
+endif ()
+
 # Unfortunately, compiling rust with sanitizers requires the nightly compiler.
 SET(Rust_RESOLVE_RUSTUP_TOOLCHAINS OFF)
 SET(Rust_TOOLCHAIN "nightly")

--- a/docker/dependency/Dependency.dockerfile
+++ b/docker/dependency/Dependency.dockerfile
@@ -83,6 +83,8 @@ RUN --mount=type=secret,id=VCPKG_CACHE_ACCESS_KEY \
     if [ "$STDLIB" = "libcxx" ]; then VCPKG_STDLIB="libcxx"; else VCPKG_STDLIB="local"; fi; \
     \
     cd /vcpkg_input; \
+    # An image build has no terminal, so git would wait on an auth challenge until the build times out.
+    export GIT_TERMINAL_PROMPT=0; \
     git clone https://github.com/microsoft/vcpkg.git vcpkg_repository; \
     git -C vcpkg_repository checkout "$(grep -o "\"builtin-baseline\": \"[0-9a-f]*\"" vcpkg.json | cut -d\" -f4)"; \
     ./vcpkg_repository/bootstrap-vcpkg.sh --disableMetrics; \

--- a/docs/rust-cmake-integration.md
+++ b/docs/rust-cmake-integration.md
@@ -62,13 +62,15 @@ nes_network = { workspace = true }
 
 Every workspace dependency must be used by at least one member. This ensures it is
 present in `Cargo.lock` and vendored into the development image as soon as it is added.
-`scripts/check_rust_dependency_policy.py` enforces both rules before the
-dependency-image hash is calculated. Consequently, member `Cargo.toml` files do not
-need to participate in that hash: changing which already-vendored workspace dependency
-a member uses cannot introduce an unvendored crate.
+`scripts/check_rust_dependency_policy.py` enforces both rules at CMake configure time.
+Consequently, member `Cargo.toml` files do not need to participate in the
+dependency-image hash: changing which already-vendored workspace dependency a member
+uses cannot introduce an unvendored crate.
 
-Running the dependency-image hash requires Python 3.11 or newer so the checker can use
-the standard-library `tomllib` parser.
+The checker requires Python 3.11 or newer for the standard-library `tomllib` parser.
+The development image ships a newer Python, so this only constrains a configure run
+outside the container. Computing the dependency-image hash itself needs no Python,
+which keeps the local image install script runnable on a host with an older default.
 
 Each member inherits the package defaults:
 

--- a/scripts/check_rust_dependency_policy.py
+++ b/scripts/check_rust_dependency_policy.py
@@ -25,8 +25,10 @@ from typing import Any, Iterable
 try:
     import tomllib
 except ModuleNotFoundError:
+    version = ".".join(str(part) for part in sys.version_info[:3])
     print(
-        "Python 3.11 or newer is required to validate Rust workspace dependencies.",
+        f"Python 3.11 or newer is required to validate Rust workspace dependencies, "
+        f"but {sys.executable} is {version}.",
         file=sys.stderr,
     )
     sys.exit(2)

--- a/scripts/hash_dependencies.sh
+++ b/scripts/hash_dependencies.sh
@@ -22,12 +22,12 @@ set -euo pipefail
 # cd to root of git repo
 cd "$(git rev-parse --show-toplevel)"
 
-# Member manifests are deliberately excluded from the dependency image hash. Enforce the
-# invariants that make that safe: members can only inherit dependencies from the workspace,
-# and the workspace cannot keep dependencies that are not yet used (and therefore not vendored).
-python3 scripts/check_rust_dependency_policy.py
-
 # paths of dirs or files that affect the dependency images
+#
+# This list deliberately excludes member manifests.
+# Excluding them is only safe while every member inherits its dependencies from the workspace and the workspace keeps nothing unused.
+# CMake enforces both rules at configure time.
+# The list covers the script it runs, because relaxing either rule invalidates every image already vendored.
 #
 # Do not use trailing slashes on dirs since this leads to diverging hashes on macos.
 HASH_PATHS=(


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

Two fixes by @keyseven123 that showed up on the coordinator stack because they change the dependency hash and therefore rebuild the dev images. They are independent of the coordinator work and useful to every PR that touches dependencies.

The change list is as follows:

- `docker/dependency/Dependency.dockerfile`: the vcpkg clone now runs with `http.version=HTTP/1.1` and `GIT_TERMINAL_PROMPT=0`. The dependency image needs a full clone of the vcpkg repository. Under load, GitHub aborts large HTTP/2 clones with `curl 92 HTTP/2 stream was not closed cleanly`, and HTTP/1.1 avoids that. The disabled prompt makes git fail fast instead of hanging on an auth challenge in a Docker build with no terminal. Ported onto main's Dockerfile; the original branch had this as two commits, first a retry loop and then this replacement.
- `scripts/check_rust_dependency_policy.py`: falls back to an installed `python3.11` or newer when the default `python3` has no `tomllib`. The script runs on every CMake configure through the dependency hash and in the local image install script, so a host whose default Python is older (Ubuntu 22.04 ships 3.10) could not configure at all. An environment variable guards against a re-exec loop. CI runners and the dev container already run Python 3.12, so this only affects developer hosts.

## Verifying this change

This change is tested by
- the dev image rebuild that this PR triggers itself, since the dockerfile is part of the dependency hash. The `get-dev-images` jobs exercise the changed clone on every image variant.
- the same two changes on the coordinator branches on 2026-09-02, where every `Build Dev Images` job passed after they were added.
- the policy script on a host with Python 3.14, unchanged behaviour when `tomllib` is present.

## What components does this pull request potentially affect?

- Dependencies: the dependency image build only. No dependency is added or upgraded.
- Build: the dependency hash script, and with it CMake configuration on hosts with an old default Python.


## Issue Closed by this pull request:

No issue. The failures were observed on the coordinator stack CI.
