### PR TITLE
Capture Docker Compose logs for Bats test diagnostics

### DIFF
--- a/nes-systests/systest/remote-test/distributed.bats
+++ b/nes-systests/systest/remote-test/distributed.bats
@@ -62,7 +62,7 @@ setup() {
 }
 
 teardown() {
-  docker compose down -v || true
+  nes_distributed_teardown
 }
 
 function setup_distributed() {
@@ -105,13 +105,7 @@ function setup_distributed() {
   rm -rf "$config_dir"
 
   $NES_DIR/nes-systests/systest/remote-test/create_compose.sh "$1" >docker-compose.yaml
-  local compose_output exit_code=0
-  compose_output=$(docker compose up -d --wait 2>&1) || exit_code=$?
-  if [ "$exit_code" -ne 0 ]; then
-    echo "# [docker compose up] (status=$exit_code):" >&3
-    while IFS= read -r line; do echo "#   $line" >&3; done <<< "$compose_output"
-  fi
-  return $exit_code
+  nes_distributed_start
 }
 
 docker_systest() {

--- a/scripts/testing/distributed_bats_lib.bash
+++ b/scripts/testing/distributed_bats_lib.bash
@@ -25,7 +25,7 @@
 #   Layer 2 — preset for the cli/repl/MQTT-style suites:
 #     nes_distributed_setup_file, nes_distributed_teardown_file
 #     nes_distributed_setup, nes_distributed_teardown
-#     setup_distributed
+#     setup_distributed, nes_distributed_start
 #     docker_nes_cli, wait_until_status [--require-healthy <regex>]
 #                                            (used by cli/MQTT* suites)
 #
@@ -321,6 +321,35 @@ nes_distributed_setup() {
 
 nes_distributed_teardown() {
   docker compose down -v || true
+  if [ -n "${NES_COMPOSE_LOG_PID:-}" ]; then
+    kill "$NES_COMPOSE_LOG_PID" 2>/dev/null || true
+    wait "$NES_COMPOSE_LOG_PID" 2>/dev/null || true
+    unset NES_COMPOSE_LOG_PID
+  fi
+}
+
+# Create containers before attaching so the follower has services to watch,
+# including while startup waits for dependencies to become healthy.
+nes_distributed_start() {
+  local compose_output exit_code=0
+  compose_output=$(docker compose create 2>&1) || exit_code=$?
+  if [ "$exit_code" -ne 0 ]; then
+    printf '%s\n' "$compose_output" > "$TEST_DIR/docker-compose.log"
+    echo "# [docker compose create] (status=$exit_code):" >&3
+    while IFS= read -r line; do echo "#   $line" >&3; done <<< "$compose_output"
+    return $exit_code
+  fi
+  # Close Bats' reporting pipe in the background process to avoid holding it open.
+  docker compose logs --follow --no-color --timestamps \
+    > "$TEST_DIR/docker-compose.log" 2>&1 3>&- &
+  NES_COMPOSE_LOG_PID=$!
+
+  compose_output=$(docker compose up -d --wait 2>&1) || exit_code=$?
+  if [ "$exit_code" -ne 0 ]; then
+    echo "# [docker compose up] (status=$exit_code):" >&3
+    while IFS= read -r line; do echo "#   $line" >&3; done <<< "$compose_output"
+  fi
+  return $exit_code
 }
 
 # Generate docker-compose.yaml from a topology file using the suite's local
@@ -328,13 +357,7 @@ nes_distributed_teardown() {
 # `cd`'d into a working directory containing tests/util/create_compose.sh.
 setup_distributed() {
   tests/util/create_compose.sh "$1" > docker-compose.yaml
-  local compose_output exit_code=0
-  compose_output=$(docker compose up -d --wait 2>&1) || exit_code=$?
-  if [ "$exit_code" -ne 0 ]; then
-    echo "# [docker compose up] (status=$exit_code):" >&3
-    while IFS= read -r line; do echo "#   $line" >&3; done <<< "$compose_output"
-  fi
-  return $exit_code
+  nes_distributed_start
 }
 
 docker_nes_cli() {


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log

Docker Compose Bats tests remove their containers during teardown without saving the Compose logs. When a CI test fails, those logs are unavailable in the uploaded artifacts, making service startup and health-check failures difficult to diagnose.

Create the Compose containers first, then attach a background `docker compose logs --follow --no-color --timestamps` process before starting the services with the existing `up -d --wait` command. The logger writes container output to `$TEST_DIR/docker-compose.log` throughout the test. Teardown runs `docker compose down -v`, then stops and reaps the logger.

Both the shared distributed Bats suites and remote systests use this startup and teardown flow. If `docker compose create` fails, its exit status and error output are reported in the Bats diagnostics, and the error is saved to the same log file.

The log is written into each test directory and included automatically by the existing CI log upload; no workflow changes are needed.

MQTT source tests use a local parallel publishing helper that waits only for its publisher PIDs. This keeps their data-publishing waits from also waiting for the long-running Compose logger, which would prevent the tests from reaching teardown. The helper preserves the existing publisher counts and message payloads and reports publisher failures.

## Verifying this change

- Focused Docker checks with local Alpine containers verified live startup output, shutdown messages, restarts, and logger/container cleanup after successful and failed startup.
- A malformed YAML check verified that creation errors are reported and saved, and no logger is started.
- `bash -n scripts/testing/distributed_bats_lib.bash` and `git diff --check` passed.
- The MQTT publishing refactor passed Bats parsing/test discovery (`bats --count`) and `git diff --check`; its test cases were not executed.
- Full NES test suites were not run.

## What components does this pull request potentially affect?

Shared distributed Bats helpers, MQTT source test publishing, remote systest setup and teardown, and the diagnostic logs included in CI artifacts.

